### PR TITLE
examples: add client option for requests to different URLs

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -85,7 +85,7 @@ fn main() {
     let poll = mio::Poll::new().unwrap();
     let mut events = mio::Events::with_capacity(1024);
 
-    // We'll only connect to the first server provided in URL list
+    // We'll only connect to the first server provided in URL list.
     let connect_url = &urls[0];
 
     // Resolve server address.

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -89,7 +89,7 @@ fn main() {
     let poll = mio::Poll::new().unwrap();
     let mut events = mio::Events::with_capacity(1024);
 
-    // We'll only connect to the first server provided in URL list
+    // We'll only connect to the first server provided in URL list.
     let connect_url = &urls[0];
 
     // Resolve server address.


### PR DESCRIPTION
Previously we allows only a single URL value on the CLI meaning
that we restricted `client` to making a single HTTP/0.9
request per conection, and `http3-client` to making multiple requests
for the same resource in a single connection if `-n` was provided.

With this change, we extend the CLI to allow a list of URLs.
`client` and `http3-client` then create one connection to the first
host in that list and issue as many requests as required.

When `http3-client` is invoked with multiple URLs together with
`-n` each URL is requested that many times before moving to the next.