### PR TITLE
docker: small build time improvement

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -7,23 +7,18 @@ RUN apt-get update && apt-get install -y git cmake golang && \
 
 RUN git clone --recurse-submodules --depth 1 https://github.com/cloudflare/quiche
 RUN cd quiche && \
-    cargo build --release --examples
-RUN cd quiche && \
-    cargo build --manifest-path tools/apps/Cargo.toml --release
+    git log --oneline -n 1 && \
+    cargo build --manifest-path tools/apps/Cargo.toml
 
 ##
 ## quiche-base: base quiche image
 ##
 FROM debian:latest as quiche-base
+
 RUN apt-get update && apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-RUN update-ca-certificates
-COPY --from=build /build/quiche/target/release/examples/http3-client \
-     /build/quiche/target/release/examples/http3-server \
-     /build/quiche/target/release/examples/client \
-     /build/quiche/target/release/examples/server \
-     /build/quiche/tools/apps/target/release/quiche-client \
-     /build/quiche/tools/apps/target/release/quiche-server \
+COPY --from=build /build/quiche/tools/apps/target/debug/quiche-client \
+     /build/quiche/tools/apps/target/debug/quiche-server \
      /usr/local/bin/
 ENV PATH="/usr/local/bin/:${PATH}"
 ENV RUST_LOG=info
@@ -43,8 +38,8 @@ WORKDIR /quiche
 COPY --from=build /build/quiche/examples/cert.crt \
      /build/quiche/examples/cert.key \
      examples/
-COPY --from=build /build/quiche/tools/apps/target/release/quiche-client \
-    /build/quiche/tools/apps/target/release/quiche-server \
+COPY --from=build /build/quiche/tools/apps/target/debug/quiche-client \
+    /build/quiche/tools/apps/target/debug/quiche-server \
      ./
 ENV RUST_LOG=trace
 


### PR DESCRIPTION
* Make a debug build for docker images
  (non-docker build is already debug build).
  qns test doesn't need a high performance so it should be ok
* No need to run `update-ca-certificates` (it will run at installation time)
* Add `git log..` for logging quiche commit is built. Only for
  travis log.

Also, current total build time is half dominated by docker build (taking >10 min) at the end of master build. Probably better to make it parallel task?