### PR TITLE
nginx: MacOS build

### DIFF
--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -100,7 +100,7 @@ new file mode 100644
 index 000000000..2c8995dd7
 --- /dev/null
 +++ b/auto/lib/quiche/conf
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,23 @@
 +
 +# Copyright (C) Cloudflare, Inc.
 +
@@ -118,6 +118,10 @@ index 000000000..2c8995dd7
 +    CORE_INCS="$CORE_INCS $QUICHE/include"
 +    CORE_DEPS="$CORE_DEPS $QUICHE/target/$QUICHE_BUILD_TARGET/libquiche.a"
 +    CORE_LIBS="$CORE_LIBS $QUICHE/target/$QUICHE_BUILD_TARGET/libquiche.a $NGX_LIBPTHREAD"
++
++    if [ "$NGX_SYSTEM" = "Darwin" ]; then
++        CORE_LIBS+=" -framework Security"
++    fi
 +
 +fi
 diff --git a/auto/lib/quiche/make b/auto/lib/quiche/make


### PR DESCRIPTION
As #17 and #23 discussed, the patched nginx needs to be linked with Apple's Security framework when compiling on macOS. https://github.com/cloudflare/quiche/commit/e1f9d135cae6f8aedaaebb31457b1234f115bc60 should fix that.