### PR TITLE
h3: add has_body flag to HTTP/3 Header Event

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -93,7 +93,7 @@ fn http3(c: &mut Criterion) {
 
     let mut config = make_bench_config();
 
-    let h3_config = quiche::h3::Config::new().unwrap();
+    let mut h3_config = quiche::h3::Config::new().unwrap();
 
     let mut s =
         quiche::h3::testing::Session::with_configs(&mut config, &mut h3_config)
@@ -132,7 +132,7 @@ fn http3(c: &mut Criterion) {
                     s.pipe.flush_client(&mut buf).unwrap();
 
                     match s.server.poll(&mut s.pipe.server) {
-                        Ok((stream, quiche::h3::Event::Headers(_))) => {
+                        Ok((stream, quiche::h3::Event::Headers { .. })) => {
                             s.server
                                 .send_response(
                                     &mut s.pipe.server,

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -328,10 +328,10 @@ fn main() {
             // Process HTTP/3 events.
             loop {
                 match http3_conn.poll(&mut conn) {
-                    Ok((stream_id, quiche::h3::Event::Headers(headers))) => {
+                    Ok((stream_id, quiche::h3::Event::Headers { list, .. })) => {
                         info!(
                             "got response headers {:?} on stream id {}",
-                            headers, stream_id
+                            list, stream_id
                         );
                     },
 

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -368,11 +368,14 @@ fn main() {
                     let http3_conn = client.http3_conn.as_mut().unwrap();
 
                     match http3_conn.poll(client.conn.as_mut()) {
-                        Ok((stream_id, quiche::h3::Event::Headers(headers))) => {
+                        Ok((
+                            stream_id,
+                            quiche::h3::Event::Headers { list, .. },
+                        )) => {
                             handle_request(
                                 client,
                                 stream_id,
-                                &headers,
+                                &list,
                                 args.get_str("--root"),
                             );
                         },

--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -1546,7 +1546,7 @@ new file mode 100644
 index 000000000..972ecd223
 --- /dev/null
 +++ b/src/http/v3/ngx_http_v3.c
-@@ -0,0 +1,2093 @@
+@@ -0,0 +1,2092 @@
 +
 +/*
 + * Copyright (C) Cloudflare, Inc.
@@ -1832,9 +1832,6 @@ index 000000000..972ecd223
 +
 +    stream->node.key = stream_id;
 +
-+    /* TODO: remove this when FLPROTO-548 is done. */
-+    stream->in_closed = quiche_conn_stream_finished(c->quic->conn, stream_id);
-+
 +    ngx_rbtree_insert(&h3c->streams, &stream->node);
 +
 +    /* Populate ngx_http_request_t from raw HTTP/3 headers. */
@@ -1848,6 +1845,8 @@ index 000000000..972ecd223
 +        ngx_http_v3_finalize_connection(h3c, NGX_HTTP_V3_INTERNAL_ERROR);
 +        return;
 +    }
++
++    stream->in_closed = !quiche_h3_event_headers_has_body(ev);
 +
 +    ngx_http_v3_run_request(stream->request);
 +}

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -359,6 +359,9 @@ int quiche_h3_event_for_each_header(quiche_h3_event *ev,
                                               void *argp),
                                     void *argp);
 
+// Check whether data will follow the headers on the stream.
+bool quiche_h3_event_headers_has_body(quiche_h3_event *ev);
+
 // Frees the HTTP/3 event object.
 void quiche_h3_event_free(quiche_h3_event *ev);
 

--- a/src/h3/ffi.rs
+++ b/src/h3/ffi.rs
@@ -125,8 +125,8 @@ pub extern fn quiche_h3_event_for_each_header(
     argp: *mut c_void,
 ) -> c_int {
     match ev {
-        h3::Event::Headers(headers) =>
-            for h in headers {
+        h3::Event::Headers { list, .. } =>
+            for h in list {
                 let rc = cb(
                     h.name().as_ptr(),
                     h.name().len(),
@@ -144,6 +144,15 @@ pub extern fn quiche_h3_event_for_each_header(
     }
 
     0
+}
+
+#[no_mangle]
+pub extern fn quiche_h3_event_headers_has_body(ev: &h3::Event) -> bool {
+    match ev {
+        h3::Event::Headers { has_body, .. } => *has_body,
+
+        _ => unreachable!(),
+    }
 }
 
 #[no_mangle]

--- a/tools/http3_test/src/lib.rs
+++ b/tools/http3_test/src/lib.rs
@@ -157,8 +157,8 @@
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut http3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
 //! match http3_conn.poll(&mut conn) {
-//!     Ok((stream_id, quiche::h3::Event::Headers(headers))) => {
-//!         test.add_response_headers(stream_id, &headers);
+//!     Ok((stream_id, quiche::h3::Event::Headers{list, has_body})) => {
+//!         test.add_response_headers(stream_id, &list);
 //!     },
 //!
 //!     Ok((stream_id, quiche::h3::Event::Data)) => {

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -209,13 +209,13 @@ pub fn run(
             // Process HTTP/3 events.
             loop {
                 match http3_conn.poll(&mut conn) {
-                    Ok((stream_id, quiche::h3::Event::Headers(headers))) => {
+                    Ok((stream_id, quiche::h3::Event::Headers { list, .. })) => {
                         info!(
                             "got response headers {:?} on stream id {}",
-                            headers, stream_id
+                            &list, stream_id
                         );
 
-                        test.add_response_headers(stream_id, &headers);
+                        test.add_response_headers(stream_id, &list);
                     },
 
                     Ok((stream_id, quiche::h3::Event::Data)) => {


### PR DESCRIPTION
~~Previously, when `quiche::h3::Connection::poll()`
returned a `Headers` or `Data` event, there was
no way to tell if that event simultaneously closed
the indicated stream. Instead, `poll()` would need
to be called until the `Finished` event occurred.~~

~~With this change a boolean `fin` flag is returned
with the Event, which allows for some more
optimised work flows.~~

~~This changes the poll API and so has ripple effects. I chose to refactor `http3-client.rs` to act on the fin flag in every event handler. While for http3_test/runner.rs I chose to just ignore the flag and continue with the existing `Finished` event.~~

~~Implementing the feature the way I have reveals two things: 1) it's not possible to receive a a Data event with fin=true (because the stream has data on it that the app needs to read, 2) it's not possible to receive a Finished event with fin=false (because otherwise we seriously messed up).~~

The previous design was quite intrusive and as the final paragraph above highlighted had some edge cases, so I reworked it to only modify the Headers event.

Previously, when `quiche::h3::Connection::poll()`
returned a `Headers` event, there was no way to tell
if it simultaneously closed the indicated stream.
Instead, `poll()` would need to be called again
until the `Finished` event occurred.
   
With this change a boolean `fin` flag is returned
with the Event, which allows for some more
optimised work flows.
    
This is changes the Rust API, the Headers event
is changes from a `Vec<Header>` to a struct.
    
This changes the FFI, the `quiche_h3_event_for_each_header`
method takes an additional parameter.

