### PR TITLE
MacOS: fix cdylib build with --no-default-features

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -180,6 +180,11 @@ fn main() {
         println!("cargo:rustc-link-lib=static=ssl");
     }
 
+    // MacOS: Allow cdylib to link with undefined symbols
+    if cfg!(target_os = "macos") {
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-undefined,dynamic_lookup");
+    }
+
     if cfg!(feature = "pkg-config-meta") {
         write_pkg_config();
     }


### PR DESCRIPTION
Seems like when you build dylib in MacOS it will try to find
all symbols defined by default, resulting cdylib link failing due to
missing boringssl library. Add a linker option to allow building
dylib without finding undefined symbols.

Ref: https://glandium.org/blog/?p=2764

Fixes #238 