### PR TITLE
Additional Fuzz Targets & Fuzzing improvements

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 [package.metadata]
 cargo-fuzz = true
 
+[profile.dev]
+opt-level = 3
+
 [dependencies]
 quiche = { path = "..", features = ["fuzzing"] }
 lazy_static = "1"

--- a/fuzz/Dockerfile
+++ b/fuzz/Dockerfile
@@ -3,6 +3,9 @@ LABEL maintainer="alessandro@cloudflare.com"
 
 WORKDIR /home/mayhem/
 
+# Install llvm-symbolizer to have source code information in stack traces
+RUN apt-get update && apt-get install llvm -y
+
 COPY ./cert.crt ./
 COPY ./cert.key ./
 

--- a/fuzz/src/qpack_decode.rs
+++ b/fuzz/src/qpack_decode.rs
@@ -3,9 +3,26 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 
+// Fuzzer for qpack codec. Checks that decode(encode(hdrs)) == hdrs. To get the
+// initial hdrs, the fuzzer deserializes the input, and skips inputs where
+// deserialization fails.
+//
+// The fuzzer could have been written to instead check encode(decode(input)) ==
+// input. However, that transformation is not guaranteed to be the identify
+// function, as there are multiple ways the same hdr list could be encoded.
 fuzz_target!(|data: &[u8]| {
-    let mut buf = data.to_vec();
     let mut decoder = quiche::h3::qpack::Decoder::new();
+    let mut encoder = quiche::h3::qpack::Encoder::new();
+    let hdrs = match decoder.decode(&mut data.to_vec(), std::u64::MAX) {
+        Err(_) => return,
+        Ok(hdrs) => hdrs,
+    };
+    let mut encoded_hdrs = vec![0; data.len() * 10 + 1000];
+    let encoded_size = encoder.encode(&hdrs, &mut encoded_hdrs).unwrap();
 
-    decoder.decode(&mut buf, std::u64::MAX).ok();
+    let decoded_hdrs = decoder
+        .decode(&mut encoded_hdrs[..encoded_size], std::u64::MAX)
+        .unwrap();
+
+    assert_eq!(hdrs, decoded_hdrs)
 });


### PR DESCRIPTION
This pull request suggests adding two fuzz targets and improving an existing one:
- `qpack_decode`: The target now checks that `decode(encode(hdrs)) == hdrs` while not panicking instead of just checking `decode(input)` doesn't panic. 
- `qpack_huffman_rt` (NEW): Fuzzer for the QPACK huffman codec. Checks that `decode(encode(input)) == input` while not raising a panic.
- `h3_frame_rt` (NEW): Fuzzer for h3::frame (de)serialization. Checks that `deserialize(serialize(frame)) == frame` while not raising a panic.

As an aside, all of those fuzzers define a buffer to store the encoded (or serialized) data. Those buffers have to be bigger than the original `data` array given by libfuzzer. This is necessary because libfuzzer sometimes find a smaller representation than what the encoder would create. Reducing the size of those buffers would likely help find places where the encoder could be improved. For instance, it helped me find this potential optimization in the QPACK encoder (not included in this PR):

```diff
diff --git a/src/h3/qpack/encoder.rs b/src/h3/qpack/encoder.rs
index 1388323..8cf8b28 100644
--- a/src/h3/qpack/encoder.rs
+++ b/src/h3/qpack/encoder.rs
@@ -83,9 +83,13 @@ impl Encoder {
                     let name_len =
                         super::huffman::encode_output_length(h.0.as_bytes())?;

-                    encode_int(name_len as u64, LITERAL | 0x08, 3, &mut b)?;
-
-                    super::huffman::encode(h.0.as_bytes(), &mut b)?;
+                    if name_len > h.0.len() {
+                        encode_int(h.0.len() as u64, LITERAL, 3, &mut b)?;
+                        b.put_bytes(h.0.as_bytes())?;
+                    } else {
+                        encode_int(name_len as u64, LITERAL | 0x08, 3, &mut b)?;
+                        super::huffman::encode(h.0.as_bytes(), &mut b)?;
+                    }

                     encode_str(&h.1, 7, &mut b)?;
                 },
@@ -278,9 +282,13 @@ fn encode_int(
 fn encode_str(v: &str, prefix: usize, b: &mut octets::Octets) -> Result<()> {
     let len = super::huffman::encode_output_length(v.as_bytes())?;

-    encode_int(len as u64, 0x80, prefix, b)?;
-
-    super::huffman::encode(v.as_bytes(), b)?;
+    if len > v.len() {
+        encode_int(v.len() as u64, 0x00, prefix, b)?;
+        b.put_bytes(v.as_bytes())?;
+    } else {
+        encode_int(len as u64, 0x80, prefix, b)?;
+        super::huffman::encode(v.as_bytes(), b)?;
+    }

     Ok(())
 }
```

This PR also adds a couple of additional fuzzing improvements:
- Install llvm-symbolizer into the mayhem docker image in order for stack traces to have symbols
- -O3 for the fuzzing harnesses to speed up fuzzing (requires cargo-fuzz 0.5.5+ to have one of our fix: https://github.com/rust-fuzz/cargo-fuzz/pull/193. See https://github.com/rust-fuzz/cargo-fuzz/issues/63 for extra info)

We are working in the background to improve fuzzing support in rust as well. We pushed a fix to cargo-fuzz to handle optimized harnesses, and we have an open PR on libfuzzer-sys (https://github.com/rust-fuzz/libfuzzer-sys/pull/44), which will improve the information printed during a crash.

From your friends at ForAllSecure :)