### PR TITLE
Replace http::{Request, Response, Uri} 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ log = "0"
 libc = "0"
 ring = "0.14"
 lazy_static = "1"
+http = "0"
 
 [dev-dependencies]
 mio = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ log = "0"
 libc = "0"
 ring = "0.14"
 lazy_static = "1"
-http = "0"
 
 [dev-dependencies]
 mio = "0"

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -1,0 +1,292 @@
+// Copyright (C) 2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[macro_use]
+extern crate log;
+
+use std::str;
+
+use http::Request;
+use http::Uri;
+use ring::rand::*;
+
+const LOCAL_CONN_ID_LEN: usize = 16;
+
+const MAX_DATAGRAM_SIZE: usize = 1452;
+
+const USAGE: &str = "Usage:
+  h3client [options] URL
+  h3client -h | --help
+
+Options:
+  --wire-version VERSION  The version number to send to the server [default: babababa].
+  --no-verify             Don't verify server's certificate.
+  -h --help               Show this screen.
+";
+
+fn main() {
+    let mut buf = [0; 65535];
+    let mut out = [0; MAX_DATAGRAM_SIZE];
+
+    env_logger::init();
+
+    let args = docopt::Docopt::new(USAGE)
+        .and_then(|dopt| dopt.parse())
+        .unwrap_or_else(|e| e.exit());
+
+    let uri = args.get_str("URL").parse::<Uri>().unwrap();
+    let uri_authority = uri.authority_part().unwrap().as_str();
+    let uri_host = uri.host().unwrap();
+
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").unwrap();
+    socket.connect(&uri_authority).unwrap();
+
+    let poll = mio::Poll::new().unwrap();
+    let mut events = mio::Events::with_capacity(1024);
+
+    let socket = mio::net::UdpSocket::from_socket(socket).unwrap();
+    poll.register(
+        &socket,
+        mio::Token(0),
+        mio::Ready::readable(),
+        mio::PollOpt::edge(),
+    )
+    .unwrap();
+
+    let mut scid = [0; LOCAL_CONN_ID_LEN];
+    SystemRandom::new().fill(&mut scid[..]).unwrap();
+
+    let version = args.get_str("--wire-version");
+    let version = u32::from_str_radix(version, 16).unwrap();
+
+    let mut quiche_config = quiche::Config::new(version).unwrap();
+
+    quiche_config.verify_peer(true);
+
+    quiche_config.set_application_protos(&[b"h3-18"]).unwrap();
+
+    quiche_config.set_idle_timeout(30);
+    quiche_config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
+    quiche_config.set_initial_max_data(10_000_000);
+    quiche_config.set_initial_max_stream_data_bidi_local(1_000_000);
+    quiche_config.set_initial_max_stream_data_bidi_remote(1_000_000);
+    quiche_config.set_initial_max_streams_bidi(100);
+    quiche_config.set_initial_max_streams_uni(100);
+    quiche_config.set_disable_migration(true);
+
+    let mut http3_conn = None;
+    let mut req_sent = false;
+
+    if args.get_bool("--no-verify") {
+        quiche_config.verify_peer(false);
+    }
+
+    if std::env::var_os("SSLKEYLOGFILE").is_some() {
+        quiche_config.log_keys();
+    }
+
+    let mut quic_conn =
+        quiche::connect(Some(uri_host), &scid, &mut quiche_config).unwrap();
+
+    let write = match quic_conn.send(&mut out) {
+        Ok(v) => v,
+
+        Err(e) => panic!("{} initial send failed: {:?}", quic_conn.trace_id(), e),
+    };
+
+    socket.send(&out[..write]).unwrap();
+
+    debug!("{} written {}", quic_conn.trace_id(), write);
+
+    loop {
+        poll.poll(&mut events, quic_conn.timeout()).unwrap();
+
+        'read: loop {
+            if events.is_empty() {
+                debug!("timed out");
+
+                quic_conn.on_timeout();
+
+                break 'read;
+            }
+
+            let len = match socket.recv(&mut buf) {
+                Ok(v) => v,
+
+                Err(e) => {
+                    if e.kind() == std::io::ErrorKind::WouldBlock {
+                        debug!("recv() would block");
+                        break 'read;
+                    }
+
+                    panic!("recv() failed: {:?}", e);
+                },
+            };
+
+            debug!("{} got {} bytes", quic_conn.trace_id(), len);
+
+            // Process potentially coalesced packets.
+            let read = match quic_conn.recv(&mut buf[..len]) {
+                Ok(v) => v,
+
+                Err(quiche::Error::Done) => {
+                    debug!("{} done reading", quic_conn.trace_id());
+                    break;
+                },
+
+                Err(e) => {
+                    error!("{} recv failed: {:?}", quic_conn.trace_id(), e);
+                    quic_conn.close(false, e.to_wire(), b"fail").unwrap();
+                    break 'read;
+                },
+            };
+
+            debug!("{} processed {} bytes", quic_conn.trace_id(), read);
+        }
+
+        if quic_conn.is_closed() {
+            debug!("{} connection closed", quic_conn.trace_id());
+            break;
+        }
+
+        if quic_conn.is_established() && http3_conn.is_none() {
+            debug!(
+                "{} QUIC handshake completed, now trying HTTP/3",
+                quic_conn.trace_id()
+            );
+
+            if quic_conn.application_proto() != b"h3-18" {
+                // TODO a better error code?
+                quic_conn
+                    .close(false, 0x0, b"I don't support your ALPNs")
+                    .unwrap();
+                break;
+            }
+
+            let h3_config = quiche::h3::Config::new(0, 1024, 0, 0).unwrap();
+            http3_conn = Some(
+                quiche::h3::connect(&mut quic_conn, &h3_config).unwrap(),
+            );
+        }
+
+        if let Some(http3_conn) = &mut http3_conn {
+            if !req_sent {
+                let req = Request::builder()
+                    .method("GET")
+                    .uri(&uri)
+                    .version(http::Version::HTTP_2)
+                    .header("User-Agent", "quiche-http/3")
+                    .body(())
+                    .unwrap();
+                info!("Sending HTTP request {:?}", req);
+
+                match http3_conn.send_request(&mut quic_conn, &req, false) {
+                    Ok(_) => {
+                        req_sent = true;
+                    },
+                    Err(e) => {
+                        error!(
+                            "{} stream send failed {:?}",
+                            quic_conn.trace_id(),
+                            e
+                        );
+                        quic_conn.close(false, 0x0, b"HTTP/3 Failed").unwrap();
+                        break;
+                    },
+                }
+            }
+
+            loop {
+                match http3_conn.process(&mut quic_conn) {
+                    Ok(quiche::h3::Event::OnRespHeaders { stream_id, value }) => {
+                        info!(
+                            "Got response headers {:?} on stream id {}",
+                            value, stream_id
+                        );
+                    },
+                    Ok(quiche::h3::Event::OnPayloadData { stream_id, value }) => {
+                        info!(
+                            "Got response data of length {} in stream id {}",
+                            value.len(),
+                            stream_id
+                        );
+
+                        info!("{}", str::from_utf8(&value).unwrap());
+                    },
+                    Ok(quiche::h3::Event::OnReqHeaders { .. }) => {
+                        error!(
+                            "{} HTTP/3 request received",
+                            quic_conn.trace_id(),
+                        );
+                    },
+                    Err(quiche::h3::Error::Done) => {
+                        break;
+                    },
+                    Err(e) => {
+                        error!(
+                            "{} HTTP/3 processing failed: {:?}",
+                            quic_conn.trace_id(),
+                            e
+                        );
+                        quic_conn.close(false, 0x0, b"HTTP/3 Failed").unwrap();
+                        break;
+                    },
+                }
+            }
+        }
+
+        loop {
+            let write = match quic_conn.send(&mut out) {
+                Ok(v) => v,
+
+                Err(quiche::Error::Done) => {
+                    debug!("{} done writing", quic_conn.trace_id());
+                    break;
+                },
+
+                Err(e) => {
+                    error!("{} send failed: {:?}", quic_conn.trace_id(), e);
+                    quic_conn.close(false, e.to_wire(), b"fail").unwrap();
+                    break;
+                },
+            };
+
+            // TODO: coalesce packets.
+            socket.send(&out[..write]).unwrap();
+
+            debug!("{} written {}", quic_conn.trace_id(), write);
+        }
+
+        if quic_conn.is_closed() {
+            info!(
+                "{} connection closed, {:?}",
+                quic_conn.trace_id(),
+                quic_conn.stats()
+            );
+            break;
+        }
+    }
+}

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -1,0 +1,456 @@
+// Copyright (C) 2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[macro_use]
+extern crate log;
+
+use std::net;
+
+use std::collections::HashMap;
+
+use http::Response;
+use ring::rand::*;
+
+const LOCAL_CONN_ID_LEN: usize = 16;
+
+const MAX_DATAGRAM_SIZE: usize = 1452;
+
+const USAGE: &str = "Usage:
+  h3server [options]
+  h3server -h | --help
+
+Options:
+  --listen <addr>   Listen on the given IP:port [default: 127.0.0.1:4433]
+  --cert <file>     TLS certificate path [default: examples/cert.crt]
+  --key <file>      TLS certificate key path [default: examples/cert.key]
+  --root <dir>      Root directory [default: examples/root/]
+  --name <str>      Name of the server [default: quic.tech]
+  -h --help         Show this screen.
+";
+struct HTTP3Client {
+    quiche_conn: Box<quiche::Connection>,
+    http3_conn: Option<quiche::h3::Connection>,
+}
+
+type HTTP3ClientMap = HashMap<Vec<u8>, (net::SocketAddr, HTTP3Client)>;
+
+fn main() {
+    let mut buf = [0; 65535];
+    let mut out = [0; MAX_DATAGRAM_SIZE];
+
+    env_logger::init();
+
+    let args = docopt::Docopt::new(USAGE)
+        .and_then(|dopt| dopt.parse())
+        .unwrap_or_else(|e| e.exit());
+
+    let socket = net::UdpSocket::bind(args.get_str("--listen")).unwrap();
+
+    let root_dir = args.get_str("--root");
+
+    let poll = mio::Poll::new().unwrap();
+    let mut events = mio::Events::with_capacity(1024);
+
+    let socket = mio::net::UdpSocket::from_socket(socket).unwrap();
+    poll.register(
+        &socket,
+        mio::Token(0),
+        mio::Ready::readable(),
+        mio::PollOpt::edge(),
+    )
+    .unwrap();
+
+    let mut clients = HTTP3ClientMap::new();
+
+    let mut quiche_config = quiche::Config::new(quiche::VERSION_DRAFT18).unwrap();
+
+    quiche_config
+        .load_cert_chain_from_pem_file(args.get_str("--cert"))
+        .unwrap();
+    quiche_config
+        .load_priv_key_from_pem_file(args.get_str("--key"))
+        .unwrap();
+
+    quiche_config.set_application_protos(&[b"h3-18"]).unwrap();
+
+    quiche_config.set_idle_timeout(30);
+    quiche_config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
+    quiche_config.set_initial_max_data(10_000_000);
+    quiche_config.set_initial_max_stream_data_bidi_local(1_000_000);
+    quiche_config.set_initial_max_stream_data_bidi_remote(1_000_000);
+    quiche_config.set_initial_max_streams_bidi(100);
+    quiche_config.set_initial_max_streams_uni(100);
+    quiche_config.set_disable_migration(true);
+
+    loop {
+        // TODO: use event loop that properly supports timers
+        let timeout = clients
+            .values()
+            .filter_map(|(_, c)| c.quiche_conn.timeout())
+            .min();
+
+        poll.poll(&mut events, timeout).unwrap();
+
+        'read: loop {
+            if events.is_empty() {
+                debug!("timed out");
+
+                clients
+                    .values_mut()
+                    .for_each(|(_, c)| c.quiche_conn.on_timeout());
+
+                break 'read;
+            }
+
+            let (len, src) = match socket.recv_from(&mut buf) {
+                Ok(v) => v,
+
+                Err(e) => {
+                    if e.kind() == std::io::ErrorKind::WouldBlock {
+                        debug!("recv() would block");
+                        break 'read;
+                    }
+
+                    panic!("recv() failed: {:?}", e);
+                },
+            };
+
+            debug!("got {} bytes", len);
+
+            let buf = &mut buf[..len];
+
+            let hdr = match quiche::Header::from_slice(buf, LOCAL_CONN_ID_LEN) {
+                Ok(v) => v,
+
+                Err(e) => {
+                    error!("Parsing packet header failed: {:?}", e);
+                    continue;
+                },
+            };
+
+            if hdr.ty == quiche::Type::VersionNegotiation {
+                error!("Version negotiation invalid on the server");
+                continue;
+            }
+
+            let (_, client) = if !clients.contains_key(&hdr.dcid) {
+                if hdr.ty != quiche::Type::Initial {
+                    error!("Packet is not Initial");
+                    continue;
+                }
+
+                if hdr.version != quiche::VERSION_DRAFT18 {
+                    warn!("Doing version negotiation");
+
+                    let len =
+                        quiche::negotiate_version(&hdr.scid, &hdr.dcid, &mut out)
+                            .unwrap();
+                    let out = &out[..len];
+
+                    socket.send_to(out, &src).unwrap();
+                    continue;
+                }
+
+                let mut scid: [u8; LOCAL_CONN_ID_LEN] = [0; LOCAL_CONN_ID_LEN];
+                SystemRandom::new().fill(&mut scid[..]).unwrap();
+
+                // Token is always present in Initial packets.
+                let token = hdr.token.as_ref().unwrap();
+
+                if token.is_empty() {
+                    warn!("Doing stateless retry");
+
+                    let new_token = mint_token(&hdr, &src);
+
+                    let len = quiche::retry(
+                        &hdr.scid, &hdr.dcid, &scid, &new_token, &mut out,
+                    )
+                    .unwrap();
+                    let out = &out[..len];
+
+                    socket.send_to(out, &src).unwrap();
+                    continue;
+                }
+
+                let odcid = validate_token(&src, token);
+
+                if odcid == None {
+                    error!("Invalid address validation token");
+                    continue;
+                }
+
+                debug!(
+                    "New connection: dcid={} scid={} lcid={}",
+                    hex_dump(&hdr.dcid),
+                    hex_dump(&hdr.scid),
+                    hex_dump(&scid)
+                );
+
+                let q = quiche::accept(&scid, odcid, &mut quiche_config).unwrap();
+
+                let client = HTTP3Client {
+                    quiche_conn: q,
+                    http3_conn: None,
+                };
+
+                clients.insert(scid.to_vec(), (src, client));
+
+                clients.get_mut(&scid[..]).unwrap()
+            } else {
+                clients.get_mut(&hdr.dcid).unwrap()
+            };
+
+            // Process potentially coalesced packets.
+            let read = match client.quiche_conn.recv(buf) {
+                Ok(v) => v,
+
+                Err(quiche::Error::Done) => {
+                    debug!("{} done reading", client.quiche_conn.trace_id());
+                    break;
+                },
+
+                Err(e) => {
+                    error!(
+                        "{} recv failed: {:?}",
+                        client.quiche_conn.trace_id(),
+                        e
+                    );
+                    client
+                        .quiche_conn
+                        .close(false, e.to_wire(), b"fail")
+                        .unwrap();
+                    break 'read;
+                },
+            };
+
+            debug!("{} processed {} bytes", client.quiche_conn.trace_id(), read);
+
+            if client.quiche_conn.is_established() {
+                if client.quiche_conn.application_proto() != b"h3-18" {
+                    // TODO a better error code?
+                    client
+                        .quiche_conn
+                        .close(false, 0x0, b"I don't support your ALPNs")
+                        .unwrap();
+                    break;
+                }
+
+                let h3_config =
+                    quiche::h3::Config::new(16, 1024, 0, 0).unwrap();
+
+                if client.http3_conn.is_none() {
+                    debug!(
+                        "{} QUIC handshake completed, now trying HTTP/3",
+                        client.quiche_conn.trace_id()
+                    );
+                    let h3_conn = quiche::h3::accept(
+                        &mut client.quiche_conn,
+                        &h3_config,
+                    )
+                    .unwrap();
+
+                    // TODO some sanity checking that H3 conn is ok before
+                    // adding it to the collection
+                    client.http3_conn = Some(h3_conn);
+                }
+            }
+
+            if let Some(http3_conn) = &mut client.http3_conn {
+                match http3_conn.process(client.quiche_conn.as_mut()) {
+                    Ok(quiche::h3::Event::OnReqHeaders { stream_id, value }) => {
+                        info!(
+                            "got request {:?} on stream id {}",
+                            value, stream_id
+                        );
+
+                        let resp = build_response(root_dir, &value);
+
+                        http3_conn.send_response(
+                            client.quiche_conn.as_mut(),
+                            stream_id,
+                            resp,
+                        );
+                    },
+                    Ok(quiche::h3::Event::OnPayloadData { stream_id, value }) => {
+                        info!(
+                            "Got request data of length {} in stream id {}",
+                            value.len(),
+                            stream_id
+                        );
+                    },
+                    Ok(quiche::h3::Event::OnRespHeaders { .. }) => {
+                        error!(
+                            "{} HTTP/3 response received",
+                            client.quiche_conn.trace_id(),
+                        );
+                    },
+                    Err(quiche::h3::Error::Done) => {
+                        // TODO
+                    },
+                    Err(e) => {
+                        error!(
+                            "{} HTTP/3 error {:?}",
+                            client.quiche_conn.trace_id(),
+                            e
+                        );
+
+                        client
+                            .quiche_conn
+                            .close(false, 0x0, b"HTTP/3 Failed")
+                            .unwrap();
+                        break;
+                    },
+                }
+            }
+        }
+
+        for (peer, client) in clients.values_mut() {
+            loop {
+                let write = match client.quiche_conn.send(&mut out) {
+                    Ok(v) => v,
+
+                    Err(quiche::Error::Done) => {
+                        debug!("{} done writing", client.quiche_conn.trace_id());
+                        break;
+                    },
+
+                    Err(e) => {
+                        error!(
+                            "{} send failed: {:?}",
+                            client.quiche_conn.trace_id(),
+                            e
+                        );
+                        client
+                            .quiche_conn
+                            .close(false, e.to_wire(), b"fail")
+                            .unwrap();
+                        break;
+                    },
+                };
+
+                // TODO: coalesce packets.
+                socket.send_to(&out[..write], &peer).unwrap();
+
+                debug!(
+                    "{} written {} bytes",
+                    client.quiche_conn.trace_id(),
+                    write
+                );
+            }
+        }
+
+        // Garbage collect closed connections.
+        clients.retain(|_, (_, ref mut c)| {
+            debug!("Collecting garbage");
+
+            if c.quiche_conn.is_closed() {
+                info!(
+                    "{} connection collected {:?}",
+                    c.quiche_conn.trace_id(),
+                    c.quiche_conn.stats()
+                );
+            }
+
+            !c.quiche_conn.is_closed()
+        });
+    }
+}
+
+fn mint_token(hdr: &quiche::Header, src: &net::SocketAddr) -> Vec<u8> {
+    let mut token = Vec::new();
+
+    token.extend_from_slice(b"quiche");
+
+    let addr = match src.ip() {
+        std::net::IpAddr::V4(a) => a.octets().to_vec(),
+        std::net::IpAddr::V6(a) => a.octets().to_vec(),
+    };
+
+    token.extend_from_slice(&addr);
+    token.extend_from_slice(&hdr.dcid);
+
+    token
+}
+
+fn validate_token<'a>(
+    src: &net::SocketAddr, token: &'a [u8],
+) -> Option<&'a [u8]> {
+    if token.len() < 6 {
+        return None;
+    }
+
+    if &token[..6] != b"quiche" {
+        return None;
+    }
+
+    let token = &token[6..];
+
+    let addr = match src.ip() {
+        std::net::IpAddr::V4(a) => a.octets().to_vec(),
+        std::net::IpAddr::V6(a) => a.octets().to_vec(),
+    };
+
+    if token.len() < addr.len() || &token[..addr.len()] != addr.as_slice() {
+        return None;
+    }
+
+    let token = &token[addr.len()..];
+
+    Some(&token[..])
+}
+
+fn hex_dump(buf: &[u8]) -> String {
+    let vec: Vec<String> = buf.iter().map(|b| format!("{:02x}", b)).collect();
+
+    vec.join("")
+}
+
+fn build_response(
+    root_dir: &str, request: &http::Request<()>,
+) -> http::Response<Vec<u8>> {
+    let mut file_path = std::path::PathBuf::from(root_dir);
+    file_path.push(request.uri().path().trim_start_matches('/'));
+
+    let mut status = 404;
+    let mut body = Vec::from(String::from("Not Found!"));
+    match std::fs::read(file_path.as_path()) {
+        Ok(data) => {
+            status = 200;
+            body = data;
+        },
+        Err(e) => {
+            error!("{:?} {}. Returning a 404.", file_path, e);
+        },
+    }
+
+    Response::builder()
+        .status(status)
+        .version(http::Version::HTTP_2)
+        .header("Server", "quiche-http/3")
+        .header("Content-Length", body.len())
+        .body(body)
+        .unwrap()
+}

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -258,7 +258,7 @@ fn main() {
                     break;
                 }
 
-                let h3_config =
+                let mut h3_config =
                     quiche::h3::Config::new(16, 1024, 0, 0).unwrap();
 
                 if client.http3_conn.is_none() {
@@ -268,7 +268,7 @@ fn main() {
                     );
                     let h3_conn = quiche::h3::accept(
                         &mut client.quiche_conn,
-                        &h3_config,
+                        &mut h3_config,
                     )
                     .unwrap();
 

--- a/src/h3/frame.rs
+++ b/src/h3/frame.rs
@@ -1,0 +1,961 @@
+// Copyright (C) 2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::mem;
+
+use crate::octets;
+
+use super::Error;
+use super::Result;
+
+const ELEM_DEPENDENCY_TYPE_MASK: u8 = 0x30;
+
+pub const DATA_FRAME_TYPE_ID: u8 = 0x0;
+pub const HEADERS_FRAME_TYPE_ID: u8 = 0x1;
+pub const PRIORITY_FRAME_TYPE_ID: u8 = 0x2;
+pub const CANCEL_PUSH_FRAME_TYPE_ID: u8 = 0x3;
+pub const SETTINGS_FRAME_TYPE_ID: u8 = 0x4;
+pub const PUSH_PROMISE_FRAME_TYPE_ID: u8 = 0x5;
+pub const GOAWAY_FRAME_TYPE_ID: u8 = 0x6;
+pub const MAX_PUSH_FRAME_TYPE_ID: u8 = 0xD;
+pub const DUPLICATE_PUSH_FRAME_TYPE_ID: u8 = 0xE;
+
+const SETTINGS_QPACK_MAX_TABLE_CAPACITY: u16 = 0x1;
+const SETTINGS_MAX_HEADER_LIST_SIZE: u16 = 0x6;
+const SETTINGS_QPACK_BLOCKED_STREAMS: u16 = 0x7;
+const SETTINGS_NUM_PLACEHOLDERS: u16 = 0x8;
+
+/// HTTP/3 Prioritized Element type.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PrioritizedElemType {
+    RequestStream,
+    PushStream,
+    Placeholder,
+    CurrentStream,
+    Error,
+}
+
+impl PrioritizedElemType {
+    fn is_peid_absent(self) -> bool {
+        match self {
+            PrioritizedElemType::CurrentStream => true,
+            PrioritizedElemType::Error => true,
+            _ => false,
+        }
+    }
+
+    fn to_bits(self) -> u8 {
+        match self {
+            PrioritizedElemType::RequestStream => 0x00,
+            PrioritizedElemType::PushStream => 0x01,
+            PrioritizedElemType::Placeholder => 0x02,
+            PrioritizedElemType::CurrentStream => 0x03,
+            _ => 0x04,
+        }
+    }
+
+    fn from_bits(bits: u8) -> PrioritizedElemType {
+        match bits {
+            0x00 => PrioritizedElemType::RequestStream,
+            0x01 => PrioritizedElemType::PushStream,
+            0x02 => PrioritizedElemType::Placeholder,
+            0x03 => PrioritizedElemType::CurrentStream,
+            _ => PrioritizedElemType::Error,
+        }
+    }
+}
+
+/// HTTP/3 Element Dependency type.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ElemDependencyType {
+    RequestStream,
+    PushStream,
+    Placeholder,
+    RootOfTree,
+    Error,
+}
+
+impl ElemDependencyType {
+    fn is_edid_absent(self) -> bool {
+        match self {
+            ElemDependencyType::RootOfTree => true,
+            ElemDependencyType::Error => true,
+            _ => false,
+        }
+    }
+
+    fn to_bits(self) -> u8 {
+        match self {
+            ElemDependencyType::RequestStream => 0x00,
+            ElemDependencyType::PushStream => 0x01,
+            ElemDependencyType::Placeholder => 0x02,
+            ElemDependencyType::RootOfTree => 0x03,
+            _ => 0x04,
+        }
+    }
+
+    fn from_bits(bits: u8) -> ElemDependencyType {
+        match bits {
+            0x00 => ElemDependencyType::RequestStream,
+            0x01 => ElemDependencyType::PushStream,
+            0x02 => ElemDependencyType::Placeholder,
+            0x03 => ElemDependencyType::RootOfTree,
+            _ => ElemDependencyType::Error,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub enum Frame {
+    Data {
+        payload: Vec<u8>,
+    },
+
+    Headers {
+        header_block: Vec<u8>,
+    },
+
+    Priority {
+        priority_elem: PrioritizedElemType,
+        elem_dependency: ElemDependencyType,
+        prioritized_element_id: Option<u64>,
+        element_dependency_id: Option<u64>,
+        weight: u8,
+    },
+
+    CancelPush {
+        push_id: u64,
+    },
+
+    Settings {
+        num_placeholders: Option<u64>,
+        max_header_list_size: Option<u64>,
+        qpack_max_table_capacity: Option<u64>,
+        qpack_blocked_streams: Option<u64>,
+    },
+
+    PushPromise {
+        push_id: u64,
+        header_block: Vec<u8>,
+    },
+
+    GoAway {
+        stream_id: u64,
+    },
+
+    MaxPushId {
+        push_id: u64,
+    },
+
+    DuplicatePush {
+        push_id: u64,
+    },
+}
+
+impl Frame {
+    pub fn from_bytes(
+        frame_type: u8, payload_length: u64, bytes: &mut [u8],
+    ) -> Result<Frame> {
+        let mut b = octets::Octets::with_slice(bytes);
+
+        // TODO: handling of 0-length frames
+        let frame = match frame_type {
+            DATA_FRAME_TYPE_ID => Frame::Data {
+                payload: b.get_bytes(payload_length as usize)?.to_vec(),
+            },
+
+            HEADERS_FRAME_TYPE_ID => Frame::Headers {
+                header_block: b.get_bytes(payload_length as usize)?.to_vec(),
+            },
+
+            PRIORITY_FRAME_TYPE_ID => parse_priority_frame(&mut b)?,
+
+            CANCEL_PUSH_FRAME_TYPE_ID => Frame::CancelPush {
+                push_id: b.get_varint()?,
+            },
+
+            SETTINGS_FRAME_TYPE_ID =>
+                parse_settings_frame(&mut b, payload_length as usize)?,
+
+            PUSH_PROMISE_FRAME_TYPE_ID =>
+                parse_push_promise(payload_length, &mut b)?,
+
+            GOAWAY_FRAME_TYPE_ID => Frame::GoAway {
+                stream_id: b.get_varint()?,
+            },
+
+            MAX_PUSH_FRAME_TYPE_ID => Frame::MaxPushId {
+                push_id: b.get_varint()?,
+            },
+
+            DUPLICATE_PUSH_FRAME_TYPE_ID => Frame::DuplicatePush {
+                push_id: b.get_varint()?,
+            },
+            _ => {
+                error!("Invalid frame type {}", frame_type);
+                return Err(Error::MalformedFrame);
+            },
+        };
+
+        Ok(frame)
+    }
+
+    pub fn to_bytes(&self, b: &mut octets::Octets) -> Result<usize> {
+        let before = b.cap();
+
+        trace!("Serializing frame type {:?}", self);
+
+        match self {
+            Frame::Data { payload } => {
+                b.put_varint(payload.len() as u64)?;
+                b.put_u8(DATA_FRAME_TYPE_ID)?;
+
+                b.put_bytes(payload.as_ref())?;
+            },
+
+            Frame::Headers { header_block } => {
+                b.put_varint(header_block.len() as u64)?;
+                b.put_u8(HEADERS_FRAME_TYPE_ID)?;
+
+                b.put_bytes(header_block.as_ref())?;
+            },
+
+            Frame::Priority {
+                priority_elem,
+                elem_dependency,
+                prioritized_element_id,
+                element_dependency_id,
+                weight,
+            } => {
+                let mut length = 2 * mem::size_of::<u8>(); // 2 u8s = (PT+DT+Empty) + Weight
+                if prioritized_element_id.is_some() {
+                    length += octets::varint_len(prioritized_element_id.unwrap());
+                }
+
+                if element_dependency_id.is_some() {
+                    length += octets::varint_len(element_dependency_id.unwrap());
+                }
+
+                b.put_varint(length as u64)?;
+                b.put_u8(PRIORITY_FRAME_TYPE_ID)?;
+
+                let mut bitfield = priority_elem.to_bits() << 6;
+                bitfield |= elem_dependency.to_bits() << 4;
+
+                b.put_u8(bitfield)?;
+
+                if prioritized_element_id.is_some() {
+                    b.put_varint(prioritized_element_id.unwrap())?;
+                }
+                if element_dependency_id.is_some() {
+                    b.put_varint(element_dependency_id.unwrap())?;
+                }
+
+                b.put_u8(*weight)?;
+            },
+
+            Frame::CancelPush { push_id } => {
+                b.put_varint(octets::varint_len(*push_id) as u64)?;
+                b.put_u8(CANCEL_PUSH_FRAME_TYPE_ID)?;
+
+                b.put_varint(*push_id)?;
+            },
+
+            Frame::Settings {
+                num_placeholders,
+                max_header_list_size,
+                qpack_max_table_capacity,
+                qpack_blocked_streams,
+            } => {
+                // TODO: make prettier
+                let mut len = 0;
+
+                if let Some(val) = num_placeholders {
+                    len += mem::size_of::<u16>();
+                    len += octets::varint_len(*val);
+                }
+
+                if let Some(val) = max_header_list_size {
+                    len += mem::size_of::<u16>();
+                    len += octets::varint_len(*val);
+                }
+
+                if let Some(val) = qpack_max_table_capacity {
+                    len += mem::size_of::<u16>();
+                    len += octets::varint_len(*val);
+                }
+
+                if let Some(val) = qpack_blocked_streams {
+                    len += mem::size_of::<u16>();
+                    len += octets::varint_len(*val);
+                }
+
+                trace!("SETTINGS payload will be {} bytes", len);
+
+                b.put_varint(len as u64)?;
+                b.put_u8(SETTINGS_FRAME_TYPE_ID)?;
+
+                if let Some(val) = num_placeholders {
+                    b.put_u16(0x8)?;
+                    b.put_varint(*val as u64)?;
+                }
+
+                if let Some(val) = max_header_list_size {
+                    b.put_u16(0x6)?;
+                    b.put_varint(*val as u64)?;
+                }
+
+                if let Some(val) = qpack_max_table_capacity {
+                    b.put_u16(0x1)?;
+                    b.put_varint(*val as u64)?;
+                }
+
+                if let Some(val) = qpack_blocked_streams {
+                    b.put_u16(0x7)?;
+                    b.put_varint(*val as u64)?;
+                }
+            },
+
+            Frame::PushPromise {
+                push_id,
+                header_block,
+            } => {
+                let len = octets::varint_len(*push_id) + header_block.len();
+                b.put_varint(len as u64)?;
+                b.put_u8(PUSH_PROMISE_FRAME_TYPE_ID)?;
+
+                b.put_varint(*push_id)?;
+                b.put_bytes(header_block.as_ref())?;
+            },
+
+            Frame::GoAway { stream_id } => {
+                b.put_varint(octets::varint_len(*stream_id) as u64)?;
+                b.put_u8(GOAWAY_FRAME_TYPE_ID)?;
+
+                b.put_varint(*stream_id)?;
+            },
+
+            Frame::MaxPushId { push_id } => {
+                b.put_varint(octets::varint_len(*push_id) as u64)?;
+                b.put_u8(MAX_PUSH_FRAME_TYPE_ID)?;
+
+                b.put_varint(*push_id)?;
+            },
+
+            Frame::DuplicatePush { push_id } => {
+                b.put_varint(octets::varint_len(*push_id) as u64)?;
+                b.put_u8(DUPLICATE_PUSH_FRAME_TYPE_ID)?;
+
+                b.put_varint(*push_id)?;
+            },
+        }
+
+        Ok(before - b.cap())
+    }
+}
+
+impl std::fmt::Debug for Frame {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Frame::Data { payload } => {
+                write!(f, "DATA len={}", payload.len())?;
+            },
+
+            Frame::Headers { header_block } => {
+                write!(f, "HEADERS len={}", header_block.len())?;
+            },
+
+            Frame::Priority {
+                priority_elem,
+                elem_dependency,
+                prioritized_element_id,
+                element_dependency_id,
+                weight,
+            } => {
+                let peid = match prioritized_element_id {
+                    Some(x) => x.to_string(),
+                    None => String::from("None"),
+                };
+
+                let edid = match element_dependency_id {
+                    Some(x) => x.to_string(),
+                    None => String::from("None"),
+                };
+
+                write!(f, "PRIORITY priority element type={:?} element dependency type={:?} prioritized element id={:?} element dependency id={:?} weight={:?}", priority_elem, elem_dependency, peid, edid, weight)?;
+            },
+
+            Frame::CancelPush { push_id } => {
+                write!(f, "CANCEL_PUSH push id={}", push_id)?;
+            },
+
+            Frame::Settings {
+                num_placeholders,
+                max_header_list_size,
+                qpack_max_table_capacity,
+                qpack_blocked_streams,
+            } => {
+                write!(f, "SETTINGS num placeholders={:?}, max header list size={:?}, qpack max table capacity={:?}, qpack blocked streams={:?} ", num_placeholders, max_header_list_size, qpack_max_table_capacity, qpack_blocked_streams)?;
+            },
+
+            Frame::PushPromise {
+                push_id,
+                header_block,
+            } => {
+                write!(
+                    f,
+                    "PUSH_PROMISE push id={} len={}",
+                    push_id,
+                    header_block.len()
+                )?;
+            },
+
+            Frame::GoAway { stream_id } => {
+                write!(f, "GOAWAY stream id={}", stream_id)?;
+            },
+
+            Frame::MaxPushId { push_id } => {
+                write!(f, "MAX_PUSH_ID push id={}", push_id)?;
+            },
+
+            Frame::DuplicatePush { push_id } => {
+                write!(f, "DUPLICATE_PUSH push id={}", push_id)?;
+            },
+        }
+
+        Ok(())
+    }
+}
+
+fn parse_settings_frame(
+    b: &mut octets::Octets, settings_length: usize,
+) -> Result<Frame> {
+    trace!("Parsing SETTINGS frame with contents {:?}", b);
+    let mut num_placeholders = None;
+    let mut max_header_list_size = None;
+    let mut qpack_max_table_capacity = None;
+    let mut qpack_blocked_streams = None;
+
+    while b.off() < settings_length {
+        let setting = b.get_u16()?;
+
+        match setting {
+            SETTINGS_QPACK_MAX_TABLE_CAPACITY => {
+                qpack_max_table_capacity = Some(b.get_varint()?);
+            },
+            SETTINGS_MAX_HEADER_LIST_SIZE => {
+                max_header_list_size = Some(b.get_varint()?);
+            },
+            SETTINGS_QPACK_BLOCKED_STREAMS => {
+                qpack_blocked_streams = Some(b.get_varint()?);
+            },
+            SETTINGS_NUM_PLACEHOLDERS => {
+                num_placeholders = Some(b.get_varint()?);
+            },
+            _ => {
+                // Unknown Settings parameters must be ignored
+                trace!("Setting parameter type {} not implemented!", setting);
+            },
+        }
+    }
+
+    Ok(Frame::Settings {
+        num_placeholders,
+        max_header_list_size,
+        qpack_max_table_capacity,
+        qpack_blocked_streams,
+    })
+}
+
+fn parse_priority_frame(b: &mut octets::Octets) -> Result<Frame> {
+    let bitfield = b.get_u8()?;
+    let mut prioritized_element_id = None;
+    let mut element_dependency_id = None;
+
+    let priority_elem = PrioritizedElemType::from_bits(bitfield >> 6);
+
+    let elem_dependency = ElemDependencyType::from_bits(
+        (bitfield & ELEM_DEPENDENCY_TYPE_MASK) >> 4,
+    );
+
+    if !priority_elem.is_peid_absent() {
+        prioritized_element_id = Some(b.get_varint()?);
+    }
+
+    if !elem_dependency.is_edid_absent() {
+        element_dependency_id = Some(b.get_varint()?);
+    }
+
+    let weight = b.get_u8()?;
+    Ok(Frame::Priority {
+        priority_elem,
+        elem_dependency,
+        prioritized_element_id,
+        element_dependency_id,
+        weight,
+    })
+}
+
+fn parse_push_promise(
+    payload_length: u64, b: &mut octets::Octets,
+) -> Result<Frame> {
+    let push_id = b.get_varint()?;
+    let header_block_length = payload_length - octets::varint_len(push_id) as u64;
+    let header_block = b.get_bytes(header_block_length as usize)?.to_vec();
+
+    Ok(Frame::PushPromise {
+        push_id,
+        header_block,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data() {
+        let mut d = [42; 128];
+
+        let payload = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        let frame_payload_len = payload.len();
+        let frame_header_len = 2;
+
+        let frame = Frame::Data { payload };
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                DATA_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn headers() {
+        let mut d = [42; 128];
+
+        let header_block = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        let frame_payload_len = header_block.len();
+        let frame_header_len = 2;
+
+        let frame = Frame::Headers { header_block };
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                HEADERS_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn priority_current_stream_to_root() {
+        let mut d = [42; 128];
+
+        let frame = Frame::Priority {
+            priority_elem: PrioritizedElemType::CurrentStream,
+            elem_dependency: ElemDependencyType::RootOfTree,
+            prioritized_element_id: None,
+            element_dependency_id: None,
+            weight: 16,
+        };
+
+        let frame_payload_len = 2;
+        let frame_header_len = 2;
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                PRIORITY_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn priority_placeholder_to_root() {
+        let mut d = [42; 128];
+
+        let frame = Frame::Priority {
+            priority_elem: PrioritizedElemType::Placeholder,
+            elem_dependency: ElemDependencyType::RootOfTree,
+            prioritized_element_id: Some(0),
+            element_dependency_id: None,
+            weight: 16,
+        };
+
+        let frame_payload_len = 3;
+        let frame_header_len = 2;
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                PRIORITY_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn priority_current_stream_to_placeholder() {
+        let mut d = [42; 128];
+
+        let frame = Frame::Priority {
+            priority_elem: PrioritizedElemType::CurrentStream,
+            elem_dependency: ElemDependencyType::Placeholder,
+            prioritized_element_id: None,
+            element_dependency_id: Some(0),
+            weight: 16,
+        };
+
+        let frame_payload_len = 3;
+        let frame_header_len = 2;
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                PRIORITY_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn priority_some_stream_to_placeholder() {
+        let mut d = [42; 128];
+
+        let frame = Frame::Priority {
+            priority_elem: PrioritizedElemType::RequestStream,
+            elem_dependency: ElemDependencyType::Placeholder,
+            prioritized_element_id: Some(0x4),
+            element_dependency_id: Some(0),
+            weight: 16,
+        };
+
+        let frame_payload_len = 4;
+        let frame_header_len = 2;
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                PRIORITY_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn cancel_push() {
+        let mut d = [42; 128];
+
+        let frame = Frame::CancelPush { push_id: 0 };
+
+        let frame_payload_len = 1;
+        let frame_header_len = 2;
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                CANCEL_PUSH_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn settings_all() {
+        let mut d = [42; 128];
+
+        let frame = Frame::Settings {
+            num_placeholders: Some(0),
+            max_header_list_size: Some(0),
+            qpack_max_table_capacity: Some(0),
+            qpack_blocked_streams: Some(0),
+        };
+
+        let frame_payload_len = 12;
+        let frame_header_len = 2;
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                SETTINGS_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn settings_h3_only() {
+        let mut d = [42; 128];
+
+        let frame = Frame::Settings {
+            num_placeholders: Some(16),
+            max_header_list_size: Some(1024),
+            qpack_max_table_capacity: None,
+            qpack_blocked_streams: None,
+        };
+
+        let frame_payload_len = 7;
+        let frame_header_len = 2;
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                SETTINGS_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn settings_qpack_only() {
+        let mut d = [42; 128];
+
+        let frame = Frame::Settings {
+            num_placeholders: None,
+            max_header_list_size: None,
+            qpack_max_table_capacity: Some(0),
+            qpack_blocked_streams: Some(0),
+        };
+
+        let frame_payload_len = 6;
+        let frame_header_len = 2;
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                SETTINGS_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn push_promise() {
+        let mut d = [42; 128];
+
+        let header_block = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        let frame_payload_len = 1 + header_block.len();
+        let frame_header_len = 2;
+
+        let frame = Frame::PushPromise {
+            push_id: 0,
+            header_block,
+        };
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                PUSH_PROMISE_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn goaway() {
+        let mut d = [42; 128];
+
+        let frame = Frame::GoAway { stream_id: 32 };
+
+        let frame_payload_len = 1;
+        let frame_header_len = 2;
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                GOAWAY_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn max_push_id() {
+        let mut d = [42; 128];
+
+        let frame = Frame::MaxPushId { push_id: 128 };
+
+        let frame_payload_len = 2;
+        let frame_header_len = 2;
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                MAX_PUSH_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn duplicate_push() {
+        let mut d = [42; 128];
+
+        let frame = Frame::DuplicatePush { push_id: 0 };
+
+        let frame_payload_len = 1;
+        let frame_header_len = 2;
+
+        let wire_len = {
+            let mut b = octets::Octets::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                DUPLICATE_PUSH_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &mut d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+}

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -26,4 +26,984 @@
 
 //! HTTP/3 client and server.
 
+use std::collections::BTreeMap;
+
+use crate::octets;
+
+use http::{
+    Request,
+    Response,
+    StatusCode,
+    Uri,
+};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub enum Event {
+    OnReqHeaders {
+        stream_id: u64,
+        value: http::Request<()>,
+    },
+    OnRespHeaders {
+        stream_id: u64,
+        value: http::Response<()>,
+    },
+    OnPayloadData {
+        stream_id: u64,
+        value: Vec<u8>,
+    },
+}
+
+/// An HTTP/3 error.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+pub enum Error {
+    /// There is no error, just stream or connection close.
+    Done                 = -1,
+
+    /// The provided buffer is too short.
+    BufferTooShort       = -2,
+
+    /// Setting sent in wrong direction.
+    WrongSettingDirection = -3,
+
+    /// The server attempted to push content that the client will not accept.
+    PushRefused          = -4,
+
+    /// Internal error in the H3 stack.
+    InternalError        = -5,
+
+    /// The server attempted to push something the client already has.
+    PushAlreadyInCache   = -6,
+
+    /// The client no longer needs the requested data.
+    RequestCancelled     = -7,
+
+    /// The request stream terminated before completing the request.
+    IncompleteRequest    = -8,
+
+    /// Forward connection failure for CONNECT target.
+    ConnectError         = -9,
+
+    /// Endpoint detected that the peer is exhibiting behaviour that causes.
+    /// excessive load
+    ExcessiveLoad        = -10,
+
+    /// Operation cannot be served over HTT/3. Retry over HTTP/1.1.
+    VersionFallback      = -11,
+
+    /// Frame received on stream where it is not permitted.
+    WrongStream          = -12,
+
+    /// Stream ID, Push ID or Placeholder Id greater that current maximum was.
+    /// used
+    LimitExceeded        = -13,
+
+    /// Push ID used in two different stream headers.
+    DuplicatePush        = -14,
+
+    /// Unknown unidirection stream type.
+    UnknownStreamType    = -15,
+
+    /// Too many unidirectional streams of a type were created.
+    WrongStreamCount     = -16,
+
+    /// A required critical stream was closed.
+    ClosedCriticalStream = -17,
+
+    /// Unidirectional stream type opened at peer that is prohibited.
+    WrongStreamDirection = -18,
+
+    /// Inform client that remainder of request is not needed. Used in
+    /// STOP_SENDING only.
+    EarlyResponse        = -19,
+
+    /// No SETTINGS frame at beggining of control stream.
+    MissingSettings      = -20,
+
+    /// A frame was received which is not permitted in the current state.
+    UnexpectedFrame      = -21,
+
+    /// Server rejected request without performing any application processing.
+    RequestRejected      = -22,
+
+    /// Peer violated protocol requirements in a way that doesn't match a more
+    /// specific code.
+    GeneralProtocolError = -23,
+
+    /// TODO: malformed frame where last on-wire byte is the frame type.
+    MalformedFrame       = -24,
+
+    /// QPACK Header block decompression failure.
+    QpackDecompressionFailed = -25,
+
+    /// QPACK encoder stream error.
+    QpackEncoderStreamError = -26,
+
+    /// QPACK decoder stream error.
+    QpackDecoderStreamError = -27,
+}
+
+impl Error {
+    pub fn to_wire(self) -> u16 {
+        match self {
+            Error::Done => 0x0,
+            Error::WrongSettingDirection => 0x1,
+            Error::PushRefused => 0x2,
+            Error::InternalError => 0x3,
+            Error::PushAlreadyInCache => 0x4,
+            Error::RequestCancelled => 0x5,
+            Error::IncompleteRequest => 0x6,
+            Error::ConnectError => 0x07,
+            Error::ExcessiveLoad => 0x08,
+            Error::VersionFallback => 0x09,
+            Error::WrongStream => 0xA,
+            Error::LimitExceeded => 0xB,
+            Error::DuplicatePush => 0xC,
+            Error::UnknownStreamType => 0xD,
+            Error::WrongStreamCount => 0xE,
+            Error::ClosedCriticalStream => 0xF,
+            Error::WrongStreamDirection => 0x10,
+            Error::EarlyResponse => 0x11,
+            Error::MissingSettings => 0x12,
+            Error::UnexpectedFrame => 0x13,
+            Error::RequestRejected => 0x14,
+            Error::GeneralProtocolError => 0xFF,
+            Error::MalformedFrame => 0x10,
+
+            Error::QpackDecompressionFailed => 0x20, // TODO: value is TBD
+            Error::QpackEncoderStreamError => 0x21,  // TODO: value is TBD
+            Error::QpackDecoderStreamError => 0x22,  // TODO: value is TBD
+            Error::BufferTooShort => 0x999,
+        }
+    }
+}
+
+impl std::convert::From<super::Error> for Error {
+    fn from(err: super::Error) -> Self {
+        match err {
+            super::Error::Done => Error::Done,
+            super::Error::BufferTooShort => Error::BufferTooShort,
+            _ => Error::GeneralProtocolError,
+        }
+    }
+}
+
+fn req_hdrs_to_qpack(
+    encoder: &mut qpack::Encoder, request: &http::Request<()>,
+) -> Vec<u8> {
+    let mut vec = vec![0u8; 65535];
+
+    let mut headers: Vec<qpack::Header> = Vec::new();
+
+    headers.push(qpack::Header::new(":method", request.method().as_str()));
+    headers.push(qpack::Header::new(
+        ":scheme",
+        request.uri().scheme_str().unwrap(),
+    ));
+    headers.push(qpack::Header::new(
+        ":authority",
+        request.uri().host().unwrap(),
+    ));
+    headers.push(qpack::Header::new(
+        ":path",
+        request.uri().path_and_query().unwrap().as_str(),
+    ));
+
+    for (key, value) in request.headers().iter() {
+        headers.push(qpack::Header::new(key.as_str(), value.to_str().unwrap()));
+    }
+
+    let len = encoder.encode(&headers, &mut vec);
+
+    vec.truncate(len.unwrap());
+    trace!("Encoded header block len={:?}", len);
+
+    vec
+}
+
+fn resp_hdrs_to_qpack(
+    encoder: &mut qpack::Encoder, response: &http::Response<Vec<u8>>,
+) -> Vec<u8> {
+    let mut vec = vec![0u8; 65535];
+
+    let mut headers: Vec<qpack::Header> = Vec::new();
+
+    headers.push(qpack::Header::new(":status", response.status().as_str()));
+
+    for (key, value) in response.headers().iter() {
+        headers.push(qpack::Header::new(key.as_str(), value.to_str().unwrap()));
+    }
+
+    let len = encoder.encode(&headers, &mut vec);
+
+    vec.truncate(len.unwrap());
+    trace!("Encoded header block len={:?}", len);
+
+    vec
+}
+
+fn req_hdrs_from_qpack(
+    decoder: &mut qpack::Decoder, hdr_block: &mut [u8],
+) -> http::Request<()> {
+    let mut req: Request<()> = Request::default();
+
+    // TODO: make pseudo header parsing more efficient. Right now, we create
+    // some variables to hold pseudo headers that may arrive in any order.
+    // Some of these are later formatted back into a complete URI
+    let mut method = String::new();
+    let mut scheme = String::new();
+    let mut authority = String::new();
+    let mut path = String::new();
+
+    for hdr in decoder.decode(hdr_block).unwrap() {
+        match hdr.name() {
+            ":method" => {
+                method = hdr.value().to_string();
+            },
+            ":scheme" => {
+                scheme = hdr.value().to_string();
+            },
+            ":authority" => {
+                authority = hdr.value().to_string();
+            },
+            ":path" => {
+                path = hdr.value().to_string();
+            },
+            _ => {
+                req.headers_mut().insert(
+                    http::header::HeaderName::from_bytes(hdr.name().as_bytes())
+                        .unwrap(),
+                    http::header::HeaderValue::from_str(hdr.value()).unwrap(),
+                );
+            },
+        }
+    }
+
+    let uri = format!("{}://{}{}", scheme, authority, path);
+
+    *req.method_mut() = method.parse().unwrap();
+    *req.version_mut() = http::Version::HTTP_2;
+    *req.uri_mut() = uri.parse::<Uri>().unwrap();
+
+    req
+}
+
+fn resp_hdrs_from_qpack(
+    decoder: &mut qpack::Decoder, hdr_block: &mut [u8],
+) -> http::Response<()> {
+    let mut resp: Response<()> = Response::default();
+
+    // TODO: make pseudo header parsing more efficient.
+    let mut status = String::new();
+
+    for hdr in decoder.decode(hdr_block).unwrap() {
+        match hdr.name() {
+            ":status" => {
+                status = hdr.value().to_string();
+            },
+            _ => {
+                resp.headers_mut().insert(
+                    http::header::HeaderName::from_bytes(hdr.name().as_bytes())
+                        .unwrap(),
+                    http::header::HeaderValue::from_str(hdr.value()).unwrap(),
+                );
+            },
+        }
+    }
+
+    *resp.status_mut() = StatusCode::from_bytes(status.as_bytes()).unwrap();
+    *resp.version_mut() = http::Version::HTTP_2;
+
+    resp
+}
+
+/// An HTTP/3 configuration.
+pub struct Config {
+    pub num_placeholders: u64,
+    pub max_header_list_size: u64,
+    pub qpack_max_table_capacity: u64,
+    pub qpack_blocked_streams: u64,
+}
+
+impl Config {
+    pub fn new(
+        num_placeholders: u64, max_header_list_size: u64,
+        qpack_max_table_capacity: u64, qpack_blocked_streams: u64,
+    ) -> Result<Config> {
+        Ok(Config {
+            num_placeholders,
+            max_header_list_size,
+            qpack_max_table_capacity,
+            qpack_blocked_streams,
+        })
+    }
+
+    pub fn set_num_placeholders(&mut self, num_placeholders: u64) {
+        self.num_placeholders = num_placeholders;
+    }
+
+    pub fn set_max_header_list_size(&mut self, max_header_list_size: u64) {
+        self.max_header_list_size = max_header_list_size;
+    }
+
+    pub fn set_qpack_max_table_capacity(
+        &mut self, qpack_max_table_capacity: u64,
+    ) {
+        self.qpack_max_table_capacity = qpack_max_table_capacity;
+    }
+
+    pub fn set_qpacked_blocked_streams(&mut self, qpack_blocked_streams: u64) {
+        self.qpack_blocked_streams = qpack_blocked_streams;
+    }
+}
+
+type StreamMap = BTreeMap<u64, stream::Stream>;
+
+pub struct ConnectionSettings {
+    pub num_placeholders: Option<u64>,
+    pub max_header_list_size: Option<u64>,
+    pub qpack_max_table_capacity: Option<u64>,
+    pub qpack_blocked_streams: Option<u64>,
+}
+
+pub struct QpackStreams {
+    pub encoder_stream_id: Option<u64>,
+    pub decoder_stream_id: Option<u64>,
+}
+
+/// An HTTP/3 connection.
+pub struct Connection {
+    is_server: bool,
+
+    highest_request_stream_id: u64,
+    highest_uni_stream_id: u64,
+
+    streams: StreamMap,
+
+    local_settings: ConnectionSettings,
+    peer_settings: ConnectionSettings,
+
+    control_stream_id: Option<u64>,
+    peer_control_stream_id: Option<u64>,
+
+    qpack_encoder: qpack::Encoder,
+    qpack_decoder: qpack::Decoder,
+
+    local_qpack_streams: QpackStreams,
+    peer_qpack_streams: QpackStreams,
+}
+
+impl Connection {
+    fn new(config: &Config, is_server: bool) -> Result<Connection> {
+        let initial_uni_stream_id = if is_server { 0x3 } else { 0x2 };
+
+        Ok(Connection {
+            is_server,
+
+            highest_request_stream_id: 0,
+            highest_uni_stream_id: initial_uni_stream_id,
+
+            streams: StreamMap::new(),
+
+            local_settings: ConnectionSettings {
+                num_placeholders: Some(config.num_placeholders),
+                max_header_list_size: Some(config.max_header_list_size),
+                qpack_max_table_capacity: Some(config.qpack_max_table_capacity),
+                qpack_blocked_streams: Some(config.qpack_blocked_streams),
+            },
+
+            peer_settings: ConnectionSettings {
+                num_placeholders: None,
+                max_header_list_size: None,
+                qpack_max_table_capacity: None,
+                qpack_blocked_streams: None,
+            },
+
+            control_stream_id: None,
+            peer_control_stream_id: None,
+
+            qpack_encoder: qpack::Encoder::new(),
+            qpack_decoder: qpack::Decoder::new(),
+
+            local_qpack_streams: QpackStreams {
+                encoder_stream_id: None,
+                decoder_stream_id: None,
+            },
+            peer_qpack_streams: QpackStreams {
+                encoder_stream_id: None,
+                decoder_stream_id: None,
+            },
+        })
+    }
+
+    /// Get a request stream ID if there is one available
+    fn get_available_request_stream(&mut self) -> Result<u64> {
+        if self.highest_request_stream_id < std::u64::MAX {
+            let ret = self.highest_request_stream_id;
+            self.highest_request_stream_id += 4;
+            return Ok(ret);
+        }
+
+        Err(Error::LimitExceeded)
+    }
+
+    /// Returns an available stream ID for the local endpoint to use
+    fn get_available_uni_stream(&mut self) -> Result<u64> {
+        if self.highest_uni_stream_id < std::u64::MAX {
+            let ret = self.highest_uni_stream_id;
+            self.highest_uni_stream_id += 4;
+            return Ok(ret);
+        }
+
+        Err(Error::LimitExceeded)
+    }
+
+    pub fn is_established(&self) -> bool {
+        trace!("is established?: control={} decoder={} encoder={} peer_control={} peer_decoder={} peer_encoder={}",
+         self.control_stream_id.is_some(),
+         self.local_qpack_streams.encoder_stream_id.is_some(),
+            self.local_qpack_streams.decoder_stream_id.is_some(),
+            self.peer_control_stream_id.is_some(),
+            self.peer_qpack_streams.decoder_stream_id.is_some(),
+            self.peer_qpack_streams.encoder_stream_id.is_some(),
+        );
+
+        self.control_stream_id.is_some() &&
+            self.local_qpack_streams.encoder_stream_id.is_some() &&
+            self.local_qpack_streams.decoder_stream_id.is_some() &&
+            self.peer_control_stream_id.is_some() &&
+            self.peer_qpack_streams.decoder_stream_id.is_some() &&
+            self.peer_qpack_streams.encoder_stream_id.is_some()
+    }
+
+    pub fn open_control_stream(
+        &mut self, quic_conn: &mut super::Connection,
+    ) -> Result<()> {
+        if self.control_stream_id.is_none() {
+            let stream_id = self.get_available_uni_stream()?;
+            quic_conn.stream_send(
+                stream_id,
+                &stream::HTTP3_CONTROL_STREAM_TYPE_ID.to_be_bytes(),
+                false,
+            )?;
+
+            self.control_stream_id = Some(stream_id);
+        }
+
+        Ok(())
+    }
+
+    fn open_qpack_streams(
+        &mut self, quic_conn: &mut super::Connection,
+    ) -> Result<()> {
+        if self.local_qpack_streams.encoder_stream_id.is_none() {
+            let stream_id = self.get_available_uni_stream()?;
+            info!("Opening QPACK Encoder stream on id {}", stream_id);
+            quic_conn.stream_send(
+                stream_id,
+                &stream::QPACK_ENCODER_STREAM_TYPE_ID.to_be_bytes(),
+                false,
+            )?;
+
+            // TODO await ACK of stream open?
+            self.local_qpack_streams.encoder_stream_id = Some(stream_id);
+        }
+
+        if self.local_qpack_streams.decoder_stream_id.is_none() {
+            let stream_id = self.get_available_uni_stream()?;
+            info!("Opening QPACK Decoder stream on id {}", stream_id);
+            quic_conn.stream_send(
+                stream_id,
+                &stream::QPACK_DECODER_STREAM_TYPE_ID.to_be_bytes(),
+                false,
+            )?;
+
+            // TODO await ACK of stream open?
+            self.local_qpack_streams.decoder_stream_id = Some(stream_id);
+        }
+
+        Ok(())
+    }
+
+    /// Send SETTINGS frame based on HTTP/3 config.
+    fn send_settings(&mut self, quic_conn: &mut super::Connection) -> Result<()> {
+        self.open_control_stream(quic_conn)?;
+
+        let mut d = [42; 128];
+
+        // Client cannot send placeholders, so validate here
+        let num_placeholders = if self.is_server {
+            self.local_settings.num_placeholders
+        } else {
+            None
+        };
+
+        let frame = frame::Frame::Settings {
+            num_placeholders,
+            max_header_list_size: self.local_settings.max_header_list_size,
+            qpack_max_table_capacity: self
+                .local_settings
+                .qpack_max_table_capacity,
+            qpack_blocked_streams: self.local_settings.qpack_blocked_streams,
+        };
+
+        let mut b = octets::Octets::with_slice(&mut d);
+
+        let frame_size = frame.to_bytes(&mut b).unwrap();
+        let off = b.off();
+        trace!("Frame size is {} and octet offset is {}", frame_size, off);
+
+        match self.control_stream_id {
+            Some(id) => {
+                info!("Opening Control stream on id {}", id);
+                quic_conn.stream_send(id, &d[..off], false)?;
+            },
+            None => {
+                return Err(Error::InternalError);
+            },
+        }
+
+        Ok(())
+    }
+
+    /// Prepare a request in HTTP/3 wire format, allocate a stream ID and send
+    /// it. Request body (if any) is ignored.
+    pub fn send_request(
+        &mut self, quic_conn: &mut super::Connection,
+        request: &http::Request<()>, has_body: bool,
+    ) -> Result<(u64)> {
+        let mut d = [42; 65535];
+
+        let req_frame = frame::Frame::Headers {
+            header_block: req_hdrs_to_qpack(&mut self.qpack_encoder, &request),
+        };
+
+        let mut b = octets::Octets::with_slice(&mut d);
+        req_frame.to_bytes(&mut b).unwrap();
+
+        let stream_id = self.get_available_request_stream()?;
+        self.streams
+            .insert(stream_id, stream::Stream::new(stream_id, true));
+
+        let off = b.off();
+
+        trace!(
+            "{} sending request of size {} on stream {}",
+            quic_conn.trace_id(),
+            off,
+            stream_id
+        );
+
+        if let Err(e) = quic_conn.stream_send(stream_id, &d[..off], !has_body) {
+            error!("{} stream send failed {:?}", quic_conn.trace_id(), e);
+            return Err(Error::from(e));
+        }
+
+        Ok(stream_id)
+    }
+
+    /// Prepare a response in HTTP/3 wire format, allocate a stream ID and send
+    /// it.
+    pub fn send_response(
+        &mut self, quic_conn: &mut super::Connection, stream_id: u64,
+        response: http::Response<Vec<u8>>,
+    ) {
+        let mut stream_d = [42; 65535];
+        let fin_stream = response.body().is_empty();
+
+        let headers = frame::Frame::Headers {
+            header_block: resp_hdrs_to_qpack(&mut self.qpack_encoder, &response),
+        };
+
+        let mut stream_b = octets::Octets::with_slice(&mut stream_d);
+        headers.to_bytes(&mut stream_b).unwrap();
+
+        let off = stream_b.off();
+
+        trace!(
+            "{} sending response HEADERS frame of size {} on stream {}",
+            quic_conn.trace_id(),
+            off,
+            stream_id
+        );
+
+        if let Err(e) =
+            quic_conn.stream_send(stream_id, &stream_d[..off], fin_stream)
+        {
+            error!("{} stream send failed {:?}", quic_conn.trace_id(), e);
+        }
+
+        let data = frame::Frame::Data {
+            payload: response.into_body(),
+        };
+
+        // reuse the octets object
+        let mut stream_b = octets::Octets::with_slice(&mut stream_d);
+        data.to_bytes(&mut stream_b).unwrap();
+
+        let off = stream_b.off();
+
+        info!(
+            "{} sending response DATA frame of size {} on stream {}",
+            quic_conn.trace_id(),
+            off,
+            stream_id
+        );
+
+        if let Err(e) = quic_conn.stream_send(stream_id, &stream_d[..off], true) {
+            error!("{} stream send failed {:?}", quic_conn.trace_id(), e);
+        }
+    }
+
+    pub fn process(
+        &mut self, quic_conn: &mut super::Connection,
+    ) -> Result<Event> {
+        loop {
+            match self.process_transport_streams(quic_conn) {
+                Ok(()) => {
+                    break;
+                },
+                Err(Error::Done) => {
+                    break;
+                },
+                Err(Error::BufferTooShort) => {
+                    // Keep processing transport stream
+                    // trace!("{} feed me", quic_conn.trace_id());
+                },
+
+                Err(e) => {
+                    error!(
+                        "{} process_transport_streams: {:?}",
+                        quic_conn.trace_id(),
+                        e
+                    );
+                    return Err(e);
+                },
+            }
+        }
+
+        let event = self.process_http3_streams()?;
+
+        Ok(event)
+    }
+
+    /// Read from all readable QUIC streams and assign HTTP/3 meaning
+    pub fn process_transport_streams(
+        &mut self, quic_conn: &mut super::Connection,
+    ) -> Result<()> {
+        // Read streams and handle the data on them.
+        let streams: Vec<u64> = quic_conn.readable().collect();
+
+        for s in streams {
+            debug!("{} stream id {} is readable", quic_conn.trace_id(), s);
+            loop {
+                match self.handle_stream(quic_conn, s) {
+                    Ok(_) => {
+                        // TODO
+                    },
+
+                    Err(Error::Done) => {
+                        debug!(
+                            "{} done handling stream id {}",
+                            quic_conn.trace_id(),
+                            s
+                        );
+                        break;
+                    },
+
+                    Err(Error::BufferTooShort) => {
+                        debug!(
+                            "{}pub stream id needs feeding {}",
+                            quic_conn.trace_id(),
+                            s
+                        );
+                        return Err(Error::BufferTooShort);
+                    },
+
+                    Err(e) => {
+                        error!(
+                            "{} handling stream id {} failed: {:?}",
+                            quic_conn.trace_id(),
+                            s,
+                            e
+                        );
+                        return Err(e);
+                    },
+                };
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn process_http3_streams(&mut self) -> Result<Event> {
+        for (stream_id, stream) in self.streams.iter_mut() {
+            let frame = stream.get_frame();
+
+            if frame.is_some() {
+                match frame.unwrap() {
+                    frame::Frame::Settings {
+                        num_placeholders,
+                        max_header_list_size,
+                        qpack_max_table_capacity,
+                        qpack_blocked_streams,
+                    } => {
+                        if self.is_server && num_placeholders.is_some() {
+                            error!("SETTINGS frame with placeholders received at server");
+                            return Err(Error::WrongSettingDirection);
+                        }
+
+                        self.peer_settings = ConnectionSettings {
+                            num_placeholders,
+                            max_header_list_size,
+                            qpack_max_table_capacity,
+                            qpack_blocked_streams,
+                        };
+                    },
+                    frame::Frame::Priority { .. } => {
+                        debug!("PRIORITY frame received but not doing anything.");
+                    },
+                    frame::Frame::CancelPush { .. } => {
+                        debug!(
+                            "CANCEL_PUSH frame received but not doing anything."
+                        );
+                    },
+                    frame::Frame::MaxPushId { .. } => {
+                        debug!(
+                            "MAX_PUSH_ID frame received but not doing anything."
+                        );
+                    },
+                    frame::Frame::GoAway { .. } => {
+                        if self.is_server {
+                            error!("GOAWAY frame received at server.");
+                            return Err(Error::UnexpectedFrame);
+                        }
+
+                        debug!("GOAWAY frame received but not doing anything.");
+                    },
+                    frame::Frame::Headers { mut header_block } => {
+                        if self.is_server {
+                            let req = req_hdrs_from_qpack(
+                                &mut self.qpack_decoder,
+                                &mut header_block[..],
+                            );
+
+                            return Ok(Event::OnReqHeaders {
+                                stream_id: *stream_id,
+                                value: req,
+                            });
+                        } else {
+                            let resp = resp_hdrs_from_qpack(
+                                &mut self.qpack_decoder,
+                                &mut header_block[..],
+                            );
+
+                            return Ok(Event::OnRespHeaders {
+                                stream_id: *stream_id,
+                                value: resp,
+                            });
+                        }
+                    },
+                    frame::Frame::Data { payload } => {
+                        debug!("DATA frame received on stream id {}", stream_id);
+                        return Ok(Event::OnPayloadData {
+                            stream_id: *stream_id,
+                            value: payload.to_vec(),
+                        });
+                    },
+                    _ => {
+                        // TODO: we should ignore unknown frame types but for now
+                        // generate an error and let someone else deal with it.
+                        debug!("Unknown frame type received.");
+                        return Err(Error::UnexpectedFrame);
+                    },
+                }
+            }
+        }
+
+        Err(Error::Done)
+    }
+
+    fn handle_stream(
+        &mut self, quic_conn: &mut super::Connection, stream_id: u64,
+    ) -> Result<()> {
+        let stream = self
+            .streams
+            .entry(stream_id)
+            .or_insert_with(|| stream::Stream::new(stream_id, false));
+
+        trace!("Stream id {} is in {:?} state", stream_id, stream.state());
+        // TODO: decide how many bytes we want to pull out of the QUIC stream
+        let mut d = vec![0; 124];
+        let (read, _fin) = quic_conn.stream_recv(stream_id, &mut d)?;
+        debug!(
+            "{} received {} bytes on stream {}",
+            quic_conn.trace_id(),
+            read,
+            stream_id
+        );
+        stream.add_data(&mut d.drain(..read).collect())?;
+
+        while stream.more() {
+            match stream.state() {
+                stream::State::StreamTypeLen => {
+                    // stream.add_data(&mut d.drain(..read).collect())?;
+
+                    // TODO: draft 18 uses 1 byte stream type, so we can double
+                    // jump through states
+                    let varint_len = 1;
+                    // draft 18+ let varint_len =
+                    // octets::Octets::varint_parse_len(stream.buf[stream.
+                    // buf_read_off])?;
+                    stream.set_stream_type_len(varint_len)?;
+
+                    // draft 18+ we don't set the type here, all the following
+                    // code should be moved to the next state match
+                    // `StreamTypeLen` and checked to make sure it is valid for
+                    // true varints
+                    let varint_bytes = stream.buf_bytes(varint_len as usize)?;
+                    let varint = varint_bytes[0];
+
+                    let ty = stream::Type::deserialize(varint);
+
+                    if ty.is_none() {
+                        return Err(Error::UnknownStreamType);
+                    }
+
+                    // TODO: consider if we want to set type later, after
+                    // validation...
+                    stream.set_stream_type(ty)?;
+
+                    match &ty {
+                        Some(stream::Type::Control) => {
+                            // only one control stream allowed.
+                            if self.peer_control_stream_id.is_some() {
+                                error!("Peer already opened a control stream!");
+                                return Err(Error::WrongStreamCount);
+                            }
+
+                            info!("Peer opened a Control stream on id {}.", stream_id);
+                            self.peer_control_stream_id = Some(stream_id);
+                        },
+                        Some(stream::Type::Push) => {
+                            // only clients can receive push stream.
+                            if self.is_server {
+                                error!("Client opened a push stream!");
+                                return Err(Error::WrongStreamDirection);
+                            }
+                        },
+                        Some(stream::Type::QpackEncoder) => {
+                            // only one qpack encoder stream allowed.
+                            if self.peer_qpack_streams.encoder_stream_id.is_some() {
+                                error!(
+                                    "Peer already opened a QPACK encoder stream!"
+                                );
+                                return Err(Error::WrongStreamCount);
+                            }
+
+                            info!("Peer opened a QPACK encoder stream on id {}.", stream_id);
+                            self.peer_qpack_streams.encoder_stream_id = Some(stream_id);
+
+                        },
+                        Some(stream::Type::QpackDecoder) => {
+                            // only one qpack decoder allowed.
+                            if self.peer_qpack_streams.decoder_stream_id.is_some() {
+                                error!(
+                                    "Peer already opened a QPACK decoder stream!"
+                                );
+                                return Err(Error::WrongStreamCount);
+                            }
+
+                            info!("Peer opened a QPACK decoder stream on id {}.", stream_id);
+                            self.peer_qpack_streams.decoder_stream_id = Some(stream_id);
+
+                        },
+                        // TODO: enable GREASE streamsget_varint
+                        /*Some(stream::Type::Grease) => {
+                            // TODO: Grease stream types should be ignored (by
+                            // default). Until then, return an error and let
+                            // someone else deal with it. Endpoint should
+                            // probably avoid reading from the stream at all?
+                            error!("Peer opened a GREASE stream type!");
+                            return Err(Error::UnknownStreamType);
+                        },*/
+                        Some(stream::Type::Request) => unreachable!(),
+                        None => {
+                            // We don't know the type, so we should just ignore
+                            // things being sent on this stream. But for now,
+                            // return an error and let someone else deal with it.
+                            error!("Peer opened an unknown stream type!");
+                            return Err(Error::UnknownStreamType);
+                        },
+                    }
+                },
+                stream::State::StreamType => {
+                    // TODO: populate this in draft 18+
+                },
+                stream::State::FramePayloadLenLen => {
+                    let varint_byte = stream.buf_bytes(1)?[0];
+                    stream.set_next_varint_len(octets::varint_parse_len(
+                        varint_byte,
+                    ))?
+                },
+                stream::State::FramePayloadLen => {
+                    let varint = stream.get_varint()?;
+                    stream.set_frame_payload_len(varint)?;
+                },
+                stream::State::FrameTypeLen => {
+                    let varint_byte = stream.buf_bytes(1)?[0];
+                    stream.set_next_varint_len(octets::varint_parse_len(
+                        varint_byte,
+                    ))?
+                },
+                stream::State::FrameType => {
+                    // TODO: draft 18+
+                    // let varint = stream.get_varint()?;
+                    let varint = stream.get_u8()?;
+                    stream.set_frame_type(varint)?;
+                },
+                stream::State::FramePayload => {
+                    stream.parse_frame()?;
+                },
+                stream::State::QpackInstruction => {
+                    info!("QPACK dynamic compression not supported yet.");
+                    return Err(Error::Done);
+                },
+                _ => {
+                    // TODO
+                },
+            }
+        }
+
+        Err(Error::Done)
+    }
+}
+
+/// Creates a new client-side connection.
+pub fn connect(
+    quic_conn: &mut super::Connection, config: &Config,
+) -> Result<Connection> {
+    let mut http3_conn = Connection::new(config, false)?;
+
+    http3_conn.send_settings(quic_conn)?;
+    http3_conn.open_qpack_streams(quic_conn)?;
+
+    Ok(http3_conn)
+}
+
+/// Creates a new server-side connection.
+pub fn accept(
+    quic_conn: &mut super::Connection, config: &Config,
+) -> Result<Connection> {
+    let mut http3_conn = Connection::new(config, true)?;
+
+    http3_conn.send_settings(quic_conn)?;
+    http3_conn.open_qpack_streams(quic_conn)?;
+
+    Ok(http3_conn)
+}
+
+mod frame;
 pub mod qpack;
+mod stream;

--- a/src/h3/qpack/mod.rs
+++ b/src/h3/qpack/mod.rs
@@ -35,6 +35,9 @@ const LITERAL_WITH_NAME_REF: u8 = 0b0100_0000;
 #[derive(Clone, Debug, PartialEq)]
 pub struct Header(String, String);
 
+/// A vector of Headers representing an HTTP header list.
+pub type HeaderList = Vec<Header>;
+
 impl Header {
     /// Creates a new header.
     pub fn new(name: &str, value: &str) -> Header {

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -1,0 +1,396 @@
+// Copyright (C) 2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::collections::VecDeque;
+
+use crate::octets;
+
+use super::frame::Frame;
+use super::Error;
+use super::Result;
+
+pub const HTTP3_CONTROL_STREAM_TYPE_ID: u8 = 0x43;
+pub const HTTP3_PUSH_STREAM_TYPE_ID: u8 = 0x50;
+pub const QPACK_ENCODER_STREAM_TYPE_ID: u8 = 0x48;
+pub const QPACK_DECODER_STREAM_TYPE_ID: u8 = 0x68;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Type {
+    Control,
+    Request,
+    Push,
+    QpackEncoder,
+    QpackDecoder,
+    // Grease, // TODO: enable GREASE streams
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum State {
+    StreamTypeLen,
+    StreamType,
+    FrameTypeLen,
+    FrameType,
+    FramePayloadLenLen,
+    FramePayloadLen,
+    FramePayload,
+    PushIdLen,
+    PushId,
+    QpackInstruction,
+    Invalid,
+}
+
+impl Type {
+    // TODO: draft 18+ with require true varints
+    pub fn deserialize(v: u8) -> Option<Type> {
+        match v {
+            HTTP3_CONTROL_STREAM_TYPE_ID => Some(Type::Control),
+            HTTP3_PUSH_STREAM_TYPE_ID => Some(Type::Push),
+            QPACK_ENCODER_STREAM_TYPE_ID => Some(Type::QpackEncoder),
+            QPACK_DECODER_STREAM_TYPE_ID => Some(Type::QpackDecoder),
+            // TODO: parse grease stream
+            _ => {
+                trace!("Stream type value {:x} is unknown", v);
+                None
+            },
+        }
+    }
+}
+
+/// An HTTP/3 Stream
+#[derive(Debug)]
+pub struct Stream {
+    id: u64,
+    ty: Option<Type>,
+    is_local: bool,
+    initialised: bool,
+    ty_len: u8,
+    state: State,
+    stream_offset: u64,
+    buf: Vec<u8>,
+    buf_read_off: u64,
+    buf_end_pos: u64,
+    next_varint_len: usize,
+    frame_payload_len: u64,
+    frame_type: Option<u8>,
+    frames: VecDeque<Frame>,
+}
+
+impl Stream {
+    pub fn new(id: u64, is_local: bool) -> Stream {
+        let mut ty = None;
+        let mut initialised = false;
+        let mut state = State::StreamTypeLen;
+
+        if crate::stream::is_bidi(id) {
+            ty = Some(Type::Request);
+            initialised = true;
+            // TODO draft 18+ will mean first state is not FramePayloadLenLen
+            state = State::FramePayloadLenLen;
+        };
+
+        trace!(
+            "Stream id {} is new and is starting in {:?} state",
+            id,
+            state
+        );
+
+        Stream {
+            id,
+            ty,
+            is_local,
+            initialised,
+            ty_len: 0,
+            state,
+            stream_offset: 0,
+            buf: Vec::new(), /* TODO: need a more elegant
+                              * approach to buffer management */
+            buf_read_off: 0,
+            buf_end_pos: 0,
+            next_varint_len: 0,
+            frame_payload_len: 0,
+            frame_type: None,
+            frames: VecDeque::new(),
+        }
+    }
+
+    pub fn state(&mut self) -> &State {
+        &self.state
+    }
+
+    pub fn get_frame(&mut self) -> Option<Frame> {
+        self.frames.pop_front()
+    }
+
+    pub fn buf_bytes(&mut self, size: usize) -> Result<&mut [u8]> {
+        // check there are enough meaningful bytes to read
+
+        let desired_end_index = self.buf_read_off as usize + size;
+        if desired_end_index < self.buf_end_pos as usize + 1 {
+            return Ok(
+                &mut self.buf[self.buf_read_off as usize..desired_end_index]
+            );
+        }
+
+        trace!("Tried to read {} bytes but we don't have that many.", size);
+        Err(Error::BufferTooShort)
+    }
+
+    // TODO: this function needs improvement (e.g. avoid copies)
+    pub fn add_data(&mut self, d: &mut Vec<u8>) -> Result<()> {
+        // TODO: use of unstable library feature 'try_reserve': new API (see issue
+        // #48043) self.buf.try_reserve(d.len())?;
+        trace!(
+            "Stream id {}: adding {} bytes of data buffer",
+            self.id,
+            d.len()
+        );
+        self.buf_end_pos += d.len() as u64;
+        self.buf.append(d);
+
+        Ok(())
+    }
+
+    pub fn set_stream_type_len(&mut self, len: u8) -> Result<()> {
+        if self.state == State::StreamTypeLen {
+            self.ty_len = len;
+            self.do_state_transition(State::StreamType);
+            return Ok(());
+        }
+
+        Err(Error::InternalError)
+    }
+
+    pub fn set_stream_type(&mut self, ty: Option<Type>) -> Result<()> {
+        if self.state == State::StreamType {
+            self.ty = ty;
+            self.stream_offset += u64::from(self.ty_len);
+            self.buf_read_off += u64::from(self.ty_len);
+
+            match ty {
+                Some(Type::Request) => {
+                    // TODO: draft18+ will not start in FramePayloadLenLen
+                    self.do_state_transition(State::FramePayloadLenLen);
+                },
+                Some(Type::Control) => {
+                    // TODO: draft18+ will not start in FramePayloadLenLen
+                    self.do_state_transition(State::FramePayloadLenLen);
+                },
+                Some(Type::Push) => {
+                    self.do_state_transition(State::PushIdLen);
+                },
+                Some(Type::QpackEncoder) | Some(Type::QpackDecoder) => {
+                    self.do_state_transition(State::QpackInstruction);
+                    self.initialised = true;
+                },
+                // TODO: enable GREASE streams
+                // Some(Type::Grease) => {
+                // self.state = State::Done;
+                // },
+                None => {
+                    self.do_state_transition(State::Invalid);
+                },
+            };
+
+            return Ok(());
+        }
+
+        Err(Error::InternalError)
+    }
+
+    pub fn set_next_varint_len(&mut self, len: usize) -> Result<()> {
+        self.next_varint_len = len;
+
+        match self.state {
+            State::FramePayloadLenLen =>
+                self.do_state_transition(State::FramePayloadLen),
+            State::FrameTypeLen => self.do_state_transition(State::FrameType),
+            State::PushIdLen => self.do_state_transition(State::PushId),
+            _ => { /*TODO*/ },
+        }
+
+        Ok(())
+    }
+
+    pub fn get_varint(&mut self) -> Result<(u64)> {
+        if self.buf.len() - self.buf_read_off as usize >=
+            self.next_varint_len as usize
+        {
+            let n = self.buf_read_off as usize + self.next_varint_len;
+            let varint = octets::Octets::with_slice(
+                &mut self.buf[self.buf_read_off as usize..n],
+            )
+            .get_varint()?;
+
+            self.stream_offset += self.next_varint_len as u64;
+            self.buf_read_off += self.next_varint_len as u64;
+
+            return Ok(varint);
+        }
+
+        Err(Error::Done)
+    }
+
+    // TODO: we probably don't need this in draft 18+
+    pub fn get_u8(&mut self) -> Result<(u8)> {
+        let ret = self.buf_bytes(1)?[0];
+
+        self.stream_offset += 1;
+        self.buf_read_off += 1;
+
+        Ok(ret)
+    }
+
+    pub fn set_frame_payload_len(&mut self, len: u64) -> Result<()> {
+        // Only expect frames on Control, Request and Push streams
+        if self.ty == Some(Type::Control) ||
+            self.ty == Some(Type::Request) ||
+            self.ty == Some(Type::Push)
+        {
+            self.frame_payload_len = len;
+            self.do_state_transition(State::FrameTypeLen);
+
+            return Ok(());
+        }
+
+        Err(Error::UnexpectedFrame)
+    }
+
+    fn do_state_transition(&mut self, s: State) {
+        self.state = s;
+
+        trace!(
+            "Stream id {} transitioned to {:?} state",
+            self.id,
+            self.state
+        );
+    }
+
+    pub fn set_frame_type(&mut self, ty: u8) -> Result<()> {
+        // Only expect frames on Control, Request and Push streams
+
+        match self.ty {
+            Some(Type::Control) => {
+                // Control stream starts uninitialised and only SETTINGS is
+                // accepted in that state. Other frames cause an
+                // error. Once initialised, no more SETTINGS are
+                // permitted.
+                if !self.initialised {
+                    match ty {
+                        super::frame::SETTINGS_FRAME_TYPE_ID => {
+                            self.frame_type = Some(ty);
+                            self.do_state_transition(State::FramePayload);
+
+                            self.initialised = true;
+                        },
+                        _ => {
+                            trace!("Stream {} not intialised and attempt to process a {:?} was made, this is an error.", self.id, ty);
+                            return Err(Error::MissingSettings);
+                        },
+                    }
+                } else {
+                    match ty {
+                        super::frame::SETTINGS_FRAME_TYPE_ID => {
+                            trace!("Stream {} was intialised and attempt to process  {:?} was made, this is an error.", self.id, ty);
+                            return Err(Error::UnexpectedFrame);
+                        },
+                        _ => {
+                            self.frame_type = Some(ty);
+                            self.do_state_transition(State::FramePayload);
+                        },
+                    }
+                }
+            },
+            Some(Type::Request) => {
+                match ty {
+                    super::frame::HEADERS_FRAME_TYPE_ID |
+                    super::frame::DATA_FRAME_TYPE_ID |
+                    super::frame::PRIORITY_FRAME_TYPE_ID |
+                    super::frame::PUSH_PROMISE_FRAME_TYPE_ID => {
+                        self.frame_type = Some(ty);
+                        self.do_state_transition(State::FramePayload);
+                    },
+                    _ => {
+                        error!(
+                            "Unexpected frame type {} on request stream {}",
+                            ty, self.id
+                        );
+                        return Err(Error::UnexpectedFrame);
+                    },
+                }
+                self.frame_type = Some(ty);
+            },
+            Some(Type::Push) => {
+                self.frame_type = Some(ty);
+                // TODO: draft18+
+                self.do_state_transition(State::FramePayloadLenLen);
+            },
+            _ => {
+                error!("Unexpected frame type {} on stream {}", ty, self.id);
+                return Err(Error::UnexpectedFrame);
+            },
+        }
+
+        Ok(())
+    }
+
+    pub fn parse_frame(&mut self) -> Result<()> {
+        // Now we want to parse the whole frame payload but only if
+        // there is enough data in our stream buffer.
+        // stream.buf_bytes() should return an error if we don't have
+        // enuough.
+        let frame = Frame::from_bytes(
+            self.frame_type.unwrap(),
+            self.frame_payload_len,
+            self.buf_bytes(self.frame_payload_len as usize)?,
+        )?;
+
+        debug!("Parse {:?} on stream ID {}", frame, self.id);
+
+        // TODO: bytes in the buffer are no longer needed, so we can remove them
+        // and set the offset back to 0?
+        self.buf_read_off += self.frame_payload_len;
+
+        // Stream offset always increases, so we can track how many total bytes
+        // was seen by the application layer
+        self.stream_offset += self.frame_payload_len;
+
+        // TODO: draft18+ will not got back to FramePayloadLenLen
+        self.do_state_transition(State::FramePayloadLenLen);
+
+        self.frames.push_back(frame);
+        Ok(())
+    }
+
+    pub fn more(&self) -> bool {
+        let rem_bytes = self.buf_end_pos - self.buf_read_off; //- 1;
+        trace!(
+            "Stream id {}: {} bytes remaining in buffer",
+            self.id,
+            rem_bytes
+        );
+        rem_bytes > 0
+    }
+}


### PR DESCRIPTION
A candidate set of changes to the code for passing Request/Response header fields as a `Vec<qpack::Header>`. 

This is a big simplification of the code, cutting out > 100 lines of useless conversion