### PR TITLE
nginx: vary header fix

### DIFF
--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -100,7 +100,7 @@ new file mode 100644
 index 000000000..2c8995dd7
 --- /dev/null
 +++ b/auto/lib/quiche/conf
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,23 @@
 +
 +# Copyright (C) Cloudflare, Inc.
 +
@@ -118,6 +118,10 @@ index 000000000..2c8995dd7
 +    CORE_INCS="$CORE_INCS $QUICHE/include"
 +    CORE_DEPS="$CORE_DEPS $QUICHE/target/$QUICHE_BUILD_TARGET/libquiche.a"
 +    CORE_LIBS="$CORE_LIBS $QUICHE/target/$QUICHE_BUILD_TARGET/libquiche.a $NGX_LIBPTHREAD"
++
++    if [ "$NGX_SYSTEM" = "Darwin" ]; then
++        CORE_LIBS+=" -framework Security"
++    fi
 +
 +fi
 diff --git a/auto/lib/quiche/make b/auto/lib/quiche/make

--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -1564,7 +1564,7 @@ new file mode 100644
 index 000000000..0877fb9a2
 --- /dev/null
 +++ b/src/http/v3/ngx_http_v3.c
-@@ -0,0 +1,2095 @@
+@@ -0,0 +1,2099 @@
 +
 +/*
 + * Copyright (C) Cloudflare, Inc.
@@ -3343,6 +3343,10 @@ index 000000000..0877fb9a2
 +    /* Generate Vary header. */
 +    if (r->gzip_vary) {
 +        h = ngx_array_push(headers);
++        if (h == NULL) {
++            return NGX_ERROR;
++        }
++
 +        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, fc->log, 0,
 +                       "http3 output header: \"vary: Accept-Encoding\"");
 +
@@ -4150,4 +4154,3 @@ index 000000000..72e189def
 +#endif /* _NGX_HTTP_V3_MODULE_H_INCLUDED_ */
 -- 
 2.24.1
-

--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -1564,7 +1564,7 @@ new file mode 100644
 index 000000000..0877fb9a2
 --- /dev/null
 +++ b/src/http/v3/ngx_http_v3.c
-@@ -0,0 +1,2094 @@
+@@ -0,0 +1,2095 @@
 +
 +/*
 + * Copyright (C) Cloudflare, Inc.
@@ -3342,6 +3342,7 @@ index 000000000..0877fb9a2
 +#if (NGX_HTTP_GZIP)
 +    /* Generate Vary header. */
 +    if (r->gzip_vary) {
++        h = ngx_array_push(headers);
 +        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, fc->log, 0,
 +                       "http3 output header: \"vary: Accept-Encoding\"");
 +


### PR DESCRIPTION
https://github.com/cloudflare/quiche/commit/63a9096e4a90459f547eae90bdabc16ab39b1936 fixes an error that forgets to allocate new space for the `vary` header. This caused the `content-type` header to be overwritten by `vary`, which was reported in https://github.com/cloudflare/quiche/issues/237.