### PR TITLE
stream: refactor stream flow control initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1922,21 +1922,8 @@ impl Connection {
             return Err(Error::InvalidStreamState);
         }
 
-        let max_rx_data =
-            self.local_transport_params
-                .initial_max_stream_data_bidi_local as usize;
-        let max_tx_data =
-            self.peer_transport_params
-                .initial_max_stream_data_bidi_remote as usize;
-
         // Get existing stream or create a new one.
-        let stream = self.streams.get_or_create(
-            stream_id,
-            max_rx_data,
-            max_tx_data,
-            true,
-            self.is_server,
-        )?;
+        let stream = self.get_or_create_stream(stream_id, true)?;
 
         // TODO: implement backpressure based on peer's flow control
 
@@ -2286,6 +2273,20 @@ impl Connection {
         Err(Error::Done)
     }
 
+    /// Returns the mutable stream with the given ID if it exists, or creates
+    /// a new one otherwise.
+    fn get_or_create_stream(
+        &mut self, id: u64, local: bool,
+    ) -> Result<&mut stream::Stream> {
+        self.streams.get_or_create(
+            id,
+            &self.local_transport_params,
+            &self.peer_transport_params,
+            local,
+            self.is_server,
+        )
+    }
+
     /// Processes an incoming frame.
     fn process_frame(
         &mut self, frame: frame::Frame, epoch: packet::Epoch,
@@ -2325,23 +2326,8 @@ impl Connection {
                     return Err(Error::InvalidStreamState);
                 }
 
-                let max_rx_data = self
-                    .local_transport_params
-                    .initial_max_stream_data_bidi_remote
-                    as usize;
-                let max_tx_data = self
-                    .peer_transport_params
-                    .initial_max_stream_data_bidi_local
-                    as usize;
-
                 // Get existing stream or create a new one.
-                let stream = self.streams.get_or_create(
-                    stream_id,
-                    max_rx_data,
-                    max_tx_data,
-                    false,
-                    self.is_server,
-                )?;
+                let stream = self.get_or_create_stream(stream_id, false)?;
 
                 self.rx_data += stream.recv.reset(final_size as usize)?;
 
@@ -2392,31 +2378,19 @@ impl Connection {
                     return Err(Error::InvalidStreamState);
                 }
 
-                let max_rx_data = self
-                    .local_transport_params
-                    .initial_max_stream_data_bidi_remote
-                    as usize;
-                let max_tx_data = self
-                    .peer_transport_params
-                    .initial_max_stream_data_bidi_local
-                    as usize;
+                // Check for flow control limits.
+                let data_len = data.len();
 
-                // Get existing stream or create a new one.
-                let stream = self.streams.get_or_create(
-                    stream_id,
-                    max_rx_data,
-                    max_tx_data,
-                    false,
-                    self.is_server,
-                )?;
-
-                self.rx_data += data.len();
-
-                if self.rx_data > self.max_rx_data {
+                if self.rx_data + data_len > self.max_rx_data {
                     return Err(Error::FlowControl);
                 }
 
+                // Get existing stream or create a new one.
+                let stream = self.get_or_create_stream(stream_id, false)?;
+
                 stream.recv.push(data)?;
+
+                self.rx_data += data_len;
             },
 
             frame::Frame::MaxData { max } => {
@@ -2424,23 +2398,8 @@ impl Connection {
             },
 
             frame::Frame::MaxStreamData { stream_id, max } => {
-                let max_rx_data = self
-                    .local_transport_params
-                    .initial_max_stream_data_bidi_remote
-                    as usize;
-                let max_tx_data = self
-                    .peer_transport_params
-                    .initial_max_stream_data_bidi_local
-                    as usize;
-
                 // Get existing stream or create a new one.
-                let stream = self.streams.get_or_create(
-                    stream_id,
-                    max_rx_data,
-                    max_tx_data,
-                    false,
-                    self.is_server,
-                )?;
+                let stream = self.get_or_create_stream(stream_id, false)?;
 
                 let was_writable = stream.writable();
 
@@ -2875,6 +2834,7 @@ pub mod testing {
             config.set_initial_max_data(30);
             config.set_initial_max_stream_data_bidi_local(15);
             config.set_initial_max_stream_data_bidi_remote(15);
+            config.set_initial_max_stream_data_uni(10);
             config.set_initial_max_streams_bidi(3);
             config.set_initial_max_streams_uni(3);
             config.verify_peer(false);
@@ -3378,7 +3338,7 @@ mod tests {
     }
 
     #[test]
-    fn stream_flow_control_limit() {
+    fn stream_flow_control_limit_bidi() {
         let mut buf = [0; 65535];
 
         let mut pipe = testing::Pipe::default().unwrap();
@@ -3388,6 +3348,26 @@ mod tests {
         let frames = [frame::Frame::Stream {
             stream_id: 4,
             data: stream::RangeBuf::from(b"aaaaaaaaaaaaaaaa", 0, true),
+        }];
+
+        let pkt_type = packet::Type::Application;
+        assert_eq!(
+            pipe.send_pkt_to_server(pkt_type, &frames, &mut buf),
+            Err(Error::FlowControl),
+        );
+    }
+
+    #[test]
+    fn stream_flow_control_limit_uni() {
+        let mut buf = [0; 65535];
+
+        let mut pipe = testing::Pipe::default().unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        let frames = [frame::Frame::Stream {
+            stream_id: 2,
+            data: stream::RangeBuf::from(b"aaaaaaaaaaa", 0, true),
         }];
 
         let pkt_type = packet::Type::Application;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -78,7 +78,7 @@ impl StreamMap {
     /// a new one otherwise.
     ///
     /// The `local` parameter indicates whether the stream's creation was
-    /// requested byt the local application rather than the peer, and is
+    /// requested by the local application rather than the peer, and is
     /// used to validate the requested stream ID, and to select the initial
     /// flow control values from the local and remote transport parameters
     /// (also passed as arguments).
@@ -103,7 +103,7 @@ impl StreamMap {
                         peer_params.initial_max_stream_data_bidi_remote,
                     ),
 
-                    // Locally-initiated unirectional stream.
+                    // Locally-initiated unidirectional stream.
                     (true, false) => (0, peer_params.initial_max_stream_data_uni),
 
                     // Remotely-initiated bidirectional stream.
@@ -112,7 +112,7 @@ impl StreamMap {
                         peer_params.initial_max_stream_data_bidi_local,
                     ),
 
-                    // Remotely-initiated unirectional stream.
+                    // Remotely-initiated unidirectional stream.
                     (false, false) =>
                         (local_params.initial_max_stream_data_uni, 0),
                 };

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -77,18 +77,45 @@ impl StreamMap {
     /// Returns the mutable stream with the given ID if it exists, or creates
     /// a new one otherwise.
     ///
+    /// The `local` parameter indicates whether the stream's creation was
+    /// requested byt the local application rather than the peer, and is
+    /// used to validate the requested stream ID, and to select the initial
+    /// flow control values from the local and remote transport parameters
+    /// (also passed as arguments).
+    ///
     /// This also takes care of enforcing both local and the peer's stream
     /// count limits. If one of these limits is violated, the `StreamLimit`
     /// error is returned.
-    pub fn get_or_create(
-        &mut self, id: u64, max_rx_data: usize, max_tx_data: usize, local: bool,
-        is_server: bool,
+    pub(crate) fn get_or_create(
+        &mut self, id: u64, local_params: &crate::TransportParams,
+        peer_params: &crate::TransportParams, local: bool, is_server: bool,
     ) -> Result<&mut Stream> {
         let stream = match self.streams.entry(id) {
             hash_map::Entry::Vacant(v) => {
                 if local != is_local(id, is_server) {
                     return Err(Error::InvalidStreamState);
                 }
+
+                let (max_rx_data, max_tx_data) = match (local, is_bidi(id)) {
+                    // Locally-initiated bidirectional stream.
+                    (true, true) => (
+                        local_params.initial_max_stream_data_bidi_local,
+                        peer_params.initial_max_stream_data_bidi_remote,
+                    ),
+
+                    // Locally-initiated unirectional stream.
+                    (true, false) => (0, peer_params.initial_max_stream_data_uni),
+
+                    // Remotely-initiated bidirectional stream.
+                    (false, true) => (
+                        local_params.initial_max_stream_data_bidi_remote,
+                        peer_params.initial_max_stream_data_bidi_local,
+                    ),
+
+                    // Remotely-initiated unirectional stream.
+                    (false, false) =>
+                        (local_params.initial_max_stream_data_uni, 0),
+                };
 
                 // Enforce stream count limits.
                 match (is_local(id, is_server), is_bidi(id)) {
@@ -117,7 +144,7 @@ impl StreamMap {
                             .ok_or(Error::StreamLimit)?,
                 };
 
-                let s = Stream::new(max_rx_data, max_tx_data);
+                let s = Stream::new(max_rx_data as usize, max_tx_data as usize);
                 v.insert(s)
             },
 


### PR DESCRIPTION
This also fixes setting initial flow control limits for unidirectional
streams.