### PR TITLE
Fix "error: redundant clone"

### DIFF
--- a/tools/http3_test/src/lib.rs
+++ b/tools/http3_test/src/lib.rs
@@ -274,7 +274,7 @@ impl Http3Req {
             url: url.clone(),
             hdrs,
             body,
-            expect_resp_hdrs: expect_resp_hdrs.clone(),
+            expect_resp_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
         }


### PR DESCRIPTION
This will fix today's Travis failure.

```
note: this value is dropped without further use
   --> src/lib.rs:277:31
    |
277 |             expect_resp_hdrs: expect_resp_hdrs.clone(),
    |                               ^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone
```