### PR TITLE
 h3: expose the underlying transport error via Error::TransportError

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -264,82 +264,81 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// An HTTP/3 error.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(C)]
 pub enum Error {
     /// There is no error or no work to do
-    Done                 = -1,
+    Done,
 
     /// The provided buffer is too short.
-    BufferTooShort       = -2,
+    BufferTooShort,
 
     /// Peer violated protocol requirements in a way which doesn’t match a
     /// more specific error code, or endpoint declines to use the more
     /// specific error code.
-    GeneralProtocolError = -3,
+    GeneralProtocolError,
 
     /// Internal error in the HTTP/3 stack.
-    InternalError        = -5,
+    InternalError,
 
     /// The client no longer needs the requested data.
-    RequestCancelled     = -7,
+    RequestCancelled,
 
     /// The request stream terminated before completing the request.
-    RequestIncomplete    = -8,
+    RequestIncomplete,
 
     /// Forward connection failure for CONNECT target.
-    ConnectError         = -9,
+    ConnectError,
 
     /// Endpoint detected that the peer is exhibiting behavior that causes.
     /// excessive load.
-    ExcessiveLoad        = -10,
+    ExcessiveLoad,
 
     /// Operation cannot be served over HTTP/3. Retry over HTTP/1.1.
-    VersionFallback      = -11,
+    VersionFallback,
 
     /// Stream ID or Push ID greater that current maximum was
     /// used incorrectly, such as exceeding a limit, reducing a limit,
     /// or being reused.
-    IdError              = -13,
+    IdError,
 
     /// The endpoint detected that its peer created a stream that it will not
     /// accept.
-    StreamCreationError  = -15,
+    StreamCreationError,
 
     /// A required critical stream was closed.
-    ClosedCriticalStream = -17,
+    ClosedCriticalStream,
 
     /// Inform client that remainder of request is not needed. Used in
     /// STOP_SENDING only.
-    EarlyResponse        = -19,
+    EarlyResponse,
 
     /// No SETTINGS frame at beginning of control stream.
-    MissingSettings      = -20,
+    MissingSettings,
 
     /// A frame was received which is not permitted in the current state.
-    FrameUnexpected      = -21,
+    FrameUnexpected,
 
     /// Server rejected request without performing any application processing.
-    RequestRejected      = -22,
+    RequestRejected,
 
     /// An endpoint detected an error in the payload of a SETTINGS frame:
     /// a duplicate setting was detected, a client-only setting was sent by a
     /// server, or a server-only setting by a client.
-    SettingsError        = -23,
+    SettingsError,
 
     /// Frame violated layout or size rules.
-    FrameError           = -24,
+    FrameError,
 
     /// QPACK Header block decompression failure.
-    QpackDecompressionFailed = -25,
+    QpackDecompressionFailed,
 
     /// QPACK encoder stream error.
-    QpackEncoderStreamError = -26,
+    QpackEncoderStreamError,
 
     /// QPACK decoder stream error.
-    QpackDecoderStreamError = -27,
+    QpackDecoderStreamError,
 
     /// Error originated from the transport layer.
-    TransportError       = -28,
+    TransportError,
 }
 
 impl Error {
@@ -373,7 +372,30 @@ impl Error {
     }
 
     fn to_c(self) -> libc::ssize_t {
-        self as _
+        match self {
+            Error::Done => -1,
+            Error::BufferTooShort => -2,
+            Error::GeneralProtocolError => -3,
+            Error::InternalError => -5,
+            Error::RequestCancelled => -7,
+            Error::RequestIncomplete => -8,
+            Error::ConnectError => -9,
+            Error::ExcessiveLoad => -10,
+            Error::VersionFallback => -11,
+            Error::IdError => -13,
+            Error::StreamCreationError => -15,
+            Error::ClosedCriticalStream => -17,
+            Error::EarlyResponse => -19,
+            Error::MissingSettings => -20,
+            Error::FrameUnexpected => -21,
+            Error::RequestRejected => -22,
+            Error::SettingsError => -23,
+            Error::FrameError => -24,
+            Error::QpackDecompressionFailed => -25,
+            Error::QpackEncoderStreamError => -26,
+            Error::QpackDecoderStreamError => -27,
+            Error::TransportError => -28,
+        }
     }
 }
 


### PR DESCRIPTION
This can be useful for debugging.