### PR TITLE
tools: add some more documentation of http3_test env vars

### DIFF
--- a/tools/http3_test/README.md
+++ b/tools/http3_test/README.md
@@ -1,6 +1,6 @@
-This crate provides an API to build httpbin test requests and expected
-outcomes. These can be used with the quiche HTTP/3 module to
-communicate with an httpbin test server.
+This crate provides an API to build httpbin test requests and expected outcomes.
+These can be used with the quiche HTTP/3 module to communicate with an httpbin
+test server.
 
 Building
 --------
@@ -11,13 +11,35 @@ Building
 
 Running
 --------
-We use cargo test to execute different httpbin tests. By default this points to https://cloudflare-quic.com/b
+We use cargo test to execute different httpbin tests. By default this points to
+https://cloudflare-quic.com/b
 
 ```bash
  $ cargo test
 ```
 
-To test a different server, use the HTTPBIN_ENDPOINT environment variable
+Environment Variable Overrides
+------------------------------
+
+A set of environment variables allow tuning of test beheviour:
+
+* HTTPBIN_ENDPOINT - httpbin server URL, the authority is used in SNI.
+                     Default value is https://cloudflare-quic.com/b
+
+* HTTPBIN_HOST     - httpbin server IP address and port (<SERVER>:<PORT>).
+                     Overrides the effective target authority defined in
+                     HTTPBIN_ENDPOINT. Default value does not override.
+
+* VERIFY_PEER      - boolean value ("true" or "false") that controls if
+                     the test client attempts to validate the httpbin
+                     server certificate. Default value is true.
+
+* IDLE_TIMEOUT     - client's idle timeout in integer milliseconds.
+                     Default value is 60000 (60 seconds).
+
+
+For example, to test a non-default server, use the HTTPBIN_ENDPOINT environment
+variable
 
 ```bash
  $ HTTPBIN_ENDPOINT=https://<some_other_endpoint> cargo test

--- a/tools/http3_test/tests/httpbin_tests.rs
+++ b/tools/http3_test/tests/httpbin_tests.rs
@@ -1,3 +1,29 @@
+// Copyright (C) 2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 mod httpbin_tests {
     use std::collections::HashMap;
     use std::net::ToSocketAddrs;


### PR DESCRIPTION
Since we'll be adding some more environment variables (cc @schien) I figured we probably want to document their intended purpose and the expected format.