### PR TITLE
build: add feature to generate pkg-config metadata file at build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,11 @@ exclude = [
 [features]
 default = ["boringssl-vendored"]
 
+# Build vendored BoringSSL library.
 boringssl-vendored = []
+
+# Generate pkg-config metadata file for libquiche.
+pkg-config-meta = []
 
 [package.metadata.docs.rs]
 default-features = false


### PR DESCRIPTION
This is a bit of a hack, but cargo doesn't exactly make this easy.

This can be used to build exernal projects that use libquiche.{a,so}
(e.g. curl) without having to hard-code paths.

To enable it, pass "--features pkg-config-meta" to cargo build.