### PR TITLE
Draft 25

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -243,7 +243,7 @@ int main(int argc, char *argv[]) {
     }
 
     quiche_config_set_application_protos(config,
-        (uint8_t *) "\x05hq-24\x05hq-23\x08http/0.9", 15);
+        (uint8_t *) "\x05hq-25\x05hq-24\x05hq-23\x08http/0.9", 15);
 
     quiche_config_set_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);

--- a/examples/client.c
+++ b/examples/client.c
@@ -245,7 +245,7 @@ int main(int argc, char *argv[]) {
     quiche_config_set_application_protos(config,
         (uint8_t *) "\x05hq-25\x05hq-24\x05hq-23\x08http/0.9", 15);
 
-    quiche_config_set_idle_timeout(config, 5000);
+    quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -118,7 +118,7 @@ fn main() {
         .set_application_protos(b"\x05hq-25\x05hq-24\x05hq-23\x08http/0.9")
         .unwrap();
 
-    config.set_idle_timeout(5000);
+    config.set_max_idle_timeout(5000);
     config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -115,7 +115,7 @@ fn main() {
     config.verify_peer(true);
 
     config
-        .set_application_protos(b"\x05hq-24\x05hq-23\x08http/0.9")
+        .set_application_protos(b"\x05hq-25\x05hq-24\x05hq-23\x08http/0.9")
         .unwrap();
 
     config.set_idle_timeout(5000);

--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -332,7 +332,7 @@ int main(int argc, char *argv[]) {
         (uint8_t *) QUICHE_H3_APPLICATION_PROTOCOL,
         sizeof(QUICHE_H3_APPLICATION_PROTOCOL) - 1);
 
-    quiche_config_set_idle_timeout(config, 5000);
+    quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -120,7 +120,7 @@ fn main() {
         .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
         .unwrap();
 
-    config.set_idle_timeout(5000);
+    config.set_max_idle_timeout(5000);
     config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);

--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -511,7 +511,7 @@ int main(int argc, char *argv[]) {
         (uint8_t *) QUICHE_H3_APPLICATION_PROTOCOL,
         sizeof(QUICHE_H3_APPLICATION_PROTOCOL) - 1);
 
-    quiche_config_set_idle_timeout(config, 5000);
+    quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -126,7 +126,7 @@ fn main() {
         .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
         .unwrap();
 
-    config.set_idle_timeout(5000);
+    config.set_max_idle_timeout(5000);
     config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);

--- a/examples/server.c
+++ b/examples/server.c
@@ -445,7 +445,7 @@ int main(int argc, char *argv[]) {
     quiche_config_set_application_protos(config,
         (uint8_t *) "\x05hq-25\x05hq-24\x05hq-23\x08http/0.9", 21);
 
-    quiche_config_set_idle_timeout(config, 5000);
+    quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);

--- a/examples/server.c
+++ b/examples/server.c
@@ -443,7 +443,7 @@ int main(int argc, char *argv[]) {
     quiche_config_load_priv_key_from_pem_file(config, "examples/cert.key");
 
     quiche_config_set_application_protos(config,
-        (uint8_t *) "\x05hq-24\x05hq-23\x08http/0.9", 21);
+        (uint8_t *) "\x05hq-25\x05hq-24\x05hq-23\x08http/0.9", 21);
 
     quiche_config_set_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -132,7 +132,7 @@ fn main() {
         .set_application_protos(b"\x05hq-25\x05hq-24\x05hq-23\x08http/0.9")
         .unwrap();
 
-    config.set_idle_timeout(5000);
+    config.set_max_idle_timeout(5000);
     config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -129,7 +129,7 @@ fn main() {
         .unwrap();
 
     config
-        .set_application_protos(b"\x05hq-24\x05hq-23\x08http/0.9")
+        .set_application_protos(b"\x05hq-25\x05hq-24\x05hq-23\x08http/0.9")
         .unwrap();
 
     config.set_idle_timeout(5000);

--- a/extras/nginx/README.md
+++ b/extras/nginx/README.md
@@ -89,7 +89,7 @@ http {
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
 
         # Add Alt-Svc header to negotiate HTTP/3.
-        add_header alt-svc 'h3-24=":443"; ma=86400';
+        add_header alt-svc 'h3-25=":443"; ma=86400';
     }
 }
 ```

--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -4020,7 +4020,7 @@ index 000000000..ba6274253
 +        return NGX_CONF_ERROR;
 +    }
 +
-+    quiche_config_set_idle_timeout(conf->quic.config, conf->idle_timeout);
++    quiche_config_set_max_idle_timeout(conf->quic.config, conf->idle_timeout);
 +
 +    quiche_config_set_initial_max_data(conf->quic.config, conf->max_data);
 +

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -38,7 +38,7 @@ extern "C" {
 //
 
 // The current QUIC wire version.
-#define QUICHE_PROTOCOL_VERSION 0xff000018
+#define QUICHE_PROTOCOL_VERSION 0xff000019
 
 // The maximum length of a connection ID.
 #define QUICHE_MAX_CONN_ID_LEN 20
@@ -328,7 +328,7 @@ void quiche_conn_free(quiche_conn *conn);
 //
 
 // List of ALPN tokens of supported HTTP/3 versions.
-#define QUICHE_H3_APPLICATION_PROTOCOL "\x05h3-24\x05h3-23"
+#define QUICHE_H3_APPLICATION_PROTOCOL "\x05h3-25\x05h3-24\x05h3-23"
 
 // Stores configuration shared between multiple connections.
 typedef struct Http3Config quiche_h3_config;

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -131,8 +131,8 @@ int quiche_config_set_application_protos(quiche_config *config,
                                          const uint8_t *protos,
                                          size_t protos_len);
 
-// Sets the `idle_timeout` transport parameter.
-void quiche_config_set_idle_timeout(quiche_config *config, uint64_t v);
+// Sets the `max_idle_timeout` transport parameter.
+void quiche_config_set_max_idle_timeout(quiche_config *config, uint64_t v);
 
 // Sets the `max_packet_size` transport parameter.
 void quiche_config_set_max_packet_size(quiche_config *config, uint64_t v);

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -388,7 +388,7 @@ fn hkdf_expand_label(
 }
 
 fn make_nonce(iv: &[u8], counter: u64) -> aead::Nonce {
-    let mut nonce = [0; 12];
+    let mut nonce = [0; aead::NONCE_LEN];
     nonce.copy_from_slice(&iv);
 
     // XOR the last bytes of the IV with the counter. This is equivalent to

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -146,8 +146,8 @@ pub extern fn quiche_config_set_application_protos(
 }
 
 #[no_mangle]
-pub extern fn quiche_config_set_idle_timeout(config: &mut Config, v: u64) {
-    config.set_idle_timeout(v);
+pub extern fn quiche_config_set_max_idle_timeout(config: &mut Config, v: u64) {
+    config.set_max_idle_timeout(v);
 }
 
 #[no_mangle]

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -258,7 +258,7 @@ use crate::octets;
 ///
 /// [`Config::set_application_protos()`]:
 /// ../struct.Config.html#method.set_application_protos
-pub const APPLICATION_PROTOCOL: &[u8] = b"\x05h3-24\x05h3-23";
+pub const APPLICATION_PROTOCOL: &[u8] = b"\x05h3-25\x05h3-24\x05h3-23";
 
 /// A specialized [`Result`] type for quiche HTTP/3 operations.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,8 +274,14 @@ use std::str::FromStr;
 pub use crate::cc::Algorithm as CongestionControlAlgorithm;
 
 /// The current QUIC wire version.
-pub const PROTOCOL_VERSION: u32 = 0xff00_0018;
-const PROTOCOL_VERSION_OLD: u32 = 0xff00_0017;
+pub const PROTOCOL_VERSION: u32 = PROTOCOL_VERSION_DRAFT25;
+
+/// Supported QUIC versions.
+///
+/// Note that the older ones might not be fully supported.
+const PROTOCOL_VERSION_DRAFT25: u32 = 0xff00_0019;
+const PROTOCOL_VERSION_DRAFT24: u32 = 0xff00_0018;
+const PROTOCOL_VERSION_DRAFT23: u32 = 0xff00_0017;
 
 /// The maximum length of a connection ID.
 pub const MAX_CONN_ID_LEN: usize = crate::packet::MAX_CID_LEN as usize;
@@ -957,7 +963,13 @@ pub fn retry(
 
 /// Returns true if the given protocol version is supported.
 pub fn version_is_supported(version: u32) -> bool {
-    version == PROTOCOL_VERSION || version == PROTOCOL_VERSION_OLD
+    match version {
+        PROTOCOL_VERSION |
+        PROTOCOL_VERSION_DRAFT24 |
+        PROTOCOL_VERSION_DRAFT23 => true,
+
+        _ => false,
+    }
 }
 
 impl Connection {

--- a/src/octets.rs
+++ b/src/octets.rs
@@ -395,6 +395,11 @@ impl<'a> Octets<'a> {
         self.off
     }
 
+    /// Returns a reference to the internal buffer.
+    pub fn buf(&self) -> &[u8] {
+        self.buf
+    }
+
     /// Copies the buffer from the current offset into a new `Vec<u8>`.
     pub fn to_vec(&self) -> Vec<u8> {
         self.as_ref().to_vec()

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -468,11 +468,12 @@ pub fn decode_pkt_num(largest_pn: u64, truncated_pn: u64, pn_len: usize) -> u64 
     let pn_mask = pn_win - 1;
     let candidate_pn = (expected_pn & !pn_mask) | truncated_pn;
 
-    if candidate_pn + pn_hwin <= expected_pn {
+    if candidate_pn + pn_hwin <= expected_pn && candidate_pn < (1 << 62) - pn_win
+    {
         return candidate_pn + pn_win;
     }
 
-    if candidate_pn > expected_pn + pn_hwin && candidate_pn > pn_win {
+    if candidate_pn > expected_pn + pn_hwin && candidate_pn >= pn_win {
         return candidate_pn - pn_win;
     }
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -587,7 +587,8 @@ pub fn negotiate_version(
     b.put_u8(dcid.len() as u8)?;
     b.put_bytes(&dcid)?;
     b.put_u32(crate::PROTOCOL_VERSION)?;
-    b.put_u32(crate::PROTOCOL_VERSION_OLD)?;
+    b.put_u32(crate::PROTOCOL_VERSION_DRAFT24)?;
+    b.put_u32(crate::PROTOCOL_VERSION_DRAFT23)?;
 
     Ok(b.off())
 }

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -92,7 +92,7 @@ pub fn run(
         .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
         .unwrap();
 
-    config.set_idle_timeout(idle_timeout);
+    config.set_max_idle_timeout(idle_timeout);
     config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);


### PR DESCRIPTION
This adds support for draft-25, while more or less keeping support for previous drafts.

Note that Retry is only supported with the latest draft (this was actually the case before as well, so :man_shrugging:).