### PR TITLE
Misc. build improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,12 @@ exclude = [
 ]
 
 [features]
-no_bssl = []
+default = ["boringssl-vendored"]
+
+boringssl-vendored = []
 
 [package.metadata.docs.rs]
-features = ["no_bssl"]
+default-features = false
 
 [build-dependencies]
 cmake = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ ring = "0.16"
 lazy_static = "1"
 
 [target."cfg(windows)".dependencies]
-winapi = {version = "0.3", features = ["wincrypt"] }
+winapi = { version = "0.3", features = ["wincrypt"] }
 
 [dev-dependencies]
 mio = "0.6"

--- a/src/build.rs
+++ b/src/build.rs
@@ -121,7 +121,7 @@ fn get_boringssl_cmake_config() -> cmake::Config {
 }
 
 fn main() {
-    if !cfg!(feature = "no_bssl") {
+    if cfg!(feature = "boringssl-vendored") {
         let bssl_dir = std::env::var("QUICHE_BSSL_PATH").unwrap_or_else(|_| {
             get_boringssl_cmake_config()
                 .build_target("bssl")


### PR DESCRIPTION
This replaces the non-default `no_bssl` feature with a default `boringssl-vendored` one (so the logic is inverted: no_bssl disables building bssl when enabled, but boringssl-vendored _enables_ building bssl when enabled). This makes more sense to me, as we build for BoringSSL even with `no_bssl`, it's just that we don't build BoringSSL itself.

This also contains a bunch of other minor build tweaks.