### PR TITLE
Fix windows/x86 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,13 +87,28 @@ matrix:
    - language: rust
      rust: stable
      os: windows
+     env:
+       TARGET=x86_64-pc-windows-msvc
      before_install:
       - choco install golang nasm
       # Update $PATH
       - export PATH="$(powershell -Command '("Process", "Machine" | % { [Environment]::GetEnvironmentVariable("PATH", $_) -Split ";" -Replace "\\$", "" } | Select -Unique | % { cygpath $_ }) -Join ":"')"
      script:
-      - RUSTFLAGS="-D warnings" cargo build --release --verbose
-      - RUSTFLAGS="-D warnings" cargo test --verbose
+      - RUSTFLAGS="-D warnings" cargo build --release --verbose --target=$TARGET
+      - RUSTFLAGS="-D warnings" cargo test --verbose --target=$TARGET
+   - language: rust
+     rust: stable
+     os: windows
+     env:
+       TARGET=i686-pc-windows-msvc
+     before_install:
+      - choco install golang nasm
+      # Update $PATH
+      - export PATH="$(powershell -Command '("Process", "Machine" | % { [Environment]::GetEnvironmentVariable("PATH", $_) -Split ";" -Replace "\\$", "" } | Select -Unique | % { cygpath $_ }) -Join ":"')"
+      - rustup target add $TARGET
+     script:
+      - RUSTFLAGS="-D warnings" cargo build --release --verbose --target=$TARGET
+      - RUSTFLAGS="-D warnings" cargo test --verbose --target=$TARGET
    - language: rust
      rust: stable
      env:
@@ -152,7 +167,7 @@ matrix:
       - eval "$(gimme stable)"
       - gimme --list
       # Install x86 Rust target for cross-building
-      - rustup target add $TARGET || true
+      - rustup target add $TARGET
      addons:
        apt:
          packages:

--- a/src/build.rs
+++ b/src/build.rs
@@ -122,8 +122,8 @@ fn get_boringssl_cmake_config() -> cmake::Config {
         },
 
         _ => {
-            // Configure BoringSSL for building on 32-bit platforms.
-            if arch == "x86" {
+            // Configure BoringSSL for building on 32-bit non-windows platforms.
+            if arch == "x86" && os != "windows" {
                 boringssl_cmake.define(
                     "CMAKE_TOOLCHAIN_FILE",
                     pwd.join("deps/boringssl/util/32-bit-toolchain.cmake")


### PR DESCRIPTION
When building on windows/x86, a custom CMAKE_TOOLCHAIN_FILE
is not needed. Also split windows CI into x86_64 and x86 to make sure it works.

Fixes #293 