### PR TITLE
Add support for sending POST (and other methods) requests with body to http3-client

### DIFF
--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -38,6 +38,7 @@ const USAGE: &str = "Usage:
   http3-client -h | --help
 
 Options:
+  --method METHOD          Use the given HTTP request method [default: GET].
   --max-data BYTES         Connection-wide flow control limit [default: 10000000].
   --max-stream-data BYTES  Per-stream flow control limit [default: 1000000].
   --wire-version VERSION   The version number to send to the server [default: babababa].
@@ -232,7 +233,7 @@ fn main() {
             }
 
             let req = vec![
-                quiche::h3::Header::new(":method", "GET"),
+                quiche::h3::Header::new(":method", args.get_str("--method")),
                 quiche::h3::Header::new(":scheme", url.scheme()),
                 quiche::h3::Header::new(":authority", url.host_str().unwrap()),
                 quiche::h3::Header::new(":path", &path),


### PR DESCRIPTION
This adds support for setting a custom HTTP method in http3-client and send request body.

It's not a whole lot of additional complexity IMO so adding this here shouldn't be too bad, though lsquic-client also supports this (and maybe h2load?), so I'm fine to leave this out as well.