### PR TITLE
fix markdown in qlog README

### DIFF
--- a/tools/qlog/README.md
+++ b/tools/qlog/README.md
@@ -86,7 +86,7 @@ Simply:
 
 ```rust
 serde_json::to_string_pretty(&trace).unwrap();
-``
+```
 
 which would generate the following:
 


### PR DESCRIPTION
This is breaking the rendering of the README on crates.io :)