### PR TITLE
Remove `set_max_level` of logger

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -70,7 +70,6 @@ pub extern fn quiche_enable_debug_logging(
     let logger = Box::new(Logger { cb, argp });
 
     log::set_boxed_logger(logger).unwrap();
-    log::set_max_level(log::LevelFilter::Trace);
 }
 
 #[no_mangle]


### PR DESCRIPTION
User is supposed to use `RUST_LOG` environment variable to config the log level. This function prevents that.