### PR TITLE
delay processing of frames in Application packets until after the han…

### DIFF
--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -44,9 +44,11 @@ const GRANULARITY: Duration = Duration::from_millis(1);
 const INITIAL_RTT: Duration = Duration::from_millis(500);
 
 // Congestion Control
+pub const INITIAL_WINDOW_PACKETS: usize = 10;
+
 const MAX_DATAGRAM_SIZE: usize = 1452;
 
-const INITIAL_WINDOW: usize = 10 * MAX_DATAGRAM_SIZE;
+const INITIAL_WINDOW: usize = INITIAL_WINDOW_PACKETS * MAX_DATAGRAM_SIZE;
 const MINIMUM_WINDOW: usize = 2 * MAX_DATAGRAM_SIZE;
 
 const PERSISTENT_CONGESTION_THRESHOLD: u32 = 3;


### PR DESCRIPTION
…dshake is complete

If an Application packet is received before the handshake is completed
it would get processed normally, which is potentially dangerous from a
security perspective (e.g. applications could potentially read STREAM
data even if the handshake wasn't verified), and causes stream state to
be initialized with the wrong transport parameters in some cases
(potentially causing a deadlock).

This change delays the processing of "early Application frames" (i.e.
frames in Application packets that have been received before the
handshake has completed) to after the connection is established, by
buffering the frames.

An arbitrary limit is put on the maximum number of early Application
packets that can be processed in such a way. If the limit is exceeded,
the additional packets are dropped instead, forcing the peer to resend
them.

Note that this is an optimization, as simply dropping all early Application
packets would have also fixed the problems mentioned above, but would
have introduced additional latency as packets would have needed to be
resent.