### PR TITLE
Fix 32bit x86 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,6 +141,25 @@ matrix:
       - tools/setup_android.sh
      script:
       - tools/build_android.sh --release --verbose
+   - name: "x86 cross-build"
+     language: rust
+     rust: stable
+     env:
+       TARGET=i686-unknown-linux-gnu
+     before_install:
+      # Install and use the current stable release of Go
+      - gimme --list
+      - eval "$(gimme stable)"
+      - gimme --list
+      # Install x86 Rust target for cross-building
+      - rustup target add $TARGET || true
+     addons:
+       apt:
+         packages:
+         - gcc-multilib
+         - g++-multilib
+     script:
+      - RUSTFLAGS="-D warnings" cargo build --target=$TARGET
 
 deploy:
   - provider: pages

--- a/src/build.rs
+++ b/src/build.rs
@@ -80,6 +80,7 @@ fn get_boringssl_platform_output_path(lib: &str) -> String {
 fn get_boringssl_cmake_config() -> cmake::Config {
     let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let pwd = std::env::current_dir().unwrap();
 
     let mut boringssl_cmake = cmake::Config::new("deps/boringssl");
 
@@ -120,7 +121,18 @@ fn get_boringssl_cmake_config() -> cmake::Config {
             boringssl_cmake
         },
 
-        _ => boringssl_cmake,
+        _ => {
+            // Configure BoringSSL for building on 32-bit platforms.
+            if arch == "x86" {
+                boringssl_cmake.define(
+                    "CMAKE_TOOLCHAIN_FILE",
+                    pwd.join("deps/boringssl/util/32-bit-toolchain.cmake")
+                        .as_os_str(),
+                );
+            }
+
+            boringssl_cmake
+        },
     };
 }
 


### PR DESCRIPTION
Pass 32bit toolchain to cmake for cross-building x86 linux from
x86_64 linux. Also CI target is added.

Ref: https://github.com/google/boringssl/blob/master/BUILDING.md

Fixes #277 