### PR TITLE
h3: use HashMap instead of BTreeMap to track streams

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -246,7 +246,7 @@
 //! [`send_response()`]: struct.Connection.html#method.send_response
 //! [`send_body()`]: struct.Connection.html#method.send_body
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 use crate::octets;
 
@@ -515,7 +515,7 @@ pub struct Connection {
     highest_request_stream_id: u64,
     highest_uni_stream_id: u64,
 
-    streams: BTreeMap<u64, stream::Stream>,
+    streams: HashMap<u64, stream::Stream>,
 
     local_settings: ConnectionSettings,
     peer_settings: ConnectionSettings,
@@ -542,7 +542,7 @@ impl Connection {
             highest_request_stream_id: 0,
             highest_uni_stream_id: initial_uni_stream_id,
 
-            streams: BTreeMap::new(),
+            streams: HashMap::new(),
 
             local_settings: ConnectionSettings {
                 num_placeholders: Some(config.num_placeholders),


### PR DESCRIPTION
Some (but not all) microbenchamrks show this is faster, so it must be true:

```
http3/128000            time:   [3.0736 ms 3.2788 ms 3.4550 ms]
                        change: [-20.154% -11.160% -1.2155%] (p = 0.03 < 0.05)
                        Performance has improved.
http3/256000            time:   [10.542 ms 10.748 ms 10.924 ms]
                        change: [-12.792% -10.599% -8.2133%] (p = 0.00 < 0.05)
                        Performance has improved.
http3/512000            time:   [26.139 ms 26.438 ms 26.695 ms]
                        change: [-3.8094% -2.1481% -0.4609%] (p = 0.02 < 0.05)
                        Change within noise threshold.
```