### PR TITLE
WIP: path MTU discovery

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -120,6 +120,9 @@ void quiche_config_verify_peer(quiche_config *config, bool v);
 // Configures whether to send GREASE.
 void quiche_config_grease(quiche_config *config, bool v);
 
+// Configures whether to do path MTU discovery.
+void quiche_config_discover_pmtu(quiche_config *config, bool v);
+
 // Enables logging of secrets.
 void quiche_config_log_keys(quiche_config *config);
 

--- a/src/cc/reno.rs
+++ b/src/cc/reno.rs
@@ -172,6 +172,7 @@ mod tests {
             size: 5000,
             ack_eliciting: true,
             in_flight: true,
+            pmtud: false,
         };
 
         // Send 5k x 4 = 20k, higher than default cwnd(~15k)
@@ -234,6 +235,7 @@ mod tests {
             size: 5000,
             ack_eliciting: true,
             in_flight: true,
+            pmtud: false,
         };
 
         let prev_cwnd = cc.cwnd();

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -123,6 +123,11 @@ pub extern fn quiche_config_grease(config: &mut Config, v: bool) {
 }
 
 #[no_mangle]
+pub extern fn quiche_config_discover_pmtu(config: &mut Config, v: bool) {
+    config.discover_pmtu(v);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_log_keys(config: &mut Config) {
     config.log_keys();
 }

--- a/tools/apps/src/bin/quiche-client.rs
+++ b/tools/apps/src/bin/quiche-client.rs
@@ -35,7 +35,7 @@ use ring::rand::*;
 
 use quiche_apps::*;
 
-const MAX_DATAGRAM_SIZE: usize = 1350;
+const MAX_DATAGRAM_SIZE: usize = 1500;
 
 const USAGE: &str = "Usage:
   quiche-client [options] URL...
@@ -112,7 +112,6 @@ fn main() {
     config.set_application_protos(&conn_args.alpns).unwrap();
 
     config.set_max_idle_timeout(5000);
-    config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(conn_args.max_data);
     config.set_initial_max_stream_data_bidi_local(conn_args.max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(conn_args.max_stream_data);

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -37,7 +37,7 @@ use ring::rand::*;
 
 use quiche_apps::*;
 
-const MAX_DATAGRAM_SIZE: usize = 1350;
+const MAX_DATAGRAM_SIZE: usize = 1500;
 
 const USAGE: &str = "Usage:
   quiche-server [options]
@@ -99,8 +99,9 @@ fn main() {
 
     config.set_application_protos(&conn_args.alpns).unwrap();
 
+    config.discover_pmtu(true);
+
     config.set_max_idle_timeout(5000);
-    config.set_max_packet_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(conn_args.max_data);
     config.set_initial_max_stream_data_bidi_local(conn_args.max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(conn_args.max_stream_data);


### PR DESCRIPTION
This adds initial support for PMTUD. The PMTU starts at 1200 bytes
(minimum QUIC packet size), then 1452 is tried (maximum QUIC packet
size). If the probe fails we keep using 1200 and not attempt any
additional probe.

Due to the fact that the probe might be lost due to a lower path MTU, we
also need to ignore PMTUD probe losses for congestion control purposes,
otherwise we might decrease the cwnd even though there is no actual
congestion on the path.

The probing happens immediately after the handshake is completed (on the
server it is sent after HANDSHAKE_DONE, to avoid delaying the handshake
confirmation), so it might be too aggressive as it means the connection
incurs the cost of sending the additional packet even when the total
number of bytes is very small (e.g. potentially if the whole data would
have taken a single flight to send, it will now take 2).

For these reasons, PMTUD is disabled by default, and can be enabled with
a config flag. In the future we can experiment with smarter strategies.

---

I need to some additional testing, but this should be ready for review now.