### PR TITLE
Revert "add Cargo cache to Travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: rust
 
-cache: cargo
-
 dist: xenial
 
 rust:


### PR DESCRIPTION
This seems to be breaking PR builds due to having "branch" and "pull request"
builds which reuse the same build artifacts, which in turn confuses the C
examples Makefile and cause the C examples to fail to build.

See e.g. https://github.com/cloudflare/quiche/pull/20/checks?check_run_id=59225473

This is really the Makefile's fault for being too stupid, but until I can
figure out how to fix it (e.g. make cargo build C examples?), it's just
easier to disable the build cache.

This reverts commit 5ddb63a879067702c4fac749adc96674cb61dc39.