### PR TITLE
crypto: update to ring 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cmake = "0.1"
 [dependencies]
 log = "0.4"
 libc = "0.2"
-ring = "0.14"
+ring = "0.16"
 lazy_static = "1"
 
 [target."cfg(windows)".dependencies]


### PR DESCRIPTION
Both HKDF and AEAD APIs changed quite significantly, unfortunately not
always for the better (see e.g. the hack to make the HKDF expand()
function accept an arbitrary length, or the fact that we now need to
manually append the AEAD tag to a sealed message).