### PR TITLE
ignore frames on closed and collected streams

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -150,7 +150,7 @@ impl StreamMap {
 
                 // Stream has already been closed and garbage collected.
                 if self.collected.contains(&id) {
-                    return Err(Error::InvalidStreamState);
+                    return Err(Error::Done);
                 }
 
                 let (max_rx_data, max_tx_data) = match (local, is_bidi(id)) {


### PR DESCRIPTION
Due to the fact that we have already dropped the state of the stream, we
cannot know whether the frame is valid or not. Before we would assume
that this is an error, but in some cases (e.g. spurious retransmissions
due to loss of ACK frames) it's possible to receive a valid frame on a
dropped stream.

Fixes #350.