### PR TITLE
h3: Add support for GREASE frames

### DIFF
--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -42,6 +42,7 @@ Options:
   --max-stream-data BYTES  Per-stream flow control limit [default: 1000000].
   --wire-version VERSION   The version number to send to the server [default: babababa].
   --no-verify              Don't verify server's certificate.
+  --no-grease              Don't send GREASE.
   -h --help                Show this screen.
 ";
 
@@ -105,6 +106,10 @@ fn main() -> Result<(), Box<std::error::Error>> {
 
     if args.get_bool("--no-verify") {
         config.verify_peer(false);
+    }
+
+    if args.get_bool("--no-grease") {
+        config.grease(false);
     }
 
     if std::env::var_os("SSLKEYLOGFILE").is_some() {

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -48,6 +48,7 @@ Options:
   --root <dir>      Root directory [default: examples/root/]
   --name <str>      Name of the server [default: quic.tech]
   --no-retry        Disable stateless retry.
+  --no-grease       Don't send GREASE.
   -h --help         Show this screen.
 ";
 
@@ -104,6 +105,10 @@ fn main() -> Result<(), Box<std::error::Error>> {
 
     if std::env::var_os("SSLKEYLOGFILE").is_some() {
         config.log_keys();
+    }
+
+    if args.get_bool("--no-grease") {
+        config.grease(false);
     }
 
     loop {

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -109,6 +109,9 @@ int quiche_config_load_priv_key_from_pem_file(quiche_config *config,
 // Configures whether to verify the peer's certificate.
 void quiche_config_verify_peer(quiche_config *config, bool v);
 
+// Configures whether to send GREASE.
+void quiche_config_grease(quiche_config *config, bool v);
+
 // Enables logging of secrets.
 void quiche_config_log_keys(quiche_config *config);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -107,6 +107,11 @@ pub extern fn quiche_config_verify_peer(config: &mut Config, v: bool) {
 }
 
 #[no_mangle]
+pub extern fn quiche_config_grease(config: &mut Config, v: bool) {
+    config.grease(v);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_log_keys(config: &mut Config) {
     config.log_keys();
 }

--- a/src/h3/frame.rs
+++ b/src/h3/frame.rs
@@ -33,7 +33,7 @@ use crate::octets;
 
 pub const DATA_FRAME_TYPE_ID: u8 = 0x0;
 pub const HEADERS_FRAME_TYPE_ID: u8 = 0x1;
-pub const PRIORITY_FRAME_TYPE_ID: u8 = 0x2;
+pub const _PRIORITY_FRAME_TYPE_ID: u8 = 0x2;
 pub const CANCEL_PUSH_FRAME_TYPE_ID: u8 = 0x3;
 pub const SETTINGS_FRAME_TYPE_ID: u8 = 0x4;
 pub const PUSH_PROMISE_FRAME_TYPE_ID: u8 = 0x5;

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -275,16 +275,7 @@ impl Stream {
                 self.state = State::FramePayload;
             },
 
-            Some(Type::Request) => match ty {
-                frame::HEADERS_FRAME_TYPE_ID |
-                frame::DATA_FRAME_TYPE_ID |
-                frame::PRIORITY_FRAME_TYPE_ID |
-                frame::PUSH_PROMISE_FRAME_TYPE_ID => {
-                    self.state = State::FramePayload;
-                },
-
-                _ => return Err(Error::UnexpectedFrame),
-            },
+            Some(Type::Request) => self.state = State::FramePayload,
 
             Some(Type::Push) => self.state = State::FramePayloadLenLen,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,6 +353,8 @@ pub struct Config {
     tls_ctx: tls::Context,
 
     application_protos: Vec<Vec<u8>>,
+
+    grease: bool,
 }
 
 impl Config {
@@ -365,6 +367,7 @@ impl Config {
             version,
             tls_ctx,
             application_protos: Vec::new(),
+            grease: true,
         })
     }
 
@@ -390,6 +393,11 @@ impl Config {
     /// Configures whether to verify the peer's certificate.
     pub fn verify_peer(&mut self, verify: bool) {
         self.tls_ctx.set_verify(verify);
+    }
+
+    /// Configures whether to send GREASE values.
+    pub fn grease(&mut self, grease: bool) {
+        self.grease = grease;
     }
 
     /// Enables logging of secrets.
@@ -612,6 +620,9 @@ pub struct Connection {
 
     /// Whether the connection is closed.
     closed: bool,
+
+    /// Whether to send GREASE.
+    grease: bool,
 }
 
 /// Creates a new server-side connection.
@@ -768,6 +779,8 @@ impl Connection {
             draining: false,
 
             closed: false,
+
+            grease: config.grease,
         });
 
         if let Some(odcid) = odcid {


### PR DESCRIPTION
This fixes the bug that we were rejecting unknown frame types.

In order to make this more testable in the future, I added a new utility function in the library to send two stream types (the first two in the reserved range); one has a 0-length payload, the second has some 'random' bytes. These frames are sent at the start of request or response streams conditionally, that boolean is passed new parameter to `send_request` or `send_response`. This kind sucks and it means the ffi has to change. A different approach would be to set a HTTP/3 config option and then check that within the functions. I've left it as is for now to discuss.

I added the `--grease` command line argument to rust examples. We should discuss if this should be more fine grain i.e. controlling grease of transport and HTTP/3: streams, frames, SETTINGS etc.

I've now realised that I forgot to modify the C examples. So those will probably be broken until I fix up. But that will depend on some of the choices above.