### PR TITLE
discard 1-RTT packets received before handshake completion

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -358,12 +358,6 @@ impl StreamMap {
             self.local_max_streams_uni_next / 2 >
                 self.local_max_streams_uni - self.peer_opened_streams_uni
     }
-
-    /// Creates an iterator over all streams.
-    #[cfg(test)]
-    pub fn iter_mut(&mut self) -> hash_map::IterMut<u64, Stream> {
-        self.streams.iter_mut()
-    }
 }
 
 /// A QUIC stream.


### PR DESCRIPTION
Even if we only decrypt the packets but not process the frames they
carry, there is still some risk for side effects (see e.g.
a0e69eda9da97ebb03ccda38f4bb58cfea572163).

In the future we may want to buffer received packets so we can later
process them as an optimization.

---

Forgot to create this during the hackathon...