### PR TITLE
duration_float is now a stable feature, so use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ be linked directly into C/C++ applications.
 Building
 --------
 
-quiche requires Rust 1.35 or later to build. The latest stable Rust release can
+quiche requires Rust 1.38 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched

--- a/tools/quic-trace-log/src/main.rs
+++ b/tools/quic-trace-log/src/main.rs
@@ -24,8 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#![feature(duration_float)]
-
 use std::io::BufRead;
 
 use regex::Regex;


### PR DESCRIPTION
Instead of doing weird hacks in `recovery` we can just do operations between `Duration` and floats directly, so the code is slightly easier to understand and we can follow the recovery draft more closely.