### PR TITLE
ffi: avoid panic on multiple quiche_enable_debug_logging

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -95,7 +95,7 @@ enum quiche_error {
 const char *quiche_version(void);
 
 // Enables logging. |cb| will be called with log messages
-void quiche_enable_debug_logging(void (*cb)(const char *line, void *argp),
+int quiche_enable_debug_logging(void (*cb)(const char *line, void *argp),
                                  void *argp);
 
 // Stores configuration shared between multiple connections.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -65,12 +65,17 @@ impl log::Log for Logger {
 #[no_mangle]
 pub extern fn quiche_enable_debug_logging(
     cb: extern fn(line: *const u8, argp: *mut c_void), argp: *mut c_void,
-) {
+) -> c_int {
     let argp = atomic::AtomicPtr::new(argp);
     let logger = Box::new(Logger { cb, argp });
 
-    log::set_boxed_logger(logger).unwrap();
+    if log::set_boxed_logger(logger).is_err() {
+        return -1;
+    }
+
     log::set_max_level(log::LevelFilter::Trace);
+
+    0
 }
 
 #[no_mangle]


### PR DESCRIPTION
Previously, multiple calls to `quiche_enable_debug_logging()` would
cause a Rust panic, requiring applications to implement their
own housekeeping to avoid the problem. With this change we
manage things more gracefully, returning 0 on success of or -1
if there was some problem.