### PR TITLE
Fix C examples, adding uthash to submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = deps/boringssl
 	url = https://boringssl.googlesource.com/boringssl
 	ignore = dirty
+[submodule "deps/uthash"]
+	path = deps/uthash
+	url = git@github.com:troydhanson/uthash.git

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,6 +5,8 @@ BUILD_DIR = $(CURDIR)/build
 LIB_DIR = $(BUILD_DIR)/debug
 INCLUDE_DIR = ../include
 
+# added for uthash
+INCLUDES = -I$(INCLUDE_DIR) -I../deps/uthash/include
 CFLAGS = -I. -Wall -Werror -pedantic -fsanitize=address -g
 
 ifeq ($(OS), Darwin)
@@ -21,16 +23,16 @@ LIBS = -lcrypto -lssl -lquiche -lev -ldl -pthread
 all: client server http3-client http3-server
 
 client: client.c $(INCLUDE_DIR)/quiche.h $(LIB_DIR)/libquiche.a
-	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ -I$(INCLUDE_DIR) $(LIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ $(INCLUDES) $(LIBS)
 
 server: server.c $(INCLUDE_DIR)/quiche.h $(LIB_DIR)/libquiche.a
-	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ -I$(INCLUDE_DIR) $(LIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ $(INCLUDES) $(LIBS)
 
 http3-client: http3-client.c $(INCLUDE_DIR)/quiche.h $(LIB_DIR)/libquiche.a
-	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ -I$(INCLUDE_DIR) $(LIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ $(INCLUDES) $(LIBS)
 
 http3-server: http3-server.c $(INCLUDE_DIR)/quiche.h $(LIB_DIR)/libquiche.a
-	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ -I$(INCLUDE_DIR) $(LIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ $(INCLUDES) $(LIBS)
 
 $(LIB_DIR)/libquiche.a: $(SOURCE_DIR)/**/*.rs
 	cd .. && cargo build --target-dir $(BUILD_DIR)

--- a/examples/client.c
+++ b/examples/client.c
@@ -25,6 +25,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -156,7 +157,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
         quiche_readable *iter = quiche_conn_readable(conn_io->conn);
 
         while (quiche_readable_next(iter, &s)) {
-            fprintf(stderr, "stream %llu is readable\n", s);
+            fprintf(stderr, "stream %" PRIu64 " is readable\n", s);
 
             bool fin = false;
             ssize_t recv_len = quiche_conn_stream_recv(conn_io->conn, s,
@@ -196,7 +197,7 @@ static void timeout_cb(EV_P_ ev_timer *w, int revents) {
         quiche_conn_stats_lost(conn_io->conn, &lost);
         quiche_conn_stats_rtt_as_nanos(conn_io->conn, &rtt);
 
-        fprintf(stderr, "connection closed, sent=%lld lost=%lld rtt=%lldns\n",
+        fprintf(stderr, "connection closed, sent=%" PRIu64 " lost=%" PRIu64 " rtt=%" PRIu64 "ns\n",
                 sent, lost, rtt);
 
         ev_break(EV_A_ EVBREAK_ONE);

--- a/examples/client.c
+++ b/examples/client.c
@@ -156,7 +156,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
         quiche_readable *iter = quiche_conn_readable(conn_io->conn);
 
         while (quiche_readable_next(iter, &s)) {
-            fprintf(stderr, "stream %zu is readable\n", s);
+            fprintf(stderr, "stream %llu is readable\n", s);
 
             bool fin = false;
             ssize_t recv_len = quiche_conn_stream_recv(conn_io->conn, s,
@@ -196,7 +196,7 @@ static void timeout_cb(EV_P_ ev_timer *w, int revents) {
         quiche_conn_stats_lost(conn_io->conn, &lost);
         quiche_conn_stats_rtt_as_nanos(conn_io->conn, &rtt);
 
-        fprintf(stderr, "connection closed, sent=%ld lost=%ld rtt=%ldns\n",
+        fprintf(stderr, "connection closed, sent=%lld lost=%lld rtt=%lldns\n",
                 sent, lost, rtt);
 
         ev_break(EV_A_ EVBREAK_ONE);

--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -173,7 +173,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                                                    conn_io->conn,
                                                    headers, 5, true);
 
-        fprintf(stderr, "sent HTTP request %zu\n", stream_id);
+        fprintf(stderr, "sent HTTP request %llu\n", stream_id);
 
         req_sent = true;
     }
@@ -232,7 +232,7 @@ static void timeout_cb(EV_P_ ev_timer *w, int revents) {
         quiche_conn_stats_lost(conn_io->conn, &lost);
         quiche_conn_stats_rtt_as_nanos(conn_io->conn, &rtt);
 
-        fprintf(stderr, "connection closed, sent=%ld lost=%ld rtt=%ldns\n",
+        fprintf(stderr, "connection closed, sent=%lld lost=%lld rtt=%lldns\n",
                 sent, lost, rtt);
 
         ev_break(EV_A_ EVBREAK_ONE);

--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -24,6 +24,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -173,7 +174,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                                                    conn_io->conn,
                                                    headers, 5, true);
 
-        fprintf(stderr, "sent HTTP request %llu\n", stream_id);
+        fprintf(stderr, "sent HTTP request %" PRId64 "\n", stream_id);
 
         req_sent = true;
     }
@@ -232,7 +233,7 @@ static void timeout_cb(EV_P_ ev_timer *w, int revents) {
         quiche_conn_stats_lost(conn_io->conn, &lost);
         quiche_conn_stats_rtt_as_nanos(conn_io->conn, &rtt);
 
-        fprintf(stderr, "connection closed, sent=%lld lost=%lld rtt=%lldns\n",
+        fprintf(stderr, "connection closed, sent=%" PRIu64 " lost=%" PRIu64 " rtt=%" PRIu64 "ns\n",
                 sent, lost, rtt);
 
         ev_break(EV_A_ EVBREAK_ONE);

--- a/examples/server.c
+++ b/examples/server.c
@@ -334,7 +334,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
             quiche_readable *iter = quiche_conn_readable(conn_io->conn);
 
             while (quiche_readable_next(iter, &s)) {
-                fprintf(stderr, "stream %zu is readable\n", s);
+                fprintf(stderr, "stream %llu is readable\n", s);
 
                 bool fin = false;
                 ssize_t recv_len = quiche_conn_stream_recv(conn_io->conn, s,

--- a/examples/server.c
+++ b/examples/server.c
@@ -25,6 +25,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -334,7 +335,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
             quiche_readable *iter = quiche_conn_readable(conn_io->conn);
 
             while (quiche_readable_next(iter, &s)) {
-                fprintf(stderr, "stream %llu is readable\n", s);
+                fprintf(stderr, "stream %" PRIu64 " is readable\n", s);
 
                 bool fin = false;
                 ssize_t recv_len = quiche_conn_stream_recv(conn_io->conn, s,


### PR DESCRIPTION
Tested with MacOS X (Apple LLVM version 10.0.1 (clang-1001.0.46.3) and debian 9.8 (cc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516)