### PR TITLE
add stream_shutdown() API

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -213,6 +213,15 @@ ssize_t quiche_conn_stream_recv(quiche_conn *conn, uint64_t stream_id,
 ssize_t quiche_conn_stream_send(quiche_conn *conn, uint64_t stream_id,
                                 const uint8_t *buf, size_t buf_len, bool fin);
 
+enum quiche_shutdown {
+    QUICHE_SHUTDOWN_READ = 0,
+    QUICHE_SHUTDOWN_WRITE = 1,
+};
+
+// Shuts down reading or writing from/to the specified stream.
+int quiche_conn_stream_shutdown(quiche_conn *conn, uint64_t stream_id,
+                                enum quiche_shutdown direction, uint64_t err);
+
 // Returns true if all the data has been read from the specified stream.
 bool quiche_conn_stream_finished(quiche_conn *conn, uint64_t stream_id);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -437,6 +437,17 @@ pub extern fn quiche_conn_stream_send(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_stream_shutdown(
+    conn: &mut Connection, stream_id: u64, direction: Shutdown, err: u64,
+) -> c_int {
+    match conn.stream_shutdown(stream_id, direction, err) {
+        Ok(_) => 0,
+
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_stream_finished(
     conn: &mut Connection, stream_id: u64,
 ) -> bool {

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -1380,12 +1380,10 @@ impl Connection {
                 },
 
                 stream::State::Drain => {
-                    let mut d = [0; 4096];
+                    // Discard incoming data on the stream.
+                    conn.stream_shutdown(stream_id, crate::Shutdown::Read, 0)?;
 
-                    // Read data from the stream and discard immediately.
-                    loop {
-                        conn.stream_recv(stream_id, &mut d)?;
-                    }
+                    break;
                 },
             }
         }


### PR DESCRIPTION
This allows applications to discard incoming or outgoing stream data. For
example an application might want to ignore incoming HTTP request data
in case of errors. Without this, the application would have to consume
all the incoming data in the stream manually, otherwise the HTTP/3 layer
would keep reporting "Data" events forever.

Currently that's all this API does currently, but in the future it can
be used to trigger sending STOP_SENDING and RESET_STREAM frames for
specific streams.