### PR TITLE
WIP recovery: separate logging for congestion control events

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -47,6 +47,7 @@ Options:
   --wire-version VERSION   The version number to send to the server [default: babababa].
   --dump-packets PATH      Dump the incoming packets as files in the given directory.
   --no-verify              Don't verify server's certificate.
+  --cc-algorithm NAME      Set client congestion control algorithm [default: reno].
   -h --help                Show this screen.
 ";
 
@@ -133,6 +134,11 @@ fn main() {
     if std::env::var_os("SSLKEYLOGFILE").is_some() {
         config.log_keys();
     }
+
+    // Congestion control options
+    config
+        .set_cc_algorithm_name(args.get_str("--cc-algorithm"))
+        .unwrap();
 
     // Generate a random source connection ID for the connection.
     let mut scid = [0; quiche::MAX_CONN_ID_LEN];

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -45,6 +45,7 @@ Options:
   --wire-version VERSION   The version number to send to the server [default: babababa].
   --no-verify              Don't verify server's certificate.
   --no-grease              Don't send GREASE.
+  --cc-algorithm NAME      Set client congestion control algorithm [default: reno].
   -H --header HEADER ...   Add a request header.
   -n --requests REQUESTS   Send the given number of identical requests [default: 1].
   -h --help                Show this screen.
@@ -142,6 +143,11 @@ fn main() {
     if std::env::var_os("SSLKEYLOGFILE").is_some() {
         config.log_keys();
     }
+
+    // Congestion control options
+    config
+        .set_cc_algorithm_name(args.get_str("--cc-algorithm"))
+        .unwrap();
 
     // Generate a random source connection ID for the connection.
     let mut scid = [0; quiche::MAX_CONN_ID_LEN];

--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -520,6 +520,7 @@ int main(int argc, char *argv[]) {
     quiche_config_set_initial_max_streams_bidi(config, 100);
     quiche_config_set_initial_max_streams_uni(config, 100);
     quiche_config_set_disable_active_migration(config, true);
+    quiche_config_set_cc_algorithm(config, QUICHE_CC_RENO);
 
     http3_config = quiche_h3_config_new();
     if (http3_config == NULL) {

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -52,6 +52,7 @@ Options:
   --early-data                Enables receiving early data.
   --no-retry                  Disable stateless retry.
   --no-grease                 Don't send GREASE.
+  --cc-algorithm NAME         Set server congestion control algorithm [default: reno].
   -h --help                   Show this screen.
 ";
 
@@ -146,6 +147,11 @@ fn main() {
     if std::env::var_os("SSLKEYLOGFILE").is_some() {
         config.log_keys();
     }
+
+    // Congestion control options
+    config
+        .set_cc_algorithm_name(args.get_str("--cc-algorithm"))
+        .unwrap();
 
     let h3_config = quiche::h3::Config::new().unwrap();
 

--- a/examples/server.c
+++ b/examples/server.c
@@ -451,6 +451,7 @@ int main(int argc, char *argv[]) {
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_bidi_remote(config, 1000000);
     quiche_config_set_initial_max_streams_bidi(config, 100);
+    quiche_config_set_cc_algorithm(config, QUICHE_CC_RENO);
 
     struct connections c;
     c.sock = sock;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -54,6 +54,7 @@ Options:
   --dump-packets PATH         Dump the incoming packets as files in the given directory.
   --early-data                Enables receiving early data.
   --no-retry                  Disable stateless retry.
+  --cc-algorithm NAME         Set server congestion control algorithm [default: reno].
   -h --help                   Show this screen.
 ";
 
@@ -148,6 +149,11 @@ fn main() {
     if std::env::var_os("SSLKEYLOGFILE").is_some() {
         config.log_keys();
     }
+
+    // Congestion control options
+    config
+        .set_cc_algorithm_name(args.get_str("--cc-algorithm"))
+        .unwrap();
 
     let mut clients = ClientMap::new();
 

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -88,6 +88,9 @@ enum quiche_error {
 
     // The received data exceeds the stream's final size.
     QUICHE_ERR_FINAL_SIZE = -13,
+
+    // Error in congestion control.
+    QUICHE_ERR_CONGESTION_CONTROL = -14,
 };
 
 // Returns a human readable string with the quiche version number.
@@ -160,6 +163,16 @@ void quiche_config_set_max_ack_delay(quiche_config *config, uint64_t v);
 
 // Sets the `disable_active_migration` transport parameter.
 void quiche_config_set_disable_active_migration(quiche_config *config, bool v);
+
+enum quiche_cc_algorithm {
+    QUICHE_CC_RENO = 0,
+};
+
+// Sets the congestion control algorithm used (string).
+void quiche_config_set_cc_algorithm(quiche_config *config, enum quiche_cc_algorithm algo);
+
+// Sets the initial congestion control window size (bytes).
+void quiche_config_set_cc_initcwnd(quiche_config *config, size_t v);
 
 // Frees the config object.
 void quiche_config_free(quiche_config *config);

--- a/src/cc/log.rs
+++ b/src/cc/log.rs
@@ -1,0 +1,28 @@
+use std::env;
+use std::sync::Once;
+
+static mut USE_CCLOG: bool = false;
+static INIT_ONCE: Once = Once::new();
+
+pub fn log_init() -> bool {
+    unsafe {
+        INIT_ONCE.call_once(|| {
+            if env::var_os("QUICHE_CCLOG").is_some() {
+                USE_CCLOG = true;
+                ::log::log!(::log::Level::Error, "CC Logging initialized");
+            }
+        });
+
+        USE_CCLOG
+    }
+}
+
+/// Logging for Congestion Control.
+///
+/// Use cclog!() macro for CC logging.
+/// Will be displayed only when QUICHE_CCLOG environment variable is set.
+#[macro_export]
+macro_rules! cclog {
+    ($($arg:tt)*) => ( {
+        if cc::log::log_init() { ::log::log!(::log::Level::Error, $($arg)*); }} );
+}

--- a/src/cc/mod.rs
+++ b/src/cc/mod.rs
@@ -43,6 +43,9 @@ pub const MAX_DATAGRAM_SIZE: usize = 1452;
 
 pub const LOSS_REDUCTION_FACTOR: f64 = 0.5;
 
+#[macro_use]
+mod log;
+
 /// Available congestion control algorithms.
 ///
 /// This enum provides currently available list of congestion control
@@ -124,7 +127,7 @@ where
 
 // Returns a congestion control module. `algo` is one of cc::Algorithm enum.
 pub fn new_congestion_control(algo: Algorithm) -> Box<dyn CongestionControl> {
-    trace!("Congestion Control initialized: {:?}", algo);
+    cclog!("Congestion Control initialized: {:?}", algo);
     match algo {
         Algorithm::Reno => Box::new(cc::reno::Reno::new()),
     }

--- a/src/cc/mod.rs
+++ b/src/cc/mod.rs
@@ -1,0 +1,160 @@
+// Copyright (C) 2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::fmt::Debug;
+use std::str::FromStr;
+use std::time::Duration;
+use std::time::Instant;
+
+use crate::cc;
+use crate::recovery::Sent;
+
+// Congestion Control constants
+pub const INITIAL_WINDOW_PACKETS: usize = 10;
+
+pub const INITIAL_WINDOW: usize = INITIAL_WINDOW_PACKETS * MAX_DATAGRAM_SIZE;
+
+pub const MINIMUM_WINDOW: usize = 2 * MAX_DATAGRAM_SIZE;
+
+pub const MAX_DATAGRAM_SIZE: usize = 1452;
+
+pub const LOSS_REDUCTION_FACTOR: f64 = 0.5;
+
+/// Available congestion control algorithms.
+///
+/// This enum provides currently available list of congestion control
+/// algorithms.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Algorithm {
+    /// Reno congestion control algorithm (default). `reno` in a string form.
+    Reno = 0,
+}
+
+/// Return `CongestionControlAlgorithm` from the string.
+impl FromStr for Algorithm {
+    type Err = crate::Error;
+
+    /// Converts a string to `CongestionControlAlgorithm`.
+    ///
+    /// If `name` is not an available name, `Err(Error::CongestionControl)`
+    /// will be returned.
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        match name {
+            "reno" => Ok(Algorithm::Reno),
+            _ => Err(crate::Error::CongestionControl),
+        }
+    }
+}
+
+// Congestion Control Trait
+pub trait CongestionControl
+where
+    Self: Debug,
+{
+    fn new() -> Self
+    where
+        Self: Sized;
+
+    // Access to internal variables
+    fn cwnd(&self) -> usize;
+
+    fn bytes_in_flight(&self) -> usize;
+
+    fn decrease_bytes_in_flight(&mut self, bytes_in_flight: usize);
+
+    fn congestion_recovery_start_time(&self) -> Option<Instant>;
+
+    fn is_app_limited(&self) -> bool {
+        false
+    }
+
+    // Reset to minimum window.
+    fn collapse_cwnd(&mut self);
+
+    // Congestion Control hooks defined in QUIC recovery draft.
+
+    // OnPacketSentCC(bytes_sent)
+    fn on_packet_sent_cc(&mut self, bytes_sent: usize, trace_id: &str);
+
+    // InCongestionRecovery(sent_time)
+    fn in_congestion_recovery(&self, sent_time: Instant) -> bool {
+        match self.congestion_recovery_start_time() {
+            Some(congestion_recovery_start_time) =>
+                sent_time <= congestion_recovery_start_time,
+
+            None => false,
+        }
+    }
+
+    // OnPacketAckedCC(packet)
+    fn on_packet_acked_cc(
+        &mut self, packet: &Sent, srtt: Duration, min_rtt: Duration,
+        trace_id: &str,
+    );
+
+    // CongestionEvent(time_sent)
+    // now is passed as well not to look up current time again.
+    fn congestion_event(
+        &mut self, time_sent: Instant, now: Instant, trace_id: &str,
+    );
+}
+
+// Returns a congestion control module. `algo` is one of cc::Algorithm enum.
+pub fn new_congestion_control(algo: Algorithm) -> Box<dyn CongestionControl> {
+    trace!("Congestion Control initialized: {:?}", algo);
+    match algo {
+        Algorithm::Reno => Box::new(cc::reno::Reno::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_cc() {
+        let cc = new_congestion_control(Algorithm::Reno);
+
+        assert!(cc.cwnd() > 0);
+        assert_eq!(cc.bytes_in_flight(), 0);
+    }
+
+    #[test]
+    fn lookup_cc_algo_ok() {
+        let algo = Algorithm::from_str("reno").unwrap();
+
+        assert_eq!(algo, Algorithm::Reno);
+    }
+
+    #[test]
+    #[should_panic]
+    fn lookup_cc_algo_bad() {
+        let _ = Algorithm::from_str("???").unwrap(); // should panic!()
+    }
+}
+
+// List of CC modules.
+mod reno;

--- a/src/cc/reno.rs
+++ b/src/cc/reno.rs
@@ -86,7 +86,7 @@ impl cc::CongestionControl for Reno {
     fn on_packet_sent_cc(&mut self, bytes_sent: usize, trace_id: &str) {
         self.bytes_in_flight += bytes_sent;
 
-        trace!("{} OnPacketSentCC() {:?}", trace_id, &self);
+        cclog!("{} OnPacketSentCC() {:?}", trace_id, &self);
     }
 
     fn on_packet_acked_cc(
@@ -107,13 +107,13 @@ impl cc::CongestionControl for Reno {
             // Slow start.
             self.congestion_window += packet.size;
 
-            trace!("{} OnPacketAckedCC() SLOW_START {:?}", trace_id, &self);
+            cclog!("{} OnPacketAckedCC() SLOW_START {:?}", trace_id, &self);
         } else {
             // Congestion avoidance.
             self.congestion_window +=
                 (cc::MAX_DATAGRAM_SIZE * packet.size) / self.congestion_window;
 
-            trace!("{} OnPacketAckedCC() CONG_AVOIDANCE {:?}", trace_id, &self);
+            cclog!("{} OnPacketAckedCC() CONG_AVOIDANCE {:?}", trace_id, &self);
         }
     }
 
@@ -132,7 +132,7 @@ impl cc::CongestionControl for Reno {
                 std::cmp::max(self.congestion_window, cc::MINIMUM_WINDOW);
             self.ssthresh = self.congestion_window;
 
-            trace!("{} CongestionEvent() {:?}", trace_id, &self);
+            cclog!("{} CongestionEvent() {:?}", trace_id, &self);
         }
     }
 }

--- a/src/cc/reno.rs
+++ b/src/cc/reno.rs
@@ -1,0 +1,273 @@
+// Copyright (C) 2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+use std::time::Duration;
+use std::time::Instant;
+
+use crate::cc;
+use crate::recovery::Sent;
+
+// Reno Congestion Control
+pub struct Reno {
+    congestion_window: usize,
+
+    bytes_in_flight: usize,
+
+    congestion_recovery_start_time: Option<Instant>,
+
+    ssthresh: usize,
+    /* TODO: ECN is not implemented.
+     * ecn_ce_counters: [usize; packet::EPOCH_COUNT] */
+}
+
+impl cc::CongestionControl for Reno {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        Reno {
+            congestion_window: cc::INITIAL_WINDOW,
+
+            bytes_in_flight: 0,
+
+            congestion_recovery_start_time: None,
+
+            ssthresh: std::usize::MAX,
+            /* TODO: ECN is not implemented.
+             * ecn_ce_counters: [0; packet::EPOCH_COUNT], */
+        }
+    }
+
+    fn cwnd(&self) -> usize {
+        self.congestion_window
+    }
+
+    fn collapse_cwnd(&mut self) {
+        self.congestion_window = cc::INITIAL_WINDOW;
+    }
+
+    fn bytes_in_flight(&self) -> usize {
+        self.bytes_in_flight
+    }
+
+    fn decrease_bytes_in_flight(&mut self, bytes_in_flight: usize) {
+        self.bytes_in_flight =
+            self.bytes_in_flight.saturating_sub(bytes_in_flight);
+    }
+
+    fn congestion_recovery_start_time(&self) -> Option<Instant> {
+        self.congestion_recovery_start_time
+    }
+
+    // Congestion Control hooks
+    fn on_packet_sent_cc(&mut self, bytes_sent: usize, trace_id: &str) {
+        self.bytes_in_flight += bytes_sent;
+
+        trace!("{} OnPacketSentCC() {:?}", trace_id, &self);
+    }
+
+    fn on_packet_acked_cc(
+        &mut self, packet: &Sent, _srtt: Duration, _min_rtt: Duration,
+        trace_id: &str,
+    ) {
+        self.bytes_in_flight -= packet.size;
+
+        if self.in_congestion_recovery(packet.time) {
+            return;
+        }
+
+        if self.is_app_limited() {
+            return;
+        }
+
+        if self.congestion_window < self.ssthresh {
+            // Slow start.
+            self.congestion_window += packet.size;
+
+            trace!("{} OnPacketAckedCC() SLOW_START {:?}", trace_id, &self);
+        } else {
+            // Congestion avoidance.
+            self.congestion_window +=
+                (cc::MAX_DATAGRAM_SIZE * packet.size) / self.congestion_window;
+
+            trace!("{} OnPacketAckedCC() CONG_AVOIDANCE {:?}", trace_id, &self);
+        }
+    }
+
+    fn congestion_event(
+        &mut self, time_sent: Instant, now: Instant, trace_id: &str,
+    ) {
+        // Start a new congestion event if packet was sent after the
+        // start of the previous congestion recovery period.
+        if !self.in_congestion_recovery(time_sent) {
+            self.congestion_recovery_start_time = Some(now);
+
+            self.congestion_window = (self.congestion_window as f64 *
+                cc::LOSS_REDUCTION_FACTOR)
+                as usize;
+            self.congestion_window =
+                std::cmp::max(self.congestion_window, cc::MINIMUM_WINDOW);
+            self.ssthresh = self.congestion_window;
+
+            trace!("{} CongestionEvent() {:?}", trace_id, &self);
+        }
+    }
+}
+
+impl std::fmt::Debug for Reno {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "cwnd={} ssthresh={} bytes_in_flight={}",
+            self.congestion_window, self.ssthresh, self.bytes_in_flight,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TRACE_ID: &str = "test_id";
+
+    fn init() {
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
+
+    #[test]
+    fn reno_init() {
+        let cc = cc::new_congestion_control(cc::Algorithm::Reno);
+
+        assert!(cc.cwnd() > 0);
+        assert_eq!(cc.bytes_in_flight(), 0);
+    }
+
+    #[test]
+    fn reno_send() {
+        init();
+
+        let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
+
+        cc.on_packet_sent_cc(1000, TRACE_ID);
+
+        assert_eq!(cc.bytes_in_flight(), 1000);
+    }
+
+    #[test]
+    fn reno_slow_start() {
+        init();
+
+        let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
+
+        let p = Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time: std::time::Instant::now(),
+            size: 5000,
+            ack_eliciting: true,
+            in_flight: true,
+        };
+
+        // Send 5k x 4 = 20k, higher than default cwnd(~15k)
+        // to become no longer app limited
+        cc.on_packet_sent_cc(p.size, TRACE_ID);
+        cc.on_packet_sent_cc(p.size, TRACE_ID);
+        cc.on_packet_sent_cc(p.size, TRACE_ID);
+        cc.on_packet_sent_cc(p.size, TRACE_ID);
+
+        let cwnd_prev = cc.cwnd();
+
+        cc.on_packet_acked_cc(
+            &p,
+            Duration::new(0, 1),
+            Duration::new(0, 1),
+            TRACE_ID,
+        );
+
+        // Check if cwnd increased by packet size (slow start)
+        assert_eq!(cc.cwnd(), cwnd_prev + p.size);
+    }
+
+    #[test]
+    fn reno_congestion_event() {
+        init();
+
+        let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
+        let prev_cwnd = cc.cwnd();
+
+        cc.congestion_event(
+            std::time::Instant::now(),
+            std::time::Instant::now(),
+            TRACE_ID,
+        );
+
+        // In Reno, after congestion event, cwnd will be cut by half
+        assert_eq!(prev_cwnd / 2, cc.cwnd());
+    }
+
+    #[test]
+    fn reno_congestion_avoidance() {
+        init();
+
+        let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
+        let prev_cwnd = cc.cwnd();
+
+        // Send 20K bytes
+        cc.on_packet_sent_cc(20000, TRACE_ID);
+
+        cc.congestion_event(
+            std::time::Instant::now(),
+            std::time::Instant::now(),
+            TRACE_ID,
+        );
+
+        // In Reno, after congestion event, cwnd will be cut by half
+        assert_eq!(prev_cwnd / 2, cc.cwnd());
+
+        let p = Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time: std::time::Instant::now(),
+            size: 5000,
+            ack_eliciting: true,
+            in_flight: true,
+        };
+
+        let prev_cwnd = cc.cwnd();
+
+        // Ack 5000 bytes
+        cc.on_packet_acked_cc(
+            &p,
+            Duration::new(0, 1),
+            Duration::new(0, 1),
+            TRACE_ID,
+        );
+
+        // Check if cwnd increase is smaller than a packet size (congestion
+        // avoidance)
+        assert!(cc.cwnd() < prev_cwnd + 1111);
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -213,6 +213,25 @@ pub extern fn quiche_config_set_disable_active_migration(
 }
 
 #[no_mangle]
+pub extern fn quiche_config_set_cc_algorithm_name(
+    config: &mut Config, name: *const c_char,
+) -> c_int {
+    let name = unsafe { ffi::CStr::from_ptr(name).to_str().unwrap() };
+    match config.set_cc_algorithm_name(name) {
+        Ok(_) => 0,
+
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
+pub extern fn quiche_config_set_cc_algorithm(
+    config: &mut Config, algo: cc::Algorithm,
+) {
+    config.set_cc_algorithm(algo);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_free(config: *mut Config) {
     unsafe { Box::from_raw(config) };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,36 @@
 //! [`readable()`]: struct.Connection.html#method.readable
 //! [`stream_recv()`]: struct.Connection.html#method.stream_recv
 //! [HTTP/3 module]: h3/index.html
+//!
+//! ## Congestion Control
+//!
+//! The quiche provides a high level API for configuring which
+//! congestion control algorithm to use throughout the QUIC connection.
+//!
+//! When you create a QUIC connection, you can optionally choose which CC
+//! algorithm to use. See [CongestionControlAlgorithm] for currently
+//! available congestion control algorithms.
+//!
+//! For example:
+//!
+//! ```
+//! let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+//! config.set_cc_algorithm(quiche::CongestionControlAlgorithm::Reno);
+//! ```
+//!
+//! Alternatively, you can configure a congestion control algorithm to use
+//! by its name.
+//!
+//! ```
+//! let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+//! config.set_cc_algorithm_name("reno").unwrap();
+//! ```
+//!
+//! Note that those API should be called before you call [`connect()`]
+//! or [`accept()`]. Otherwise the connection will use a default CC algorithm.
+//! By default `Reno` will be used as a default congestion control.
+//!
+//! [CongestionControlAlgorithm]: cc/enum.Algorithm.html
 
 #![allow(improper_ctypes)]
 #![warn(missing_docs)]
@@ -240,6 +270,9 @@ use std::cmp;
 use std::time;
 
 use std::pin::Pin;
+use std::str::FromStr;
+
+pub use crate::cc::Algorithm as CongestionControlAlgorithm;
 
 /// The current QUIC wire version.
 pub const PROTOCOL_VERSION: u32 = 0xff00_0018;
@@ -315,6 +348,9 @@ pub enum Error {
 
     /// The received data exceeds the stream's final size.
     FinalSize          = -13,
+
+    /// Error in congestion control.
+    CongestionControl  = -14,
 }
 
 impl Error {
@@ -381,6 +417,9 @@ pub struct Config {
     application_protos: Vec<Vec<u8>>,
 
     grease: bool,
+
+    // Congestion control algorithm to use
+    cc_algorithm: cc::Algorithm,
 }
 
 impl Config {
@@ -401,6 +440,7 @@ impl Config {
             tls_ctx,
             application_protos: Vec::new(),
             grease: true,
+            cc_algorithm: cc::Algorithm::Reno, // default cc algorithm
         })
     }
 
@@ -621,6 +661,35 @@ impl Config {
     /// The default value is `false`.
     pub fn set_disable_active_migration(&mut self, v: bool) {
         self.local_transport_params.disable_active_migration = v;
+    }
+
+    /// Sets the congestion control algorithm used by string.
+    ///
+    /// The default value is `reno`. If failed, `Error::CongestionControl`
+    /// will be returned.
+    ///
+    /// ## Examples:
+    ///
+    /// ```
+    /// # let mut config = quiche::Config::new(0xbabababa)?;
+    /// config.set_cc_algorithm_name("reno");
+    /// # Ok::<(), quiche::Error>(())
+    /// ```
+    pub fn set_cc_algorithm_name(&mut self, name: &str) -> Result<()> {
+        match CongestionControlAlgorithm::from_str(name) {
+            Ok(cc) => {
+                self.cc_algorithm = cc;
+                Ok(())
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Sets the congestion control algorithm used.
+    ///
+    /// The default value is `quiche::CongestionControlAlgorithm::Reno`.
+    pub fn set_cc_algorithm(&mut self, algo: CongestionControlAlgorithm) {
+        self.cc_algorithm = algo;
     }
 }
 
@@ -934,7 +1003,7 @@ impl Connection {
 
             handshake: tls,
 
-            recovery: recovery::Recovery::default(),
+            recovery: recovery::Recovery::new(&config),
 
             application_protos: config.application_protos.clone(),
 
@@ -1600,7 +1669,7 @@ impl Connection {
         }
 
         // Calculate available space in the packet based on congestion window.
-        let mut left = cmp::min(self.recovery.cwnd(), b.cap());
+        let mut left = cmp::min(self.recovery.cwnd_available(), b.cap());
 
         // Limit data sent by the server based on the amount of data received
         // from the client before its address is validated.
@@ -2515,7 +2584,7 @@ impl Connection {
             recv: self.recv_count,
             sent: self.sent_count,
             lost: self.recovery.lost_count,
-            cwnd: self.recovery.cwnd(),
+            cwnd: self.recovery.cc.cwnd(),
             rtt: self.recovery.rtt(),
         }
     }
@@ -4872,6 +4941,7 @@ pub use crate::packet::Header;
 pub use crate::packet::Type;
 pub use crate::stream::StreamIter;
 
+mod cc;
 mod crypto;
 mod ffi;
 mod frame;

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -31,9 +31,11 @@ use std::time::Instant;
 
 use std::collections::BTreeMap;
 
+use crate::Config;
 use crate::Error;
 use crate::Result;
 
+use crate::cc;
 use crate::frame;
 use crate::packet;
 use crate::ranges;
@@ -46,14 +48,6 @@ const TIME_THRESHOLD: f64 = 9.0 / 8.0;
 const GRANULARITY: Duration = Duration::from_millis(1);
 
 const INITIAL_RTT: Duration = Duration::from_millis(500);
-
-// Congestion Control
-pub const INITIAL_WINDOW_PACKETS: usize = 10;
-
-const MAX_DATAGRAM_SIZE: usize = 1452;
-
-const INITIAL_WINDOW: usize = INITIAL_WINDOW_PACKETS * MAX_DATAGRAM_SIZE;
-const MINIMUM_WINDOW: usize = 2 * MAX_DATAGRAM_SIZE;
 
 const PERSISTENT_CONGESTION_THRESHOLD: u32 = 3;
 
@@ -103,19 +97,14 @@ pub struct Recovery {
 
     pub lost_count: usize,
 
-    bytes_in_flight: usize,
-
-    cwnd: usize,
-
-    recovery_start_time: Option<Instant>,
-
-    ssthresh: usize,
-
     pub loss_probes: [usize; packet::EPOCH_COUNT],
+
+    // Congestion Control
+    pub cc: Box<dyn cc::CongestionControl>,
 }
 
-impl Default for Recovery {
-    fn default() -> Recovery {
+impl Recovery {
+    pub fn new(config: &Config) -> Self {
         Recovery {
             loss_detection_timer: None,
 
@@ -147,20 +136,12 @@ impl Default for Recovery {
 
             lost_count: 0,
 
-            bytes_in_flight: 0,
-
-            cwnd: INITIAL_WINDOW,
-
-            recovery_start_time: None,
-
-            ssthresh: std::usize::MAX,
-
             loss_probes: [0; packet::EPOCH_COUNT],
+
+            cc: cc::new_congestion_control(config.cc_algorithm),
         }
     }
-}
 
-impl Recovery {
     pub fn on_packet_sent(
         &mut self, pkt: Sent, epoch: packet::Epoch, handshake_completed: bool,
         now: Instant, trace_id: &str,
@@ -180,7 +161,7 @@ impl Recovery {
             }
 
             // OnPacketSentCC
-            self.bytes_in_flight += sent_bytes;
+            self.cc.on_packet_sent_cc(sent_bytes, trace_id);
 
             self.set_loss_detection_timer(handshake_completed);
         }
@@ -232,7 +213,7 @@ impl Recovery {
         // Processing acked packets in reverse order (from largest to smallest)
         // appears to be faster, possibly due to the BTreeMap implementation.
         for pn in ranges.flatten().rev() {
-            let newly_acked = self.on_packet_acked(pn, epoch);
+            let newly_acked = self.on_packet_acked(pn, epoch, trace_id);
             has_newly_acked = cmp::max(has_newly_acked, newly_acked);
 
             if newly_acked {
@@ -292,7 +273,7 @@ impl Recovery {
             unacked_bytes += p.size;
         }
 
-        self.bytes_in_flight -= unacked_bytes;
+        self.cc.decrease_bytes_in_flight(unacked_bytes);
 
         self.loss_time[epoch] = None;
         self.loss_probes[epoch] = 0;
@@ -307,13 +288,13 @@ impl Recovery {
         self.loss_detection_timer
     }
 
-    pub fn cwnd(&self) -> usize {
+    pub fn cwnd_available(&self) -> usize {
         // Ignore cwnd when sending probe packets.
         if self.loss_probes.iter().any(|&x| x > 0) {
             return std::usize::MAX;
         }
 
-        self.cwnd.saturating_sub(self.bytes_in_flight)
+        self.cc.cwnd().saturating_sub(self.cc.bytes_in_flight())
     }
 
     pub fn rtt(&self) -> Duration {
@@ -394,7 +375,7 @@ impl Recovery {
             return;
         }
 
-        if self.bytes_in_flight == 0 {
+        if self.cc.bytes_in_flight() == 0 {
             // TODO: check if peer is awaiting address validation.
             self.loss_detection_timer = None;
             return;
@@ -465,19 +446,13 @@ impl Recovery {
         }
 
         if !lost_pkt.is_empty() {
-            self.on_packets_lost(lost_pkt, epoch, now);
+            self.on_packets_lost(lost_pkt, epoch, now, trace_id);
         }
     }
 
-    fn in_recovery(&self, sent_time: Instant) -> bool {
-        match self.recovery_start_time {
-            Some(recovery_start_time) => sent_time <= recovery_start_time,
-
-            None => false,
-        }
-    }
-
-    fn on_packet_acked(&mut self, pkt_num: u64, epoch: packet::Epoch) -> bool {
+    fn on_packet_acked(
+        &mut self, pkt_num: u64, epoch: packet::Epoch, trace_id: &str,
+    ) -> bool {
         // If the acked packet number is lower than the lowest unacked packet
         // number it means that the packet is not newly acked, so return early.
         if let Some(lowest) = self.sent[epoch].values().nth(0) {
@@ -491,20 +466,13 @@ impl Recovery {
             self.acked[epoch].append(&mut p.frames);
 
             if p.in_flight {
-                // OnPacketAckedCC
-                self.bytes_in_flight -= p.size;
-
-                if self.in_recovery(p.time) {
-                    return true;
-                }
-
-                if self.cwnd < self.ssthresh {
-                    // Slow start.
-                    self.cwnd += p.size;
-                } else {
-                    // Congestion avoidance.
-                    self.cwnd += (MAX_DATAGRAM_SIZE * p.size) / self.cwnd;
-                }
+                // OnPacketAckedCC(acked_packet)
+                self.cc.on_packet_acked_cc(
+                    &p,
+                    self.rtt(),
+                    self.min_rtt,
+                    trace_id,
+                );
             }
 
             return true;
@@ -514,6 +482,7 @@ impl Recovery {
         false
     }
 
+    // TODO: move to Congestion Control and implement draft 24
     fn in_persistent_congestion(&mut self, _largest_lost_pkt: &Sent) -> bool {
         let _congestion_period = self.pto() * PERSISTENT_CONGESTION_THRESHOLD;
 
@@ -521,8 +490,10 @@ impl Recovery {
         false
     }
 
+    // TODO: move to Congestion Control
     fn on_packets_lost(
         &mut self, lost_pkt: Vec<u64>, epoch: packet::Epoch, now: Instant,
+        trace_id: &str,
     ) {
         // Differently from OnPacketsLost(), we need to handle both
         // in-flight and non-in-flight packets, so need to keep track
@@ -539,7 +510,7 @@ impl Recovery {
                 continue;
             }
 
-            self.bytes_in_flight -= p.size;
+            self.cc.decrease_bytes_in_flight(p.size);
 
             self.lost[epoch].append(&mut p.frames);
 
@@ -548,16 +519,11 @@ impl Recovery {
 
         if let Some(largest_lost_pkt) = largest_lost_pkt {
             // CongestionEvent
-            if !self.in_recovery(largest_lost_pkt.time) {
-                self.recovery_start_time = Some(now);
-
-                self.cwnd /= 2;
-                self.cwnd = cmp::max(self.cwnd, MINIMUM_WINDOW);
-                self.ssthresh = self.cwnd;
-            }
+            self.cc
+                .congestion_event(largest_lost_pkt.time, now, trace_id);
 
             if self.in_persistent_congestion(&largest_lost_pkt) {
-                self.cwnd = MINIMUM_WINDOW;
+                self.cc.collapse_cwnd();
             }
         }
     }
@@ -582,14 +548,13 @@ impl std::fmt::Debug for Recovery {
             },
         };
 
-        write!(f, "inflight={} ", self.bytes_in_flight)?;
-        write!(f, "cwnd={} ", self.cwnd)?;
         write!(f, "latest_rtt={:?} ", self.latest_rtt)?;
         write!(f, "srtt={:?} ", self.smoothed_rtt)?;
         write!(f, "min_rtt={:?} ", self.min_rtt)?;
         write!(f, "rttvar={:?} ", self.rttvar)?;
         write!(f, "loss_time={:?} ", self.loss_time)?;
         write!(f, "loss_probes={:?} ", self.loss_probes)?;
+        write!(f, "{:?} ", self.cc)?;
 
         Ok(())
     }


### PR DESCRIPTION
Related to #299 and fixes #303 

The idea is to have a `cclog!()` macro basically same to other logging macro but basically it's not enabled without QUICHE_CC_LOG=1, so only we need logging from CC we can set this environment variable.

I used CC_LOG static mut variable, but it only changed in the call_once() and not changed, so using it under unsafe is fine (or I can't find not to use unsafe in the scenario).

p.s. This PR assumes #299.