### PR TITLE
h3: make GREASE numbers more uniform

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -1400,7 +1400,7 @@ impl Connection {
 
 /// Generates an HTTP/3 GREASE variable length integer.
 fn grease_value() -> u64 {
-    let n = std::cmp::min(super::rand::rand_u64(), 148_764_065_110_560_899);
+    let n = super::rand::rand_u64_uniform(148_764_065_110_560_899);
     31 * n + 33
 }
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -47,6 +47,19 @@ pub fn rand_u64() -> u64 {
     u64::from_ne_bytes(buf)
 }
 
+pub fn rand_u64_uniform(max: u64) -> u64 {
+    let chunk_size = u64::max_value() / max;
+    let end_of_last_chunk = chunk_size * max;
+
+    let mut r = rand_u64();
+
+    while r >= end_of_last_chunk {
+        r = super::rand::rand_u64();
+    }
+
+    r / chunk_size
+}
+
 extern {
     fn RAND_bytes(buf: *mut u8, len: libc::size_t) -> libc::c_int;
 }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -54,7 +54,7 @@ pub fn rand_u64_uniform(max: u64) -> u64 {
     let mut r = rand_u64();
 
     while r >= end_of_last_chunk {
-        r = super::rand::rand_u64();
+        r = rand_u64();
     }
 
     r / chunk_size


### PR DESCRIPTION
We've had many compliments during interop testing on our use of **very large values** when sending greasy things. The generation of these values is "uniform random" but the frequency of these compliments made me suspicious. I knocked together a quick dummy program to test things over 100000 iterations:

```
grease_value() on master
0.00020000020000019998'th percentile of data is 2251799813685247 with 2 samples
0.0005000005000005'th percentile of data is 4503599627370495 with 3 samples
0.001000001000001'th percentile of data is 9007199254740991 with 5 samples
0.0024000024000024'th percentile of data is 18014398509481983 with 14 samples
0.0051000051000051'th percentile of data is 36028797018963967 with 27 samples
0.011700011700011701'th percentile of data is 72057594037927935 with 66 samples
0.0237000237000237'th percentile of data is 144115188075855871 with 120 samples
0.0472000472000472'th percentile of data is 288230376151711743 with 235 samples
0.097000097000097'th percentile of data is 576460752303423487 with 498 samples
0.1968001968001968'th percentile of data is 1152921504606846975 with 998 samples
0.4031004031004031'th percentile of data is 2305843009213693951 with 2063 samples
100'th percentile of data is 4611686018427387903 with 995968 samples
```
this shows a _slight_ skew towards the maximum allowed value.

I substituted the `RAND_bytes()` call for a Rust random call, and the results start to look way more uniform (unfortunately I only captured 10000 iterations):

```
grease_value() alternative
0.030003000300030006'th percentile of data is 562949953421311 with 3 samples
0.040004000400040006'th percentile of data is 2251799813685247 with 1 samples
0.1000100010001'th percentile of data is 4503599627370495 with 6 samples
0.22002200220022'th percentile of data is 9007199254740991 with 12 samples
0.37003700370037007'th percentile of data is 18014398509481983 with 15 samples
0.8000800080008'th percentile of data is 36028797018963967 with 43 samples
1.69016901690169'th percentile of data is 72057594037927935 with 89 samples
3.2603260326032606'th percentile of data is 144115188075855871 with 157 samples
6.410641064106411'th percentile of data is 288230376151711743 with 315 samples
12.8012801280128'th percentile of data is 576460752303423487 with 639 samples
25.272527252725276'th percentile of data is 1152921504606846975 with 1247 samples
49.874987498749874'th percentile of data is 2305843009213693951 with 2460 samples
100'th percentile of data is 4611686018427387903 with 5012 samples
```

This should also shave a few bytes off requests/responses due to varints, but I doubt that is a major perf win.

If we prefer to use SSL library functions for proper uniformality, we either need more hand-rolled code, use [BN_rand_range](https://linux.die.net/man/3/bn_rand) or something else(?).