### PR TITLE
examples: validate the destination CID after retry

### DIFF
--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -262,6 +262,11 @@ fn main() {
                         continue;
                     }
 
+                    if scid.len() != hdr.dcid.len() {
+                        error!("Invalid destination connection ID");
+                        continue;
+                    }
+
                     // Reuse the source connection ID we sent in the Retry
                     // packet, instead of changing it again.
                     scid.copy_from_slice(&hdr.dcid);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -255,6 +255,11 @@ fn main() {
                         continue;
                     }
 
+                    if scid.len() != hdr.dcid.len() {
+                        error!("Invalid destination connection ID");
+                        continue;
+                    }
+
                     // Reuse the source connection ID we sent in the Retry
                     // packet, instead of changing it again.
                     scid.copy_from_slice(&hdr.dcid);


### PR DESCRIPTION
This fixes a potential crash if the client sends a DCID of different
size than what we expect.