### PR TITLE
examples: handle socket.send() result

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -140,14 +140,14 @@ fn main() {
         Err(e) => panic!("initial send failed: {:?}", e),
     };
 
-    
-    while let Err(e) = socket.send(&out[..write]) {    
+    while let Err(e) = socket.send(&out[..write]) {
         if e.kind() == std::io::ErrorKind::WouldBlock {
             debug!("send() would block");
+            continue;
         }
 
-        panic!("send() failed: {:?}", e);            
-    } 
+        panic!("send() failed: {:?}", e);
+    }
 
     debug!("written {}", write);
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -140,7 +140,14 @@ fn main() {
         Err(e) => panic!("initial send failed: {:?}", e),
     };
 
-    socket.send(&out[..write]).unwrap();
+    
+    while let Err(e) = socket.send(&out[..write]) {    
+        if e.kind() == std::io::ErrorKind::WouldBlock {
+            debug!("send() would block");
+        }
+
+        panic!("send() failed: {:?}", e);            
+    } 
 
     debug!("written {}", write);
 
@@ -266,7 +273,14 @@ fn main() {
                 },
             };
 
-            socket.send(&out[..write]).unwrap();
+            if let Err(e) = socket.send(&out[..write]) {
+                if e.kind() == std::io::ErrorKind::WouldBlock {
+                    debug!("send() would block");
+                    break;
+                }
+
+                panic!("send() failed: {:?}", e);
+            }
 
             debug!("written {}", write);
         }

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -145,7 +145,13 @@ fn main() {
         Err(e) => panic!("initial send failed: {:?}", e),
     };
 
-    socket.send(&out[..write]).unwrap();
+    while let Err(e) = socket.send(&out[..write]) {    
+        if e.kind() == std::io::ErrorKind::WouldBlock {
+            debug!("send() would block");
+        }
+
+        panic!("send() failed: {:?}", e);            
+    }
 
     debug!("written {}", write);
 
@@ -315,7 +321,14 @@ fn main() {
                 },
             };
 
-            socket.send(&out[..write]).unwrap();
+            if let Err(e) = socket.send(&out[..write]) {
+                if e.kind() == std::io::ErrorKind::WouldBlock {
+                    debug!("send() would block");
+                    break;
+                }
+
+                panic!("send() failed: {:?}", e);
+            }
 
             debug!("written {}", write);
         }

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -145,12 +145,13 @@ fn main() {
         Err(e) => panic!("initial send failed: {:?}", e),
     };
 
-    while let Err(e) = socket.send(&out[..write]) {    
+    while let Err(e) = socket.send(&out[..write]) {
         if e.kind() == std::io::ErrorKind::WouldBlock {
             debug!("send() would block");
+            continue;
         }
 
-        panic!("send() failed: {:?}", e);            
+        panic!("send() failed: {:?}", e);
     }
 
     debug!("written {}", write);

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -200,7 +200,14 @@ fn main() {
 
                     let out = &out[..len];
 
-                    socket.send_to(out, &src).unwrap();
+                    if let Err(e) = socket.send_to(out, &src) {
+                        if e.kind() == std::io::ErrorKind::WouldBlock {
+                            debug!("send() would block");
+                            break;
+                        }
+
+                        panic!("send() failed: {:?}", e);
+                    }
                     continue;
                 }
 
@@ -226,7 +233,14 @@ fn main() {
                         .unwrap();
                         let out = &out[..len];
 
-                        socket.send_to(out, &src).unwrap();
+                        if let Err(e) = socket.send_to(out, &src) {
+                            if e.kind() == std::io::ErrorKind::WouldBlock {
+                                debug!("send() would block");
+                                break;
+                            }
+
+                            panic!("send() failed: {:?}", e);
+                        }
                         continue;
                     }
 
@@ -368,7 +382,14 @@ fn main() {
                 };
 
                 // TODO: coalesce packets.
-                socket.send_to(&out[..write], &peer).unwrap();
+                if let Err(e) = socket.send_to(&out[..write], &peer) {
+                    if e.kind() == std::io::ErrorKind::WouldBlock {
+                        debug!("send() would block");
+                        break;
+                    }
+
+                    panic!("send() failed: {:?}", e);
+                }
 
                 debug!("{} written {} bytes", client.conn.trace_id(), write);
             }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -188,7 +188,14 @@ fn main() {
 
                     let out = &out[..len];
 
-                    socket.send_to(out, &src).unwrap();
+                    if let Err(e) = socket.send_to(out, &src) {
+                        if e.kind() == std::io::ErrorKind::WouldBlock {
+                            debug!("send() would block");
+                            break;
+                        }
+
+                        panic!("send() failed: {:?}", e);
+                    }
                     continue;
                 }
 
@@ -215,7 +222,14 @@ fn main() {
 
                         let out = &out[..len];
 
-                        socket.send_to(out, &src).unwrap();
+                        if let Err(e) = socket.send_to(out, &src) {
+                            if e.kind() == std::io::ErrorKind::WouldBlock {
+                                debug!("send() would block");
+                                break;
+                            }
+
+                            panic!("send() failed: {:?}", e);
+                        }
                         continue;
                     }
 
@@ -314,7 +328,14 @@ fn main() {
                 };
 
                 // TODO: coalesce packets.
-                socket.send_to(&out[..write], &peer).unwrap();
+                if let Err(e) = socket.send_to(&out[..write], &peer) {
+                    if e.kind() == std::io::ErrorKind::WouldBlock {
+                        debug!("send() would block");
+                        break;
+                    }
+
+                    panic!("send() failed: {:?}", e);
+                }
 
                 debug!("{} written {} bytes", conn.trace_id(), write);
             }


### PR DESCRIPTION
fixes #56

All Rust examples changed to handle the result of socket.send[_to](). Tested local and remote interop of http3-client.