### PR TITLE
silence improper_ctypes warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,7 @@
 //! [`stream_recv()`]: struct.Connection.html#method.stream_recv
 //! [HTTP/3 module]: h3/index.html
 
+#![allow(improper_ctypes)]
 #![warn(missing_docs)]
 
 #[macro_use]


### PR DESCRIPTION
This is actually a false positive, as the structs are only exposed to
FFI as pointers, so they are effectively opaque from the non-Rust
perspective

The warning showed up in nightly after the following PR was merged:
https://github.com/rust-lang/rust/pull/65134