### PR TITLE
Add Cargo cache to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 
+cache: cargo
+
 dist: xenial
 
 rust:


### PR DESCRIPTION
This allows to avoid rebuilding all deps on each CI run, thus significantly speeding up compilations.