### PR TITLE
tools: http3_test detect client idle timeout

### DIFF
--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -31,6 +31,7 @@ pub fn run(
     verify_peer: bool,
 ) {
     const MAX_DATAGRAM_SIZE: usize = 1350;
+    const IDLE_TIMEOUT: u64 = 60000;
 
     let mut buf = [0; 65535];
     let mut out = [0; MAX_DATAGRAM_SIZE];
@@ -83,7 +84,7 @@ pub fn run(
         .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
         .unwrap();
 
-    config.set_idle_timeout(60000);
+    config.set_idle_timeout(IDLE_TIMEOUT);
     config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);
@@ -180,6 +181,12 @@ pub fn run(
 
         if conn.is_closed() {
             info!("connection closed, {:?}", conn.stats());
+
+            if reqs_complete != reqs_count {
+                panic!("Client timed out after {:?} and only completed {}/{} requests",
+                req_start.elapsed() , reqs_complete, reqs_count);
+            }
+
             break;
         }
 
@@ -305,6 +312,12 @@ pub fn run(
 
         if conn.is_closed() {
             info!("connection closed, {:?}", conn.stats());
+
+            if reqs_complete != reqs_count {
+                panic!("Client timed out after {:?} and only completed {}/{} requests",
+                req_start.elapsed() , reqs_complete, reqs_count);
+            }
+
             break;
         }
     }

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -184,7 +184,7 @@ pub fn run(
 
             if reqs_complete != reqs_count {
                 panic!("Client timed out after {:?} and only completed {}/{} requests",
-                req_start.elapsed() , reqs_complete, reqs_count);
+                req_start.elapsed(), reqs_complete, reqs_count);
             }
 
             break;
@@ -315,7 +315,7 @@ pub fn run(
 
             if reqs_complete != reqs_count {
                 panic!("Client timed out after {:?} and only completed {}/{} requests",
-                req_start.elapsed() , reqs_complete, reqs_count);
+                req_start.elapsed(), reqs_complete, reqs_count);
             }
 
             break;


### PR DESCRIPTION
Previously, the runner would appear to complete successfully if the
idle timeout triggered without all requests completing. Test
assertions are only done once all requests are complete so, if the
idle timeout is hit before then, just panic.

The downside of this is that it may reveal problems that were previously masked, but in the long term this is a good thing.

Finally, the idle timeout is quite generous in order to support the example httpbin integration test suite. We should probably parameterize it but I figure we can do that in a separate PR.