### PR TITLE
travis: fix Windows x86_64 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,7 @@ matrix:
       - choco install golang nasm
       # Update $PATH
       - export PATH="$(powershell -Command '("Process", "Machine" | % { [Environment]::GetEnvironmentVariable("PATH", $_) -Split ";" -Replace "\\$", "" } | Select -Unique | % { cygpath $_ }) -Join ":"')"
+      - rustup target add $TARGET
      script:
       - RUSTFLAGS="-D warnings" cargo build --release --verbose --target=$TARGET
       - RUSTFLAGS="-D warnings" cargo test --verbose --target=$TARGET


### PR DESCRIPTION
Apparently we need to explicitly install the target now.