### PR TITLE
WIP: bundle an ACK frame every 4 packets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1734,7 +1734,11 @@ impl Connection {
         let mut payload_len = 0;
 
         // Create ACK frame.
-        if self.pkt_num_spaces[epoch].ack_elicited && !is_closing {
+        if (self.pkt_num_spaces[epoch].ack_elicited ||
+            (!self.pkt_num_spaces[epoch].recv_pkt_need_ack.is_empty() &&
+                pn % 4 == 0)) &&
+            !is_closing
+        {
             let ack_delay =
                 self.pkt_num_spaces[epoch].largest_rx_pkt_time.elapsed();
 

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -107,6 +107,14 @@ impl RangeSet {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn flatten(&self) -> Flatten {
         Flatten {
             inner: self.inner.iter(),


### PR DESCRIPTION
When sending a packet, we generally don't bundle ACK frames unless an
ack was elicited. This means that if a client has a large flow control
window we will not ack the client's acks for a long while. The client
will then keep sending bigger and bigger ACK frames, which end-up being
very expensive to process.

Note however that this will not trigger sending an ACK-only packet, just
bundling an ACK frame when other frames were already going to be sent.