### PR TITLE
qns: disable trace logs for transfer test

### DIFF
--- a/extras/docker/qns/run_endpoint.sh
+++ b/extras/docker/qns/run_endpoint.sh
@@ -21,8 +21,12 @@ check_testcase () {
     TESTNAME=$1
 
     case $1 in
-    handshake | transfer | resumption )
+    handshake | resumption )
         echo "supported"
+        ;;
+    transfer )
+        echo "supported"
+        RUST_LOG="info"
         ;;
     retry )
         echo "supported"


### PR DESCRIPTION
The transfer test is also used to get the goodput measurement, so the
trace logs might affect performance. Unfortunately there is no way to
only disable the logs for the measurement, and they need to be disabled
for the whole test.