### PR TITLE
http3-client: send multiple identical requests

### DIFF
--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -343,10 +343,10 @@ fn main() {
                                 Ok(_) | Err(quiche::Error::Done) => (),
 
                                 Err(e) => panic!("error closing conn: {:?}", e),
-                            }
-                        }
+                            }                        
 
-                        break;
+                            break;
+                        }
                     },
 
                     Err(quiche::h3::Error::Done) => {


### PR DESCRIPTION
Adds a new CLI option `-n`,`--requests` that allows the client to send multiple identical requests at the same time. Default is 1.

```
http3-client -n3 https://cloudflare-quic.com
```

The PR is is a lowest impact way to add this feature. The downsides are: only record and report timing of all requests, request bodies printed to stdout will get horribly intermingled.