### PR TITLE
Use find instead of glob pattern

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -33,7 +33,7 @@ http3-client: http3-client.c $(INCLUDE_DIR)/quiche.h $(LIB_DIR)/libquiche.a
 http3-server: http3-server.c $(INCLUDE_DIR)/quiche.h $(LIB_DIR)/libquiche.a
 	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ $(INCS) $(LIBS)
 
-$(LIB_DIR)/libquiche.a: $(SOURCE_DIR)/**/*.rs
+$(LIB_DIR)/libquiche.a: $(shell find $(SOURCE_DIR) -name ".rs")
 	cd .. && cargo build --target-dir $(BUILD_DIR)
 
 clean:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -33,7 +33,7 @@ http3-client: http3-client.c $(INCLUDE_DIR)/quiche.h $(LIB_DIR)/libquiche.a
 http3-server: http3-server.c $(INCLUDE_DIR)/quiche.h $(LIB_DIR)/libquiche.a
 	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ $(INCS) $(LIBS)
 
-$(LIB_DIR)/libquiche.a: $(shell find $(SOURCE_DIR) -name ".rs")
+$(LIB_DIR)/libquiche.a: $(shell find $(SOURCE_DIR) -type f -name '*.rs')
 	cd .. && cargo build --target-dir $(BUILD_DIR)
 
 clean:


### PR DESCRIPTION
The glob pattern is not cross platform. At least not working in my Macbook. See [Stackoverflow question](https://stackoverflow.com/questions/4036191/sources-from-subdirectories-in-makefile).
Change it to `find` fix the problem.