### PR TITLE
pad Initial packets from the server

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1797,8 +1797,8 @@ impl Connection {
             return Err(Error::Done);
         }
 
-        // Pad the client's initial packet.
-        if !self.is_server && pkt_type == packet::Type::Initial {
+        // Pad all initial packets.
+        if pkt_type == packet::Type::Initial {
             let pkt_len = pn_len + payload_len + overhead;
 
             let frame = frame::Frame::Padding {


### PR DESCRIPTION
We were previously only padding Initial packets from the client, but
it's useful (albeit not required) to also pad server Initial packets to
make sure the path supports packets of at least 1200 bytes as soon as
possible.