### PR TITLE
http3_tests: make idle timeout configurable in runner

### DIFF
--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -28,10 +28,9 @@ use ring::rand::*;
 
 pub fn run(
     test: &mut crate::Http3Test, peer_addr: std::net::SocketAddr,
-    verify_peer: bool,
+    verify_peer: bool, idle_timeout: u64,
 ) {
     const MAX_DATAGRAM_SIZE: usize = 1350;
-    const IDLE_TIMEOUT: u64 = 60000;
 
     let mut buf = [0; 65535];
     let mut out = [0; MAX_DATAGRAM_SIZE];
@@ -84,7 +83,7 @@ pub fn run(
         .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
         .unwrap();
 
-    config.set_idle_timeout(IDLE_TIMEOUT);
+    config.set_idle_timeout(idle_timeout);
     config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);

--- a/tools/http3_test/tests/httpbin_tests.rs
+++ b/tools/http3_test/tests/httpbin_tests.rs
@@ -59,6 +59,15 @@ mod httpbin_tests {
         };
     }
 
+    fn idle_timeout() -> u64 {
+        match std::env::var_os("IDLE_TIMEOUT") {
+            Some(val) =>
+                u64::from_str_radix(&val.into_string().unwrap(), 10).unwrap(),
+
+            None => 60000,
+        }
+    }
+
     // A rudimentary structure to hold httpbin response data
     #[derive(Debug, serde::Deserialize)]
     struct HttpBinResponseBody {
@@ -89,7 +98,7 @@ mod httpbin_tests {
         });
 
         let mut test = Http3Test::new(endpoint(None), reqs, assert, concurrent);
-        runner::run(&mut test, host(), verify_peer());
+        runner::run(&mut test, host(), verify_peer(), idle_timeout());
     }
 
     // Build a single request and expected response with status code


### PR DESCRIPTION
Adds a timeout parameter to `runner.rs` and a env var to httpbin_tests that exercises it.