### PR TITLE
recovery: configurable congestion control

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -47,6 +47,7 @@ Options:
   --wire-version VERSION   The version number to send to the server [default: babababa].
   --dump-packets PATH      Dump the incoming packets as files in the given directory.
   --no-verify              Don't verify server's certificate.
+  --cc-algorithm NAME      Set client congestion control algorithm [default: reno].
   -h --help                Show this screen.
 ";
 
@@ -133,6 +134,10 @@ fn main() {
     if std::env::var_os("SSLKEYLOGFILE").is_some() {
         config.log_keys();
     }
+
+    config
+        .set_cc_algorithm_name(args.get_str("--cc-algorithm"))
+        .unwrap();
 
     // Generate a random source connection ID for the connection.
     let mut scid = [0; quiche::MAX_CONN_ID_LEN];

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -45,6 +45,7 @@ Options:
   --wire-version VERSION   The version number to send to the server [default: babababa].
   --no-verify              Don't verify server's certificate.
   --no-grease              Don't send GREASE.
+  --cc-algorithm NAME      Set client congestion control algorithm [default: reno].
   -H --header HEADER ...   Add a request header.
   -n --requests REQUESTS   Send the given number of identical requests [default: 1].
   -h --help                Show this screen.
@@ -142,6 +143,10 @@ fn main() {
     if std::env::var_os("SSLKEYLOGFILE").is_some() {
         config.log_keys();
     }
+
+    config
+        .set_cc_algorithm_name(args.get_str("--cc-algorithm"))
+        .unwrap();
 
     // Generate a random source connection ID for the connection.
     let mut scid = [0; quiche::MAX_CONN_ID_LEN];

--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -520,6 +520,7 @@ int main(int argc, char *argv[]) {
     quiche_config_set_initial_max_streams_bidi(config, 100);
     quiche_config_set_initial_max_streams_uni(config, 100);
     quiche_config_set_disable_active_migration(config, true);
+    quiche_config_set_cc_algorithm(config, QUICHE_CC_RENO);
 
     http3_config = quiche_h3_config_new();
     if (http3_config == NULL) {

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -52,6 +52,7 @@ Options:
   --early-data                Enables receiving early data.
   --no-retry                  Disable stateless retry.
   --no-grease                 Don't send GREASE.
+  --cc-algorithm NAME         Set server congestion control algorithm [default: reno].
   -h --help                   Show this screen.
 ";
 
@@ -146,6 +147,10 @@ fn main() {
     if std::env::var_os("SSLKEYLOGFILE").is_some() {
         config.log_keys();
     }
+
+    config
+        .set_cc_algorithm_name(args.get_str("--cc-algorithm"))
+        .unwrap();
 
     let h3_config = quiche::h3::Config::new().unwrap();
 

--- a/examples/server.c
+++ b/examples/server.c
@@ -451,6 +451,7 @@ int main(int argc, char *argv[]) {
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_bidi_remote(config, 1000000);
     quiche_config_set_initial_max_streams_bidi(config, 100);
+    quiche_config_set_cc_algorithm(config, QUICHE_CC_RENO);
 
     struct connections c;
     c.sock = sock;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -54,6 +54,7 @@ Options:
   --dump-packets PATH         Dump the incoming packets as files in the given directory.
   --early-data                Enables receiving early data.
   --no-retry                  Disable stateless retry.
+  --cc-algorithm NAME         Set server congestion control algorithm [default: reno].
   -h --help                   Show this screen.
 ";
 
@@ -148,6 +149,10 @@ fn main() {
     if std::env::var_os("SSLKEYLOGFILE").is_some() {
         config.log_keys();
     }
+
+    config
+        .set_cc_algorithm_name(args.get_str("--cc-algorithm"))
+        .unwrap();
 
     let mut clients = ClientMap::new();
 

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -88,6 +88,9 @@ enum quiche_error {
 
     // The received data exceeds the stream's final size.
     QUICHE_ERR_FINAL_SIZE = -13,
+
+    // Error in congestion control.
+    QUICHE_ERR_CONGESTION_CONTROL = -14,
 };
 
 // Returns a human readable string with the quiche version number.
@@ -160,6 +163,13 @@ void quiche_config_set_max_ack_delay(quiche_config *config, uint64_t v);
 
 // Sets the `disable_active_migration` transport parameter.
 void quiche_config_set_disable_active_migration(quiche_config *config, bool v);
+
+enum quiche_cc_algorithm {
+    QUICHE_CC_RENO = 0,
+};
+
+// Sets the congestion control algorithm used.
+void quiche_config_set_cc_algorithm(quiche_config *config, enum quiche_cc_algorithm algo);
 
 // Frees the config object.
 void quiche_config_free(quiche_config *config);

--- a/src/cc/mod.rs
+++ b/src/cc/mod.rs
@@ -1,0 +1,154 @@
+// Copyright (C) 2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::str::FromStr;
+
+use std::time::Duration;
+use std::time::Instant;
+
+use crate::cc;
+use crate::recovery::Sent;
+
+pub const INITIAL_WINDOW_PACKETS: usize = 10;
+
+pub const INITIAL_WINDOW: usize = INITIAL_WINDOW_PACKETS * MAX_DATAGRAM_SIZE;
+
+pub const MINIMUM_WINDOW: usize = 2 * MAX_DATAGRAM_SIZE;
+
+pub const MAX_DATAGRAM_SIZE: usize = 1452;
+
+pub const LOSS_REDUCTION_FACTOR: f64 = 0.5;
+
+/// Available congestion control algorithms.
+///
+/// This enum provides currently available list of congestion control
+/// algorithms.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Algorithm {
+    /// Reno congestion control algorithm (default). `reno` in a string form.
+    Reno = 0,
+}
+
+impl FromStr for Algorithm {
+    type Err = crate::Error;
+
+    /// Converts a string to `CongestionControlAlgorithm`.
+    ///
+    /// If `name` is not valid, `Error::CongestionControl` is returned.
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        match name {
+            "reno" => Ok(Algorithm::Reno),
+            _ => Err(crate::Error::CongestionControl),
+        }
+    }
+}
+
+/// Congestion control algorithm.
+pub trait CongestionControl
+where
+    Self: std::fmt::Debug,
+{
+    fn new() -> Self
+    where
+        Self: Sized;
+
+    fn cwnd(&self) -> usize;
+
+    fn bytes_in_flight(&self) -> usize;
+
+    fn decrease_bytes_in_flight(&mut self, bytes_in_flight: usize);
+
+    fn congestion_recovery_start_time(&self) -> Option<Instant>;
+
+    fn is_app_limited(&self) -> bool {
+        false
+    }
+
+    /// Resets the congestion window to the minimum size.
+    fn collapse_cwnd(&mut self);
+
+    /// OnPacketSentCC(bytes_sent)
+    fn on_packet_sent_cc(&mut self, bytes_sent: usize, trace_id: &str);
+
+    /// InCongestionRecovery(sent_time)
+    fn in_congestion_recovery(&self, sent_time: Instant) -> bool {
+        match self.congestion_recovery_start_time() {
+            Some(congestion_recovery_start_time) =>
+                sent_time <= congestion_recovery_start_time,
+
+            None => false,
+        }
+    }
+
+    /// OnPacketAckedCC(packet)
+    fn on_packet_acked_cc(
+        &mut self, packet: &Sent, srtt: Duration, min_rtt: Duration,
+        trace_id: &str,
+    );
+
+    /// CongestionEvent(time_sent)
+    fn congestion_event(
+        &mut self, time_sent: Instant, now: Instant, trace_id: &str,
+    );
+}
+
+/// Instances a congestion control implementation based on the CC algorithm ID.
+pub fn new_congestion_control(algo: Algorithm) -> Box<dyn CongestionControl> {
+    trace!("Initializing congestion control: {:?}", algo);
+    match algo {
+        Algorithm::Reno => Box::new(cc::reno::Reno::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_cc() {
+        let cc = new_congestion_control(Algorithm::Reno);
+
+        assert!(cc.cwnd() > 0);
+        assert_eq!(cc.bytes_in_flight(), 0);
+    }
+
+    #[test]
+    fn lookup_cc_algo_ok() {
+        let algo = Algorithm::from_str("reno").unwrap();
+
+        assert_eq!(algo, Algorithm::Reno);
+    }
+
+    #[test]
+    fn lookup_cc_algo_bad() {
+        assert_eq!(
+            Algorithm::from_str("???"),
+            Err(crate::Error::CongestionControl)
+        );
+    }
+}
+
+mod reno;

--- a/src/cc/reno.rs
+++ b/src/cc/reno.rs
@@ -1,0 +1,264 @@
+// Copyright (C) 2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::time::Duration;
+use std::time::Instant;
+
+use crate::cc;
+use crate::recovery::Sent;
+
+/// Reno congestion control implementation.
+pub struct Reno {
+    congestion_window: usize,
+
+    bytes_in_flight: usize,
+
+    congestion_recovery_start_time: Option<Instant>,
+
+    ssthresh: usize,
+    /* TODO: ECN is not implemented.
+     * ecn_ce_counters: [usize; packet::EPOCH_COUNT] */
+}
+
+impl cc::CongestionControl for Reno {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        Reno {
+            congestion_window: cc::INITIAL_WINDOW,
+
+            bytes_in_flight: 0,
+
+            congestion_recovery_start_time: None,
+
+            ssthresh: std::usize::MAX,
+            /* TODO: ECN is not implemented.
+             * ecn_ce_counters: [0; packet::EPOCH_COUNT], */
+        }
+    }
+
+    fn cwnd(&self) -> usize {
+        self.congestion_window
+    }
+
+    fn collapse_cwnd(&mut self) {
+        self.congestion_window = cc::INITIAL_WINDOW;
+    }
+
+    fn bytes_in_flight(&self) -> usize {
+        self.bytes_in_flight
+    }
+
+    fn decrease_bytes_in_flight(&mut self, bytes_in_flight: usize) {
+        self.bytes_in_flight =
+            self.bytes_in_flight.saturating_sub(bytes_in_flight);
+    }
+
+    fn congestion_recovery_start_time(&self) -> Option<Instant> {
+        self.congestion_recovery_start_time
+    }
+
+    fn on_packet_sent_cc(&mut self, bytes_sent: usize, _trace_id: &str) {
+        self.bytes_in_flight += bytes_sent;
+    }
+
+    fn on_packet_acked_cc(
+        &mut self, packet: &Sent, _srtt: Duration, _min_rtt: Duration,
+        _trace_id: &str,
+    ) {
+        self.bytes_in_flight -= packet.size;
+
+        if self.in_congestion_recovery(packet.time) {
+            return;
+        }
+
+        if self.is_app_limited() {
+            return;
+        }
+
+        if self.congestion_window < self.ssthresh {
+            // Slow start.
+            self.congestion_window += packet.size;
+        } else {
+            // Congestion avoidance.
+            self.congestion_window +=
+                (cc::MAX_DATAGRAM_SIZE * packet.size) / self.congestion_window;
+        }
+    }
+
+    fn congestion_event(
+        &mut self, time_sent: Instant, now: Instant, _trace_id: &str,
+    ) {
+        // Start a new congestion event if packet was sent after the
+        // start of the previous congestion recovery period.
+        if !self.in_congestion_recovery(time_sent) {
+            self.congestion_recovery_start_time = Some(now);
+
+            self.congestion_window = (self.congestion_window as f64 *
+                cc::LOSS_REDUCTION_FACTOR)
+                as usize;
+            self.congestion_window =
+                std::cmp::max(self.congestion_window, cc::MINIMUM_WINDOW);
+            self.ssthresh = self.congestion_window;
+        }
+    }
+}
+
+impl std::fmt::Debug for Reno {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "cwnd={} ssthresh={} bytes_in_flight={}",
+            self.congestion_window, self.ssthresh, self.bytes_in_flight,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TRACE_ID: &str = "test_id";
+
+    fn init() {
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
+
+    #[test]
+    fn reno_init() {
+        let cc = cc::new_congestion_control(cc::Algorithm::Reno);
+
+        assert!(cc.cwnd() > 0);
+        assert_eq!(cc.bytes_in_flight(), 0);
+    }
+
+    #[test]
+    fn reno_send() {
+        init();
+
+        let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
+
+        cc.on_packet_sent_cc(1000, TRACE_ID);
+
+        assert_eq!(cc.bytes_in_flight(), 1000);
+    }
+
+    #[test]
+    fn reno_slow_start() {
+        init();
+
+        let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
+
+        let p = Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time: std::time::Instant::now(),
+            size: 5000,
+            ack_eliciting: true,
+            in_flight: true,
+        };
+
+        // Send 5k x 4 = 20k, higher than default cwnd(~15k)
+        // to become no longer app limited.
+        cc.on_packet_sent_cc(p.size, TRACE_ID);
+        cc.on_packet_sent_cc(p.size, TRACE_ID);
+        cc.on_packet_sent_cc(p.size, TRACE_ID);
+        cc.on_packet_sent_cc(p.size, TRACE_ID);
+
+        let cwnd_prev = cc.cwnd();
+
+        cc.on_packet_acked_cc(
+            &p,
+            Duration::new(0, 1),
+            Duration::new(0, 1),
+            TRACE_ID,
+        );
+
+        // Check if cwnd increased by packet size (slow start).
+        assert_eq!(cc.cwnd(), cwnd_prev + p.size);
+    }
+
+    #[test]
+    fn reno_congestion_event() {
+        init();
+
+        let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
+        let prev_cwnd = cc.cwnd();
+
+        cc.congestion_event(
+            std::time::Instant::now(),
+            std::time::Instant::now(),
+            TRACE_ID,
+        );
+
+        // In Reno, after congestion event, cwnd will be cut in half.
+        assert_eq!(prev_cwnd / 2, cc.cwnd());
+    }
+
+    #[test]
+    fn reno_congestion_avoidance() {
+        init();
+
+        let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
+        let prev_cwnd = cc.cwnd();
+
+        // Send 20K bytes.
+        cc.on_packet_sent_cc(20000, TRACE_ID);
+
+        cc.congestion_event(
+            std::time::Instant::now(),
+            std::time::Instant::now(),
+            TRACE_ID,
+        );
+
+        // In Reno, after congestion event, cwnd will be cut in half.
+        assert_eq!(prev_cwnd / 2, cc.cwnd());
+
+        let p = Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time: std::time::Instant::now(),
+            size: 5000,
+            ack_eliciting: true,
+            in_flight: true,
+        };
+
+        let prev_cwnd = cc.cwnd();
+
+        // Ack 5000 bytes.
+        cc.on_packet_acked_cc(
+            &p,
+            Duration::new(0, 1),
+            Duration::new(0, 1),
+            TRACE_ID,
+        );
+
+        // Check if cwnd increase is smaller than a packet size (congestion
+        // avoidance).
+        assert!(cc.cwnd() < prev_cwnd + 1111);
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -213,6 +213,25 @@ pub extern fn quiche_config_set_disable_active_migration(
 }
 
 #[no_mangle]
+pub extern fn quiche_config_set_cc_algorithm_name(
+    config: &mut Config, name: *const c_char,
+) -> c_int {
+    let name = unsafe { ffi::CStr::from_ptr(name).to_str().unwrap() };
+    match config.set_cc_algorithm_name(name) {
+        Ok(_) => 0,
+
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
+pub extern fn quiche_config_set_cc_algorithm(
+    config: &mut Config, algo: cc::Algorithm,
+) {
+    config.set_cc_algorithm(algo);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_free(config: *mut Config) {
     unsafe { Box::from_raw(config) };
 }


### PR DESCRIPTION
Configurable Congestion Control

The purpose of this mega patch is to make congestion control
configurable. Also it's extensive so that we can add more congestion
module later and make it easier to switch between different CC
algorithms using config API.

New Modules
-----------

`cc/` directory is created.

- `cc/mod.rs` contains basic CC constants such as
  INITIAL_WINDOW. Also it defines CongestonControlTrait which has
  method of CC related functions and hooks.

- new_congestion_control(name) is a factory method to return
  a new CC module based on its name.

- `cc/reno.rs` implements `Reno` CC algotirhm, following
  QUIC recovery draft 24 based.

Currently besides of basic method, you need to implement
the following CC-specific hooks called from the stack:

- on_packet_sent_cc()
- on_packet_acked_cc()
- congestion_event()

Note that there is still some CC hooks missing or unimplmented.

Notably
- `IsAppLimited()``: moved to cc/mod.rs but still dummy
- `InPersistentCongestion()``: still in recovery.rs
- `ProcessECN()``: not implemented
- `OnPacketLost()``: still in recovery.rs. It has no CC specific
  other than calling `CongestionEvent()`` already moved to CC module.

lib.rs
------

- CC is now initialized using `cc::new_congestion_control()`.

recovery.rs
-----------

- CC constants moved to `cc/mod.rs`
- CC fields such as `bytes_in_flight`, `cwnd`, `recovery_start_time`, `ssthresh`
  are moved into cc modules. Also added `cc` field which is CC algorithm object.
  Due to the change above, code accessing fields above now use the following
  methods for reading/writing those values in CC module:
  `self.bytes_in_flight` -> `self.cc.bytes_in_flight()`
  reading `self.cwnd` -> use `self.cc.cwnd()`
  updating `self.cwnd` -> use `self.cc.set_cwnd()`
  reading `self.ssthresh` -> use `self.cc.ssthresh()`
- `OnPacketSentCC`, `OnPacketAckedCC`, `CongestionEvent` moved to
  CC module, so only calling cc methods here.
- `in_recovery()` moved to CC module.
- recovery.cwnd() is renamed to recovery.cwnd_available().

Config API
----------

`Config` struct now has `cc_algorithm`.


There is 2 APIs added for configuration those new parameters:

* config.set_cc_algorithm_name(<name>): set which CC algorithm to use by
  name.
* config.set_cc_algorithm(<enum>): set which CC algorithm to use. values
  are from quiche::CongestionControlAlgorithm.

ffi.rs
------

Corresponing C Config API is also added.

`quiche_config_set_cc_algorithm_name()`
`quiche_config_set_cc_algorithm()`

Those config should be called before new connection is made or accepted.

Examples
--------

Rust example of http3-server., server, http3-client, client has
a new options name `--cc-algorithm` to specify which CC algorithms can be used.

C example of http3-server and server calls quiche_config_set_cc_*() APIs.

Others
------
- Documentation in the source
- Test cases added