### PR TITLE
Make it easier to use Quiche in projects that already link OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ env_logger = "0"
 debug = true
 
 [lib]
-crate-type = ["lib", "staticlib"]
+crate-type = ["lib", "staticlib", "cdylib"]

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -16,7 +16,7 @@ LIBSSL_DIR = $(dir $(shell find ${BUILD_DIR} -name libssl.a))
 
 LDFLAGS = -L$(LIBCRYPTO_DIR) -L$(LIBSSL_DIR) -L$(LIB_DIR)
 
-LIBS = -lcrypto -lssl -lquiche -lev -ldl -pthread
+LIBS = -lcrypto -lssl -l:libquiche.a -lev -ldl -pthread
 
 all: client server http3-client http3-server
 
@@ -34,3 +34,6 @@ http3-server: http3-server.c $(INCLUDE_DIR)/quiche.h $(LIB_DIR)/libquiche.a
 
 $(LIB_DIR)/libquiche.a: $(SOURCE_DIR)/**/*.rs
 	cd .. && cargo build --target-dir $(BUILD_DIR)
+
+clean:
+	rm -rf client server http3-client http3-server build/


### PR DESCRIPTION
## Overview
Currently Quiche builds a static library that includes BoringSSL. Unfortunately this can't be linked into projects that already link OpenSSL because there will be symbol conflicts. To solve this issue we can also build a dynamic library alongside the static one. The change is pretty simple, just add `cdylib` as a crate type in Cargo.toml and fix the `Makefile`  in examples/ so that it still picks up the static library. I guess that other people will also encounter this problem, so I've added a small paragraph in the Readme explaining how to use Quiche in projects that already link OpenSSl.
I've also added a `clean` target to the Makefile in examples/.

## Possible problems
The only problem I can think of is that if you have a static and dynamic library in the same directory `gcc`  will pick the dynamic one. If Quiche starts building a dynamic library alongside the static one some existing C/C++ projects that link Quiche might experience problems.