### PR TITLE
drop packets that fail decryption again

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -2318,8 +2318,9 @@ mod tests {
         let d = [0; 20];
 
         s.pipe.client.stream_send(e_stream_id, &d, false).unwrap();
-        s.pipe.client.stream_send(d_stream_id, &d, false).unwrap();
+        s.advance().ok();
 
+        s.pipe.client.stream_send(d_stream_id, &d, false).unwrap();
         s.advance().ok();
 
         loop {


### PR DESCRIPTION
In e739f55 we started rejecting all undecryptable packets because the
logic to simply ignore invalid packets was incomplete, so that was a
simplification.

However we do actually need this, even in legitimate connections,
because Firefox sends "padded" Initial packets (i.e. UDP packet with
Initial and a bunch of zero bytes appended), and we would close the
connection.

We do still need to close the connection if the first packet is broken,
in order to avoid keeping a connection alive when some junk that looks
like Initial is received and no other data is received afterwards, so
the logic is updated to check for the number of packet already processed
before deciding whether to send Error::Done (i.e. ignore packet) or some
other error which would cause the connection to be closed.

We already have a test case for this situation from the commit mentioned
above.