### PR TITLE
Send (and receive) zero length STREAM frames with fin=true

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1576,11 +1576,16 @@ impl Connection {
 
                     let was_flushable = stream.is_flushable();
 
+                    let empty_fin = data.is_empty() && data.fin();
+
                     stream.send.push(data)?;
 
                     // If the stream is now flushable push it to the flushable
                     // queue, but only if it wasn't already queued.
-                    if stream.is_flushable() && !was_flushable {
+                    //
+                    // Consider the stream flushable also when we are sending a
+                    // zero-length frame that has the fin flag set.
+                    if (stream.is_flushable() || empty_fin) && !was_flushable {
                         self.streams.push_flushable(stream_id);
                     }
                 },
@@ -1859,7 +1864,7 @@ impl Connection {
 
                 let stream_buf = stream.send.pop(stream_len)?;
 
-                if stream_buf.is_empty() {
+                if stream_buf.is_empty() && !stream_buf.fin() {
                     continue;
                 }
 
@@ -2110,11 +2115,18 @@ impl Connection {
 
         let sent = stream.send.push_slice(buf, fin)?;
 
+        let flushable = stream.is_flushable();
+
         let writable = stream.is_writable();
+
+        let empty_fin = buf.is_empty() && fin;
 
         // If the stream is now flushable push it to the flushable queue, but
         // only if it wasn't already queued.
-        if stream.is_flushable() && !was_flushable {
+        //
+        // Consider the stream flushable also when we are sending a zero-length
+        // frame that has the fin flag set.
+        if (flushable || empty_fin) && !was_flushable {
             self.streams.push_flushable(stream_id);
         }
 
@@ -4727,6 +4739,54 @@ mod tests {
         );
 
         assert_eq!(pipe.server.readable().len(), 3);
+    }
+
+    #[test]
+    /// Tests that the stream's fin flag is properly flushed even if there's no
+    /// data in the buffer, and that the buffer becomes readable on the other
+    /// side.
+    fn stream_zero_length_fin() {
+        let mut buf = [0; 65535];
+
+        let mut pipe = testing::Pipe::default().unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        assert_eq!(
+            pipe.client.stream_send(0, b"aaaaaaaaaaaaaaa", false),
+            Ok(15)
+        );
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        let mut r = pipe.server.readable();
+        assert_eq!(r.next(), Some(0));
+        assert!(r.next().is_none());
+
+        let mut b = [0; 15];
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Client sends zero-length frame.
+        assert_eq!(pipe.client.stream_send(0, b"", true), Ok(0));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Stream should be readable on the server after receiving empty fin.
+        let mut r = pipe.server.readable();
+        assert_eq!(r.next(), Some(0));
+        assert!(r.next().is_none());
+
+        let mut b = [0; 15];
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Client sends zero-length frame (again).
+        assert_eq!(pipe.client.stream_send(0, b"", true), Ok(0));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Stream should _not_ be readable on the server after receiving empty
+        // fin, because it was already finished.
+        let mut r = pipe.server.readable();
+        assert_eq!(r.next(), None);
     }
 }
 


### PR DESCRIPTION
Make sure to flush STREAM frames with fin=true even if the stream has
otherwise no data to send. This requires marking the stream as
flushable when the application calls Connection::stream_send() with an
empty buffer, but fin=true.

In addition, on reception of empty STREAM frames with fin=true, make
sure that the stream is marked as readable, so the application can
receive the end of the stream.

---

TODO:
* [x] We shouldn't mark a stream as readable every time we get an empty STREAM frame with fin=true as it could be used as a DoS vector.

* [x] Find better ways to detect flushability and readability.

* [x] Handle zero-length STREAM retransmit case.

@LPardue this is pretty hacky, but it should fix the immediate problem. Can you check if you can still reproduce the problem you are seeing with this applied on both the client and tbe server?