### PR TITLE
Fix http3-client on MacOS

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -29,6 +29,7 @@
 extern crate log;
 
 use ring::rand::*;
+use std::net::ToSocketAddrs;
 
 const MAX_DATAGRAM_SIZE: usize = 1350;
 

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -82,7 +82,7 @@ fn main() {
     let mut bind_addr = "[::]:0"; // ipv6 by default
     match addr {
         Some(ip) => {
-            println!("addr = {:?}", ip);
+            debug!("addr = {:?}", ip);
             if ip.is_ipv4() {
                 bind_addr = "0.0.0.0:0";
             }

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -78,14 +78,16 @@ fn main() {
     // To work with MacOS (or BSD). Linux v6 socket can handle v4 connection
     // as well so not required but this should work both.
     let mut addrs_iter = url.to_socket_addrs().unwrap();
-    let addr = addrs_iter.next();
-    let mut bind_addr = "[::]:0"; // ipv6 by default
+    let addr = addrs_iter.next(); // get next IP address resolved from URL hostname
+    let bind_addr;
     match addr {
         Some(ip) => {
             debug!("addr = {:?}", ip);
-            if ip.is_ipv4() {
-                bind_addr = "0.0.0.0:0";
-            }
+            bind_addr = if ip.is_ipv4() {
+                "0.0.0.0:0" // v4
+            } else {
+                "[::]:0" // v6
+           }
         },
         None => panic!("IP address not found"),
     }

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -72,11 +72,13 @@ fn main() {
     let poll = mio::Poll::new().unwrap();
     let mut events = mio::Events::with_capacity(1024);
 
-    // Take a look at server address resolved to check if it's ipv4 or ipv6
+    // Take a look at server address resolved to check if it's ipv4 or ipv6.
     // Depending on the IP family, bind_addr will be default address of
-    // v4 or v6
-    // To work with MacOS (or BSD). Linux v6 socket can handle v4 connection
-    // as well so not required but this should work both.
+    // v4 or v6 for calling bind() later.
+    // This workaround is to work with MacOS (or BSD variants which
+    // doesn't allow v4 and v6 can be bind() in one socket).
+    // Note that linux doesn't need this because it can handle v4 and v6 socket
+    // when bind() with "::".
     let mut addrs_iter = url.to_socket_addrs().unwrap();
     let addr = addrs_iter.next(); // get next IP address resolved from URL hostname
     let bind_addr;


### PR DESCRIPTION
Problem is when we bind() udp socket, Linux understand '::' as v6 and v4 socket both, so connect() with v4 address will succeed. However in MacOS (or BSD I believe) we need to specify it's v4 or v6.

This patch try to read 1st resolved address from URL and set bind address accordingly. When IP address of 1st resolved hostname is v4 then it bind() to '0.0.0.0', otherwise bind() to '::'.