### PR TITLE
Try to fill the whole packet buffer

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -967,6 +967,15 @@ impl SendBuf {
         Ok(())
     }
 
+    /// Returns the lowest offset of data buffered.
+    pub fn off(&self) -> u64 {
+        match self.data.peek() {
+            Some(v) => v.off(),
+
+            None => self.off,
+        }
+    }
+
     /// Returns true if all data in the stream has been sent.
     ///
     /// This happens when the stream's send final size is knwon, and the
@@ -996,15 +1005,6 @@ impl SendBuf {
     /// Returns true if there is data to be written.
     fn ready(&self) -> bool {
         !self.data.is_empty()
-    }
-
-    /// Returns the lowest offset of data buffered.
-    fn off(&self) -> u64 {
-        match self.data.peek() {
-            Some(v) => v.off(),
-
-            None => self.off,
-        }
     }
 
     /// Returns the highest contiguously acked offset.


### PR DESCRIPTION
Currently, when sending stream data, we don't fill the entire output packet buffer due to a couple of accounting discrepancies. While this is only by a handful of bytes, so performance is not really affected, this potentially complicates applications that can's assume a whole buffer is filled. This is particularly annoying when dealing with UDP GSO.