### PR TITLE
Use include instead of exclude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/boringssl
 /target
 **/*.rs.bk
 Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
      script:
       - RUSTFLAGS="-D warnings" cargo build --release --verbose
       - RUSTFLAGS="-D warnings" cargo test --verbose
+      - RUSTFLAGS="-D warnings" cargo package --verbose --allow-dirty
       - cargo clippy --examples -- -D warnings
       - cargo doc --no-deps
       - make -C examples
@@ -41,6 +42,7 @@ matrix:
      script:
       - RUSTFLAGS="-D warnings" cargo build --release --verbose
       - RUSTFLAGS="-D warnings" cargo test --verbose
+      - RUSTFLAGS="-D warnings" cargo package --verbose --allow-dirty
       - cargo fmt -- --check
       - cargo doc --no-deps
       - make -C examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,25 @@ readme = "README.md"
 keywords = ["quic", "http3"]
 categories = ["network-programming"]
 license = "BSD-2-Clause"
-exclude = [
-    "deps/boringssl/crypto/**/*_test.txt",
-    "deps/boringssl/crypto/**/*_tests.txt",
-    "deps/boringssl/**/nist_cavp/*.txt",
-    "deps/boringssl/fuzz/*",
-    "deps/boringssl/go.mod",
-    "deps/boringssl/ssl/test/runner/*",
-    "deps/boringssl/third_party/wycheproof_testvectors/*",
-    "fuzz/*",
-    "tools/*",
+include = [
+     "/*.md",
+     "/*.toml",
+     "/CODEOWNERS",
+     "/COPYING",
+     "/benches",
+     "/deps/boringssl/**/*.[chS]",
+     "/deps/boringssl/**/*.cc",
+     "/deps/boringssl/**/*.errordata",
+     "/deps/boringssl/**/*.go",
+     "/deps/boringssl/**/*.pl",
+     "/deps/boringssl/**/CMakeLists.txt",
+     "/deps/boringssl/*.md",
+     "/deps/boringssl/LICENSE",
+     "/deps/boringssl/sources.cmake",
+     "/examples",
+     "/include",
+     "/quiche.svg",
+     "/src",
 ]
 
 [features]


### PR DESCRIPTION
For internal testing, using `exclude` will cause a lot of
directory traversing when running `cargo test`, slow down
test run a much (adding a minutes) when there is a lot of
files to scan and where file system operation is slow, such
as MacOS + Docker environment.

Using `include` will prevent this from happening.