### PR TITLE
 h3: return early from poll() when the connection is closing

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -267,6 +267,9 @@ bool quiche_conn_is_established(quiche_conn *conn);
 // enough to send or receive early data.
 bool quiche_conn_is_in_early_data(quiche_conn *conn);
 
+// Returns true if the connection is in the process of being closed..
+bool quiche_conn_is_closing(quiche_conn *conn);
+
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -577,6 +577,11 @@ pub extern fn quiche_conn_is_in_early_data(conn: &mut Connection) -> bool {
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_is_closing(conn: &mut Connection) -> bool {
+    conn.is_closing()
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_is_closed(conn: &mut Connection) -> bool {
     conn.is_closed()
 }

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -826,6 +826,12 @@ impl Connection {
     /// [`send_body()`]: struct.Connection.html#method.send_body
     /// [`close()`]: ../struct.Connection.html#method.close
     pub fn poll(&mut self, conn: &mut super::Connection) -> Result<(u64, Event)> {
+        // When the connection is closing (e.g. due to a protocol error) it might
+        // be in a broken state, so return early.
+        if conn.is_closing() {
+            return Err(Error::Done);
+        }
+
         // Process control streams first.
         if let Some(stream_id) = self.peer_control_stream_id {
             self.process_control_stream(conn, stream_id)?;
@@ -2635,6 +2641,51 @@ mod tests {
             s.client.send_request(&mut s.pipe.client, &req, true),
             Err(Error::TransportError(crate::Error::StreamLimit))
         );
+    }
+
+    #[test]
+    /// Tests that calling poll() after an error occured does nothing.
+    fn poll_after_error() {
+        // DATA frames don't consume the state buffer, so can be of any size.
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        let mut d = [42; 128];
+        let mut b = octets::Octets::with_slice(&mut d);
+
+        let frame_type = b.put_varint(frame::DATA_FRAME_TYPE_ID).unwrap();
+        s.pipe.client.stream_send(0, frame_type, false).unwrap();
+
+        let frame_len = b.put_varint(1 << 24).unwrap();
+        s.pipe.client.stream_send(0, frame_len, false).unwrap();
+
+        s.pipe.client.stream_send(0, &d, false).unwrap();
+
+        s.advance().ok();
+
+        assert_eq!(s.server.poll(&mut s.pipe.server), Ok((0, Event::Data)));
+
+        // GREASE frames consume the state buffer, so need to be limited.
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        let mut d = [42; 128];
+        let mut b = octets::Octets::with_slice(&mut d);
+
+        let frame_type = b.put_varint(148_764_065_110_560_899).unwrap();
+        s.pipe.client.stream_send(0, frame_type, false).unwrap();
+
+        let frame_len = b.put_varint(1 << 24).unwrap();
+        s.pipe.client.stream_send(0, frame_len, false).unwrap();
+
+        s.pipe.client.stream_send(0, &d, false).unwrap();
+
+        s.advance().ok();
+
+        assert_eq!(s.server.poll(&mut s.pipe.server), Err(Error::InternalError));
+
+        // Try to call poll() again after an error occurred.
+        assert_eq!(s.server.poll(&mut s.pipe.server), Err(Error::Done));
     }
 }
 


### PR DESCRIPTION
When "close()" is called (e.g. due to an internal error) the connection
(both transport and HTTP/3 one) might be in a broken state, so we should
avoid doing any work that might cause undefined behavior.