### PR TITLE
h3: body recv API

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -159,10 +159,16 @@ fn http3(c: &mut Criterion) {
 
                     while let Ok(ev) = s.client.poll(&mut s.pipe.client) {
                         match ev {
-                            (_, quiche::h3::Event::Data(data)) => {
-                                &mut recv_buf[recv_len..recv_len + data.len()]
-                                    .copy_from_slice(&data);
-                                recv_len += data.len();
+                            (stream_id, quiche::h3::Event::Data) => {
+                                let b = &mut recv_buf[recv_len..size];
+
+                                if let Ok(r) = s.client.recv_body(
+                                    &mut s.pipe.client,
+                                    stream_id,
+                                    b,
+                                ) {
+                                    recv_len += r;
+                                }
                             },
 
                             _ => (),

--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -240,10 +240,14 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                 }
 
                 case QUICHE_H3_EVENT_DATA: {
-                    uint8_t *data;
-                    size_t len = quiche_h3_event_data(ev, &data);
+                    ssize_t len = quiche_h3_recv_body(conn_io->http3,
+                                                      conn_io->conn, s,
+                                                      buf, sizeof(buf));
+                    if (len <= 0) {
+                        break;
+                    }
 
-                    printf("%.*s", (int) len, data);
+                    printf("%.*s", (int) len, buf);
                     break;
                 }
 

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -241,17 +241,21 @@ fn main() {
                         );
                     },
 
-                    Ok((stream_id, quiche::h3::Event::Data(data))) => {
-                        debug!(
-                            "{} got response data of length {} in stream id {}",
-                            conn.trace_id(),
-                            data.len(),
-                            stream_id
-                        );
+                    Ok((stream_id, quiche::h3::Event::Data)) => {
+                        if let Ok(read) =
+                            http3_conn.recv_body(&mut conn, stream_id, &mut buf)
+                        {
+                            debug!(
+                                "{} got {} bytes of response data on stream {}",
+                                conn.trace_id(),
+                                read,
+                                stream_id
+                            );
 
-                        print!("{}", unsafe {
-                            std::str::from_utf8_unchecked(&data)
-                        });
+                            print!("{}", unsafe {
+                                std::str::from_utf8_unchecked(&buf[..read])
+                            });
+                        }
                     },
 
                     Ok((_stream_id, quiche::h3::Event::Finished)) => {

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -319,11 +319,10 @@ fn main() {
                             );
                         },
 
-                        Ok((stream_id, quiche::h3::Event::Data(data))) => {
+                        Ok((stream_id, quiche::h3::Event::Data)) => {
                             info!(
-                                "{} got data of length {} on stream id {}",
+                                "{} got data on stream id {}",
                                 client.conn.trace_id(),
-                                data.len(),
                                 stream_id
                             );
                         },

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -319,9 +319,6 @@ int quiche_h3_event_for_each_header(quiche_h3_event *ev,
                                               void *argp),
                                     void *argp);
 
-// Returns the data from the event.
-size_t quiche_h3_event_data(quiche_h3_event *ev, uint8_t **out);
-
 // Frees the HTTP/3 event object.
 void quiche_h3_event_free(quiche_h3_event *ev);
 
@@ -347,6 +344,10 @@ int quiche_h3_send_response(quiche_h3_conn *conn, quiche_conn *quic_conn,
 ssize_t quiche_h3_send_body(quiche_h3_conn *conn, quiche_conn *quic_conn,
                             uint64_t stream_id, uint8_t *body, size_t body_len,
                             bool fin);
+
+// Reads request or response body data into the provided buffer.
+ssize_t quiche_h3_recv_body(quiche_h3_conn *conn, quiche_conn *quic_conn,
+                            uint64_t stream_id, uint8_t *out, size_t out_len);
 
 // Frees the HTTP/3 connection object.
 void quiche_h3_conn_free(quiche_h3_conn *conn);


### PR DESCRIPTION
This adds a new recv_body() method to the HTTP/3 connection, that can
be used by the application to retrieve request/response data from the
transport stream. The application can thus decide when and how much
data to read.

The Data event is changed to only be a signal that some data is
available, instead of returning the data itself. The Data event is now
level-triggered, meaning it will keep firing until the application has
read all of the data. This means that the application has no way of
discarding stream data currently. In the future we will need to add
support for STOP_SENDING if we need this functionality.

Internally, a new stream state is added which only sets a stream flag
indicating that the specific stream can be read. This flag triggers the
Data event itself, which is only returned after all stream frames have
already been handled (but before Finished is returned).

---

The benchmarks don't really show any improvement (but also no regression :)), which is somewhat disappointing but I suspect it's because there's a fairly big bottleneck down the stack (will need to look into that separately), but in any case that wasn't the main reason why we need this so it's fine.