### PR TITLE
CODEOWNERS: add whole team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @ghedo
-src/h3/* @ghedo @LPardue
+* @cloudflare/protocols


### PR DESCRIPTION
This adds the whole team as default reviewers for PRs to the quiche repository. Thoughts?