### PR TITLE
Don't decrease tx_data when retransmit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1660,11 +1660,6 @@ impl Connection {
                         None => continue,
                     };
 
-                    // TODO: due to a packet loss edge case the following could
-                    // go negative, though it's not clear why, so will need to
-                    // figure it out.
-                    self.tx_data = self.tx_data.saturating_sub(data.len() as u64);
-
                     let was_flushable = stream.is_flushable();
 
                     let empty_fin = data.is_empty() && data.fin();


### PR DESCRIPTION
tx_data is "The sum of the largest received offsets on all streams"
so it need to be increased when we send a new data. If we decrease
tx_data while retransmitting it will result sending more data,
so the receiver will get more data than reported in MAX_DATA frame,
causing FLOW_CONTROL_ERROR.