### PR TITLE
coalesce small STREAM frames when fuzzing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1989,6 +1989,13 @@ impl Connection {
                     self.streams.push_flushable(stream_id);
                 }
 
+                // When fuzzing, try to coalesce multiple STREAM frames in the
+                // same packet, so it's easier to generate fuzz corpora.
+                if cfg!(feature = "fuzzing") && left > frame::MAX_STREAM_OVERHEAD
+                {
+                    continue;
+                }
+
                 break;
             }
         }


### PR DESCRIPTION
When fuzzing it's useful to coalesce mutliple QUIC packets to increase
the coverage, but there can only be only one 1-RTT packet. By stashing
multiple small STREAM frames in the same packet we can store all initial
HTTP/3 frames (various control stream opening, SETTINGS, HEADERS, ...)
from the client in a single packet.