### PR TITLE
stream application data API

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -270,6 +270,19 @@ bool quiche_conn_is_in_early_data(quiche_conn *conn);
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);
 
+// Initializes the stream's application data.
+//
+// Stream data can only be initialized once. Additional calls to this method
+// will fail.
+//
+// Note that the application is responsible for freeing the data.
+int quiche_conn_stream_init_application_data(quiche_conn *conn,
+                                             uint64_t stream_id,
+                                             void *data);
+
+// Returns the stream's application data, if any was initialized.
+void *quiche_conn_stream_application_data(quiche_conn *conn, uint64_t stream_id);
+
 // Fetches the next stream from the given iterator. Returns false if there are
 // no more elements in the iterator.
 bool quiche_stream_iter_next(quiche_stream_iter *iter, uint64_t *stream_id);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -498,6 +498,28 @@ pub extern fn quiche_conn_writable(conn: &Connection) -> *mut StreamIter {
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_stream_init_application_data(
+    conn: &mut Connection, stream_id: u64, data: *mut c_void,
+) -> c_int {
+    match conn.stream_init_application_data(stream_id, data) {
+        Ok(_) => 0,
+
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_stream_application_data(
+    conn: &mut Connection, stream_id: u64,
+) -> *mut c_void {
+    match conn.stream_application_data(stream_id) {
+        Some(v) => *v.downcast_mut::<*mut c_void>().unwrap(),
+
+        None => ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_close(
     conn: &mut Connection, app: bool, err: u64, reason: *const u8,
     reason_len: size_t,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -395,6 +395,9 @@ pub struct Stream {
 
     /// Whether the stream was created by the local endpoint.
     pub local: bool,
+
+    /// Application data.
+    pub data: Option<Box<dyn std::any::Any>>,
 }
 
 impl Stream {
@@ -407,6 +410,7 @@ impl Stream {
             send: SendBuf::new(max_tx_data),
             bidi,
             local,
+            data: None,
         }
     }
 


### PR DESCRIPTION
This allows applications to store stream-specific data inside quiche, so
as to avoid having to track streams by themselves.

One potential use-case was storing internal HTTP/3 stream state, so we
wouldn't need to keep separate streams maps for both transport and
HTTP/3 however the current structure of the HTTP/3 implementation does
not allow for this (due to cross-references that make borrow checker
sad). Though this can be useful for other applications.

Fixes #112.