### PR TITLE
Remove one unwrap() call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1527,6 +1527,12 @@ impl Connection {
             return Err(Error::Done);
         }
 
+        // If the Initial secrets have not been derived yet, there's no point
+        // in trying to send a packet, so return early.
+        if !self.derived_initial_secrets {
+            return Err(Error::Done);
+        }
+
         let is_closing = self.error.is_some() || self.app_error.is_some();
 
         if !is_closing {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1611,7 +1611,8 @@ impl Connection {
         let pn_len = packet::pkt_num_len(pn)?;
 
         // The AEAD overhead at the current encryption level.
-        let overhead = self.pkt_num_spaces[epoch].overhead();
+        let overhead =
+            self.pkt_num_spaces[epoch].overhead().ok_or(Error::Done)?;
 
         let hdr = Header {
             ty: pkt_type,
@@ -3378,8 +3379,8 @@ pub mod testing {
 
         hdr.to_bytes(&mut b)?;
 
-        let payload_len =
-            frames.iter().fold(0, |acc, x| acc + x.wire_len()) + space.overhead();
+        let payload_len = frames.iter().fold(0, |acc, x| acc + x.wire_len()) +
+            space.overhead().unwrap();
 
         if pkt_type != packet::Type::Short {
             let len = pn_len + payload_len;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -673,8 +673,8 @@ impl PktNumSpace {
         self.ack_elicited = false;
     }
 
-    pub fn overhead(&self) -> usize {
-        self.crypto_seal.as_ref().unwrap().alg().tag_len()
+    pub fn overhead(&self) -> Option<usize> {
+        Some(self.crypto_seal.as_ref()?.alg().tag_len())
     }
 
     pub fn ready(&self) -> bool {


### PR DESCRIPTION
This removes an `unwrap()` call in `packet.rs`. In addition a slight optimization is added, to avoid trying to generate packets if it's obvious that will fail later.

In practice removing the `unwrap()` is not needed if the other check is present, but fixing it anyway doesn't hurt.