### PR TITLE
examples: add Dockerfile

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,25 @@
+FROM rust:1.35 as build
+
+WORKDIR /usr/src/
+
+RUN apt-get update && apt-get install -y \
+    git \
+    cmake \
+    golang \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --recurse-submodules --depth 1 https://github.com/cloudflare/quiche
+
+RUN cd quiche && cargo build --release --examples
+
+FROM debian:latest
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+RUN update-ca-certificates
+WORKDIR /usr/src/
+COPY --from=build /usr/src/quiche/target/release/examples/http3-client ./
+COPY --from=build /usr/src/quiche/target/release/examples/http3-server ./
+COPY --from=build /usr/src/quiche/target/release/examples/client ./
+COPY --from=build /usr/src/quiche/target/release/examples/server ./
+ENV RUST_LOG=trace

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates
-WORKDIR /usr/src/
-COPY --from=build /usr/src/quiche/target/release/examples/http3-client ./
-COPY --from=build /usr/src/quiche/target/release/examples/http3-server ./
-COPY --from=build /usr/src/quiche/target/release/examples/client ./
-COPY --from=build /usr/src/quiche/target/release/examples/server ./
-ENV RUST_LOG=trace
+COPY --from=build /usr/src/quiche/target/release/examples/http3-client /usr/local/quiche/bin/
+COPY --from=build /usr/src/quiche/target/release/examples/http3-server /usr/local/quiche/bin/
+COPY --from=build /usr/src/quiche/target/release/examples/client /usr/local/quiche/bin/
+COPY --from=build /usr/src/quiche/target/release/examples/server /usr/local/quiche/bin/
+ENV PATH="/usr/local/quiche/bin/:${PATH}"
+ENV RUST_LOG=info

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,3 +18,22 @@ Simply run `make` in this directory.
 % make clean
 % make
 ```
+
+Examples Docker image
+---------------------
+You can experiment with [http3-client](http3-client.rs), [http3-server](http3-server.rs), [client](client.rs) and [server](server.rs) using Docker.
+
+The Examples [Dockerfile](Dockerfile) builds a Debian image.
+
+To build:
+
+```
+docker build -t cloudflare-quiche .
+```
+
+To run http3-client once the image is built:
+
+```
+docker run -it cloudflare-quiche
+root@d137bc3a84f9:/usr/src# ./http3-client https://cloudflare-quic.com
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,9 @@ Simply run `make` in this directory.
 
 Examples Docker image
 ---------------------
-You can experiment with [http3-client](http3-client.rs), [http3-server](http3-server.rs), [client](client.rs) and [server](server.rs) using Docker.
+You can experiment with [http3-client](http3-client.rs),
+[http3-server](http3-server.rs), [client](client.rs) and [server](server.rs)
+using Docker.
 
 The Examples [Dockerfile](Dockerfile) builds a Debian image.
 
@@ -31,9 +33,8 @@ To build:
 docker build -t cloudflare-quiche .
 ```
 
-To run http3-client once the image is built:
+To make an HTTP/3 request:
 
 ```
-docker run -it cloudflare-quiche
-root@d137bc3a84f9:/usr/src# ./http3-client https://cloudflare-quic.com
+docker run -it cloudflare-quiche http3-client https://cloudflare-quic.com
 ```


### PR DESCRIPTION
Adds a Dockerfile that works in 2 stages:

1) creates a build image from official Rust sources, installs build prereqs and does a release build of examples with cargo

2) creates a distribution image, ensures system root store is up to date and copies just the binaries from stage 1.

Updated readme.md to show how to use this thing.