### PR TITLE
Handle partial writes of HTTP/3 HEADERS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2202,6 +2202,11 @@ impl Connection {
     /// up to the amount that the peer allows it to send (that is, up to the
     /// stream's outgoing flow control capacity).
     ///
+    /// This means that the number of written bytes returned can be lower than
+    /// the length of the input buffer when the stream doesn't have enough
+    /// capacity for the operation to complete. The application should retry the
+    /// operation once the stream is reported as writable again.
+    ///
     /// [`Done`]: enum.Error.html#variant.Done
     ///
     /// ## Examples:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1931,7 +1931,6 @@ impl Connection {
 
         // Create a single STREAM frame for the first stream that is flushable.
         if pkt_type == packet::Type::Short &&
-            self.max_tx_data > self.tx_data &&
             left > frame::MAX_STREAM_OVERHEAD &&
             !is_closing
         {
@@ -1942,10 +1941,6 @@ impl Connection {
                     None => continue,
                 };
 
-                // Make sure we can fit the data in the packet.
-                let max_len =
-                    cmp::min(left, (self.max_tx_data - self.tx_data) as usize);
-
                 let off = stream.send.off();
 
                 // Try to accurately account for the STREAM frame's overhead,
@@ -1954,9 +1949,9 @@ impl Connection {
                 let overhead = 1 +
                     octets::varint_len(stream_id) +
                     octets::varint_len(off) +
-                    octets::varint_len(max_len as u64);
+                    octets::varint_len(left as u64);
 
-                let max_len = match max_len.checked_sub(overhead) {
+                let max_len = match left.checked_sub(overhead) {
                     Some(v) => v,
 
                     None => continue,
@@ -1967,8 +1962,6 @@ impl Connection {
                 if stream_buf.is_empty() && !stream_buf.fin() {
                     continue;
                 }
-
-                self.tx_data += stream_buf.len() as u64;
 
                 let frame = frame::Frame::Stream {
                     stream_id,
@@ -2268,6 +2261,8 @@ impl Connection {
         if !writable {
             self.streams.mark_writable(stream_id, false);
         }
+
+        self.tx_data += sent as u64;
 
         Ok(sent)
     }
@@ -4439,12 +4434,27 @@ mod tests {
         assert!(pipe.client.is_established());
 
         // Send 1-RTT packet #0.
-        assert_eq!(pipe.client.stream_send(0, b"hello, world", true), Ok(12));
-        assert_eq!(pipe.advance(&mut buf), Ok(()));
+        let frames = [frame::Frame::Stream {
+            stream_id: 0,
+            data: stream::RangeBuf::from(b"hello, world", 0, true),
+        }];
+
+        let pkt_type = packet::Type::Short;
+        let written =
+            testing::encode_pkt(&mut pipe.client, pkt_type, &frames, &mut buf)
+                .unwrap();
+        assert_eq!(pipe.server.recv(&mut buf[..written]), Ok(written));
 
         // Send 1-RTT packet #1.
-        assert_eq!(pipe.client.stream_send(4, b"hello, world", true), Ok(12));
-        assert_eq!(pipe.advance(&mut buf), Ok(()));
+        let frames = [frame::Frame::Stream {
+            stream_id: 4,
+            data: stream::RangeBuf::from(b"hello, world", 0, true),
+        }];
+
+        let written =
+            testing::encode_pkt(&mut pipe.client, pkt_type, &frames, &mut buf)
+                .unwrap();
+        assert_eq!(pipe.server.recv(&mut buf[..written]), Ok(written));
 
         assert!(!pipe.server.is_established());
 
@@ -4468,8 +4478,6 @@ mod tests {
                 .largest_rx_pkt_num,
             0
         );
-
-        assert_eq!(pipe.client.stats().sent, pipe.server.stats().recv + 2);
     }
 
     #[test]
@@ -4613,6 +4621,9 @@ mod tests {
         let mut r = pipe.client.readable();
         assert_eq!(r.next(), None);
 
+        let mut r = pipe.server.readable();
+        assert_eq!(r.next(), None);
+
         assert_eq!(pipe.advance(&mut buf), Ok(()));
 
         // Server received stream.
@@ -4638,7 +4649,7 @@ mod tests {
         let mut r = pipe.client.readable();
         assert_eq!(r.next(), None);
 
-        // Server suts down stream.
+        // Server shuts down stream.
         let mut r = pipe.server.readable();
         assert_eq!(r.next(), Some(4));
         assert_eq!(r.next(), None);
@@ -4763,7 +4774,7 @@ mod tests {
             Ok(15)
         );
         assert_eq!(pipe.advance(&mut buf), Ok(()));
-        assert_eq!(pipe.client.stream_send(8, b"a", false), Ok(1));
+        assert_eq!(pipe.client.stream_send(8, b"a", false), Ok(0));
         assert_eq!(pipe.advance(&mut buf), Ok(()));
 
         let mut r = pipe.server.readable();


### PR DESCRIPTION
See commit messages.

The first commit is actually a follow-up to https://github.com/cloudflare/quiche/commit/56fc60bfa2d92e3abfd6c06a47c191dcb439eac8. It fixes the fact that the flow control limit didn't actually decrease until a STREAM frame was sent on the wire, so the application could keep writing data without having the connecion flow control matter. It's not strictly necessary for the HTTP/3 fix, but it makes writing a test for that easier so I put them in the same PR.