### PR TITLE
stream: stream_recv writes data to a provided buffer

### DIFF
--- a/examples/server.c
+++ b/examples/server.c
@@ -336,19 +336,19 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
             while (quiche_readable_next(iter, &s)) {
                 fprintf(stderr, "stream %zu is readable\n", s);
 
-                quiche_rangebuf *b = quiche_conn_stream_recv(conn_io->conn, s,
-                                                             SIZE_MAX);
-                if (b == NULL) {
+                bool fin = false;
+                ssize_t recv_len = quiche_conn_stream_recv(conn_io->conn, s,
+                                                           buf, sizeof(buf),
+                                                           &fin);
+                if (recv_len < 0) {
                     break;
                 }
 
-                if (quiche_rangebuf_fin(b)) {
+                if (fin) {
                     static const char *resp = "byez\n";
                     quiche_conn_stream_send(conn_io->conn, s, (uint8_t *) resp,
                                             5, true);
                 }
-
-                quiche_rangebuf_free(b);
             }
 
             quiche_readable_free(iter);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -189,24 +189,12 @@ ssize_t quiche_conn_send(quiche_conn *conn, uint8_t *out, size_t out_len);
 typedef struct RangeBuf quiche_rangebuf;
 
 // Reads contiguous data from a stream.
-quiche_rangebuf *quiche_conn_stream_recv(quiche_conn *conn, uint64_t stream_id,
-                                         size_t max_len);
+ssize_t quiche_conn_stream_recv(quiche_conn *conn, uint64_t stream_id,
+                                uint8_t *out, size_t buf_len, bool *fin);
 
 // Writes data to a stream.
 ssize_t quiche_conn_stream_send(quiche_conn *conn, uint64_t stream_id,
                                 const uint8_t *buf, size_t buf_len, bool fin);
-
-// Returns the data of the buffer.
-const uint8_t *quiche_rangebuf_data(quiche_rangebuf *b);
-
-// Returns the length of the buffer.
-size_t quiche_rangebuf_len(quiche_rangebuf *b);
-
-// Returns whether `self` holds the final offset in the stream.
-bool quiche_rangebuf_fin(quiche_rangebuf *b);
-
-// Frees the buffer object.
-void quiche_rangebuf_free(quiche_rangebuf *b);
 
 // An iterator over the streams that have outstanding data to read.
 typedef struct Readable quiche_readable;


### PR DESCRIPTION
The buffer is provided from 'c' as a pointer to an array of uint8_t and
a length thereof.

In addition, from 'c', a reference to a bool is provided so that the fin
status of the read can be returned to the caller.

The return value for the 'c' function is the number of bytes written
into the provided buffer.

The rust interface is similar, in that it also provides a buffer, in
the form of a mutable slice of 'u8' type.  The slice self reports its
own size.

The number of bytes written to the slice, and the fin status of the
read is returned as a tuple.

The important fix is in the RecvBuf class, where the pop method now
takes a slice as a parameter and copies queued pages of data into the
slice.

The existing RangeBuf interface is removed from RecvBuf::pop and
Stream::recv_pop and as a result, RecvBuf no longer needs to be
exposed through the ffi interface.