### PR TITLE
remove implementations of Error::description() method

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -384,11 +384,6 @@ impl std::fmt::Display for Error {
 }
 
 impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        // TODO: fill this
-        ""
-    }
-
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
     }

--- a/src/h3/qpack/mod.rs
+++ b/src/h3/qpack/mod.rs
@@ -62,15 +62,6 @@ impl std::fmt::Display for Error {
 }
 
 impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match self {
-            Error::BufferTooShort => "buffer is too short",
-            Error::InvalidHuffmanEncoding => "invalid huffman encoding",
-            Error::InvalidStaticTableIndex => "invalid QPACK static table index",
-            Error::InvalidHeaderValue => "invalid QPACK header name or value",
-        }
-    }
-
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,24 +337,6 @@ impl std::fmt::Display for Error {
 }
 
 impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match self {
-            Error::Done => "nothing else to do",
-            Error::BufferTooShort => "buffer is too short",
-            Error::UnknownVersion => "version is unknown",
-            Error::InvalidFrame => "frame is invalid",
-            Error::InvalidPacket => "packet is invalid",
-            Error::InvalidState => "connection state is invalid",
-            Error::InvalidStreamState => "stream state is invalid",
-            Error::InvalidTransportParam => "transport parameter is invalid",
-            Error::CryptoFail => "crypto operation failed",
-            Error::TlsFail => "TLS failed",
-            Error::FlowControl => "flow control limit was violated",
-            Error::StreamLimit => "stream limit was violated",
-            Error::FinalSize => "data exceeded stream's final size",
-        }
-    }
-
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
     }

--- a/src/octets.rs
+++ b/src/octets.rs
@@ -48,10 +48,6 @@ impl std::fmt::Display for BufferTooShortError {
 }
 
 impl std::error::Error for BufferTooShortError {
-    fn description(&self) -> &str {
-        "buffer is too short"
-    }
-
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
     }


### PR DESCRIPTION
This method is deprecated https://doc.rust-lang.org/std/error/trait.Error.html#method.description

We already implement Display for the error types, so this is not needed.