### PR TITLE
limit stream send buffer size

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -225,6 +225,8 @@ enum quiche_shutdown {
 int quiche_conn_stream_shutdown(quiche_conn *conn, uint64_t stream_id,
                                 enum quiche_shutdown direction, uint64_t err);
 
+ssize_t quiche_conn_stream_capacity(quiche_conn *conn, uint64_t stream_id);
+
 // Returns true if all the data has been read from the specified stream.
 bool quiche_conn_stream_finished(quiche_conn *conn, uint64_t stream_id);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -454,6 +454,17 @@ pub extern fn quiche_conn_stream_shutdown(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_stream_capacity(
+    conn: &mut Connection, stream_id: u64,
+) -> ssize_t {
+    match conn.stream_capacity(stream_id) {
+        Ok(v) => v as ssize_t,
+
+        Err(e) => e.to_c(),
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_stream_finished(
     conn: &mut Connection, stream_id: u64,
 ) -> bool {


### PR DESCRIPTION
In order to avoid buffering an infinite amount of data in the stream's
send buffer, we now only allow streams to buffer outgoing data up to the
amount that the peer allows us to send.

This also adds a new Connection method, stream_capacity() which can be
used by applications to know how much data they can write in advance.

This is required by the HTTP/3 code that needs to know the size of body
it can write in advance in order to set a proper size in the DATA frame
header. Without stream_capacity(), send_body() could potentially write
an incomplete DATA frame in the stream send buffer which would be
complicated to recover from.

---

TODO:
- [x] Merge #124.
- [x] Update server examples to resume sending data after stream is blocked (requires #124).