### PR TITLE
[wip] qlog: add a new crate for qlog and add example usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,10 @@ libc = "0.2"
 ring = "0.16"
 lazy_static = "1"
 
+serde_json = "1"
+
+qlog = {path = "./qlog"}
+
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3", features = ["wincrypt"] }
 

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -432,6 +432,16 @@ fn main() {
             break;
         }
     }
+
+    let qlog_log = qlog::Qlog {
+        qlog_version: "draft-01".to_string(),
+        title: Some("Quiche http3-client qlog log".to_string()),
+        description: Some("Quiche qlog log description".to_string()),
+        summary: None,
+        traces: vec![conn.qlog_trace],
+    };
+
+    trace!("{}", serde_json::to_string(&qlog_log).unwrap());
 }
 
 fn hex_dump(buf: &[u8]) -> String {

--- a/qlog/Cargo.toml
+++ b/qlog/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "qlog"
+version = "0.1.0"
+authors = ["Lucas Pardue <lucaspardue.24.7@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+docopt = "1"
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
+serde_with = "1.3.1"

--- a/qlog/examples/qlogger.rs
+++ b/qlog/examples/qlogger.rs
@@ -1,0 +1,159 @@
+// Copyright (C) 2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use qlog::*;
+
+fn main() {
+
+    let ty = PacketType::Initial;
+
+    println!("{}", serde_json::to_string(&ty).unwrap());
+
+    let pkt_hdr_1 = PacketHeader {
+        packet_number: "0".to_string(),
+        packet_size: Some(1251),
+        payload_length: Some(1224),
+        version: Some("0xff000016".to_string()),
+        scil: Some("8".to_string()),
+        dcil: Some("8".to_string()),
+        scid: Some("7e37e4dcc6682da8".to_string()),
+        dcid: Some("36ce104eee50101c".to_string()),
+    };
+
+     println!(
+        "packet header: {}",
+        serde_json::to_string(&pkt_hdr_1).unwrap()
+    );
+
+    let pkt_sent_evt_0 = EventData::PacketSent {
+        raw_encrypted: None,
+        raw_decrypted: None,
+        packet_type: PacketType::Initial,
+        header: pkt_hdr_1.clone(),
+        frames: None,
+        is_coalesced: None
+    };
+
+    println!(
+        "packet 0: {}",
+        serde_json::to_string(&pkt_sent_evt_0).unwrap()
+    );
+
+    let mut frames = Vec::new();
+    frames.push(QuicFrame::padding());
+
+    frames.push(QuicFrame::ping());
+
+    frames.push(QuicFrame::stream(
+        "0".to_string(),
+        "0".to_string(),
+        "100".to_string(),
+        true,
+        None,
+    ));
+
+    let pkt_sent_evt_1 = EventData::PacketSent {
+        raw_encrypted: None,
+        raw_decrypted: None,
+        packet_type: PacketType::Initial,
+        header: pkt_hdr_1.clone(),
+        frames: Some(frames),
+        is_coalesced: None
+    };
+    println!(
+        "packet 1: {}",
+        serde_json::to_string(&pkt_sent_evt_1).unwrap()
+    );
+
+    let pkt_hdr_2 = PacketHeader {
+        packet_number: "0".to_string(),
+        packet_size: Some(1251),
+        payload_length: Some(1224),
+        version: Some("0xff000016".to_string()),
+        scil: None,
+        dcil: None,
+        scid: None,
+        dcid: None,
+    };
+
+    let pkt_sent_evt_2 = EventData::PacketSent {
+        raw_encrypted: None,
+        raw_decrypted: None,
+        packet_type: PacketType::Initial,
+        header: pkt_hdr_2,
+        frames: None,
+        is_coalesced: None
+    };
+    println!(
+        "packet 2: {}",
+        serde_json::to_string(&pkt_sent_evt_2).unwrap()
+    );
+
+    let vantage_point = VantagePoint {
+        name: None,
+        ty: VantagePointType::Client,
+        flow: None,
+    };
+
+    let mut trace = Trace {
+        vantage_point,
+        title: Some("Test trace".to_string()),
+        description: Some("Test trace description".to_string()),
+        configuration: Some(Configuration {
+            time_offset: Some("0".to_string()),
+            time_units: Some(TimeUnits::Ms),
+            original_uris: None,
+        }),
+        common_fields: None,
+        event_fields: vec![
+            "relative_time".to_string(),
+            "category".to_string(),
+            "event".to_string(),
+            "trigger".to_string(),
+            "data".to_string(),
+        ], // TODO: hack
+        events: Vec::new(), // vec![vec![rt, cat, ev, trigger, data]],
+    };
+
+    trace.push_transport_event(
+        "0".to_string(),
+        TransportEventType::PacketSent,
+        TransportEventTrigger::Line,
+        pkt_sent_evt_1,
+    );
+
+    println!("trace {}", serde_json::to_string(&trace).unwrap());
+
+    let qlog = Qlog {
+        qlog_version: "WIP".to_string(),
+        title: Some("Test log".to_string()),
+        description: Some("Test log description".to_string()),
+        summary: None,
+        traces: vec![trace],
+    };
+
+    println!("log {}", serde_json::to_string(&qlog).unwrap());
+}

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -1,0 +1,1643 @@
+// Copyright (C) 2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+extern crate serde;
+extern crate serde_json;
+
+#[serde_with::skip_serializing_none]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Qlog {
+    pub qlog_version: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub summary: Option<String>,
+
+    pub traces: Vec<Trace>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Trace {
+    pub vantage_point: VantagePoint,
+    pub title: Option<String>,
+    pub description: Option<String>,
+
+    pub configuration: Option<Configuration>,
+
+    pub common_fields: Option<CommonFields>,
+    pub event_fields: Vec<String>,
+
+    pub events: Vec<Vec<EventField>>,
+}
+
+/// Helper functions for using a qlog trace.
+impl Trace {
+    fn push_event(
+        &mut self, relative_time: String, category: EventCategory,
+        event: EventType, trigger: EventTrigger, data: EventData,
+    ) {
+        self.events.push(vec![
+            EventField::RelativeTime(relative_time),
+            EventField::Category(category),
+            EventField::Event(event),
+            EventField::Trigger(trigger),
+            EventField::Data(data),
+        ]);
+    }
+
+    /// Appends an `ConnectivityEventType` to the back of a qlog trace.
+    pub fn push_connectivity_event(
+        &mut self, relative_time: String, event: ConnectivityEventType,
+        trigger: ConnectivityEventTrigger, data: EventData,
+    ) {
+        self.push_event(
+            relative_time,
+            EventCategory::Connectivity,
+            EventType::ConnectivityEventType(event),
+            EventTrigger::ConnectivityEventTrigger(trigger),
+            data,
+        );
+    }
+
+    /// Appends a `TransportEventType` to the back of a qlog trace.
+    pub fn push_transport_event(
+        &mut self, relative_time: String, event: TransportEventType,
+        trigger: TransportEventTrigger, data: EventData,
+    ) {
+        self.push_event(
+            relative_time,
+            EventCategory::Transport,
+            EventType::TransportEventType(event),
+            EventTrigger::TransportEventTrigger(trigger),
+            data,
+        );
+    }
+
+    /// Appends a `TransportEventType` to the back of a qlog trace.
+    pub fn push_security_event(
+        &mut self, relative_time: String, event: SecurityEventType,
+        trigger: SecurityEventTrigger, data: EventData,
+    ) {
+        self.push_event(
+            relative_time,
+            EventCategory::Security,
+            EventType::SecurityEventType(event),
+            EventTrigger::SecurityEventTrigger(trigger),
+            data,
+        );
+    }
+
+    /// Appends a `TransportEventType` to the back of a qlog trace.
+    pub fn push_recovery_event(
+        &mut self, relative_time: String, event: RecoveryEventType,
+        trigger: RecoveryEventTrigger, data: EventData,
+    ) {
+        self.push_event(
+            relative_time,
+            EventCategory::Recovery,
+            EventType::RecoveryEventType(event),
+            EventTrigger::RecoveryEventTrigger(trigger),
+            data,
+        );
+    }
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct VantagePoint {
+    pub name: Option<String>,
+
+    #[serde(rename = "type")]
+    pub ty: VantagePointType,
+
+    pub flow: Option<VantagePointType>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VantagePointType {
+    Client,
+    Server,
+    Network,
+    Unknown,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TimeUnits {
+    Ms,
+    Us
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Configuration {
+    pub time_units: Option<TimeUnits>,
+    pub time_offset: Option<String>,
+
+    pub original_uris: Option<Vec<String>>,
+
+    // TODO
+    // additionalUserSpecifiedProperty
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct CommonFields {
+    pub group_id: Option<String>,
+    pub protocol_type: Option<String>,
+
+    pub reference_time: Option<String>,
+
+    // TODO
+    // additionalUserSpecifiedProperty
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum EventType {
+    ConnectivityEventType(ConnectivityEventType),
+
+    TransportEventType(TransportEventType),
+
+    SecurityEventType(SecurityEventType),
+
+    RecoveryEventType(RecoveryEventType),
+
+    Http3EventType(Http3EventType),
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum EventTrigger {
+    ConnectivityEventTrigger(ConnectivityEventTrigger),
+
+    TransportEventTrigger(TransportEventTrigger),
+
+    SecurityEventTrigger(SecurityEventTrigger),
+
+    RecoveryEventTrigger(RecoveryEventTrigger),
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum EventField {
+    RelativeTime(String),
+
+    Category(EventCategory),
+
+    Event(EventType),
+
+    Trigger(EventTrigger),
+
+    Data(EventData),
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventCategory {
+    Connectivity,
+    Security,
+    Transport,
+    Recovery,
+    Http,
+    Qpack,
+
+    Error,
+    Warning,
+    Info,
+    Debug,
+    Verbose,
+    Simulation,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectivityEventType {
+    ServerListening,
+    ConnectionStarted,
+    ConnectionIdUpdated,
+    SpinBitUpdated,
+    ConnectionStateUpdated,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectivityEventTrigger {
+    Line,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportEventType {
+    ParametersSet,
+
+    DatagramsSent,
+    DatagramsReceived,
+    DatagramDropped,
+
+    PacketSent,
+    PacketReceived,
+    PacketDropped,
+    PacketBuffered,
+
+    FramesProcessed,
+
+    StreamStateUpdated,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportEventTrigger {
+    Line,
+    Retransmit,
+    KeysUnavailable,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecurityEventType {
+    KeyUpdated,
+    KeyRetired,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecurityEventTrigger {
+    Tls,
+    Implicit,
+    RemoteUpdate,
+    LocalUpdate,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryEventType {
+    ParametersSet,
+    MetricsUpdated,
+    CongestionStateUpdated,
+    LossTimerSet,
+    LossTimerTriggered,
+    PacketLost,
+    MarkedForRetransmit,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryEventTrigger {
+    AckReceived,
+    PacketSent,
+    Alarm,
+    Unknown,
+}
+
+// ================================================================== //
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KeyType {
+    ServerInitialSecret,
+    ClientInitialSecret,
+
+    ServerHandshakeSecret,
+    ClientHandshakeSecret,
+
+    Server0RttSecret,
+    Client0RttSecret,
+
+    Server1RttSecret,
+    Client1RttSecret,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectionState {
+    Attempted,
+    Reset,
+    Handshake,
+    Active,
+    Keepalive,
+    Draining,
+    Closed,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportOwner {
+    Local,
+    Remote
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct PreferredAddress {
+    ip_v4: String,
+    ip_v6: String,
+
+    port_v4: u64,
+    port_v6: u64,
+
+    connection_id: String,
+    stateless_reset_token: String
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamSide {
+    Sending,
+    Receiving
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamState {
+    // bidirectional stream states, draft-23 3.4.
+    Idle,
+    Open,
+    HalfClosedLocal,
+    HalfClosedRemote,
+    Closed,
+
+    // sending-side stream states, draft-23 3.1.
+    Ready,
+    Send,
+    DataSent,
+    ResetSent,
+    ResetReceived,
+
+    // receive-side stream states, draft-23 3.2.
+    Receive,
+    SizeKnown,
+    DataRead,
+    ResetRead,
+
+    // both-side states
+    DataReceived,
+
+    // qlog-defined
+    Destroyed
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TimerType {
+    Ack,
+    Pto
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum H3Owner {
+    Local,
+    Remote
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum H3StreamType {
+    Data,
+    Control,
+    Push,
+    Reserved,
+    QpackEncode,
+    QpackDecode
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum H3DataRecipient {
+    Application,
+    Transport
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum H3PushDecision {
+    Claimed,
+    Abandoned
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QpackOwner {
+    Local,
+    Remote
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QpackStreamState {
+    Blocked,
+    Unblocked
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QpackUpdateType
+ {
+    Added,
+    Evicted
+}
+
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct QpackDynamicTableEntry {
+    index: u64,
+    name: Option<String>,
+    value: Option<String>
+}
+
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct QpackHeaderBlockPrefix {
+    required_insert_count: u64,
+    sign_bit: bool,
+    delta_base: u64
+}
+
+
+#[serde_with::skip_serializing_none]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum EventData {
+    // ================================================================== //
+    // CONNECTIVITY
+    ServerListening {
+        ip_v4: Option<String>,
+        ip_v6: Option<String>,
+        port_v4: u64,
+        port_v6: u64,
+
+        quic_versions: Option<Vec<String>>,
+        alpn_values: Option<Vec<String>>,
+
+        stateless_reset_required: Option<bool>
+    },
+
+    ConnectionStarted {
+        ip_version: String,
+        src_ip: String,
+        dst_ip: String,
+
+        protocol: Option<String>,
+        src_port: u64,
+        dst_port: u64,
+
+        quic_version: Option<String>,
+        src_cid: Option<String>,
+        dst_cid: Option<String>,
+    },
+
+    ConnectionIdUpdated {
+        src_old: Option<String>,
+        src_new: Option<String>,
+
+        dst_old: Option<String>,
+        dst_new: Option<String>,
+    },
+
+    SpinBitUpdated {
+        state: bool,
+    },
+
+    ConnectionStateUpdated {
+        old: Option<ConnectionState>,
+        new: ConnectionState,
+    },
+
+    // ================================================================== //
+    // SECURITY
+
+
+    KeyUpdated {
+        key_type: KeyType,
+        old: Option<String>,
+        new: String,
+        generation: Option<u64>,
+    },
+
+    KeyRetired {
+        key_type: KeyType,
+        key: Option<String>,
+        generation: Option<u64>,
+    },
+
+
+    // ================================================================== //
+    // TRANSPORT
+    TransportParametersSet {
+        owner: Option<TransportOwner>,
+
+        resumption_allowed: Option<bool>,
+        early_data_enabled: Option<bool>,
+        alpn: Option<String>,
+        version: Option<String>,
+        tls_cipher: Option<String>,
+
+        original_connection_id: Option<String>,
+        stateless_reset_token: Option<String>,
+        disable_active_migration: Option<bool>,
+
+        idle_timeout: Option<u64>,
+        max_packet_size: Option<u64>,
+        ack_delay_exponent: Option<u64>,
+        max_ack_delay: Option<u64>,
+        active_connection_id_limit: Option<u64>,
+
+        initial_max_data: Option<String>,
+        initial_max_stream_data_bidi_local: Option<String>,
+        initial_max_stream_data_bidi_remote: Option<String>,
+        initial_max_stream_data_uni: Option<String>,
+        initial_max_streams_bidi: Option<String>,
+        initial_max_streams_uni: Option<String>,
+
+        preferred_address: Option<PreferredAddress>,
+    },
+
+    DatagramsReceived {
+        count: Option<u64>,
+        byte_length: Option<u64>,
+    },
+
+    DatagramsSent {
+        count: Option<u64>,
+        byte_length: Option<u64>,
+    },
+
+    DatagramDropped {
+        byte_length: Option<u64>,
+    },
+
+    PacketReceived {
+        packet_type: PacketType,
+        header: PacketHeader,
+        frames: Option<Vec<QuicFrame>>,
+
+        is_coalesced: Option<bool>,
+
+        raw_encrypted: Option<String>,
+        raw_decrypted: Option<String>,
+    },
+
+    PacketSent {
+        packet_type: PacketType,
+        header: PacketHeader,
+        frames: Option<Vec<QuicFrame>>,
+
+        is_coalesced: Option<bool>,
+
+        raw_encrypted: Option<String>,
+        raw_decrypted: Option<String>,
+    },
+
+    PacketDropped {
+        packet_type: Option<PacketType>,
+        packet_size: Option<u64>,
+
+        raw: Option<String>,
+    },
+
+    PacketBuffered {
+        packet_type: PacketType,
+        packet_number: String,
+    },
+
+    SteamStateUpdated {
+        stream_id: String,
+        stream_type: Option<StreamType>,
+
+        old: Option<StreamState>,
+        new: StreamState,
+
+        stream_side: Option<StreamSide>
+    },
+
+    FramesProcessed {
+        frames: Vec<QuicFrame>
+    },
+
+    // ================================================================== //
+    // RECOVERY
+
+    RecoveryParametersSet {
+        reordering_threshold: Option<u64>,
+        time_threshold: Option<u64>,
+        timer_granularity: Option<u64>,
+        initial_rtt: Option<u64>,
+
+        max_datagram_size: Option<u64>,
+        initial_congestion_window: Option<u64>,
+        minimum_congestion_window: Option<u64>,
+        loss_reduction_factor: Option<u64>,
+        persistent_congestion_threshold: Option<u64>,
+
+    },
+
+    MetricsUpdated {
+        min_rtt: Option<u64>,
+        smoothed_rtt: Option<u64>,
+        latest_rtt: Option<u64>,
+        rtt_variance: Option<u64>,
+
+        max_ack_delay: Option<u64>,
+        pto_count: Option<u64>,
+
+        congestion_window: Option<u64>,
+        bytes_in_flight: Option<u64>,
+
+        ssthresh: Option<u64>,
+
+        // qlog defined
+        packets_in_flight: Option<u64>,
+        in_recovery: Option<bool>,
+
+        pacing_rate: Option<u64>,
+    },
+
+    CongestionStateUpdated {
+        old: Option<String>,
+        new: String,
+    },
+
+    LossTimerSet {
+        timer_type:Option<TimerType>,
+        timeout: Option<String>,
+    },
+
+    PacketLost {
+        packet_type: PacketType,
+        packet_number: String,
+
+        header: Option<PacketHeader>,
+        frames: Vec<QuicFrame>,
+    },
+
+    MarkedForRetransmit {
+        frames: Vec<QuicFrame>,
+    },
+
+    // ================================================================== //
+    // HTTP/3
+
+    H3ParametersSet {
+        owner: Option<H3Owner>,
+
+        max_header_list_size: Option<u64>,
+        max_table_capacity: Option<u64>,
+        blocked_streams_count: Option<u64>,
+
+        push_allowed: Option<bool>,
+
+        waits_for_settings: Option<bool>
+    },
+
+    H3StreamTypeSet {
+        stream_id: String,
+        owner: Option<H3Owner>,
+
+        old: Option<H3StreamType>,
+        new: H3StreamType
+
+    },
+
+    H3FrameCreated {
+        stream_id: String,
+        frame: Http3Frame,
+        byte_length: Option<String>,
+
+        raw: Option<String>,
+    },
+
+    H3FrameParsed {
+        stream_id: String,
+        frame: Http3Frame,
+        byte_length: Option<String>,
+
+        raw: Option<String>,
+    },
+
+    H3DataMoved {
+        stream_id: String,
+        offset: Option<String>,
+
+        from: Option<H3DataRecipient>,
+        to: Option<H3DataRecipient>,
+
+        raw: Option<String>,
+    },
+
+    H3PushResolved {
+        push_id: Option<String>,
+        stream_id: Option<String>,
+
+        decision: Option<H3PushDecision>,
+    },
+
+    // ================================================================== //
+    // QPACK
+
+    QpackStateUpdated {
+        owner: Option<QpackOwner>,
+
+        dynamic_table_capacity: Option<u64>,
+        dynamic_table_size: Option<u64>,
+
+        known_received_count: Option<u64>,
+        current_insert_count: Option<u64>,
+    },
+
+    QpackStreamStateUpdated {
+        stream_id: String,
+
+        state: QpackStreamState,
+    },
+
+    QpackDynamicTableUpdated {
+        update_type: QpackUpdateType,
+
+        entries: Vec<QpackDynamicTableEntry>,
+    },
+
+    QpackHeadersEncoded {
+        stream_id: Option<String>,
+
+        headers: Option<HttpHeader>,
+
+        block_prefix: QpackHeaderBlockPrefix,
+        header_block: Vec<QpackHeaderBlockRepresentation>,
+
+        raw: Option<String>
+    },
+
+    QpackHeadersDecoded {
+        stream_id: Option<String>,
+
+        headers: Option<HttpHeader>,
+
+        block_prefix: QpackHeaderBlockPrefix,
+        header_block: Vec<QpackHeaderBlockRepresentation>,
+
+        raw: Option<String>
+    },
+
+    QpackInstructionSent {
+        instruction: QPackInstruction,
+        byte_length: Option<String>,
+
+        raw: Option<String>
+    },
+
+    QpackInstructionReceived {
+        instruction: QPackInstruction,
+        byte_length: Option<String>,
+
+        raw: Option<String>
+    },
+
+    // ================================================================== //
+    // Generic
+
+    ConnectionError {
+        code: Option<ConnectionErrorCode>,
+        description: Option<String>
+    },
+
+    ApplicationError {
+        code: Option<ApplicationErrorCode>,
+        description: Option<String>
+    },
+
+    InternalError {
+        code: Option<u64>,
+        description: Option<String>
+    },
+
+    InternalWarning {
+        code: Option<u64>,
+        description: Option<String>
+    },
+
+    Message {
+        message: String
+    },
+
+    Marker {
+        marker_type: String,
+        message: Option<String>
+    }
+
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PacketType {
+    Initial,
+    Handshake,
+
+    #[serde(rename = "0RTT")]
+    ZeroRtt,
+
+    #[serde(rename = "1RTT")]
+    OneRtt,
+
+    Retry,
+    VersionNegotiation,
+    Unknown,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Http3EventType {
+    StreamStateUpdate,
+    StreamTypeUpdate,
+    FrameCreated,
+    FrameParsed,
+    DataMoved,
+    DatagramReceived,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QpackEventType {
+    StateUpdated,
+    StreamStateUpdate,
+    DynamicTableUpdated,
+    HeadersEncoded,
+    HeadersDecoded,
+    InstructionSent,
+    InstructionReceived,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuicFrameTypeName {
+    Padding,
+    Ping,
+    Ack,
+    ResetStream,
+    StopSending,
+    Crypto,
+    NewToken,
+    Stream,
+    MaxData,
+    MaxStreamData,
+    MaxStreams,
+    DataBlocked,
+    StreamDataBlocked,
+    StreamsBlocked,
+    NewConnectionId,
+    RetireConnectionId,
+    PathChallenge,
+    PathResponse,
+    ConnectionClose,
+    ApplicationClose,
+    Unknown,
+}
+
+// TODO: search for pub enum Error { to see how best to encode errors in qlog.
+#[serde_with::skip_serializing_none]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct PacketHeader {
+    pub packet_number: String,
+    pub packet_size: Option<u64>,
+    pub payload_length: Option<u64>,
+    pub version: Option<String>,
+    pub scil: Option<String>,
+    pub dcil: Option<String>,
+    pub scid: Option<String>,
+    pub dcid: Option<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamType {
+    Bidirectional,
+    Unidirectional,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorSpace {
+    TransportError,
+    ApplicationError,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GenericEventType {
+    ConnectionError,
+    ApplicationError,
+    InternalError,
+    InternalWarning,
+
+    Message,
+    Marker,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum ConnectionErrorCode {
+    TransportError(TransportError),
+    CryptoError(CryptoError),
+    Value(u64),
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum ApplicationErrorCode {
+    ApplicationError(ApplicationError),
+    Value(u64),
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportError {
+    NoError,
+    InternalError,
+    ServerBusy,
+    FlowControlError,
+    StreamLimitError,
+    StreamStateError,
+    FinalSizeError,
+    FrameEncodingError,
+    TransportParameterError,
+    ProtocolViolation,
+    InvalidMigration,
+    CryptoBufferExceeded,
+    Unknown,
+}
+
+// TODO
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CryptoError {
+    Prefix
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApplicationError {
+    HttpNoError,
+    HttpGeneralProtocolError,
+    HttpInternalError,
+    HttpRequestCancelled,
+    HttpIncompleteRequest,
+    HttpConnectError,
+    HttpFrameError,
+    HttpExcessiveLoad,
+    HttpVersionFallback,
+    HttpIdError,
+    HttpStreamCreationError,
+    HttpClosedCriticalStream,
+    HttpEarlyResponse,
+    HttpMissingSettings,
+    HttpUnexpectedFrame,
+    HttpRequestRejection,
+    HttpSettingsError,
+    Unknown
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum QuicFrame {
+    Padding {
+        frame_type: QuicFrameTypeName,
+    },
+
+    Ping {
+        frame_type: QuicFrameTypeName,
+    },
+
+    Ack {
+        frame_type: QuicFrameTypeName,
+        ack_delay: Option<String>,
+        acked_ranges: Option<Vec<(u64, u64)>>,
+
+        ect1: Option<String>,
+
+        ect0: Option<String>,
+
+        ce: Option<String>,
+    },
+
+    ResetStream {
+        frame_type: QuicFrameTypeName,
+        stream_id: String,
+        error_code: u64,
+        final_size: String,
+    },
+
+    StopSending {
+        frame_type: QuicFrameTypeName,
+        stream_id: String,
+        error_code: u64,
+    },
+
+    Crypto {
+        frame_type: QuicFrameTypeName,
+        offset: String,
+        length: String,
+    },
+
+    NewToken {
+        frame_type: QuicFrameTypeName,
+        length: String,
+        token: String,
+    },
+
+    Stream {
+        frame_type: QuicFrameTypeName,
+        stream_id: String,
+        offset: String,
+        length: String,
+        fin: bool,
+
+        raw: Option<String>,
+    },
+
+    MaxData {
+        frame_type: QuicFrameTypeName,
+        maximum: String,
+    },
+
+    MaxStreamData {
+        frame_type: QuicFrameTypeName,
+        stream_id: String,
+        maximum: String,
+    },
+
+    MaxStreams {
+        frame_type: QuicFrameTypeName,
+        stream_type: StreamType,
+        maximum: String,
+    },
+
+    DataBlocked {
+        frame_type: QuicFrameTypeName,
+        limit: String,
+    },
+
+    StreamDataBlocked {
+        frame_type: QuicFrameTypeName,
+        stream_id: String,
+        limit: String,
+    },
+
+    StreamsBlocked {
+        frame_type: QuicFrameTypeName,
+        stream_type: StreamType,
+        limit: String,
+    },
+
+    NewConnectionId {
+        frame_type: QuicFrameTypeName,
+        sequence_number: String,
+        retire_prior_to: String,
+        length: u64,
+        connection_id: String,
+        reset_token: String,
+    },
+
+    RetireConnectionId {
+        frame_type: QuicFrameTypeName,
+        sequence_number: String,
+    },
+
+    PathChallenge {
+        frame_type: QuicFrameTypeName,
+
+        data: Option<String>,
+    },
+
+    PathResponse {
+        frame_type: QuicFrameTypeName,
+
+        data: Option<String>,
+    },
+
+    ConnectionClose {
+        frame_type: QuicFrameTypeName,
+        error_space: ErrorSpace,
+        error_code: u64,
+        raw_error_code: u64,
+        reason: String,
+
+        trigger_frame_type: Option<String>,
+    },
+
+    Unknown {
+        frame_type: QuicFrameTypeName,
+        raw_frame_type: u64,
+    },
+}
+
+impl QuicFrame {
+    pub fn padding() -> Self {
+        QuicFrame::Padding {
+            frame_type: QuicFrameTypeName::Padding,
+        }
+    }
+
+    pub fn ping() -> Self {
+        QuicFrame::Ping {
+            frame_type: QuicFrameTypeName::Ping,
+        }
+    }
+
+    pub fn ack(
+        ack_delay: Option<String>, acked_ranges: Option<Vec<(u64, u64)>>, ect1: Option<String>,
+        ect0: Option<String>, ce: Option<String>,
+    ) -> Self {
+        QuicFrame::Ack {
+            frame_type: QuicFrameTypeName::Ack,
+            ack_delay,
+            acked_ranges,
+            ect1,
+            ect0,
+            ce,
+        }
+    }
+
+    pub fn reset_stream(stream_id: String, error_code: u64, final_size: String) -> Self {
+        QuicFrame::ResetStream {
+            frame_type: QuicFrameTypeName::ResetStream,
+            stream_id,
+            error_code,
+            final_size,
+        }
+    }
+
+    pub fn stop_sending(stream_id: String, error_code: u64) -> Self {
+        QuicFrame::StopSending {
+            frame_type: QuicFrameTypeName::StopSending,
+            stream_id,
+            error_code,
+        }
+    }
+
+    pub fn crypto(offset: String, length: String) -> Self {
+        QuicFrame::Crypto {
+            frame_type: QuicFrameTypeName::Crypto,
+            offset,
+            length,
+        }
+    }
+
+    pub fn new_token(length: String, token: String) -> Self {
+        QuicFrame::NewToken {
+            frame_type: QuicFrameTypeName::NewToken,
+            length,
+            token,
+        }
+    }
+
+    pub fn stream(
+        stream_id: String, offset: String, length: String, fin: bool,
+        raw: Option<String>,
+    ) -> Self {
+        QuicFrame::Stream {
+            frame_type: QuicFrameTypeName::Stream,
+            stream_id,
+            offset,
+            length,
+            fin,
+            raw,
+        }
+    }
+
+    pub fn max_data(maximum: String) -> Self {
+        QuicFrame::MaxData {
+            frame_type: QuicFrameTypeName::MaxData,
+            maximum,
+        }
+    }
+
+    pub fn max_stream_data(stream_id: String, maximum: String) -> Self {
+        QuicFrame::MaxStreamData {
+            frame_type: QuicFrameTypeName::MaxStreamData,
+            stream_id,
+            maximum,
+        }
+    }
+
+    pub fn max_streams(stream_type: StreamType, maximum: String) -> Self {
+        QuicFrame::MaxStreams {
+            frame_type: QuicFrameTypeName::MaxStreams,
+            stream_type,
+            maximum,
+        }
+    }
+
+    pub fn data_blocked(limit: String) -> Self {
+        QuicFrame::DataBlocked {
+            frame_type: QuicFrameTypeName::DataBlocked,
+            limit,
+        }
+    }
+
+    pub fn stream_data_blocked(stream_id: String, limit: String) -> Self {
+        QuicFrame::StreamDataBlocked {
+            frame_type: QuicFrameTypeName::StreamDataBlocked,
+            stream_id,
+            limit,
+        }
+    }
+
+    pub fn streams_blocked(stream_type: StreamType, limit: String) -> Self {
+        QuicFrame::StreamsBlocked {
+            frame_type: QuicFrameTypeName::StreamsBlocked,
+            stream_type,
+            limit,
+        }
+    }
+
+    pub fn new_connection_id(
+        sequence_number: String, retire_prior_to: String, length: u64,
+        connection_id: String, reset_token: String,
+    ) -> Self {
+        QuicFrame::NewConnectionId {
+            frame_type: QuicFrameTypeName::NewConnectionId,
+            sequence_number,
+            retire_prior_to,
+            length,
+            connection_id,
+            reset_token,
+        }
+    }
+
+    pub fn retire_connection_id(sequence_number: String) -> Self {
+        QuicFrame::RetireConnectionId {
+            frame_type: QuicFrameTypeName::RetireConnectionId,
+            sequence_number,
+        }
+    }
+
+    pub fn path_challenge(data: Option<String>) -> Self {
+        QuicFrame::PathChallenge {
+            frame_type: QuicFrameTypeName::PathChallenge,
+            data,
+        }
+    }
+
+    pub fn path_response(data: Option<String>) -> Self {
+        QuicFrame::PathResponse {
+            frame_type: QuicFrameTypeName::PathResponse,
+            data,
+        }
+    }
+
+    pub fn connection_close(
+        error_space: ErrorSpace, error_code: u64, raw_error_code: u64,
+        reason: String, trigger_frame_type: Option<String>,
+    ) -> Self {
+        QuicFrame::ConnectionClose {
+            frame_type: QuicFrameTypeName::ConnectionClose,
+            error_space,
+            error_code,
+            raw_error_code,
+            reason,
+            trigger_frame_type,
+        }
+    }
+
+    pub fn unknown(raw_frame_type: u64) -> Self {
+        QuicFrame::Unknown {
+            frame_type: QuicFrameTypeName::Unknown,
+            raw_frame_type,
+        }
+    }
+}
+
+// ================================================================== //
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Http3FrameTypeName {
+    Data,
+    Headers,
+    CancelPush,
+    Settings,
+    PushPromise,
+    Goaway,
+    MaxPushId,
+    DuplicatePush,
+    Reserved,
+    Unknown,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct HttpHeader {
+    name: String,
+    value: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Setting {
+    name: String,
+    value: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum Http3Frame {
+    Data {
+        frame_type: Http3FrameTypeName,
+
+        raw: Option<String>
+    },
+
+    Headers {
+        frame_type: Http3FrameTypeName,
+        headers: Vec<HttpHeader>,
+    },
+
+    CancelPush {
+        frame_type: Http3FrameTypeName,
+        push_id: String,
+    },
+
+    Settings {
+        frame_type: Http3FrameTypeName,
+        settings: Vec<Setting>,
+    },
+
+    PushPromise {
+        frame_type: Http3FrameTypeName,
+        push_id: String,
+        headers: Vec<HttpHeader>,
+    },
+
+    Goaway {
+        frame_type: Http3FrameTypeName,
+        stream_id: String,
+    },
+
+    MaxPushId {
+        frame_type: Http3FrameTypeName,
+        push_id: String,
+    },
+
+    DuplicatePush {
+        frame_type: Http3FrameTypeName,
+        push_id: String,
+    },
+
+    Reserved {
+        frame_type: Http3FrameTypeName,
+    },
+
+    Unknown {
+        frame_type: Http3FrameTypeName,
+    },
+}
+
+impl Http3Frame {
+    fn data(raw: Option<String>) -> Self {
+        Http3Frame::Data {
+            frame_type: Http3FrameTypeName::Data,
+            raw
+        }
+    }
+
+    fn headers(headers: Vec<HttpHeader>) -> Self {
+        Http3Frame::Headers {
+            frame_type: Http3FrameTypeName::Headers,
+            headers,
+        }
+    }
+
+    fn cancel_push(push_id: String) -> Self {
+        Http3Frame::CancelPush {
+            frame_type: Http3FrameTypeName::CancelPush,
+            push_id,
+        }
+    }
+
+    fn settings(settings: Vec<Setting>) -> Self {
+        Http3Frame::Settings {
+            frame_type: Http3FrameTypeName::Settings,
+            settings,
+        }
+    }
+
+    fn push_promise(push_id: String, headers: Vec<HttpHeader>) -> Self {
+        Http3Frame::PushPromise {
+            frame_type: Http3FrameTypeName::PushPromise,
+            push_id,
+            headers,
+        }
+    }
+
+    fn goaway(stream_id: String) -> Self {
+        Http3Frame::Goaway {
+            frame_type: Http3FrameTypeName::Goaway,
+            stream_id,
+        }
+    }
+
+    fn max_push_id(push_id: String) -> Self {
+        Http3Frame::MaxPushId {
+            frame_type: Http3FrameTypeName::MaxPushId,
+            push_id,
+        }
+    }
+
+    fn duplicate_push(push_id: String) -> Self {
+        Http3Frame::DuplicatePush {
+            frame_type: Http3FrameTypeName::DuplicatePush,
+            push_id,
+        }
+    }
+
+    fn reserved() -> Self {
+        Http3Frame::Reserved {
+            frame_type: Http3FrameTypeName::Reserved,
+        }
+    }
+
+    fn unknown() -> Self {
+        Http3Frame::Unknown {
+            frame_type: Http3FrameTypeName::Unknown,
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QpackInstructionTypeName {
+    SetDynamicTableCapacityInstruction,
+    InsertWithNameReferenceInstruction,
+    InsertWithoutNameReferenceInstruction,
+    DuplicateInstruction,
+    HeaderAcknowledgementInstruction,
+    StreamCancellationInstruction,
+    InsertCountIncrementInstruction,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QpackTableType {
+    Static,
+    Dynamic
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum QPackInstruction {
+     SetDynamicTableCapacityInstruction {
+        instruction_type: QpackInstructionTypeName,
+
+        capacity: u64,
+    },
+
+    InsertWithNameReferenceInstruction {
+        instruction_type: QpackInstructionTypeName,
+
+        table_type: QpackTableType,
+
+        name_index: u64,
+
+        huffman_encoded_value: bool,
+        value_length: u64,
+        value: String
+    },
+
+    InsertWithoutNameReferenceInstruction {
+        instruction_type: QpackInstructionTypeName,
+
+        huffman_encoded_name: bool,
+        name_length: u64,
+        name: String,
+
+        huffman_encoded_value: bool,
+        value_length: u64,
+        value: String
+    },
+
+    DuplicateInstruction {
+        instruction_type: QpackInstructionTypeName,
+
+        index: u64
+    },
+
+    HeaderAcknowledgementInstruction {
+        instruction_type: QpackInstructionTypeName,
+
+        stream_id: String
+    },
+
+    StreamCancellationInstruction {
+        instruction_type: QpackInstructionTypeName,
+
+        stream_id: String
+    },
+
+    InsertCountIncrementInstruction {
+        instruction_type: QpackInstructionTypeName,
+
+        increment: u64
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QpackHeaderBlockRepresentationTypeName {
+    IndexedHeaderField,
+    LiteralHeaderFieldWithName,
+    LiteralHeaderFieldWithoutName,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum QpackHeaderBlockRepresentation {
+    IndexedHeaderField {
+        header_field_type: QpackHeaderBlockRepresentationTypeName,
+
+        table_type: QpackTableType,
+        index: u64,
+
+        is_post_base: Option<bool>
+    },
+
+    LiteralHeaderFieldWithName {
+        header_field_type: QpackHeaderBlockRepresentationTypeName,
+
+        preserve_literal: bool,
+        table_type: QpackTableType,
+        name_index: u64,
+
+        huffman_encoded_value: bool,
+        value_length: u64,
+        value: String,
+
+        is_post_base: Option<bool>
+
+    },
+
+    LiteralHeaderFieldWithoutName {
+        header_field_type: QpackHeaderBlockRepresentationTypeName,
+
+        preserve_literal: bool,
+        table_type: QpackTableType,
+        name_index: u64,
+
+        huffman_encoded_name: bool,
+        name_length: u64,
+        name: String,
+
+        huffman_encoded_value: bool,
+        value_length: u64,
+        value: String,
+
+        is_post_base: Option<bool>
+
+    },
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct QPackHeaderBlockPrefix {
+    required_insert_count: u64,
+    sign_bit: bool,
+    delta_base: u64
+}
+
+pub struct HexSlice<'a>(&'a [u8]);
+
+impl<'a> HexSlice<'a> {
+    pub fn new<T>(data: &'a T) -> HexSlice<'a>
+    where
+        T: ?Sized + AsRef<[u8]> + 'a,
+    {
+        HexSlice(data.as_ref())
+    }
+}
+
+impl<'a> std::fmt::Display for HexSlice<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        for byte in self.0 {
+            // Decide if you want to pad out the value here
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is not ready for merging but would benefit from more eyes.

The PR has 2 parts: the first is adding a QLOG data model, the second is some rough integration with http3-client to show the bare minimum of how we might integrate this. 

The QLOG datamodel that makes heavy use of serde to allow easy creation of QLOG compliant JSON. The structure is heavily based on the TypeScript schema - https://github.com/quiclog/qlog/blob/master/TypeScript/draft-01/QLog.ts. Sometimes this causes counter-intuitive code I'm hoping there are more Rust tricks to play.

The quiche integration needs more work - we shouldn't buffer all packets and frames and write at the end.