### PR TITLE
 stream: fix handling of remote max streams limit updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4519,7 +4519,15 @@ mod tests {
         assert_eq!(pipe.client.stream_send(12, b"a", false), Ok(1));
         assert_eq!(pipe.advance(&mut buf), Ok(()));
 
-        assert_eq!(pipe.server.readable().len(), 2);
+        assert_eq!(pipe.client.stream_send(16, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(
+            pipe.client.stream_send(20, b"a", false),
+            Err(Error::StreamLimit)
+        );
+
+        assert_eq!(pipe.server.readable().len(), 3);
     }
 
     #[test]
@@ -4576,7 +4584,15 @@ mod tests {
         assert_eq!(pipe.client.stream_send(14, b"a", false), Ok(1));
         assert_eq!(pipe.advance(&mut buf), Ok(()));
 
-        assert_eq!(pipe.server.readable().len(), 2);
+        assert_eq!(pipe.client.stream_send(18, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(
+            pipe.client.stream_send(22, b"a", false),
+            Err(Error::StreamLimit)
+        );
+
+        assert_eq!(pipe.server.readable().len(), 3);
     }
 }
 


### PR DESCRIPTION
Before this change we would decrease the maximum stream limit every time
we attempt creating a new local stream, without tracking how many
streams we actually opened.

This would work if the remote stream limits were static, however the
peer can send a MAX_STREAMS frame (which carries absolute values, rather
than incremental updates) which would cause us to reset the limits to
the maximum value. We would then attempt to create new streams without
keeping into consideration streams that were already opened.

This change adds counters for the local streams that were actually
opened (like we already did for remote ones in df75104), so that we can
simply compare that against the max limits.

---

While working on #164 I thought I'd implement support for retrying HTTP/3 requests when stream limits are hit in the example client to test the server-side support for sending MAX_STREAMS, but I noticed that the client behavior was wrong, hence this fix (though this problem is unrelated to the other PR and has been here since forever, we just never supported sending more requests once the initial max streams limits were hit).