### PR TITLE
h3: add PRIORITY frame tests

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -2029,6 +2029,71 @@ mod tests {
     }
 
     #[test]
+    /// Send a prioritized request from the client, ensure server accepts it
+    fn priority_request() {
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        let mut d = [42; 128];
+        let mut b = octets::Octets::with_slice(&mut d);
+
+        // Create an approximate PRIORITY frame in the buffer
+        b.put_varint(frame::PRIORITY_FRAME_TYPE_ID).unwrap();
+        b.put_varint(2).unwrap(); // 2 u8s = Bitfield + Weight
+        b.put_u8(0).unwrap(); // bitfield
+        b.put_u8(16).unwrap(); // weight
+        let off = b.off();
+
+        let stream = 0;
+        s.pipe.client.stream_send(stream, &d[..off], false).unwrap();
+        s.advance().ok();
+
+        let req = vec![
+            Header::new(":method", "GET"),
+            Header::new(":scheme", "https"),
+            Header::new(":authority", "quic.tech"),
+            Header::new(":path", "/test"),
+            Header::new("user-agent", "quiche-test"),
+        ];
+
+        s.client
+            .send_headers(&mut s.pipe.client, stream, &req, true)
+            .unwrap();
+        s.advance().ok();
+
+        assert_eq!(s.poll_server(), Ok((stream, Event::Headers(req))));
+        assert_eq!(s.poll_server(), Ok((stream, Event::Finished)));
+    }
+
+    #[test]
+    /// Send a PRIORITY frame from the client, ensure server accepts it
+    fn priority_control_stream() {
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        let mut d = [42; 128];
+        let mut b = octets::Octets::with_slice(&mut d);
+
+        // Create an approximate PRIORITY frame in the buffer
+        b.put_varint(frame::PRIORITY_FRAME_TYPE_ID).unwrap();
+        b.put_varint(1 + octets::varint_parse_len(1) as u64 + 1)
+            .unwrap(); // 2 u8s = Bitfield + varint + Weight
+        b.put_u8(176).unwrap(); // bitfield
+        b.put_varint(1).unwrap();
+        b.put_u8(16).unwrap(); // weight
+        let off = b.off();
+
+        s.pipe
+            .client
+            .stream_send(s.client.control_stream_id.unwrap(), &d[..off], false)
+            .unwrap();
+
+        s.advance().ok();
+
+        assert_eq!(s.poll_server(), Err(Error::Done));
+    }
+
+    #[test]
     /// Ensure quiche allocates streams for client and server roles as expected.
     fn uni_stream_local_counting() {
         let config = Config::new(0, 1024, 0, 0).unwrap();

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -2029,7 +2029,7 @@ mod tests {
     }
 
     #[test]
-    /// Send a prioritized request from the client, ensure server accepts it
+    /// Send a prioritized request from the client, ensure server accepts it.
     fn priority_request() {
         let mut s = Session::default().unwrap();
         s.handshake().unwrap();
@@ -2037,7 +2037,7 @@ mod tests {
         let mut d = [42; 128];
         let mut b = octets::Octets::with_slice(&mut d);
 
-        // Create an approximate PRIORITY frame in the buffer
+        // Create an approximate PRIORITY frame in the buffer.
         b.put_varint(frame::PRIORITY_FRAME_TYPE_ID).unwrap();
         b.put_varint(2).unwrap(); // 2 u8s = Bitfield + Weight
         b.put_u8(0).unwrap(); // bitfield
@@ -2066,7 +2066,7 @@ mod tests {
     }
 
     #[test]
-    /// Send a PRIORITY frame from the client, ensure server accepts it
+    /// Send a PRIORITY frame from the client, ensure server accepts it.
     fn priority_control_stream() {
         let mut s = Session::default().unwrap();
         s.handshake().unwrap();
@@ -2074,7 +2074,7 @@ mod tests {
         let mut d = [42; 128];
         let mut b = octets::Octets::with_slice(&mut d);
 
-        // Create an approximate PRIORITY frame in the buffer
+        // Create an approximate PRIORITY frame in the buffer.
         b.put_varint(frame::PRIORITY_FRAME_TYPE_ID).unwrap();
         b.put_varint(1 + octets::varint_parse_len(1) as u64 + 1)
             .unwrap(); // 2 u8s = Bitfield + varint + Weight

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -769,7 +769,7 @@ mod tests {
         let hdrs = frame::Frame::Headers { header_block };
         let data = frame::Frame::Data { payload };
 
-        // Create an approximate PRIORITY frame in the buffer
+        // Create an approximate PRIORITY frame in the buffer.
         b.put_varint(frame::PRIORITY_FRAME_TYPE_ID).unwrap();
         b.put_varint(2).unwrap(); // 2 u8s = Bitfield + Weight
         b.put_u8(0).unwrap(); // bitfield
@@ -781,7 +781,7 @@ mod tests {
 
         stream.push(&mut d[..off]).unwrap();
 
-        // parse the PRIORITY frame
+        // Parse the PRIORITY frame.
         assert_eq!(stream.more(), true);
         let frame_ty_len =
             octets::varint_parse_len(stream.buf_bytes(1).unwrap()[0]);
@@ -812,7 +812,7 @@ mod tests {
         // TODO: if/when PRIRORITY frame is fully implemented, test it
         // e.g. `assert_eq!(stream.get_frame(), Some(priority));`
 
-        // parse the HEADERS frame
+        // Parse the HEADERS frame.
         assert_eq!(stream.more(), true);
         let frame_ty_len =
             octets::varint_parse_len(stream.buf_bytes(1).unwrap()[0]);
@@ -842,7 +842,7 @@ mod tests {
 
         assert_eq!(stream.get_frame(), Some(hdrs));
 
-        // parse the DATA frame
+        // Parse the DATA frame.
         assert_eq!(stream.more(), true);
         let frame_ty_len =
             octets::varint_parse_len(stream.buf_bytes(1).unwrap()[0]);
@@ -894,7 +894,7 @@ mod tests {
         b.put_varint(HTTP3_CONTROL_STREAM_TYPE_ID).unwrap();
         settings.to_bytes(&mut b).unwrap();
 
-        // Create an approximate PRIORITY frame in the buffer
+        // Create an approximate PRIORITY frame in the buffer.
         b.put_varint(frame::PRIORITY_FRAME_TYPE_ID).unwrap();
         b.put_varint(1 + octets::varint_parse_len(1) as u64 + 1)
             .unwrap(); // 2 u8s = Bitfield + varint + Weight
@@ -952,7 +952,7 @@ mod tests {
 
         assert_eq!(stream.get_frame(), Some(settings));
 
-        // parse the PRIORITY frame
+        // Parse the PRIORITY frame.
         assert_eq!(stream.more(), true);
         let frame_ty_len =
             octets::varint_parse_len(stream.buf_bytes(1).unwrap()[0]);


### PR DESCRIPTION
Make sure we are robust when a client sends PRIORITY frames on request or control streams, even though we don't handle them for now.