### PR TITLE
cc: pass timestamp to hooks

### DIFF
--- a/src/cc/mod.rs
+++ b/src/cc/mod.rs
@@ -87,7 +87,9 @@ where
     fn collapse_cwnd(&mut self);
 
     /// OnPacketSentCC(bytes_sent)
-    fn on_packet_sent_cc(&mut self, bytes_sent: usize, trace_id: &str);
+    fn on_packet_sent_cc(
+        &mut self, bytes_sent: usize, now: Instant, trace_id: &str,
+    );
 
     /// InCongestionRecovery(sent_time)
     fn in_congestion_recovery(&self, sent_time: Instant) -> bool {
@@ -102,7 +104,7 @@ where
     /// OnPacketAckedCC(packet)
     fn on_packet_acked_cc(
         &mut self, packet: &Sent, srtt: Duration, min_rtt: Duration,
-        app_limited: bool, trace_id: &str,
+        app_limited: bool, now: Instant, trace_id: &str,
     );
 
     /// CongestionEvent(time_sent)

--- a/src/cc/reno.rs
+++ b/src/cc/reno.rs
@@ -82,13 +82,15 @@ impl cc::CongestionControl for Reno {
         self.congestion_recovery_start_time
     }
 
-    fn on_packet_sent_cc(&mut self, bytes_sent: usize, _trace_id: &str) {
+    fn on_packet_sent_cc(
+        &mut self, bytes_sent: usize, _now: Instant, _trace_id: &str,
+    ) {
         self.bytes_in_flight += bytes_sent;
     }
 
     fn on_packet_acked_cc(
         &mut self, packet: &Sent, _srtt: Duration, _min_rtt: Duration,
-        app_limited: bool, _trace_id: &str,
+        app_limited: bool, _now: Instant, _trace_id: &str,
     ) {
         self.bytes_in_flight -= packet.size;
 
@@ -155,8 +157,9 @@ mod tests {
     #[test]
     fn reno_send() {
         let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
+        let now = Instant::now();
 
-        cc.on_packet_sent_cc(1000, TRACE_ID);
+        cc.on_packet_sent_cc(1000, now, TRACE_ID);
 
         assert_eq!(cc.bytes_in_flight(), 1000);
     }
@@ -164,11 +167,12 @@ mod tests {
     #[test]
     fn reno_slow_start() {
         let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
+        let now = Instant::now();
 
         let p = Sent {
             pkt_num: 0,
             frames: vec![],
-            time: std::time::Instant::now(),
+            time: now,
             size: 5000,
             ack_eliciting: true,
             in_flight: true,
@@ -176,10 +180,10 @@ mod tests {
 
         // Send 5k x 4 = 20k, higher than default cwnd(~15k)
         // to become no longer app limited.
-        cc.on_packet_sent_cc(p.size, TRACE_ID);
-        cc.on_packet_sent_cc(p.size, TRACE_ID);
-        cc.on_packet_sent_cc(p.size, TRACE_ID);
-        cc.on_packet_sent_cc(p.size, TRACE_ID);
+        cc.on_packet_sent_cc(p.size, now, TRACE_ID);
+        cc.on_packet_sent_cc(p.size, now, TRACE_ID);
+        cc.on_packet_sent_cc(p.size, now, TRACE_ID);
+        cc.on_packet_sent_cc(p.size, now, TRACE_ID);
 
         let cwnd_prev = cc.cwnd();
 
@@ -188,6 +192,7 @@ mod tests {
             Duration::new(0, 1),
             Duration::new(0, 1),
             false,
+            now,
             TRACE_ID,
         );
 
@@ -199,12 +204,9 @@ mod tests {
     fn reno_congestion_event() {
         let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
         let prev_cwnd = cc.cwnd();
+        let now = Instant::now();
 
-        cc.congestion_event(
-            std::time::Instant::now(),
-            std::time::Instant::now(),
-            TRACE_ID,
-        );
+        cc.congestion_event(now, now, TRACE_ID);
 
         // In Reno, after congestion event, cwnd will be cut in half.
         assert_eq!(prev_cwnd / 2, cc.cwnd());
@@ -214,15 +216,12 @@ mod tests {
     fn reno_congestion_avoidance() {
         let mut cc = cc::new_congestion_control(cc::Algorithm::Reno);
         let prev_cwnd = cc.cwnd();
+        let now = Instant::now();
 
         // Send 20K bytes.
-        cc.on_packet_sent_cc(20000, TRACE_ID);
+        cc.on_packet_sent_cc(20000, now, TRACE_ID);
 
-        cc.congestion_event(
-            std::time::Instant::now(),
-            std::time::Instant::now(),
-            TRACE_ID,
-        );
+        cc.congestion_event(now, now, TRACE_ID);
 
         // In Reno, after congestion event, cwnd will be cut in half.
         assert_eq!(prev_cwnd / 2, cc.cwnd());
@@ -230,7 +229,7 @@ mod tests {
         let p = Sent {
             pkt_num: 0,
             frames: vec![],
-            time: std::time::Instant::now(),
+            time: now,
             size: 5000,
             ack_eliciting: true,
             in_flight: true,
@@ -244,6 +243,7 @@ mod tests {
             Duration::new(0, 1),
             Duration::new(0, 1),
             false,
+            now,
             TRACE_ID,
         );
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -167,7 +167,7 @@ impl Recovery {
                 (self.cc.bytes_in_flight() + sent_bytes) < self.cc.cwnd();
 
             // OnPacketSentCC
-            self.cc.on_packet_sent_cc(sent_bytes, trace_id);
+            self.cc.on_packet_sent_cc(sent_bytes, now, trace_id);
 
             self.set_loss_detection_timer(handshake_completed);
         }
@@ -233,7 +233,7 @@ impl Recovery {
                 }
             }
 
-            let newly_acked = self.on_packet_acked(pn, epoch, trace_id);
+            let newly_acked = self.on_packet_acked(pn, epoch, now, trace_id);
             has_newly_acked = cmp::max(has_newly_acked, newly_acked);
 
             if newly_acked {
@@ -471,7 +471,8 @@ impl Recovery {
     }
 
     fn on_packet_acked(
-        &mut self, pkt_num: u64, epoch: packet::Epoch, trace_id: &str,
+        &mut self, pkt_num: u64, epoch: packet::Epoch, now: Instant,
+        trace_id: &str,
     ) -> bool {
         // Check if packet is newly acked.
         if let Some(mut p) = self.sent[epoch].remove(&pkt_num) {
@@ -484,6 +485,7 @@ impl Recovery {
                     self.rtt(),
                     self.min_rtt,
                     self.app_limited,
+                    now,
                     trace_id,
                 );
             }


### PR DESCRIPTION
To reduce calling Instant::now() inside congestion control hooks,
add a timestamp (`now`) parameter to the following hooks:
- `on_packet_sent_cc()`
- `on_packet_acked_cc()`