### PR TITLE
http3-client: panic on custom header error

### DIFF
--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -248,7 +248,7 @@ fn main() {
             // Add custom headers to the request.
             for header in &req_headers {
                 let header_split: Vec<&str> = header.splitn(2, ": ").collect();
-                if header_split.len() == 1 {
+                if header_split.len() != 2 {
                     panic!("malformed header provided - \"{}\"", header);
                 }
 

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -248,6 +248,10 @@ fn main() {
             // Add custom headers to the request.
             for header in &req_headers {
                 let header_split: Vec<&str> = header.splitn(2, ": ").collect();
+                if header_split.len() == 1 {
+                    panic!("malformed header provided - \"{}\"", header);
+                }
+
                 req.push(quiche::h3::Header::new(
                     header_split[0],
                     header_split[1],


### PR DESCRIPTION
Due to fat fingers I stumbled across an unhelpful error message when I forgot to include a `:` in a header name. So this PR adds some very basic error checking and panics with the value of the bad header.