### PR TITLE
h3: only send GREASE frames once per connection

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -523,6 +523,8 @@ pub struct Connection {
     max_push_id: u64,
 
     finished_streams: VecDeque<u64>,
+
+    frames_greased: bool,
 }
 
 impl Connection {
@@ -570,6 +572,8 @@ impl Connection {
             max_push_id: 0,
 
             finished_streams: VecDeque::new(),
+
+            frames_greased: false,
         })
     }
 
@@ -651,8 +655,9 @@ impl Connection {
 
         let header_block = self.encode_header_block(headers)?;
 
-        if conn.grease {
+        if !self.frames_greased && conn.grease {
             self.send_grease_frames(conn, stream_id)?;
+            self.frames_greased = true;
         }
 
         trace!(


### PR DESCRIPTION
The H3 code naively sends 2 GREASE frames every time HEADERS are sent. This is a bit of a waste because if the peer doesn't handle GREASE, it is likely to bomb out in the first instance. The savings are marginal but there seems little benefit in sending more than one set of GREASE frames.

Maths for H3-level savings:
1 GREASE frame with no payload = 8 bytes (worst case varint)
1 GREASE frame with "GREASE is the word" payload = 8 + 18 bytes (worst case varint)
Total: 34 bytes per HEADERS.