### PR TITLE
increase local max streams limits with MAX_STREAMS 

### DIFF
--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -47,6 +47,7 @@ Options:
   --name <str>             Name of the server [default: quic.tech]
   --max-data BYTES         Connection-wide flow control limit [default: 10000000].
   --max-stream-data BYTES  Per-stream flow control limit [default: 1000000].
+  --max-streams STREAMS    Number of allowed concurrent streams [default: 100].
   --no-retry               Disable stateless retry.
   --no-grease              Don't send GREASE.
   -h --help                Show this screen.
@@ -86,6 +87,9 @@ fn main() {
     let max_stream_data = args.get_str("--max-stream-data");
     let max_stream_data = u64::from_str_radix(max_stream_data, 10).unwrap();
 
+    let max_streams = args.get_str("--max-streams");
+    let max_streams = u64::from_str_radix(max_streams, 10).unwrap();
+
     // Setup the event loop.
     let poll = mio::Poll::new().unwrap();
     let mut events = mio::Events::with_capacity(1024);
@@ -122,8 +126,8 @@ fn main() {
     config.set_initial_max_stream_data_bidi_local(max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(max_stream_data);
     config.set_initial_max_stream_data_uni(max_stream_data);
-    config.set_initial_max_streams_bidi(100);
-    config.set_initial_max_streams_uni(5);
+    config.set_initial_max_streams_bidi(max_streams);
+    config.set_initial_max_streams_uni(max_streams);
     config.set_disable_active_migration(true);
 
     if std::env::var_os("SSLKEYLOGFILE").is_some() {

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -40,17 +40,18 @@ const USAGE: &str = "Usage:
   http3-server -h | --help
 
 Options:
-  --listen <addr>          Listen on the given IP:port [default: 127.0.0.1:4433]
-  --cert <file>            TLS certificate path [default: examples/cert.crt]
-  --key <file>             TLS certificate key path [default: examples/cert.key]
-  --root <dir>             Root directory [default: examples/root/]
-  --name <str>             Name of the server [default: quic.tech]
-  --max-data BYTES         Connection-wide flow control limit [default: 10000000].
-  --max-stream-data BYTES  Per-stream flow control limit [default: 1000000].
-  --max-streams STREAMS    Number of allowed concurrent streams [default: 100].
-  --no-retry               Disable stateless retry.
-  --no-grease              Don't send GREASE.
-  -h --help                Show this screen.
+  --listen <addr>             Listen on the given IP:port [default: 127.0.0.1:4433]
+  --cert <file>               TLS certificate path [default: examples/cert.crt]
+  --key <file>                TLS certificate key path [default: examples/cert.key]
+  --root <dir>                Root directory [default: examples/root/]
+  --name <str>                Name of the server [default: quic.tech]
+  --max-data BYTES            Connection-wide flow control limit [default: 10000000].
+  --max-stream-data BYTES     Per-stream flow control limit [default: 1000000].
+  --max-streams-bidi STREAMS  Number of allowed concurrent streams [default: 100].
+  --max-streams-uni STREAMS   Number of allowed concurrent streams [default: 100].
+  --no-retry                  Disable stateless retry.
+  --no-grease                 Don't send GREASE.
+  -h --help                   Show this screen.
 ";
 
 struct PartialResponse {
@@ -87,8 +88,11 @@ fn main() {
     let max_stream_data = args.get_str("--max-stream-data");
     let max_stream_data = u64::from_str_radix(max_stream_data, 10).unwrap();
 
-    let max_streams = args.get_str("--max-streams");
-    let max_streams = u64::from_str_radix(max_streams, 10).unwrap();
+    let max_streams_bidi = args.get_str("--max-streams-bidi");
+    let max_streams_bidi = u64::from_str_radix(max_streams_bidi, 10).unwrap();
+
+    let max_streams_uni = args.get_str("--max-streams-uni");
+    let max_streams_uni = u64::from_str_radix(max_streams_uni, 10).unwrap();
 
     // Setup the event loop.
     let poll = mio::Poll::new().unwrap();
@@ -126,8 +130,8 @@ fn main() {
     config.set_initial_max_stream_data_bidi_local(max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(max_stream_data);
     config.set_initial_max_stream_data_uni(max_stream_data);
-    config.set_initial_max_streams_bidi(max_streams);
-    config.set_initial_max_streams_uni(max_streams);
+    config.set_initial_max_streams_bidi(max_streams_bidi);
+    config.set_initial_max_streams_uni(max_streams_uni);
     config.set_disable_active_migration(true);
 
     if std::env::var_os("SSLKEYLOGFILE").is_some() {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -50,6 +50,7 @@ Options:
   --name <str>             Name of the server [default: quic.tech]
   --max-data BYTES         Connection-wide flow control limit [default: 10000000].
   --max-stream-data BYTES  Per-stream flow control limit [default: 1000000].
+  --max-streams STREAMS    Number of allowed concurrent streams [default: 100].
   --dump-packets PATH      Dump the incoming packets as files in the given directory.
   --no-retry               Disable stateless retry.
   -h --help                Show this screen.
@@ -86,6 +87,9 @@ fn main() {
 
     let max_stream_data = args.get_str("--max-stream-data");
     let max_stream_data = u64::from_str_radix(max_stream_data, 10).unwrap();
+
+    let max_streams = args.get_str("--max-streams");
+    let max_streams = u64::from_str_radix(max_streams, 10).unwrap();
 
     let dump_path = if args.get_str("--dump-packets") != "" {
         Some(args.get_str("--dump-packets"))
@@ -129,8 +133,8 @@ fn main() {
     config.set_initial_max_stream_data_bidi_local(max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(max_stream_data);
     config.set_initial_max_stream_data_uni(max_stream_data);
-    config.set_initial_max_streams_bidi(100);
-    config.set_initial_max_streams_uni(5);
+    config.set_initial_max_streams_bidi(max_streams);
+    config.set_initial_max_streams_uni(max_streams);
     config.set_disable_active_migration(true);
 
     if std::env::var_os("SSLKEYLOGFILE").is_some() {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -43,17 +43,18 @@ const USAGE: &str = "Usage:
   server -h | --help
 
 Options:
-  --listen <addr>          Listen on the given IP:port [default: 127.0.0.1:4433]
-  --cert <file>            TLS certificate path [default: examples/cert.crt]
-  --key <file>             TLS certificate key path [default: examples/cert.key]
-  --root <dir>             Root directory [default: examples/root/]
-  --name <str>             Name of the server [default: quic.tech]
-  --max-data BYTES         Connection-wide flow control limit [default: 10000000].
-  --max-stream-data BYTES  Per-stream flow control limit [default: 1000000].
-  --max-streams STREAMS    Number of allowed concurrent streams [default: 100].
-  --dump-packets PATH      Dump the incoming packets as files in the given directory.
-  --no-retry               Disable stateless retry.
-  -h --help                Show this screen.
+  --listen <addr>             Listen on the given IP:port [default: 127.0.0.1:4433]
+  --cert <file>               TLS certificate path [default: examples/cert.crt]
+  --key <file>                TLS certificate key path [default: examples/cert.key]
+  --root <dir>                Root directory [default: examples/root/]
+  --name <str>                Name of the server [default: quic.tech]
+  --max-data BYTES            Connection-wide flow control limit [default: 10000000].
+  --max-stream-data BYTES     Per-stream flow control limit [default: 1000000].
+  --max-streams-bidi STREAMS  Number of allowed concurrent streams [default: 100].
+  --max-streams-uni STREAMS   Number of allowed concurrent streams [default: 100].
+  --dump-packets PATH         Dump the incoming packets as files in the given directory.
+  --no-retry                  Disable stateless retry.
+  -h --help                   Show this screen.
 ";
 
 struct PartialResponse {
@@ -88,8 +89,11 @@ fn main() {
     let max_stream_data = args.get_str("--max-stream-data");
     let max_stream_data = u64::from_str_radix(max_stream_data, 10).unwrap();
 
-    let max_streams = args.get_str("--max-streams");
-    let max_streams = u64::from_str_radix(max_streams, 10).unwrap();
+    let max_streams_bidi = args.get_str("--max-streams-bidi");
+    let max_streams_bidi = u64::from_str_radix(max_streams_bidi, 10).unwrap();
+
+    let max_streams_uni = args.get_str("--max-streams-uni");
+    let max_streams_uni = u64::from_str_radix(max_streams_uni, 10).unwrap();
 
     let dump_path = if args.get_str("--dump-packets") != "" {
         Some(args.get_str("--dump-packets"))
@@ -133,8 +137,8 @@ fn main() {
     config.set_initial_max_stream_data_bidi_local(max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(max_stream_data);
     config.set_initial_max_stream_data_uni(max_stream_data);
-    config.set_initial_max_streams_bidi(max_streams);
-    config.set_initial_max_streams_uni(max_streams);
+    config.set_initial_max_streams_bidi(max_streams_bidi);
+    config.set_initial_max_streams_uni(max_streams_uni);
     config.set_disable_active_migration(true);
 
     if std::env::var_os("SSLKEYLOGFILE").is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -903,7 +903,10 @@ impl Connection {
 
             max_send_bytes: 0,
 
-            streams: stream::StreamMap::default(),
+            streams: stream::StreamMap::new(
+                config.local_transport_params.initial_max_streams_bidi,
+                config.local_transport_params.initial_max_streams_uni,
+            ),
 
             odcid: None,
 
@@ -954,14 +957,6 @@ impl Connection {
         }
 
         conn.handshake.init(&conn)?;
-
-        conn.streams.update_local_max_streams_bidi(
-            config.local_transport_params.initial_max_streams_bidi,
-        );
-
-        conn.streams.update_local_max_streams_uni(
-            config.local_transport_params.initial_max_streams_uni,
-        );
 
         // Derive initial secrets for the client. We can do this here because
         // we already generated the random destination connection ID.
@@ -1588,6 +1583,34 @@ impl Connection {
         }
 
         if pkt_type == packet::Type::Short && !is_closing {
+            // Create MAX_STREAMS_BIDI frame.
+            if self.streams.should_update_max_streams_bidi() {
+                let max = self.streams.update_max_streams_bidi();
+                let frame = frame::Frame::MaxStreamsBidi { max };
+
+                payload_len += frame.wire_len();
+                left -= frame.wire_len();
+
+                frames.push(frame);
+
+                ack_eliciting = true;
+                in_flight = true;
+            }
+
+            // Create MAX_STREAMS_UNI frame.
+            if self.streams.should_update_max_streams_uni() {
+                let max = self.streams.update_max_streams_uni();
+                let frame = frame::Frame::MaxStreamsUni { max };
+
+                payload_len += frame.wire_len();
+                left -= frame.wire_len();
+
+                frames.push(frame);
+
+                ack_eliciting = true;
+                in_flight = true;
+            }
+
             // Create MAX_DATA frame as needed.
             if self.should_update_max_data() {
                 let frame = frame::Frame::MaxData {
@@ -2413,6 +2436,8 @@ impl Connection {
         // If there are flushable streams, use Application.
         if self.handshake_completed &&
             (self.should_update_max_data() ||
+                self.streams.should_update_max_streams_bidi() ||
+                self.streams.should_update_max_streams_uni() ||
                 self.streams.has_flushable() ||
                 self.streams.has_almost_full())
         {
@@ -4425,6 +4450,133 @@ mod tests {
             pipe.server.recv(&mut buf[..written]),
             Err(Error::CryptoFail)
         );
+    }
+
+    #[test]
+    /// Tests that the MAX_STREAMS frame is sent for bidirectional streams.
+    fn stream_limit_update_bidi() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(30);
+        config.set_initial_max_stream_data_bidi_local(15);
+        config.set_initial_max_stream_data_bidi_remote(15);
+        config.set_initial_max_stream_data_uni(10);
+        config.set_initial_max_streams_bidi(3);
+        config.set_initial_max_streams_uni(0);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        // Client sends stream data.
+        assert_eq!(pipe.client.stream_send(0, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(4, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(4, b"b", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(0, b"b", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server reads stream data.
+        let mut b = [0; 15];
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        pipe.server.stream_recv(4, &mut b).unwrap();
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server sends stream data, with fin.
+        assert_eq!(pipe.server.stream_send(0, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.server.stream_send(4, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.server.stream_send(4, b"b", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.server.stream_send(0, b"b", true), Ok(1));
+
+        // Server sends MAX_STREAMS.
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Client tries to create new streams.
+        assert_eq!(pipe.client.stream_send(8, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(12, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.server.readable().len(), 2);
+    }
+
+    #[test]
+    /// Tests that the MAX_STREAMS frame is sent for unirectional streams.
+    fn stream_limit_update_uni() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(30);
+        config.set_initial_max_stream_data_bidi_local(15);
+        config.set_initial_max_stream_data_bidi_remote(15);
+        config.set_initial_max_stream_data_uni(10);
+        config.set_initial_max_streams_bidi(0);
+        config.set_initial_max_streams_uni(3);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        // Client sends stream data.
+        assert_eq!(pipe.client.stream_send(2, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(6, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(6, b"b", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(2, b"b", true), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Server reads stream data.
+        let mut b = [0; 15];
+        pipe.server.stream_recv(2, &mut b).unwrap();
+        pipe.server.stream_recv(6, &mut b).unwrap();
+
+        // Server sends MAX_STREAMS.
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Client tries to create new streams.
+        assert_eq!(pipe.client.stream_send(10, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(14, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.server.readable().len(), 2);
     }
 }
 


### PR DESCRIPTION
This implements increasing the local max streams limits by sending
MAX_STREAMS frames, once a certain threshold is passed.

Stream credits are given back to the peer only once a non-locally
generated stream is complete, that is, once all incoming data has been
read by the application and all outgoing data has been ACKed.

---

TODO
* [x] Merge https://github.com/cloudflare/quiche/pull/158 first.