### PR TITLE
stream: merge Readable and Writable into StreamIter

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -154,9 +154,9 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
     if (quiche_conn_is_established(conn_io->conn)) {
         uint64_t s = 0;
 
-        quiche_readable *readable = quiche_conn_readable(conn_io->conn);
+        quiche_stream_iter *readable = quiche_conn_readable(conn_io->conn);
 
-        while (quiche_readable_next(readable, &s)) {
+        while (quiche_stream_iter_next(readable, &s)) {
             fprintf(stderr, "stream %" PRIu64 " is readable\n", s);
 
             bool fin = false;
@@ -176,7 +176,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
             }
         }
 
-        quiche_readable_free(readable);
+        quiche_stream_iter_free(readable);
     }
 
     flush_egress(loop, conn_io);

--- a/examples/server.c
+++ b/examples/server.c
@@ -332,9 +332,9 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
         if (quiche_conn_is_established(conn_io->conn)) {
             uint64_t s = 0;
 
-            quiche_readable *readable = quiche_conn_readable(conn_io->conn);
+            quiche_stream_iter *readable = quiche_conn_readable(conn_io->conn);
 
-            while (quiche_readable_next(readable, &s)) {
+            while (quiche_stream_iter_next(readable, &s)) {
                 fprintf(stderr, "stream %" PRIu64 " is readable\n", s);
 
                 bool fin = false;
@@ -352,7 +352,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                 }
             }
 
-            quiche_readable_free(readable);
+            quiche_stream_iter_free(readable);
         }
     }
 

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -228,6 +228,14 @@ int quiche_conn_stream_shutdown(quiche_conn *conn, uint64_t stream_id,
 // Returns true if all the data has been read from the specified stream.
 bool quiche_conn_stream_finished(quiche_conn *conn, uint64_t stream_id);
 
+typedef struct StreamIter quiche_stream_iter;
+
+// Returns an iterator over streams that have outstanding data to read.
+quiche_stream_iter *quiche_conn_readable(quiche_conn *conn);
+
+// Returns an iterator over streams that can be written to.
+quiche_stream_iter *quiche_conn_writable(quiche_conn *conn);
+
 // Returns the amount of time until the next timeout event, as nanoseconds.
 uint64_t quiche_conn_timeout_as_nanos(quiche_conn *conn);
 
@@ -248,29 +256,12 @@ bool quiche_conn_is_established(quiche_conn *conn);
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);
 
-typedef struct Readable quiche_readable;
-
-// Returns an iterator over streams that have outstanding data to read.
-quiche_readable *quiche_conn_readable(quiche_conn *conn);
-
 // Fetches the next stream from the given iterator. Returns false if there are
 // no more elements in the iterator.
-bool quiche_readable_next(quiche_readable *readable, uint64_t *stream_id);
+bool quiche_stream_iter_next(quiche_stream_iter *iter, uint64_t *stream_id);
 
-// Frees the readable iterator object.
-void quiche_readable_free(quiche_readable *readable);
-
-typedef struct Writable quiche_writable;
-
-// Returns an iterator over streams that can be written to.
-quiche_writable *quiche_conn_writable(quiche_conn *conn);
-
-// Fetches the next stream from the given iterator. Returns false if there are
-// no more elements in the iterator.
-bool quiche_writable_next(quiche_writable *writable, uint64_t *stream_id);
-
-// Frees the writable iterator object.
-void quiche_writable_free(quiche_writable *writable);
+// Frees the given stream iterator object.
+void quiche_stream_iter_free(quiche_stream_iter *iter);
 
 typedef struct {
     // The number of QUIC packets received on this connection.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -461,6 +461,16 @@ pub extern fn quiche_conn_stream_finished(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_readable(conn: &Connection) -> *mut StreamIter {
+    Box::into_raw(Box::new(conn.readable()))
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_writable(conn: &Connection) -> *mut StreamIter {
+    Box::into_raw(Box::new(conn.writable()))
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_close(
     conn: &mut Connection, app: bool, err: u64, reason: *const u8,
     reason_len: size_t,
@@ -509,15 +519,10 @@ pub extern fn quiche_conn_is_closed(conn: &mut Connection) -> bool {
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_readable(conn: &Connection) -> *mut Readable {
-    Box::into_raw(Box::new(conn.readable()))
-}
-
-#[no_mangle]
-pub extern fn quiche_readable_next(
-    readable: &mut Readable, stream_id: *mut u64,
+pub extern fn quiche_stream_iter_next(
+    iter: &mut StreamIter, stream_id: *mut u64,
 ) -> bool {
-    if let Some(v) = readable.next() {
+    if let Some(v) = iter.next() {
         unsafe { *stream_id = v };
         return true;
     }
@@ -526,30 +531,8 @@ pub extern fn quiche_readable_next(
 }
 
 #[no_mangle]
-pub extern fn quiche_readable_free(readable: *mut Readable) {
-    unsafe { Box::from_raw(readable) };
-}
-
-#[no_mangle]
-pub extern fn quiche_conn_writable(conn: &Connection) -> *mut Writable {
-    Box::into_raw(Box::new(conn.writable()))
-}
-
-#[no_mangle]
-pub extern fn quiche_writable_next(
-    writable: &mut Writable, stream_id: *mut u64,
-) -> bool {
-    if let Some(v) = writable.next() {
-        unsafe { *stream_id = v };
-        return true;
-    }
-
-    false
-}
-
-#[no_mangle]
-pub extern fn quiche_writable_free(writable: *mut Writable) {
-    unsafe { Box::from_raw(writable) };
+pub extern fn quiche_stream_iter_free(iter: *mut StreamIter) {
+    unsafe { Box::from_raw(iter) };
 }
 
 #[repr(C)]


### PR DESCRIPTION
As @nqv pointed out in https://github.com/cloudflare/quiche/pull/124#issuecomment-522730990
they are basically the same structure, so there's no need to duplicate
them.