### PR TITLE
travis: don't do superfluous 'cargo build'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ matrix:
       - rustup component add rustfmt
       - cargo install cargo-fuzz
      script:
-      - RUSTFLAGS="-D warnings" cargo build --verbose
       - RUSTFLAGS="-D warnings" cargo test --verbose
       - RUSTFLAGS="-D warnings" cargo package --verbose --allow-dirty
       - cargo fmt -- --check


### PR DESCRIPTION
The `cargo build` for the stable build was accidentally removed in
15d04c3, however since we already do `cargo package` anyway, this is
probably superfluous, so remove it from nightly build as well.