### PR TITLE
http3-client: add request headers

### DIFF
--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -248,10 +248,10 @@ fn main() {
             // Add custom headers to the request.
             for header in &req_headers {
                 let header_split: Vec<&str> = header.splitn(2, ": ").collect();
-                // Convert header field to lowercase
-                let (field, value) =
-                    (&header_split[0].to_lowercase().to_string(), header_split[1]);
-                req.push(quiche::h3::Header::new(field, value));
+                req.push(quiche::h3::Header::new(
+                    header_split[0],
+                    header_split[1],
+                ));
             }
 
             info!("sending HTTP request {:?}", req);


### PR DESCRIPTION
Adding -H/--header "field: value" option to http3-client
to add request headers in the command line. Can be multiple.

Useful when you need more http-related tests.

Currently it can't override default headers (e.g. user-agent).
If you add, there will be 2 headers with same name.

e.g.

```
http3-client -H 'cache-control: no-cache' https://cloudflare-quic.com
http3-client -H 'content-type: application/x-www-form-urlencoded' --method PUT --body test.dat https://httpbin-like...
```