### PR TITLE
Fix ssize_t fmt in C examples

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -71,7 +71,7 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
         }
 
         if (written < 0) {
-            fprintf(stderr, "failed to create packet: %ld\n", written);
+            fprintf(stderr, "failed to create packet: %zd\n", written);
             return;
         }
 
@@ -81,7 +81,7 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
             return;
         }
 
-        fprintf(stderr, "sent %lu bytes\n", sent);
+        fprintf(stderr, "sent %zd bytes\n", sent);
     }
 
     double t = quiche_conn_timeout_as_nanos(conn_io->conn) / 1e9f;
@@ -121,7 +121,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
             return;
         }
 
-        fprintf(stderr, "recv %lu bytes\n", done);
+        fprintf(stderr, "recv %zd bytes\n", done);
     }
 
     if (quiche_conn_is_closed(conn_io->conn)) {

--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -72,7 +72,7 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
         }
 
         if (written < 0) {
-            fprintf(stderr, "failed to create packet: %ld\n", written);
+            fprintf(stderr, "failed to create packet: %zd\n", written);
             return;
         }
 
@@ -82,7 +82,7 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
             return;
         }
 
-        fprintf(stderr, "sent %lu bytes\n", sent);
+        fprintf(stderr, "sent %zd bytes\n", sent);
     }
 
     double t = quiche_conn_timeout_as_nanos(conn_io->conn) / 1e9f;
@@ -127,11 +127,11 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
         }
 
         if (done < 0) {
-            fprintf(stderr, "failed to process packet: %ld\n", done);
+            fprintf(stderr, "failed to process packet: %zd\n", done);
             return;
         }
 
-        fprintf(stderr, "recv %lu bytes\n", done);
+        fprintf(stderr, "recv %zd bytes\n", done);
     }
 
     if (quiche_conn_is_closed(conn_io->conn)) {

--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -98,7 +98,7 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
         }
 
         if (written < 0) {
-            fprintf(stderr, "failed to create packet: %ld\n", written);
+            fprintf(stderr, "failed to create packet: %zd\n", written);
             return;
         }
 
@@ -110,7 +110,7 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
             return;
         }
 
-        fprintf(stderr, "sent %lu bytes\n", sent);
+        fprintf(stderr, "sent %zd bytes\n", sent);
     }
 
     double t = quiche_conn_timeout_as_nanos(conn_io->conn) / 1e9f;
@@ -263,7 +263,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                                                            out, sizeof(out));
 
                 if (written < 0) {
-                    fprintf(stderr, "failed to create vneg packet: %ld\n",
+                    fprintf(stderr, "failed to create vneg packet: %zd\n",
                             written);
                     return;
                 }
@@ -276,7 +276,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                     return;
                 }
 
-                fprintf(stderr, "sent %lu bytes\n", sent);
+                fprintf(stderr, "sent %zd bytes\n", sent);
                 return;
             }
 
@@ -293,7 +293,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                                                out, sizeof(out));
 
                 if (written < 0) {
-                    fprintf(stderr, "failed to create retry packet: %ld\n",
+                    fprintf(stderr, "failed to create retry packet: %zd\n",
                             written);
                     return;
                 }
@@ -306,7 +306,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                     return;
                 }
 
-                fprintf(stderr, "sent %lu bytes\n", sent);
+                fprintf(stderr, "sent %zd bytes\n", sent);
                 return;
             }
 
@@ -334,11 +334,11 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
         }
 
         if (done < 0) {
-            fprintf(stderr, "failed to process packet: %ld\n", done);
+            fprintf(stderr, "failed to process packet: %zd\n", done);
             return;
         }
 
-        fprintf(stderr, "recv %lu bytes\n", done);
+        fprintf(stderr, "recv %zd bytes\n", done);
 
         if (quiche_conn_is_established(conn_io->conn)) {
             quiche_h3_event *ev;

--- a/examples/server.c
+++ b/examples/server.c
@@ -96,7 +96,7 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
         }
 
         if (written < 0) {
-            fprintf(stderr, "failed to create packet: %ld\n", written);
+            fprintf(stderr, "failed to create packet: %zd\n", written);
             return;
         }
 
@@ -108,7 +108,7 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
             return;
         }
 
-        fprintf(stderr, "sent %lu bytes\n", sent);
+        fprintf(stderr, "sent %zd bytes\n", sent);
     }
 
     double t = quiche_conn_timeout_as_nanos(conn_io->conn) / 1e9f;
@@ -252,7 +252,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                                                            out, sizeof(out));
 
                 if (written < 0) {
-                    fprintf(stderr, "failed to create vneg packet: %ld\n",
+                    fprintf(stderr, "failed to create vneg packet: %zd\n",
                             written);
                     return;
                 }
@@ -265,7 +265,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                     return;
                 }
 
-                fprintf(stderr, "sent %lu bytes\n", sent);
+                fprintf(stderr, "sent %zd bytes\n", sent);
                 return;
             }
 
@@ -282,7 +282,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                                                out, sizeof(out));
 
                 if (written < 0) {
-                    fprintf(stderr, "failed to create retry packet: %ld\n",
+                    fprintf(stderr, "failed to create retry packet: %zd\n",
                             written);
                     return;
                 }
@@ -295,7 +295,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                     return;
                 }
 
-                fprintf(stderr, "sent %lu bytes\n", sent);
+                fprintf(stderr, "sent %zd bytes\n", sent);
                 return;
             }
 
@@ -323,11 +323,11 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
         }
 
         if (done < 0) {
-            fprintf(stderr, "failed to process packet: %ld\n", done);
+            fprintf(stderr, "failed to process packet: %zd\n", done);
             return;
         }
 
-        fprintf(stderr, "recv %lu bytes\n", done);
+        fprintf(stderr, "recv %zd bytes\n", done);
 
         if (quiche_conn_is_established(conn_io->conn)) {
             uint64_t s = 0;


### PR DESCRIPTION
For `ssize_t` type, use `%zd` in C example. It will remove compile warning/error.
Test in the following platforms:

- cc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516 (x86-64)
- cc (Debian 8.3.0-6) 8.3.0 (x86)
- Apple LLVM version 10.0.1 (clang-1001.0.46.4) Target: x86_64-apple-darwin18.6.0
