### PR TITLE
stream: implement Writable iterator

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -260,6 +260,18 @@ bool quiche_readable_next(quiche_readable *readable, uint64_t *stream_id);
 // Frees the readable iterator object.
 void quiche_readable_free(quiche_readable *readable);
 
+typedef struct Writable quiche_writable;
+
+// Returns an iterator over streams that can be written to.
+quiche_writable *quiche_conn_writable(quiche_conn *conn);
+
+// Fetches the next stream from the given iterator. Returns false if there are
+// no more elements in the iterator.
+bool quiche_writable_next(quiche_writable *writable, uint64_t *stream_id);
+
+// Frees the writable iterator object.
+void quiche_writable_free(quiche_writable *writable);
+
 typedef struct {
     // The number of QUIC packets received on this connection.
     size_t recv;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -530,6 +530,28 @@ pub extern fn quiche_readable_free(readable: *mut Readable) {
     unsafe { Box::from_raw(readable) };
 }
 
+#[no_mangle]
+pub extern fn quiche_conn_writable(conn: &Connection) -> *mut Writable {
+    Box::into_raw(Box::new(conn.writable()))
+}
+
+#[no_mangle]
+pub extern fn quiche_writable_next(
+    writable: &mut Writable, stream_id: *mut u64,
+) -> bool {
+    if let Some(v) = writable.next() {
+        unsafe { *stream_id = v };
+        return true;
+    }
+
+    false
+}
+
+#[no_mangle]
+pub extern fn quiche_writable_free(writable: *mut Writable) {
+    unsafe { Box::from_raw(writable) };
+}
+
 #[repr(C)]
 pub struct Stats {
     pub recv: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4274,6 +4274,13 @@ mod tests {
         assert!(w.next().is_none());
 
         assert_eq!(w.len(), 0);
+
+        // Server finishes stream.
+        assert_eq!(pipe.server.stream_send(12, b"aaaaa", true), Ok(5));
+
+        let mut w = pipe.server.writable();
+        assert_eq!(w.next(), Some(8));
+        assert_eq!(w.next(), None);
     }
 
     #[test]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -293,6 +293,12 @@ impl Iterator for Readable {
     }
 }
 
+impl ExactSizeIterator for Readable {
+    fn len(&self) -> usize {
+        self.streams.len()
+    }
+}
+
 /// Receive-side stream buffer.
 ///
 /// Stream data received by the peer is buffered in a list of data chunks


### PR DESCRIPTION
This implements an iterator for writable streams, that is, streams that
have enough flow control capacity to be written to.

This can be used by applications to resume sending on streams that were
previously blocked by flow control.

---

This also renames the previous uses of "writable" to "flushable" to avoid confusion.

TODO:
- [x] Merge #119.
- [x] Add some tests.