### PR TITLE
recovery: reject ACK frames that have a largest ACKed that is too large

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2445,7 +2445,7 @@ impl Connection {
                     epoch,
                     now,
                     &self.trace_id,
-                );
+                )?;
 
                 // When we receive an ACK for a 1-RTT packet after handshake
                 // completion, it means the handshake has been confirmed.


### PR DESCRIPTION
This is somewhat of an optimization to help reject obviously invalid ACK
frames. In order to do this we track the largest packet number that has
been sent, and compare if against the largest ACK packet from ACK
frames.

The spec says:

>  An endpoint SHOULD treat receipt of an acknowledgment for a packet it
>  did not send as a connection error of type PROTOCOL_VIOLATION
    
So we are free to close the connection as well.