### PR TITLE
WIP: recovery: handling max_datagram_size

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -44,6 +44,7 @@
 
 #define LOCAL_CONN_ID_LEN 16
 
+#define MAX_UDP_SIZE 65527
 #define MAX_DATAGRAM_SIZE 1350
 
 struct conn_io {
@@ -93,7 +94,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
 
     struct conn_io *conn_io = w->data;
 
-    static uint8_t buf[65535];
+    static uint8_t buf[MAX_UDP_SIZE];
 
     while (1) {
         ssize_t read = recv(conn_io->sock, buf, sizeof(buf), 0);
@@ -247,6 +248,7 @@ int main(int argc, char *argv[]) {
 
     quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);
+    quiche_config_set_max_datagram_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_uni(config, 1000000);

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -33,6 +33,7 @@ use std::io::prelude::*;
 
 use ring::rand::*;
 
+const MAX_UDP_SIZE: usize = 65527;
 const MAX_DATAGRAM_SIZE: usize = 1350;
 
 const HTTP_REQ_STREAM_ID: u64 = 4;
@@ -52,7 +53,7 @@ Options:
 ";
 
 fn main() {
-    let mut buf = [0; 65535];
+    let mut buf = [0; MAX_UDP_SIZE];
     let mut out = [0; MAX_DATAGRAM_SIZE];
 
     env_logger::builder()
@@ -120,6 +121,7 @@ fn main() {
 
     config.set_max_idle_timeout(5000);
     config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_datagram_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(max_stream_data);

--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -44,6 +44,7 @@
 
 #define LOCAL_CONN_ID_LEN 16
 
+#define MAX_UDP_SIZE 65527
 #define MAX_DATAGRAM_SIZE 1350
 
 struct conn_io {
@@ -106,7 +107,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
 
     struct conn_io *conn_io = w->data;
 
-    static uint8_t buf[65535];
+    static uint8_t buf[MAX_UDP_SIZE];
 
     while (1) {
         ssize_t read = recv(conn_io->sock, buf, sizeof(buf), 0);
@@ -334,6 +335,7 @@ int main(int argc, char *argv[]) {
 
     quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);
+	quiche_config_set_max_datagram_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_bidi_remote(config, 1000000);

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -31,6 +31,7 @@ use std::net::ToSocketAddrs;
 
 use ring::rand::*;
 
+const MAX_UDP_SIZE: usize = 65527;
 const MAX_DATAGRAM_SIZE: usize = 1350;
 
 const USAGE: &str = "Usage:
@@ -52,7 +53,7 @@ Options:
 ";
 
 fn main() {
-    let mut buf = [0; 65535];
+    let mut buf = [0; MAX_UDP_SIZE];
     let mut out = [0; MAX_DATAGRAM_SIZE];
 
     env_logger::builder()
@@ -122,6 +123,7 @@ fn main() {
 
     config.set_max_idle_timeout(5000);
     config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_datagram_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(max_stream_data);

--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -45,6 +45,7 @@
 
 #define LOCAL_CONN_ID_LEN 16
 
+#define MAX_UDP_SIZE 65527
 #define MAX_DATAGRAM_SIZE 1350
 
 #define MAX_TOKEN_LEN \
@@ -207,7 +208,7 @@ static int for_each_header(uint8_t *name, size_t name_len,
 static void recv_cb(EV_P_ ev_io *w, int revents) {
     struct conn_io *tmp, *conn_io = NULL;
 
-    static uint8_t buf[65535];
+    static uint8_t buf[MAX_UDP_SIZE];
     static uint8_t out[MAX_DATAGRAM_SIZE];
 
     while (1) {
@@ -513,6 +514,7 @@ int main(int argc, char *argv[]) {
 
     quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);
+	quiche_config_set_max_datagram_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_bidi_remote(config, 1000000);

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -33,6 +33,7 @@ use std::collections::HashMap;
 
 use ring::rand::*;
 
+const MAX_UDP_SIZE: usize = 65527;
 const MAX_DATAGRAM_SIZE: usize = 1350;
 
 const USAGE: &str = "Usage:
@@ -73,7 +74,7 @@ struct Client {
 type ClientMap = HashMap<Vec<u8>, (net::SocketAddr, Client)>;
 
 fn main() {
-    let mut buf = [0; 65535];
+    let mut buf = [0; MAX_UDP_SIZE];
     let mut out = [0; MAX_DATAGRAM_SIZE];
 
     env_logger::builder()
@@ -128,6 +129,7 @@ fn main() {
 
     config.set_max_idle_timeout(5000);
     config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_datagram_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(max_stream_data);

--- a/examples/server.c
+++ b/examples/server.c
@@ -45,6 +45,7 @@
 
 #define LOCAL_CONN_ID_LEN 16
 
+#define MAX_UDP_SIZE 65527
 #define MAX_DATAGRAM_SIZE 1350
 
 #define MAX_TOKEN_LEN \
@@ -195,7 +196,7 @@ static struct conn_io *create_conn(uint8_t *odcid, size_t odcid_len) {
 static void recv_cb(EV_P_ ev_io *w, int revents) {
     struct conn_io *tmp, *conn_io = NULL;
 
-    static uint8_t buf[65535];
+    static uint8_t buf[MAX_UDP_SIZE];
     static uint8_t out[MAX_DATAGRAM_SIZE];
 
     while (1) {
@@ -447,6 +448,7 @@ int main(int argc, char *argv[]) {
 
     quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);
+	quiche_config_set_max_datagram_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_bidi_remote(config, 1000000);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -35,6 +35,7 @@ use std::collections::HashMap;
 
 use ring::rand::*;
 
+const MAX_UDP_SIZE: usize = 65527;
 const MAX_DATAGRAM_SIZE: usize = 1350;
 
 const USAGE: &str = "Usage:
@@ -73,7 +74,7 @@ struct Client {
 type ClientMap = HashMap<Vec<u8>, (net::SocketAddr, Client)>;
 
 fn main() {
-    let mut buf = [0; 65535];
+    let mut buf = [0; MAX_UDP_SIZE];
     let mut out = [0; MAX_DATAGRAM_SIZE];
 
     env_logger::builder()
@@ -134,6 +135,7 @@ fn main() {
 
     config.set_max_idle_timeout(5000);
     config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_datagram_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(max_stream_data);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -171,6 +171,9 @@ enum quiche_cc_algorithm {
 // Sets the congestion control algorithm used.
 void quiche_config_set_cc_algorithm(quiche_config *config, enum quiche_cc_algorithm algo);
 
+// Sets the maximum datagram size.
+void quiche_config_set_max_datagram_size(quiche_config *config, size_t v);
+
 // Frees the config object.
 void quiche_config_free(quiche_config *config);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -232,6 +232,11 @@ pub extern fn quiche_config_set_cc_algorithm(
 }
 
 #[no_mangle]
+pub extern fn quiche_config_set_max_datagram_size(config: &mut Config, v: usize) {
+    config.set_max_datagram_size(v);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_free(config: *mut Config) {
     unsafe { Box::from_raw(config) };
 }

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -139,7 +139,7 @@ impl Recovery {
 
             loss_probes: [0; packet::EPOCH_COUNT],
 
-            cc: cc::new_congestion_control(config.cc_algorithm),
+            cc: cc::new_congestion_control(&config),
 
             app_limited: false,
         }


### PR DESCRIPTION
recovery: handling max_datagram_size

Currently quiche use MAX_DATAGRAM_SIZE(1452) as a fixed value.
This value is used for congestion window update, so getting a real
value is important for stable congestion control.

According to the draft, this value need to be set as a result of
PMTU discovery. However right now quiche and its server doesn't handle
PMTU and quiche library itself is not handling network sockets.
To support updating max_datagram_size, a new API is added.

  Rust: config.set_max_datagram_size(v)
  C: quiche_config_set_max_datagram_size(config, v)

Note that until Handshake completes, we will use 1200 as a
max_datagram_size. Also when peer transport parameter max_packet_size
is available (after Handshake completes), make sure
max_datagram_size is same or smaller than peer's
max_packet size.

For example, when server has max_datagram_size=1400
but client advertised max_packet_size=1300, it means client
may drop the packet size > 1300. For this case, server's
max_datagram_size will be updated to 1300 when handshake
completes.

Other changes:
- examples: use MAX_UDP_SIZE for maximum udp packet size received.
- cc: CongestionControlParams contains a default parameter
  when congestion control is initialized, such as initcwnd,
  minimum_window and max_datagram_size. Those values are
  updated when params.max_datagram_size() is called again.
- cc: set_max_datagram_size() to update max_datagram_size.
- cc: max_datagram_size() to get max_datagram_size.
- lib: defined MIN_PACKET_LEN (1200)
- lib: use self.recovery.cc.max_datagram_size() when getting
  max_pkt_len.

Fixes #298 