### PR TITLE
[wip] lib: declare some public enums as non-exhaustive

### DIFF
--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -377,6 +377,10 @@ fn main() {
                         }
                     },
 
+                    Ok((stream_id, _)) => {
+                        warn!("unsupported event on stream {}", stream_id);
+                    },
+
                     Err(quiche::h3::Error::Done) => {
                         break;
                     },

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -390,6 +390,10 @@ fn main() {
 
                         Ok((_stream_id, quiche::h3::Event::Finished)) => (),
 
+                        Ok((stream_id, _)) => {
+                            warn!("unsupported event on stream {}", stream_id);
+                        },
+
                         Err(quiche::h3::Error::Done) => {
                             break;
                         },

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -56,6 +56,7 @@ impl Level {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Algorithm {
     #[allow(non_camel_case_types)]
     AES128_GCM,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -37,6 +37,7 @@ pub const MAX_STREAM_OVERHEAD: usize = 12;
 pub const MAX_STREAM_SIZE: u64 = 1 << 62;
 
 #[derive(Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Frame {
     Padding {
         len: usize,

--- a/src/h3/frame.rs
+++ b/src/h3/frame.rs
@@ -42,6 +42,7 @@ const SETTINGS_MAX_HEADER_LIST_SIZE: u64 = 0x6;
 const SETTINGS_QPACK_BLOCKED_STREAMS: u64 = 0x7;
 
 #[derive(Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Frame {
     Data {
         payload: Vec<u8>,

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -156,7 +156,11 @@
 //!
 //!         Ok((stream_id, quiche::h3::Event::Finished)) => {
 //!             // Peer terminated stream, handle it.
-//!         }
+//!         },
+//!
+//!         Ok((stream_id, _)) => {
+//!             // Catch-all match for other events.
+//!         },
 //!
 //!         Err(quiche::h3::Error::Done) => {
 //!             // Done reading.
@@ -202,6 +206,10 @@
 //!         Ok((stream_id, quiche::h3::Event::Finished)) => {
 //!             // Peer terminated stream, handle it.
 //!         }
+//!
+//!         Ok((stream_id, _)) => {
+//!             // Catch-all match for other events.
+//!         },
 //!
 //!         Err(quiche::h3::Error::Done) => {
 //!             // Done reading.
@@ -270,6 +278,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// An HTTP/3 error.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     /// There is no error or no work to do
     Done,
@@ -498,6 +507,7 @@ impl Header {
 
 /// An HTTP/3 connection event.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Event {
     /// Request/response headers were received.
     Headers {

--- a/src/h3/qpack/mod.rs
+++ b/src/h3/qpack/mod.rs
@@ -41,6 +41,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// A QPACK error.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     /// The provided buffer is too short.
     BufferTooShort,

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -39,6 +39,7 @@ pub const QPACK_DECODER_STREAM_TYPE_ID: u64 = 0x3;
 const MAX_STATE_BUF_SIZE: usize = (1 << 24) - 1;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Type {
     Control,
     Request,
@@ -49,6 +50,7 @@ pub enum Type {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum State {
     /// Reading the stream's type.
     StreamType,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// A QUIC error.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 #[repr(C)]
 pub enum Error {
     /// There is no more work to do.

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -266,6 +266,10 @@ pub fn run(
                         }
                     },
 
+                    Ok((stream_id, _)) => {
+                        warn!("unsupported event on stream {}", stream_id);
+                    },
+
                     Err(quiche::h3::Error::Done) => {
                         break;
                     },


### PR DESCRIPTION
not sure if we want to do this but...

rust 1.40 adds `non_exhaustive`, which seems to align well to making the quiche crate more extensible because it forces downstream crates to code for the possibility of new fields in structs or new enums variants.

I've focused on just quiche's public enums here, the small pact can be seen in the rust example client and server. There's probably also some other things like the integration tests or C examples that CI will catch - once it's uplifted to 1.40+.