### PR TITLE
32bit architecture support

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -33,8 +33,8 @@ use crate::packet;
 use crate::ranges;
 use crate::stream;
 
-pub const MAX_CRYPTO_OVERHEAD: usize = 8;
-pub const MAX_STREAM_OVERHEAD: usize = 12;
+pub const MAX_CRYPTO_OVERHEAD: u64 = 8;
+pub const MAX_STREAM_OVERHEAD: u64 = 12;
 pub const MAX_STREAM_SIZE: u64 = 1 << 62;
 
 #[derive(Clone, PartialEq)]
@@ -176,7 +176,7 @@ impl Frame {
             },
 
             0x06 => {
-                let offset = b.get_varint()? as usize;
+                let offset = b.get_varint()?;
                 let data = b.get_bytes_with_varint_length()?;
                 let data = stream::RangeBuf::from(data.as_ref(), offset, false);
 
@@ -850,7 +850,7 @@ fn parse_stream_frame(ty: u64, b: &mut octets::Octets) -> Result<Frame> {
     let stream_id = b.get_varint()?;
 
     let offset = if first & 0x04 != 0 {
-        b.get_varint()? as usize
+        b.get_varint()?
     } else {
         0
     };
@@ -861,7 +861,7 @@ fn parse_stream_frame(ty: u64, b: &mut octets::Octets) -> Result<Frame> {
         b.cap()
     };
 
-    if offset + len >= MAX_STREAM_SIZE  {
+    if offset + len as u64 >= MAX_STREAM_SIZE {
         return Err(Error::InvalidFrame);
     }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -35,6 +35,7 @@ use crate::stream;
 
 pub const MAX_CRYPTO_OVERHEAD: usize = 8;
 pub const MAX_STREAM_OVERHEAD: usize = 12;
+pub const MAX_STREAM_SIZE: u64 = 1 << 62;
 
 #[derive(Clone, PartialEq)]
 pub enum Frame {
@@ -860,7 +861,7 @@ fn parse_stream_frame(ty: u64, b: &mut octets::Octets) -> Result<Frame> {
         b.cap()
     };
 
-    if offset + len > 2usize.pow(62) {
+    if offset + len >= MAX_STREAM_SIZE  {
         return Err(Error::InvalidFrame);
     }
 
@@ -1144,7 +1145,7 @@ mod tests {
 
         let frame = Frame::Stream {
             stream_id: 32,
-            data: stream::RangeBuf::from(&data, 2usize.pow(62) - 11, true),
+            data: stream::RangeBuf::from(&data, MAX_STREAM_SIZE - 11, true),
         };
 
         let wire_len = {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -33,8 +33,8 @@ use crate::packet;
 use crate::ranges;
 use crate::stream;
 
-pub const MAX_CRYPTO_OVERHEAD: u64 = 8;
-pub const MAX_STREAM_OVERHEAD: u64 = 12;
+pub const MAX_CRYPTO_OVERHEAD: usize = 8;
+pub const MAX_STREAM_OVERHEAD: usize = 12;
 pub const MAX_STREAM_SIZE: u64 = 1 << 62;
 
 #[derive(Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ pub const MIN_CLIENT_INITIAL_LEN: usize = 1200;
 
 const PAYLOAD_MIN_LEN: usize = 4;
 
-const MAX_AMPLIFICATION_FACTOR: usize = 3;
+const MAX_AMPLIFICATION_FACTOR: u64 = 3;
 
 /// A specialized [`Result`] type for quiche operations.
 ///
@@ -608,24 +608,24 @@ pub struct Connection {
     sent_count: usize,
 
     /// Total number of bytes received from the peer.
-    rx_data: usize,
+    rx_data: u64,
 
     /// Local flow control limit for the connection.
-    max_rx_data: usize,
+    max_rx_data: u64,
 
     /// Updated local flow control limit for the connection. This is used to
     /// trigger sending MAX_DATA frames after a certain threshold.
-    max_rx_data_next: usize,
+    max_rx_data_next: u64,
 
     /// Total number of bytes sent to the peer.
-    tx_data: usize,
+    tx_data: u64,
 
     /// Peer's flow control limit for the connection.
-    max_tx_data: usize,
+    max_tx_data: u64,
 
     /// Total number of bytes the server can send before the peer's address
     /// is verified.
-    max_send_bytes: usize,
+    max_send_bytes: u64,
 
     /// Streams map, indexed by stream ID.
     streams: stream::StreamMap,
@@ -888,8 +888,8 @@ impl Connection {
             sent_count: 0,
 
             rx_data: 0,
-            max_rx_data: max_rx_data as usize,
-            max_rx_data_next: max_rx_data as usize,
+            max_rx_data: max_rx_data as u64,
+            max_rx_data_next: max_rx_data as u64,
 
             tx_data: 0,
             max_tx_data: 0,
@@ -1290,7 +1290,7 @@ impl Connection {
         // is an error there is enough credit to send a CONNECTION_CLOSE.
         if !self.verified_peer_address {
             self.max_send_bytes +=
-                (header_len + payload_len) * MAX_AMPLIFICATION_FACTOR;
+                ((header_len + payload_len) as u64) * MAX_AMPLIFICATION_FACTOR;
         }
 
         // To avoid sending an ACK in response to an ACK-only packet, we need
@@ -1477,7 +1477,7 @@ impl Connection {
                     // TODO: due to a packet loss edge case the following could
                     // go negative, though it's not clear why, so will need to
                     // figure it out.
-                    self.tx_data = self.tx_data.saturating_sub(data.len());
+                    self.tx_data = self.tx_data.saturating_sub(data.len() as u64);
 
                     let was_writable = stream.writable();
 
@@ -1499,7 +1499,7 @@ impl Connection {
         }
 
         // Calculate available space in the packet based on congestion window.
-        let mut left = cmp::min(self.recovery.cwnd(), b.cap());
+        let mut left:u64 = cmp::min(self.recovery.cwnd(), b.cap()) as u64;
 
         // Limit data sent by the server based on the amount of data received
         // from the client before its address is validated.
@@ -1532,7 +1532,7 @@ impl Connection {
         // length, the packet number and the AEAD overhead. We assume that
         // the payload length can always be encoded with a 2-byte varint.
         left = left
-            .checked_sub(b.off() + 2 + pn_len + overhead)
+            .checked_sub((b.off() + 2 + pn_len + overhead) as u64)
             .ok_or(Error::Done)?;
 
         let mut frames: Vec<frame::Frame> = Vec::new();
@@ -1557,11 +1557,11 @@ impl Connection {
                 ranges: self.pkt_num_spaces[epoch].recv_pkt_need_ack.clone(),
             };
 
-            if frame.wire_len() <= left {
+            if frame.wire_len() as u64 <= left {
                 self.pkt_num_spaces[epoch].ack_elicited = false;
 
                 payload_len += frame.wire_len();
-                left -= frame.wire_len();
+                left -= frame.wire_len() as u64;
 
                 frames.push(frame);
             }
@@ -1578,11 +1578,11 @@ impl Connection {
                 max: self.max_rx_data_next as u64,
             };
 
-            if frame.wire_len() <= left {
+            if frame.wire_len() as u64 <= left {
                 self.max_rx_data = self.max_rx_data_next;
 
                 payload_len += frame.wire_len();
-                left -= frame.wire_len();
+                left -= frame.wire_len() as u64;
 
                 frames.push(frame);
 
@@ -1603,12 +1603,12 @@ impl Connection {
                     max: stream.recv.update_max_data() as u64,
                 };
 
-                if frame.wire_len() > left {
+                if frame.wire_len() as u64 > left {
                     break;
                 }
 
                 payload_len += frame.wire_len();
-                left -= frame.wire_len();
+                left -= frame.wire_len() as u64;
 
                 frames.push(frame);
 
@@ -1622,7 +1622,7 @@ impl Connection {
             let frame = frame::Frame::Ping;
 
             payload_len += frame.wire_len();
-            left -= frame.wire_len();
+            left -= frame.wire_len() as u64;
 
             frames.push(frame);
 
@@ -1641,7 +1641,7 @@ impl Connection {
             };
 
             payload_len += frame.wire_len();
-            left -= frame.wire_len();
+            left -= frame.wire_len() as u64;
 
             frames.push(frame);
 
@@ -1660,7 +1660,7 @@ impl Connection {
                 };
 
                 payload_len += frame.wire_len();
-                left -= frame.wire_len();
+                left -= frame.wire_len() as u64;
 
                 frames.push(frame);
 
@@ -1678,7 +1678,7 @@ impl Connection {
             };
 
             payload_len += frame.wire_len();
-            left -= frame.wire_len();
+            left -= frame.wire_len() as u64;
 
             frames.push(frame);
 
@@ -1702,7 +1702,7 @@ impl Connection {
             let frame = frame::Frame::Crypto { data: crypto_buf };
 
             payload_len += frame.wire_len();
-            left -= frame.wire_len();
+            left -= frame.wire_len() as u64;
 
             frames.push(frame);
 
@@ -1726,13 +1726,13 @@ impl Connection {
                     self.max_tx_data - self.tx_data,
                 );
 
-                let stream_buf = stream.send.pop(stream_len)?;
+                let stream_buf = stream.send.pop(stream_len as u64)?;
 
                 if stream_buf.is_empty() {
                     continue;
                 }
 
-                self.tx_data += stream_buf.len();
+                self.tx_data += stream_buf.len() as u64;
 
                 let frame = frame::Frame::Stream {
                     stream_id,
@@ -1740,7 +1740,7 @@ impl Connection {
                 };
 
                 payload_len += frame.wire_len();
-                left -= frame.wire_len();
+                left -= frame.wire_len() as u64;
 
                 frames.push(frame);
 
@@ -1766,7 +1766,7 @@ impl Connection {
             let pkt_len = pn_len + payload_len + overhead;
 
             let frame = frame::Frame::Padding {
-                len: cmp::min(MIN_CLIENT_INITIAL_LEN - pkt_len, left),
+                len: cmp::min((MIN_CLIENT_INITIAL_LEN - pkt_len) as u64, left) as usize,
             };
 
             payload_len += frame.wire_len();
@@ -1852,7 +1852,7 @@ impl Connection {
             self.drop_epoch_state(packet::EPOCH_INITIAL);
         }
 
-        self.max_send_bytes = self.max_send_bytes.saturating_sub(written);
+        self.max_send_bytes = self.max_send_bytes.saturating_sub(written as u64);
 
         Ok(written)
     }
@@ -1902,7 +1902,7 @@ impl Connection {
 
         let (read, fin) = stream.recv.pop(out)?;
 
-        self.max_rx_data_next = self.max_rx_data_next.saturating_add(read);
+        self.max_rx_data_next = self.max_rx_data_next.saturating_add(read as u64);
 
         Ok((read, fin))
     }
@@ -2200,7 +2200,7 @@ impl Connection {
                         return Err(Error::InvalidTransportParam);
                     }
 
-                    self.max_tx_data = peer_params.initial_max_data as usize;
+                    self.max_tx_data = peer_params.initial_max_data;
 
                     self.streams.update_peer_max_streams_bidi(
                         peer_params.initial_max_streams_bidi as usize,
@@ -2351,7 +2351,7 @@ impl Connection {
                 // Get existing stream or create a new one.
                 let stream = self.get_or_create_stream(stream_id, false)?;
 
-                self.rx_data += stream.recv.reset(final_size as usize)?;
+                self.rx_data += stream.recv.reset(final_size)? as u64;
 
                 if self.rx_data > self.max_rx_data {
                     return Err(Error::FlowControl);
@@ -2401,7 +2401,7 @@ impl Connection {
                 }
 
                 // Check for flow control limits.
-                let data_len = data.len();
+                let data_len = data.len() as u64;
 
                 if self.rx_data + data_len > self.max_rx_data {
                     return Err(Error::FlowControl);
@@ -2416,7 +2416,7 @@ impl Connection {
             },
 
             frame::Frame::MaxData { max } => {
-                self.max_tx_data = cmp::max(self.max_tx_data, max as usize);
+                self.max_tx_data = cmp::max(self.max_tx_data, max);
             },
 
             frame::Frame::MaxStreamData { stream_id, max } => {
@@ -2425,7 +2425,7 @@ impl Connection {
 
                 let was_writable = stream.writable();
 
-                stream.send.update_max_data(max as usize);
+                stream.send.update_max_data(max);
 
                 // If the stream is now writable push it to the writable queue,
                 // but only if it wasn't already queued.
@@ -3319,7 +3319,7 @@ mod tests {
         let server_sent =
             testing::recv_send(&mut pipe.server, &mut buf, client_sent).unwrap();
 
-        assert_eq!(server_sent, (client_sent - 1) * MAX_AMPLIFICATION_FACTOR);
+        assert_eq!(server_sent, (client_sent - 1) * MAX_AMPLIFICATION_FACTOR as usize);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -889,7 +889,7 @@ impl Connection {
 
             rx_data: 0,
             max_rx_data: max_rx_data as u64,
-            max_rx_data_next: max_rx_data as u64,
+            max_rx_data_next: max_rx_data,
 
             tx_data: 0,
             max_tx_data: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -888,7 +888,7 @@ impl Connection {
             sent_count: 0,
 
             rx_data: 0,
-            max_rx_data: max_rx_data as u64,
+            max_rx_data,
             max_rx_data_next: max_rx_data,
 
             tx_data: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1697,7 +1697,7 @@ impl Connection {
             let crypto_buf = self.pkt_num_spaces[epoch]
                 .crypto_stream
                 .send
-                .pop(crypto_len as u64)?;
+                .pop(crypto_len)?;
 
             let frame = frame::Frame::Crypto { data: crypto_buf };
 
@@ -1726,7 +1726,7 @@ impl Connection {
                     (self.max_tx_data - self.tx_data) as usize
                 );
 
-                let stream_buf = stream.send.pop(stream_len as u64)?;
+                let stream_buf = stream.send.pop(stream_len)?;
 
                 if stream_buf.is_empty() {
                     continue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1499,7 +1499,7 @@ impl Connection {
         }
 
         // Calculate available space in the packet based on congestion window.
-        let mut left:u64 = cmp::min(self.recovery.cwnd(), b.cap()) as u64;
+        let mut left: u64 = cmp::min(self.recovery.cwnd(), b.cap()) as u64;
 
         // Limit data sent by the server based on the amount of data received
         // from the client before its address is validated.
@@ -1766,7 +1766,8 @@ impl Connection {
             let pkt_len = pn_len + payload_len + overhead;
 
             let frame = frame::Frame::Padding {
-                len: cmp::min((MIN_CLIENT_INITIAL_LEN - pkt_len) as u64, left) as usize,
+                len: cmp::min((MIN_CLIENT_INITIAL_LEN - pkt_len) as u64, left)
+                    as usize,
             };
 
             payload_len += frame.wire_len();
@@ -3319,7 +3320,10 @@ mod tests {
         let server_sent =
             testing::recv_send(&mut pipe.server, &mut buf, client_sent).unwrap();
 
-        assert_eq!(server_sent, (client_sent - 1) * MAX_AMPLIFICATION_FACTOR as usize);
+        assert_eq!(
+            server_sent,
+            (client_sent - 1) * MAX_AMPLIFICATION_FACTOR as usize
+        );
     }
 
     #[test]

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -653,8 +653,7 @@ impl PktNumSpace {
     }
 
     pub fn clear(&mut self) {
-        self.crypto_stream =
-            stream::Stream::new(std::u64::MAX, std::u64::MAX);
+        self.crypto_stream = stream::Stream::new(std::u64::MAX, std::u64::MAX);
 
         self.ack_elicited = false;
     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -648,13 +648,13 @@ impl PktNumSpace {
             crypto_open: None,
             crypto_seal: None,
 
-            crypto_stream: stream::Stream::new(std::usize::MAX, std::usize::MAX),
+            crypto_stream: stream::Stream::new(std::u64::MAX, std::u64::MAX),
         }
     }
 
     pub fn clear(&mut self) {
         self.crypto_stream =
-            stream::Stream::new(std::usize::MAX, std::usize::MAX);
+            stream::Stream::new(std::u64::MAX, std::u64::MAX);
 
         self.ack_elicited = false;
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -144,7 +144,7 @@ impl StreamMap {
                             .ok_or(Error::StreamLimit)?,
                 };
 
-                let s = Stream::new(max_rx_data as usize, max_tx_data as usize);
+                let s = Stream::new(max_rx_data, max_tx_data);
                 v.insert(s)
             },
 
@@ -228,7 +228,7 @@ pub struct Stream {
 
 impl Stream {
     /// Creates a new stream with the given flow control limits.
-    pub fn new(max_rx_data: usize, max_tx_data: usize) -> Stream {
+    pub fn new(max_rx_data: u64, max_tx_data: u64) -> Stream {
         Stream {
             recv: RecvBuf::new(max_rx_data),
             send: SendBuf::new(max_tx_data),
@@ -300,19 +300,19 @@ pub struct RecvBuf {
     data: BinaryHeap<RangeBuf>,
 
     /// The lowest data offset that has yet to be read by the application.
-    off: usize,
+    off: u64,
 
     /// The total length of data received on this stream.
     len: usize,
 
     /// The maximum offset the peer is allowed to send us.
-    max_data: usize,
+    max_data: u64,
 
     /// The updated maximum offset the peer is allowed to send us.
-    max_data_next: usize,
+    max_data_next: u64,
 
     /// The final stream offset received from the peer, if any.
-    fin_off: Option<usize>,
+    fin_off: Option<u64>,
 
     /// Whether incoming data is validated but not buffered.
     drain: bool,
@@ -320,7 +320,7 @@ pub struct RecvBuf {
 
 impl RecvBuf {
     /// Creates a new receive buffer.
-    fn new(max_data: usize) -> RecvBuf {
+    fn new(max_data: u64) -> RecvBuf {
         RecvBuf {
             max_data,
             max_data_next: max_data,
@@ -351,7 +351,7 @@ impl RecvBuf {
         }
 
         // Stream's known size is lower than data already received.
-        if buf.fin() && buf.max_off() < self.len {
+        if buf.fin() && buf.max_off() < self.len as u64 {
             return Err(Error::FinalSize);
         }
 
@@ -400,16 +400,16 @@ impl RecvBuf {
 
                 // New buffer's start overlaps existing buffer.
                 if buf.off() >= b.off() && buf.off() < b.max_off() {
-                    buf = buf.split_off(b.max_off() - buf.off());
+                    buf = buf.split_off((b.max_off() - buf.off()) as usize);
                 }
 
                 // New buffer's end overlaps existing buffer.
                 if buf.off() < b.off() && buf.max_off() > b.off() {
-                    tmp_buf = Some(buf.split_off(b.off() - buf.off()));
+                    tmp_buf = Some(buf.split_off((b.off() - buf.off()) as usize));
                 }
             }
 
-            self.len = cmp::max(self.len, buf.max_off());
+            self.len = cmp::max(self.len as u64, buf.max_off()) as usize;
 
             self.data.push(buf);
         }
@@ -443,7 +443,7 @@ impl RecvBuf {
             if buf.len() > cap {
                 let new_buf = RangeBuf {
                     data: buf.data.split_off(cap),
-                    off: buf.off + cap,
+                    off: buf.off + cap as u64,
                     fin: buf.fin,
                 };
 
@@ -454,19 +454,19 @@ impl RecvBuf {
 
             out[len..len + buf.len()].copy_from_slice(&buf.data);
 
-            self.off += buf.len();
+            self.off += buf.len() as u64;
 
             len += buf.len();
             cap -= buf.len();
         }
 
-        self.max_data_next = self.max_data_next.saturating_add(len);
+        self.max_data_next = self.max_data_next.saturating_add(len as u64);
 
         Ok((len, self.is_fin()))
     }
 
     /// Resets the stream at the given offset.
-    pub fn reset(&mut self, final_size: usize) -> Result<usize> {
+    pub fn reset(&mut self, final_size: u64) -> Result<usize> {
         // Stream's size is already known, forbid changing it.
         if let Some(fin_off) = self.fin_off {
             if fin_off != final_size {
@@ -475,7 +475,7 @@ impl RecvBuf {
         }
 
         // Stream's known size is lower than data already received.
-        if final_size < self.len {
+        if final_size < self.len as u64 {
             return Err(Error::FinalSize);
         }
 
@@ -483,11 +483,11 @@ impl RecvBuf {
 
         // Return how many bytes need to be removed from the connection flow
         // control.
-        Ok(final_size - self.len)
+        Ok((final_size - self.len as u64) as usize)
     }
 
     /// Commits the new max_data limit and returns it.
-    pub fn update_max_data(&mut self) -> usize {
+    pub fn update_max_data(&mut self) -> u64 {
         self.max_data = self.max_data_next;
 
         self.max_data
@@ -506,7 +506,7 @@ impl RecvBuf {
         // amount of data that can be received before blocking.
         self.fin_off.is_none() &&
             self.max_data_next != self.max_data &&
-            self.max_data_next / 2 > self.max_data - self.len
+            self.max_data_next / 2 > self.max_data - self.len as u64
     }
 
     /// Returns true if the receive-side of the stream is complete.
@@ -544,16 +544,16 @@ pub struct SendBuf {
     data: BinaryHeap<RangeBuf>,
 
     /// The maximum offset of data buffered in the stream.
-    off: usize,
+    off: u64,
 
     /// The amount of data that was ever written to this stream.
     len: usize,
 
     /// The maximum offset we are allowed to send to the peer.
-    max_data: usize,
+    max_data: u64,
 
     /// The highest contiguous ACK'd offset.
-    off_ack: usize,
+    off_ack: u64,
 
     /// Whether the stream's send-side has been shut down.
     shutdown: bool,
@@ -561,7 +561,7 @@ pub struct SendBuf {
 
 impl SendBuf {
     /// Creates a new send buffer.
-    fn new(max_data: usize) -> SendBuf {
+    fn new(max_data: u64) -> SendBuf {
         SendBuf {
             max_data,
             ..SendBuf::default()
@@ -592,7 +592,7 @@ impl SendBuf {
             let buf = RangeBuf::from(chunk, self.off, fin);
             self.push(buf)?;
 
-            self.off += chunk.len();
+            self.off += chunk.len() as u64;
         }
 
         Ok(())
@@ -617,9 +617,9 @@ impl SendBuf {
     }
 
     /// Returns contiguous data from the send buffer as a single `RangeBuf`.
-    pub fn pop(&mut self, max_data: usize) -> Result<RangeBuf> {
+    pub fn pop(&mut self, max_data: u64) -> Result<RangeBuf> {
         let mut out = RangeBuf::default();
-        out.data = Vec::with_capacity(cmp::min(max_data, self.len));
+        out.data = Vec::with_capacity(cmp::min(max_data, self.len as u64) as usize);
 
         let mut out_len = max_data;
         let mut out_off = self.data.peek().map_or_else(|| 0, RangeBuf::off);
@@ -634,8 +634,8 @@ impl SendBuf {
                 None => break,
             };
 
-            if buf.len() > out_len || buf.max_off() >= self.max_data {
-                let new_len = cmp::min(out_len, self.max_data - buf.off());
+            if buf.len() as u64 > out_len || buf.max_off() >= self.max_data {
+                let new_len = cmp::min(out_len, self.max_data - buf.off()) as usize;
                 let new_buf = buf.split_off(new_len);
 
                 self.data.push(new_buf);
@@ -647,7 +647,7 @@ impl SendBuf {
 
             self.len -= buf.len();
 
-            out_len -= buf.len();
+            out_len -= buf.len() as u64;
             out_off = buf.max_off();
 
             out.fin = out.fin || buf.fin();
@@ -659,17 +659,17 @@ impl SendBuf {
     }
 
     /// Updates the max_data limit to the given value.
-    pub fn update_max_data(&mut self, max_data: usize) {
+    pub fn update_max_data(&mut self, max_data: u64) {
         self.max_data = cmp::max(self.max_data, max_data);
     }
 
     /// Increments the ACK'd data offset.
-    pub fn ack(&mut self, off: usize, len: usize) {
+    pub fn ack(&mut self, off: u64, len: usize) {
         // Keep track of the highest contiguously ACK'd offset. This can be
         // used to avoid spurious retransmissions of data that has already
         // been ACK'd.
         if self.off_ack == off {
-            self.off_ack += len;
+            self.off_ack += len as u64;
         }
     }
 
@@ -686,7 +686,7 @@ impl SendBuf {
     }
 
     /// Returns the lowest offset of data buffered.
-    fn off(&self) -> usize {
+    fn off(&self) -> u64 {
         match self.data.peek() {
             Some(v) => v.off(),
 
@@ -699,13 +699,13 @@ impl SendBuf {
 #[derive(Clone, Debug, Default, Eq)]
 pub struct RangeBuf {
     data: Vec<u8>,
-    off: usize,
+    off: u64,
     fin: bool,
 }
 
 impl RangeBuf {
     /// Creates a new `RangeBuf` from the given slice.
-    pub(crate) fn from(buf: &[u8], off: usize, fin: bool) -> RangeBuf {
+    pub(crate) fn from(buf: &[u8], off: u64, fin: bool) -> RangeBuf {
         RangeBuf {
             data: Vec::from(buf),
             off,
@@ -719,13 +719,13 @@ impl RangeBuf {
     }
 
     /// Returns the starting offset of `self`.
-    pub fn off(&self) -> usize {
+    pub fn off(&self) -> u64 {
         self.off
     }
 
     /// Returns the final offset of `self`.
-    pub fn max_off(&self) -> usize {
-        self.off() + self.len()
+    pub fn max_off(&self) -> u64 {
+        self.off() + self.len() as u64
     }
 
     /// Returns the length of `self`.
@@ -742,7 +742,7 @@ impl RangeBuf {
     pub fn split_off(&mut self, at: usize) -> RangeBuf {
         let buf = RangeBuf {
             data: self.data.split_off(at),
-            off: self.off + at,
+            off: self.off + at as u64,
             fin: self.fin,
         };
 
@@ -791,7 +791,7 @@ mod tests {
 
     #[test]
     fn empty_read() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -857,7 +857,7 @@ mod tests {
 
     #[test]
     fn ordered_read() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -894,7 +894,7 @@ mod tests {
 
     #[test]
     fn split_read() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -934,7 +934,7 @@ mod tests {
 
     #[test]
     fn incomplete_read() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -962,7 +962,7 @@ mod tests {
 
     #[test]
     fn zero_len_read() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -990,7 +990,7 @@ mod tests {
 
     #[test]
     fn past_read() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1029,7 +1029,7 @@ mod tests {
 
     #[test]
     fn fully_overlapping_read() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1060,7 +1060,7 @@ mod tests {
 
     #[test]
     fn fully_overlapping_read2() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1091,7 +1091,7 @@ mod tests {
 
     #[test]
     fn fully_overlapping_read3() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1122,7 +1122,7 @@ mod tests {
 
     #[test]
     fn fully_overlapping_read_multi() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1159,7 +1159,7 @@ mod tests {
 
     #[test]
     fn overlapping_start_read() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1189,7 +1189,7 @@ mod tests {
 
     #[test]
     fn overlapping_end_read() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1219,7 +1219,7 @@ mod tests {
 
     #[test]
     fn partially_multi_overlapping_reordered_read() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1256,7 +1256,7 @@ mod tests {
 
     #[test]
     fn partially_multi_overlapping_reordered_read2() {
-        let mut recv = RecvBuf::new(std::usize::MAX);
+        let mut recv = RecvBuf::new(std::u64::MAX);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1311,17 +1311,17 @@ mod tests {
 
     #[test]
     fn empty_write() {
-        let mut send = SendBuf::new(std::usize::MAX);
+        let mut send = SendBuf::new(std::u64::MAX);
         assert_eq!(send.len, 0);
 
-        let write = send.pop(std::usize::MAX).unwrap();
+        let write = send.pop(std::u64::MAX).unwrap();
         assert_eq!(write.len(), 0);
         assert_eq!(write.fin(), false);
     }
 
     #[test]
     fn multi_write() {
-        let mut send = SendBuf::new(std::usize::MAX);
+        let mut send = SendBuf::new(std::u64::MAX);
         assert_eq!(send.len, 0);
 
         let first = *b"something";
@@ -1342,7 +1342,7 @@ mod tests {
 
     #[test]
     fn split_write() {
-        let mut send = SendBuf::new(std::usize::MAX);
+        let mut send = SendBuf::new(std::u64::MAX);
         assert_eq!(send.len, 0);
 
         let first = *b"something";
@@ -1378,7 +1378,7 @@ mod tests {
 
     #[test]
     fn resend() {
-        let mut send = SendBuf::new(std::usize::MAX);
+        let mut send = SendBuf::new(std::u64::MAX);
         assert_eq!(send.len, 0);
         assert_eq!(send.off(), 0);
 
@@ -1491,7 +1491,7 @@ mod tests {
 
     #[test]
     fn zero_len_write() {
-        let mut send = SendBuf::new(std::usize::MAX);
+        let mut send = SendBuf::new(std::u64::MAX);
         assert_eq!(send.len, 0);
 
         let first = *b"something";

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -619,7 +619,8 @@ impl SendBuf {
     /// Returns contiguous data from the send buffer as a single `RangeBuf`.
     pub fn pop(&mut self, max_data: u64) -> Result<RangeBuf> {
         let mut out = RangeBuf::default();
-        out.data = Vec::with_capacity(cmp::min(max_data, self.len as u64) as usize);
+        out.data =
+            Vec::with_capacity(cmp::min(max_data, self.len as u64) as usize);
 
         let mut out_len = max_data;
         let mut out_off = self.data.peek().map_or_else(|| 0, RangeBuf::off);
@@ -635,7 +636,8 @@ impl SendBuf {
             };
 
             if buf.len() as u64 > out_len || buf.max_off() >= self.max_data {
-                let new_len = cmp::min(out_len, self.max_data - buf.off()) as usize;
+                let new_len =
+                    cmp::min(out_len, self.max_data - buf.off()) as usize;
                 let new_buf = buf.split_off(new_len);
 
                 self.data.push(new_buf);


### PR DESCRIPTION
Current quiche master is not working at 32bit OS.

Here is a simple test result in x86 Debian:

```
% uname
Linux buster32 4.19.0-5-686-pae #1 SMP Debian 4.19.37-5+deb10u1 (2019-07-19) i686 GNU/Linux
```

`cargo build` runs successfully, however `cargo test` fails:

```
test result: FAILED. 129 passed; 46 failed; 0 ignored; 0 measured; 0 filtered out
```

Also `http3-client` fails at runtime

```
$ target/debug/examples/http3-client https://cloudflare-quic.com
thread 'main' panicked at 'attempt to multiply with overflow', /usr/src/rustc-1.34.2/src/libcore/num/mod.rs:3516:24
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

In above case, main issue is in `src/frame.rs:863`, where `2usize.pow(62)` overflows in 32bit platform (`usize` is 32bit in 32bit OS). However, since `usize` is used for stream offset, which makes offset calculation is limited to 32bit where QUIC spec requires bigger integer.

This patch mainly changes stream offset and other related parameter (e.g. `max_data` related which specifies stream size) to `u64` and fix for related codes. Type conversion is done for `usize` to `u64` not to lose bits.

Result:
Tested in x86 (Debian Buster) and x86-64 (Debian Stretch) has no test failures and http3-client successfully download the URL.


