### PR TITLE
reject undecryptable packets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1211,6 +1211,10 @@ impl Connection {
         let aead = match self.pkt_num_spaces[epoch].crypto_open {
             Some(ref v) => v,
 
+            // Ignore packets that can't be decrypted because we don't yet have
+            // the necessary decryption keys, to avoid packet reordering (e.g.
+            // between Initial and Handshake) to causet he connection to be
+            // closed.
             None => {
                 trace!(
                     "{} dropped undecryptable packet type={:?} len={}",
@@ -1241,28 +1245,8 @@ impl Connection {
             pn
         );
 
-        let mut payload = match packet::decrypt_pkt(
-            &mut b,
-            pn,
-            hdr.pkt_num_len,
-            payload_len,
-            &aead,
-        ) {
-            Ok(v) => v,
-
-            Err(Error::CryptoFail) => {
-                trace!(
-                    "{} dropped undecryptable packet type={:?} len={}",
-                    self.trace_id,
-                    hdr.ty,
-                    payload_len,
-                );
-
-                return Ok(header_len + payload_len);
-            },
-
-            Err(e) => return Err(e),
-        };
+        let mut payload =
+            packet::decrypt_pkt(&mut b, pn, hdr.pkt_num_len, payload_len, &aead)?;
 
         if self.pkt_num_spaces[epoch].recv_pkt_num.contains(pn) {
             trace!("{} ignored duplicate packet {}", self.trace_id, pn);
@@ -4383,6 +4367,36 @@ mod tests {
         assert!(r.next().is_some());
         assert!(r.next().is_some());
         assert!(r.next().is_none());
+    }
+
+    #[test]
+    /// Tests that invalid packets received before any other valid ones cause
+    /// the server to close the connection immediately.
+    fn invalid_initial() {
+        let mut buf = [0; 65535];
+        let mut pipe = testing::Pipe::default().unwrap();
+
+        let frames = [frame::Frame::Padding { len: 10 }];
+
+        let written = testing::encode_pkt(
+            &mut pipe.client,
+            packet::Type::Initial,
+            &frames,
+            &mut buf,
+        )
+        .unwrap();
+
+        // Corrupt the packets's last byte to make decryption fail (the last
+        // byte is part of the AEAD tag, so changing it means that the packet
+        // cannot be authenticated during decryption).
+        buf[written - 1] = 0;
+
+        assert_eq!(pipe.server.timeout(), None);
+
+        assert_eq!(
+            pipe.server.recv(&mut buf[..written]),
+            Err(Error::CryptoFail)
+        );
     }
 }
 


### PR DESCRIPTION
We try to ignore invalid incoming packets (e.g. ones that fail
decryption) to prevent an attacker from causing the connection to be
closed by injecting invalid packets (this is unlike TCP, where e.g. RST
packets can be injected due to lack of encryption).

However currently this is not applied consistently, and there are
several cases where invalid and unauthenticated packets would cause the
connection to fail.

In addition, one problem with this design is represented by the fact
that packets that look like Initial packets but are in fact not QUIC
packets at all, could be received and trick the server into allocating
connection state.

This is unavoidable as to process Initial packets connection state is
required. However if no other valid packet is received, the connection
will never be closed, due to the fact that the invalid packets are not
considered an error but would not cause the idle timer to be initialized
either. So the connection would stay open and never timeout.

This could be fixed by adding a check for this special case to the
existing code, however it's probably not worth the effort and the added
complexity, since, as mentioned above, there are other ways for an
attacker to cause the connection to fail by injecting packets.

Because of the above reasons, this makes packet decryption failures to
close the connection. In the future we can revisit this and implement
a proper mechanism to ignore invalid packets, that can be applied to all
cases and also cover the idle timer edge case.