### PR TITLE
tls: load certs from Windows system store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ libc = "0"
 ring = "0.14"
 lazy_static = "1"
 
+[target."cfg(windows)".dependencies]
+winapi = {version = "0", features = ["wincrypt"] }
+
 [dev-dependencies]
 mio = "0"
 url = "1"

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -166,7 +166,7 @@ impl Context {
 
     #[cfg(not(windows))]
     fn load_ca_certs(&mut self) -> Result<()> {
-        unsafe { map_result(SSL_CTX_set_default_verify_paths(ctx_raw)) }
+        unsafe { map_result(SSL_CTX_set_default_verify_paths(self.as_ptr())) }
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
Rough first stab at this, PTAL. Fixes #61 .

Since this problem and its solution are windows specific, there is liberal peppering of `#[cfg(windows)]`.  I'm keen to see if this actually works as it appears on paper.

Happy to hear more elegant ways to do this. Tidy up code is not great, windows API example code is a bit rubbish.