### PR TITLE
Choose highest version supported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1231,21 +1231,15 @@ impl Connection {
                 None => return Err(Error::InvalidPacket),
             };
 
-            let mut new_version = 0;
-            for v in versions.iter() {
-                if version_is_supported(*v) {
-                    new_version = *v;
-                    break;
-                }
-            }
-
-            // We don't support any of the versions offered.
-            if new_version == 0 {
+            if let Some(version) =
+                versions.iter().filter(|v| version_is_supported(**v)).max()
+            {
+                self.version = *version;
+                self.did_version_negotiation = true;
+            } else {
+                // We don't support any of the versions offered.
                 return Err(Error::UnknownVersion);
             }
-
-            self.version = new_version;
-            self.did_version_negotiation = true;
 
             // Reset connection state to force sending another Initial packet.
             self.got_peer_conn_id = false;


### PR DESCRIPTION
When we do version negotiation, try to choose highest version
supported, not the first seen version supported from a list of
versions from the peer.

e.g. litespeed send the version list like this:

versions=[51303433, 51303436, 51303530, ff000018, ff000019]

Currently we pick up h3-24 (ff000018), but better to pick up
h3-25 (ff000019) in the last.