### PR TITLE
expose delivery rate in Stats + clean-up

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -313,8 +313,11 @@ typedef struct {
     // The estimated round-trip time of the connection (in nanoseconds).
     uint64_t rtt;
 
-    // The size in bytes of the connection's congestion window.
+    // The size of the connection's congestion window in bytes.
     size_t cwnd;
+
+    // The estimated data delivery rate in bytes/s.
+    uint64_t delivery_rate;
 } quiche_stats;
 
 // Collects and returns statistics about the connection.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -624,6 +624,7 @@ pub struct Stats {
     pub lost: usize,
     pub rtt: u64,
     pub cwnd: usize,
+    pub delivery_rate: u64,
 }
 
 #[no_mangle]
@@ -635,6 +636,7 @@ pub extern fn quiche_conn_stats(conn: &Connection, out: &mut Stats) {
     out.lost = stats.lost;
     out.rtt = stats.rtt.as_nanos() as u64;
     out.cwnd = stats.cwnd;
+    out.delivery_rate = stats.delivery_rate as u64;
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2662,6 +2662,7 @@ impl Connection {
             lost: self.recovery.lost_count,
             cwnd: self.recovery.cc.cwnd(),
             rtt: self.recovery.rtt(),
+            delivery_rate: self.recovery.delivery_rate(),
         }
     }
 
@@ -3134,16 +3135,24 @@ pub struct Stats {
     /// The estimated round-trip time of the connection.
     pub rtt: time::Duration,
 
-    /// The size in bytes of the connection's congestion window.
+    /// The size of the connection's congestion window in bytes.
     pub cwnd: usize,
+
+    /// The estimated data delivery rate in bytes/s.
+    pub delivery_rate: f64,
 }
 
 impl std::fmt::Debug for Stats {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "recv={} sent={} lost={} rtt={:?} cwnd={}",
-            self.recv, self.sent, self.lost, self.rtt, self.cwnd
+            "recv={} sent={} lost={} rtt={:?} cwnd={} delivery_rate={}",
+            self.recv,
+            self.sent,
+            self.lost,
+            self.rtt,
+            self.cwnd,
+            self.delivery_rate
         )
     }
 }

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -131,15 +131,15 @@ pub struct Recovery {
 
     app_limited: bool,
 
-    pub delivered: usize,
+    delivered: usize,
 
-    pub delivered_time: Option<Instant>,
+    delivered_time: Option<Instant>,
 
-    pub recent_delivered_packet_sent_time: Option<Instant>,
+    recent_delivered_packet_sent_time: Option<Instant>,
 
-    pub app_limited_at_pkt: usize,
+    app_limited_at_pkt: usize,
 
-    pub rate_sample: RateSample,
+    rate_sample: RateSample,
 }
 
 impl Recovery {

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -778,7 +778,7 @@ mod tests {
         };
 
         recovery.rate_on_packet_sent(&mut pkt_1, Instant::now());
-        std::thread::sleep(Duration::new(0, 50000000));
+        std::thread::sleep(Duration::from_millis(50));
         recovery.rate_on_ack_received(pkt_1, Instant::now());
 
         let mut pkt_2 = Sent {
@@ -795,7 +795,7 @@ mod tests {
         };
 
         recovery.rate_on_packet_sent(&mut pkt_2, Instant::now());
-        std::thread::sleep(Duration::new(0, 50000000));
+        std::thread::sleep(Duration::from_millis(50));
         recovery.rate_on_ack_received(pkt_2, Instant::now());
         recovery.rate_estimate();
 
@@ -821,7 +821,7 @@ mod tests {
         };
 
         recvry.rate_on_packet_sent(&mut pkt_1, Instant::now());
-        std::thread::sleep(Duration::new(0, 50000000));
+        std::thread::sleep(Duration::from_millis(50));
         recvry.rate_on_ack_received(pkt_1, Instant::now());
 
         let mut pkt_2 = Sent {
@@ -840,7 +840,7 @@ mod tests {
         recvry.app_limited = true;
         recvry.rate_check_app_limited();
         recvry.rate_on_packet_sent(&mut pkt_2, Instant::now());
-        std::thread::sleep(Duration::new(0, 50000000));
+        std::thread::sleep(Duration::from_millis(50));
         recvry.rate_on_ack_received(pkt_2, Instant::now());
         recvry.rate_estimate();
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -647,6 +647,7 @@ impl Recovery {
             Some(_) => {
                 self.rate_sample.delivered =
                     self.delivered - self.rate_sample.prior_delivered;
+
                 self.rate_sample.interval = cmp::max(
                     self.rate_sample.send_elapsed,
                     self.rate_sample.ack_elapsed,
@@ -697,14 +698,10 @@ impl std::fmt::Debug for Recovery {
         write!(f, "{:?} ", self.cc)?;
         write!(f, "delivered={:?} ", self.delivered)?;
         if let Some(t) = self.delivered_time {
-            write!(f, "delivered_time={:?}", t.elapsed().as_millis())?;
+            write!(f, "delivered_time={:?}", t.elapsed())?;
         }
         if let Some(t) = self.recent_delivered_packet_sent_time {
-            write!(
-                f,
-                "recent_delivered_packet_sent_time={:?} ",
-                t.elapsed().as_millis()
-            )?;
+            write!(f, "recent_delivered_packet_sent_time={:?} ", t.elapsed())?;
         }
         write!(f, "app_limited_at_pkt={:?} ", self.app_limited_at_pkt)?;
 
@@ -715,13 +712,13 @@ impl std::fmt::Debug for Recovery {
 impl std::fmt::Debug for RateSample {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "delivery_rate={:?} ", self.delivery_rate)?;
-        write!(f, "interval={:?} ", self.interval.as_millis())?;
+        write!(f, "interval={:?} ", self.interval)?;
         write!(f, "delivered={:?} ", self.delivered)?;
         write!(f, "prior_delivered={:?} ", self.prior_delivered)?;
-        write!(f, "send_elapsed={:?} ", self.send_elapsed.as_millis())?;
-        write!(f, "ack_elapsed={:?} ", self.ack_elapsed.as_millis())?;
+        write!(f, "send_elapsed={:?} ", self.send_elapsed)?;
+        write!(f, "ack_elapsed={:?} ", self.ack_elapsed)?;
         if let Some(t) = self.prior_time {
-            write!(f, "prior_time={:?} ", t.elapsed().as_millis())?;
+            write!(f, "prior_time={:?} ", t.elapsed())?;
         }
 
         Ok(())
@@ -731,18 +728,14 @@ impl std::fmt::Debug for RateSample {
 impl std::fmt::Debug for Sent {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "pkt_num={:?} ", self.pkt_num)?;
-        write!(f, "pkt_sent_time={:?} ", self.time.elapsed().as_millis())?;
+        write!(f, "pkt_sent_time={:?} ", self.time.elapsed())?;
         write!(f, "pkt_size={:?} ", self.size)?;
         write!(f, "delivered={:?} ", self.delivered)?;
-        write!(
-            f,
-            "delivered_time ={:?} ",
-            self.delivered_time.elapsed().as_millis()
-        )?;
+        write!(f, "delivered_time ={:?} ", self.delivered_time.elapsed())?;
         write!(
             f,
             "recent_delivered_packet_sent_time={:?} ",
-            self.recent_delivered_packet_sent_time.elapsed().as_millis()
+            self.recent_delivered_packet_sent_time.elapsed()
         )?;
         write!(f, "is_app_limited={:?} ", self.is_app_limited)?;
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -376,6 +376,10 @@ impl Recovery {
         self.rtt() + cmp::max(self.rttvar * 4, GRANULARITY) + self.max_ack_delay
     }
 
+    pub fn delivery_rate(&self) -> f64 {
+        self.rate_sample.delivery_rate
+    }
+
     fn update_rtt(&mut self, latest_rtt: Duration, ack_delay: Duration) {
         self.latest_rtt = latest_rtt;
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -656,9 +656,9 @@ impl Recovery {
             None => return,
         }
 
-        if self.rate_sample.interval.as_millis() > 0 {
+        if self.rate_sample.interval.as_secs_f64() > 0.0 {
             self.rate_sample.delivery_rate = self.rate_sample.delivered as f64 /
-                self.rate_sample.interval.as_millis() as f64;
+                self.rate_sample.interval.as_secs_f64();
         }
     }
 


### PR DESCRIPTION
My original objective was to expose the delivery rate via `Stats`, though while at it I made some clean-up to the recovery and rate estimation code.