### PR TITLE
Fix server timeout caused by a packet loss at Handshake

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2347,20 +2347,28 @@ impl Connection {
                     // so the stream (usually id 0) is already opened and have
                     // some data to write, but actual
                     // packetization is prevented because of
-                    // max_tx_data = 0.
-                    // What we do here is update max_data if max_data=0
-                    // In normal situation (handshake is complete before getting
-                    // request) it will not do anything.
+                    // stream.send.max_tx_data = 0.
+                    // What we do here is update stream.send.max_data if
+                    // max_data=0 to its initial value used in
+                    // Stream::new(). In normal situation
+                    // (handshake is complete before getting
+                    // request) it will not do anything because
+                    // send.get_max_data() != 0
                     for (id, stream) in self
                         .streams
                         .iter_mut()
                         .filter(|(_, s)| s.send.get_max_data() == 0)
                     {
-                        stream.send.update_max_data(self.max_tx_data);
+                        // we use same value of Stream::new()
+                        stream.send.update_max_data(
+                            self.peer_transport_params
+                                .initial_max_stream_data_bidi_local
+                                as usize,
+                        );
                         trace!(
-                            "stream_id={} update max_data={}",
+                            "stream_id={} update stream.send.max_data={}",
                             id,
-                            self.max_tx_data
+                            stream.send.get_max_data()
                         );
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -623,6 +623,10 @@ pub struct Connection {
     /// Received address verification token.
     token: Option<Vec<u8>>,
 
+    /// Number of Application packets received before the handshake was
+    /// completed.
+    early_app_pkts: usize,
+
     /// Error code to be sent to the peer in CONNECTION_CLOSE.
     error: Option<u16>,
 
@@ -877,6 +881,8 @@ impl Connection {
             odcid: None,
 
             token: None,
+
+            early_app_pkts: 0,
 
             error: None,
 
@@ -1236,6 +1242,22 @@ impl Connection {
         if self.pkt_num_spaces[epoch].recv_pkt_num.contains(pn) {
             trace!("{} ignored duplicate packet {}", self.trace_id, pn);
             return Err(Error::Done);
+        }
+
+        // Keep track of the number of Application packets received before the
+        // handshake is completed, and drop any that exceed the initial
+        // congestion window packet count.
+        if hdr.ty == packet::Type::Application && !self.is_established() {
+            self.early_app_pkts += 1;
+
+            if self.early_app_pkts > recovery::INITIAL_WINDOW_PACKETS {
+                error!(
+                    "{} dropped early application packet len={} pn={}",
+                    self.trace_id, payload_len, pn,
+                );
+
+                return Ok(header_len + payload_len);
+            }
         }
 
         // Keep track of how many bytes we received from the client, so we
@@ -3751,6 +3773,117 @@ mod tests {
                 data: vec![0xba; 8],
             })
         );
+    }
+
+    #[test]
+    /// Simulates reception of an early Application packet on the server, by
+    /// delaying the client's Handshake packet that completes the handshake.
+    fn buffer_early_app_frames() {
+        let mut buf = [0; 65535];
+
+        let mut pipe = testing::Pipe::default().unwrap();
+
+        // Client sends initial flight
+        let mut len = pipe.client.send(&mut buf).unwrap();
+
+        // Server sends initial flight..
+        len = testing::recv_send(&mut pipe.server, &mut buf, len).unwrap();
+
+        // Client sends Handshake packet.
+        len = testing::recv_send(&mut pipe.client, &mut buf, len).unwrap();
+
+        // Emulate handshake packet delay by not making server process client
+        // packet.
+        let mut delayed = (&buf[..len]).to_vec();
+        testing::recv_send(&mut pipe.server, &mut buf, 0).unwrap();
+
+        assert!(pipe.client.is_established());
+        assert_eq!(pipe.client.streams.iter_mut().len(), 0);
+
+        assert_eq!(pipe.client.stream_send(4, b"hello, world", true), Ok(12));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Before handshake
+        assert!(!pipe.server.is_established());
+        assert_eq!(pipe.server.streams.iter_mut().len(), 1);
+
+        // Process delayed packet.
+        pipe.server.recv(&mut delayed).unwrap();
+
+        // After handshake
+        assert!(pipe.server.is_established());
+        assert_eq!(pipe.server.streams.iter_mut().len(), 1);
+
+        assert_eq!(pipe.client.stats().sent, pipe.server.stats().recv);
+    }
+
+    #[test]
+    /// Simulates reception of multiple early Application packets on the server
+    /// exceeding the limit imposed for buffering of their frames.
+    fn buffer_early_app_frames_limit() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(256);
+        config.set_initial_max_stream_data_bidi_local(256);
+        config.set_initial_max_stream_data_bidi_remote(256);
+        config.set_initial_max_streams_bidi(13);
+        config.set_initial_max_streams_uni(13);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
+
+        // Client sends initial flight
+        let mut len = pipe.client.send(&mut buf).unwrap();
+
+        // Server sends initial flight..
+        len = testing::recv_send(&mut pipe.server, &mut buf, len).unwrap();
+
+        // Client sends Handshake packet.
+        len = testing::recv_send(&mut pipe.client, &mut buf, len).unwrap();
+
+        // Emulate handshake packet delay by not making server process client
+        // packet.
+        let mut delayed = (&buf[..len]).to_vec();
+        testing::recv_send(&mut pipe.server, &mut buf, 0).unwrap();
+
+        assert!(pipe.client.is_established());
+        assert_eq!(pipe.client.streams.iter_mut().len(), 0);
+
+        // Client sends `INITIAL_WINDOW_PACKETS` + 1 Application packets to
+        // trigger the server's limit.
+        for i in 1..=recovery::INITIAL_WINDOW_PACKETS + 1 {
+            pipe.client
+                .stream_send(i as u64 * 4, b"hello, world", true)
+                .unwrap();
+            pipe.advance(&mut buf).unwrap();
+        }
+
+        assert_eq!(pipe.client.streams.iter_mut().len(), 11);
+
+        assert!(!pipe.server.is_established());
+
+        // Only able to write 10 packets
+        assert_eq!(pipe.server.streams.iter_mut().len(), 10);
+
+        // Process delayed packet.
+        pipe.server.recv(&mut delayed).unwrap();
+
+        // Server received `INITIAL_WINDOW_PACKETS` Application packets and
+        // dropped the 11th.
+        assert!(pipe.server.is_established());
+        assert_eq!(pipe.server.streams.iter_mut().len(), 10);
+
+        assert_eq!(pipe.client.stats().sent, pipe.server.stats().recv + 1);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2357,7 +2357,6 @@ impl Connection {
                     for (id, stream) in self
                         .streams
                         .iter_mut()
-                        .filter(|(_, s)| s.send.get_max_data() == 0)
                     {
                         // we use same value of Stream::new()
                         stream.send.update_max_data(
@@ -2366,7 +2365,8 @@ impl Connection {
                                 as usize,
                         );
                         trace!(
-                            "stream_id={} update stream.send.max_data={}",
+                            "{} stream_id={} update stream.send.max_data={}",
+                            &self.trace_id,
                             id,
                             stream.send.get_max_data()
                         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2344,21 +2344,24 @@ impl Connection {
                     // Update max_data of current sender streams with some data
                     // already written. This can happen when there is a
                     // Handshake packet loss but received actual request already,
-                    // so the stream (usually id 0) is already opened and have some
-                    // data to write, but actual packetization is prevented because of
+                    // so the stream (usually id 0) is already opened and have
+                    // some data to write, but actual
+                    // packetization is prevented because of
                     // max_tx_data = 0.
                     // What we do here is update max_data if max_data=0
                     // In normal situation (handshake is complete before getting
                     // request) it will not do anything.
-                    for (id, stream) in self.streams.iter_mut() {
-                        if stream.send.get_max_data() == 0 {
-                            stream.send.update_max_data(self.max_tx_data);
-                            trace!(
-                                "stream_id={} update max_data={}",
-                                id,
-                                self.max_tx_data
-                            );
-                        }
+                    for (id, stream) in self
+                        .streams
+                        .iter_mut()
+                        .filter(|(_, s)| s.send.get_max_data() == 0)
+                    {
+                        stream.send.update_max_data(self.max_tx_data);
+                        trace!(
+                            "stream_id={} update max_data={}",
+                            id,
+                            self.max_tx_data
+                        );
                     }
 
                     trace!("{} connection established: cipher={:?} proto={:?} resumed={} {:?}",

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -44,9 +44,11 @@ const GRANULARITY: Duration = Duration::from_millis(1);
 const INITIAL_RTT: Duration = Duration::from_millis(500);
 
 // Congestion Control
+pub const INITIAL_WINDOW_PACKETS: usize = 10;
+
 const MAX_DATAGRAM_SIZE: usize = 1452;
 
-const INITIAL_WINDOW: usize = 10 * MAX_DATAGRAM_SIZE;
+const INITIAL_WINDOW: usize = INITIAL_WINDOW_PACKETS * MAX_DATAGRAM_SIZE;
 const MINIMUM_WINDOW: usize = 2 * MAX_DATAGRAM_SIZE;
 
 const PERSISTENT_CONGESTION_THRESHOLD: u32 = 3;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -110,12 +110,6 @@ impl StreamMap {
                 };
 
                 let s = Stream::new(max_rx_data, max_tx_data);
-                trace!(
-                    "new stream_id={} max_rx={} max_tx={}",
-                    id,
-                    max_rx_data,
-                    max_tx_data
-                );
                 v.insert(s)
             },
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -571,7 +571,7 @@ impl SendBuf {
     }
 
     /// Return current max_data
-    pub fn get_max_data(&mut self) -> usize {
+    pub fn get_max_data(&self) -> usize {
         self.max_data
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -110,6 +110,12 @@ impl StreamMap {
                 };
 
                 let s = Stream::new(max_rx_data, max_tx_data);
+                trace!(
+                    "new stream_id={} max_rx={} max_tx={}",
+                    id,
+                    max_rx_data,
+                    max_tx_data
+                );
                 v.insert(s)
             },
 
@@ -562,6 +568,11 @@ impl SendBuf {
         }
 
         Ok(out)
+    }
+
+    /// Return current max_data
+    pub fn get_max_data(&mut self) -> usize {
+        self.max_data
     }
 
     /// Updates the max_data limit to the given value.


### PR DESCRIPTION
Update stream.send.max_data when handshake is complete.
- add new get_max_data() for accessing send.max_data
- change update_max_data()