### PR TITLE
stream: simplify the Readable iterator

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -154,7 +154,9 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
     if (quiche_conn_is_established(conn_io->conn)) {
         uint64_t s = 0;
 
-        while (quiche_readable_next(conn_io->conn, &s)) {
+        quiche_readable *readable = quiche_conn_readable(conn_io->conn);
+
+        while (quiche_readable_next(readable, &s)) {
             fprintf(stderr, "stream %" PRIu64 " is readable\n", s);
 
             bool fin = false;
@@ -173,6 +175,8 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                 }
             }
         }
+
+        quiche_readable_free(readable);
     }
 
     flush_egress(loop, conn_io);

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -224,8 +224,7 @@ fn main() {
         }
 
         // Process all readable streams.
-        let streams: Vec<u64> = conn.readable().collect();
-        for s in streams {
+        for s in conn.readable() {
             while let Ok((read, fin)) = conn.stream_recv(s, &mut buf) {
                 debug!("received {} bytes", read);
 

--- a/examples/server.c
+++ b/examples/server.c
@@ -332,7 +332,9 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
         if (quiche_conn_is_established(conn_io->conn)) {
             uint64_t s = 0;
 
-            while (quiche_readable_next(conn_io->conn, &s)) {
+            quiche_readable *readable = quiche_conn_readable(conn_io->conn);
+
+            while (quiche_readable_next(readable, &s)) {
                 fprintf(stderr, "stream %" PRIu64 " is readable\n", s);
 
                 bool fin = false;
@@ -349,6 +351,8 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                                             5, true);
                 }
             }
+
+            quiche_readable_free(readable);
         }
     }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -281,8 +281,7 @@ fn main() {
 
             if conn.is_established() {
                 // Process all readable streams.
-                let streams: Vec<u64> = conn.readable().collect();
-                for s in streams {
+                for s in conn.readable() {
                     while let Ok((read, fin)) = conn.stream_recv(s, &mut buf) {
                         debug!("{} received {} bytes", conn.trace_id(), read);
 

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -228,10 +228,6 @@ int quiche_conn_stream_shutdown(quiche_conn *conn, uint64_t stream_id,
 // Returns true if all the data has been read from the specified stream.
 bool quiche_conn_stream_finished(quiche_conn *conn, uint64_t stream_id);
 
-// Fetches the next stream that has outstanding data to read. Returns false if
-// there are no readable streams.
-bool quiche_readable_next(quiche_conn *conn, uint64_t *stream_id);
-
 // Returns the amount of time until the next timeout event, as nanoseconds.
 uint64_t quiche_conn_timeout_as_nanos(quiche_conn *conn);
 
@@ -251,6 +247,18 @@ bool quiche_conn_is_established(quiche_conn *conn);
 
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);
+
+typedef struct Readable quiche_readable;
+
+// Returns an iterator over streams that have outstanding data to read.
+quiche_readable *quiche_conn_readable(quiche_conn *conn);
+
+// Fetches the next stream from the given iterator. Returns false if there are
+// no more elements in the iterator.
+bool quiche_readable_next(quiche_readable *readable, uint64_t *stream_id);
+
+// Frees the readable iterator object.
+void quiche_readable_free(quiche_readable *readable);
 
 typedef struct {
     // The number of QUIC packets received on this connection.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -461,18 +461,6 @@ pub extern fn quiche_conn_stream_finished(
 }
 
 #[no_mangle]
-pub extern fn quiche_readable_next(
-    conn: &mut Connection, stream_id: *mut u64,
-) -> bool {
-    if let Some(v) = conn.readable().next() {
-        unsafe { *stream_id = v };
-        return true;
-    }
-
-    false
-}
-
-#[no_mangle]
 pub extern fn quiche_conn_close(
     conn: &mut Connection, app: bool, err: u64, reason: *const u8,
     reason_len: size_t,
@@ -518,6 +506,28 @@ pub extern fn quiche_conn_is_established(conn: &mut Connection) -> bool {
 #[no_mangle]
 pub extern fn quiche_conn_is_closed(conn: &mut Connection) -> bool {
     conn.is_closed()
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_readable(conn: &Connection) -> *mut Readable {
+    Box::into_raw(Box::new(conn.readable()))
+}
+
+#[no_mangle]
+pub extern fn quiche_readable_next(
+    readable: &mut Readable, stream_id: *mut u64,
+) -> bool {
+    if let Some(v) = readable.next() {
+        unsafe { *stream_id = v };
+        return true;
+    }
+
+    false
+}
+
+#[no_mangle]
+pub extern fn quiche_readable_free(readable: *mut Readable) {
+    unsafe { Box::from_raw(readable) };
 }
 
 #[repr(C)]

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -757,10 +757,8 @@ impl Connection {
     /// [`send_body()`]: struct.Connection.html#method.send_body
     /// [`close()`]: ../struct.Connection.html#method.close
     pub fn poll(&mut self, conn: &mut super::Connection) -> Result<(u64, Event)> {
-        let streams: Vec<u64> = conn.readable().collect();
-
         // Process HTTP/3 data from readable streams.
-        for s in streams {
+        for s in conn.readable() {
             trace!("{} stream id {} is readable", conn.trace_id(), s);
 
             match self.handle_stream(conn, s) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2019,7 +2019,7 @@ impl Connection {
         stream.recv.is_fin()
     }
 
-    /// Creates an iterator over streams that have outstanding data to read.
+    /// Returns an iterator over streams that have outstanding data to read.
     ///
     /// ## Examples:
     ///
@@ -2030,9 +2030,7 @@ impl Connection {
     /// # let scid = [0xba; 16];
     /// # let mut conn = quiche::accept(&scid, None, &mut config)?;
     /// // Iterate over readable streams.
-    /// let streams: Vec<u64> = conn.readable().collect();
-    ///
-    /// for stream_id in streams {
+    /// for stream_id in conn.readable() {
     ///     // Stream is readable, read until there's no more data.
     ///     while let Ok((read, fin)) = conn.stream_recv(stream_id, &mut buf) {
     ///         println!("Got {} bytes on stream {}", read, stream_id);
@@ -2040,7 +2038,7 @@ impl Connection {
     /// }
     /// # Ok::<(), quiche::Error>(())
     /// ```
-    pub fn readable(&mut self) -> Readable {
+    pub fn readable(&self) -> Readable {
         self.streams.readable()
     }
 


### PR DESCRIPTION
All users of Readable also do a collect() (otherwise they wouldn't be
able to reference the Connection while iterating), so we might as well
do it directly in the API, so we can simplify some code.

This also restores how the Readable iterator is accessed from FFI, to
before commit 67ee5f3b5dff7745abae130e8215ec7e977a5d10. The side effect
of that commit was that a user couldn't ignore a readable stream, and
every call to quiche_readable_next() would keep returning the same
stream. The new API makes it more consistent with Rust.