### PR TITLE
pin Connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ be linked directly into C/C++ applications.
 Building
 --------
 
-quiche requires Rust 1.38 or later to build. The latest stable Rust release can
+quiche requires Rust 1.39 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -62,7 +62,7 @@ struct PartialResponse {
 }
 
 struct Client {
-    conn: Box<quiche::Connection>,
+    conn: std::pin::Pin<Box<quiche::Connection>>,
 
     http3_conn: Option<quiche::h3::Connection>,
 
@@ -367,7 +367,7 @@ fn main() {
                 loop {
                     let http3_conn = client.http3_conn.as_mut().unwrap();
 
-                    match http3_conn.poll(client.conn.as_mut()) {
+                    match http3_conn.poll(&mut client.conn) {
                         Ok((
                             stream_id,
                             quiche::h3::Event::Headers { list, .. },

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -64,7 +64,7 @@ struct PartialResponse {
 }
 
 struct Client {
-    conn: Box<quiche::Connection>,
+    conn: std::pin::Pin<Box<quiche::Connection>>,
 
     partial_responses: HashMap<u64, PartialResponse>,
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -296,7 +296,7 @@ pub extern fn quiche_accept(
     };
 
     match accept(scid, odcid, config) {
-        Ok(c) => Box::into_raw(c),
+        Ok(c) => Box::into_raw(Pin::into_inner(c)),
 
         Err(_) => ptr::null_mut(),
     }
@@ -316,7 +316,7 @@ pub extern fn quiche_connect(
     let scid = unsafe { slice::from_raw_parts(scid, scid_len) };
 
     match connect(server_name, scid, config) {
-        Ok(c) => Box::into_raw(c),
+        Ok(c) => Box::into_raw(Pin::into_inner(c)),
 
         Err(_) => ptr::null_mut(),
     }
@@ -373,7 +373,7 @@ pub extern fn quiche_conn_new_with_tls(
     let tls = unsafe { tls::Handshake::from_ptr(ssl) };
 
     match Connection::with_tls(scid, odcid, config, tls, is_server) {
-        Ok(c) => Box::into_raw(c),
+        Ok(c) => Box::into_raw(Pin::into_inner(c)),
 
         Err(_) => ptr::null_mut(),
     }


### PR DESCRIPTION
Due to the fact that we store a pointer to the Connection object inside
its own Handshake context, Connection objects cannot be moved (which is
why we return a boxed object from its constructor). Using Pin on it
makes the compiler enforce this.

Fixes #45.

---

Note this requires Rust 1.39.