### PR TITLE
update nginx HTTP/3 instructions

### DIFF
--- a/extras/nginx/README.md
+++ b/extras/nginx/README.md
@@ -37,7 +37,7 @@ Next you’ll need to apply the patch to NGINX:
 
 And finally build NGINX with HTTP/3 support enabled:
 ```
- % auto/configure                              \
+ % ./configure                                 \
        --prefix=$PWD                           \
        --with-http_ssl_module                  \
        --with-http_v2_module                   \


### PR DESCRIPTION
auto/configure seems to be for git cloned nginx repo builds ? for source tarball ./configure would be the correct one to use