### PR TITLE
h3: document that app should validate headers

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -350,9 +350,11 @@ enum quiche_h3_event_type quiche_h3_event_type(quiche_h3_event *ev);
 
 // Iterates over the headers in the event.
 //
-// The `cb` callback will be called for each header in `ev`. If `cb` returns
-// any value other than `0`, processing will be interrupted and the value is
-// returned to the caller.
+// The `cb` callback will be called for each header in `ev`. `cb` should check
+// the validity of pseudo-headers and headers. If `cb` returns any value other
+// than `0`, processing will be interrupted and the value is returned to the
+// caller.
+
 int quiche_h3_event_for_each_header(quiche_h3_event *ev,
                                     int (*cb)(uint8_t *name, size_t name_len,
                                               uint8_t *value, size_t value_len,

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -354,7 +354,6 @@ enum quiche_h3_event_type quiche_h3_event_type(quiche_h3_event *ev);
 // the validity of pseudo-headers and headers. If `cb` returns any value other
 // than `0`, processing will be interrupted and the value is returned to the
 // caller.
-
 int quiche_h3_event_for_each_header(quiche_h3_event *ev,
                                     int (*cb)(uint8_t *name, size_t name_len,
                                               uint8_t *value, size_t value_len,

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -495,7 +495,8 @@ impl Header {
 pub enum Event {
     /// Request/response headers were received.
     Headers {
-        /// The list of received header fields.
+        /// The list of received header fields. The application should validate
+        /// pseudo-headers and headers.
         list: Vec<Header>,
 
         /// Whether data will follow the headers on the stream.


### PR DESCRIPTION
Make it clear that applications are responsible for validating HTTP/3 pseudo-headers and headers, to help avoid issues such as https://github.com/cloudflare/quiche/issues/248

The nginx patch included in this repo has an [example](https://github.com/cloudflare/quiche/blob/a27c2b898beae734c771bcc50803737540d288f3/extras/nginx/nginx-1.16.patch#L1728) of the sort of checks that should be done.