### PR TITLE
ffi: add function to get timeout in milliseconds

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -238,8 +238,11 @@ quiche_stream_iter *quiche_conn_readable(quiche_conn *conn);
 // Returns an iterator over streams that can be written to.
 quiche_stream_iter *quiche_conn_writable(quiche_conn *conn);
 
-// Returns the amount of time until the next timeout event, as nanoseconds.
+// Returns the amount of time until the next timeout event, in nanoseconds.
 uint64_t quiche_conn_timeout_as_nanos(quiche_conn *conn);
+
+// Returns the amount of time until the next timeout event, in milliseconds.
+uint64_t quiche_conn_timeout_as_millis(quiche_conn *conn);
 
 // Processes a timeout event.
 void quiche_conn_on_timeout(quiche_conn *conn);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -505,6 +505,15 @@ pub extern fn quiche_conn_timeout_as_nanos(conn: &mut Connection) -> u64 {
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_timeout_as_millis(conn: &mut Connection) -> u64 {
+    match conn.timeout() {
+        Some(timeout) => timeout.as_millis() as u64,
+
+        None => std::u64::MAX,
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_on_timeout(conn: &mut Connection) {
     conn.on_timeout()
 }


### PR DESCRIPTION
This is just so applications don't have to do this manually.