### PR TITLE
apps: downgrade more logs

### DIFF
--- a/tools/apps/src/bin/quiche-client.rs
+++ b/tools/apps/src/bin/quiche-client.rs
@@ -150,14 +150,14 @@ fn main() {
 
     while let Err(e) = socket.send(&out[..write]) {
         if e.kind() == std::io::ErrorKind::WouldBlock {
-            debug!("send() would block");
+            trace!("send() would block");
             continue;
         }
 
         panic!("send() failed: {:?}", e);
     }
 
-    debug!("written {}", write);
+    trace!("written {}", write);
 
     let req_start = std::time::Instant::now();
 
@@ -173,7 +173,7 @@ fn main() {
             // has expired, so handle it without attempting to read packets. We
             // will then proceed with the send loop.
             if events.is_empty() {
-                debug!("timed out");
+                trace!("timed out");
 
                 conn.on_timeout();
 
@@ -187,7 +187,7 @@ fn main() {
                     // There are no more UDP packets to read, so end the read
                     // loop.
                     if e.kind() == std::io::ErrorKind::WouldBlock {
-                        debug!("recv() would block");
+                        trace!("recv() would block");
                         break 'read;
                     }
 
@@ -195,7 +195,7 @@ fn main() {
                 },
             };
 
-            debug!("got {} bytes", len);
+            trace!("got {} bytes", len);
 
             if let Some(target_path) = conn_args.dump_packet_path.as_ref() {
                 let path = format!("{}/{}.pkt", target_path, pkt_count);
@@ -213,7 +213,7 @@ fn main() {
                 Ok(v) => v,
 
                 Err(quiche::Error::Done) => {
-                    debug!("done reading");
+                    trace!("done reading");
                     break;
                 },
 
@@ -223,7 +223,7 @@ fn main() {
                 },
             };
 
-            debug!("processed {} bytes", read);
+            trace!("processed {} bytes", read);
         }
 
         if conn.is_closed() {
@@ -278,7 +278,7 @@ fn main() {
                 Ok(v) => v,
 
                 Err(quiche::Error::Done) => {
-                    debug!("done writing");
+                    trace!("done writing");
                     break;
                 },
 
@@ -292,14 +292,14 @@ fn main() {
 
             if let Err(e) = socket.send(&out[..write]) {
                 if e.kind() == std::io::ErrorKind::WouldBlock {
-                    debug!("send() would block");
+                    trace!("send() would block");
                     break;
                 }
 
                 panic!("send() failed: {:?}", e);
             }
 
-            debug!("written {}", write);
+            trace!("written {}", write);
         }
 
         if conn.is_closed() {

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -145,7 +145,7 @@ fn main() {
             // has expired, so handle it without attempting to read packets. We
             // will then proceed with the send loop.
             if events.is_empty() {
-                debug!("timed out");
+                trace!("timed out");
 
                 clients.values_mut().for_each(|(_, c)| c.conn.on_timeout());
 
@@ -159,7 +159,7 @@ fn main() {
                     // There are no more UDP packets to read, so end the read
                     // loop.
                     if e.kind() == std::io::ErrorKind::WouldBlock {
-                        debug!("recv() would block");
+                        trace!("recv() would block");
                         break 'read;
                     }
 
@@ -167,7 +167,7 @@ fn main() {
                 },
             };
 
-            debug!("got {} bytes", len);
+            trace!("got {} bytes", len);
 
             let pkt_buf = &mut buf[..len];
 
@@ -221,7 +221,7 @@ fn main() {
 
                     if let Err(e) = socket.send_to(out, &src) {
                         if e.kind() == std::io::ErrorKind::WouldBlock {
-                            debug!("send() would block");
+                            trace!("send() would block");
                             break;
                         }
 
@@ -253,7 +253,7 @@ fn main() {
 
                         if let Err(e) = socket.send_to(out, &src) {
                             if e.kind() == std::io::ErrorKind::WouldBlock {
-                                debug!("send() would block");
+                                trace!("send() would block");
                                 break;
                             }
 
@@ -311,7 +311,7 @@ fn main() {
                 Ok(v) => v,
 
                 Err(quiche::Error::Done) => {
-                    debug!("{} done reading", client.conn.trace_id());
+                    trace!("{} done reading", client.conn.trace_id());
                     break;
                 },
 
@@ -321,7 +321,7 @@ fn main() {
                 },
             };
 
-            debug!("{} processed {} bytes", client.conn.trace_id(), read);
+            trace!("{} processed {} bytes", client.conn.trace_id(), read);
 
             // Create a new HTTP connection as soon as the QUIC connection
             // is established.
@@ -381,7 +381,7 @@ fn main() {
                     Ok(v) => v,
 
                     Err(quiche::Error::Done) => {
-                        debug!("{} done writing", client.conn.trace_id());
+                        trace!("{} done writing", client.conn.trace_id());
                         break;
                     },
 
@@ -396,20 +396,20 @@ fn main() {
                 // TODO: coalesce packets.
                 if let Err(e) = socket.send_to(&out[..write], &peer) {
                     if e.kind() == std::io::ErrorKind::WouldBlock {
-                        debug!("send() would block");
+                        trace!("send() would block");
                         break;
                     }
 
                     panic!("send() failed: {:?}", e);
                 }
 
-                debug!("{} written {} bytes", client.conn.trace_id(), write);
+                trace!("{} written {} bytes", client.conn.trace_id(), write);
             }
         }
 
         // Garbage collect closed connections.
         clients.retain(|_, (_, ref mut c)| {
-            debug!("Collecting garbage");
+            trace!("Collecting garbage");
 
             if c.conn.is_closed() {
                 info!(

--- a/tools/apps/src/lib.rs
+++ b/tools/apps/src/lib.rs
@@ -330,11 +330,11 @@ impl HttpConn for Http09Conn {
         // Process all readable streams.
         for s in conn.readable() {
             while let Ok((read, fin)) = conn.stream_recv(s, buf) {
-                debug!("received {} bytes", read);
+                trace!("received {} bytes", read);
 
                 let stream_buf = &buf[..read];
 
-                debug!(
+                trace!(
                     "stream {} has {} bytes (fin? {})",
                     s,
                     stream_buf.len(),
@@ -414,11 +414,11 @@ impl HttpConn for Http09Conn {
         // Process all readable streams.
         for s in conn.readable() {
             while let Ok((read, fin)) = conn.stream_recv(s, buf) {
-                debug!("{} received {} bytes", conn.trace_id(), read);
+                trace!("{} received {} bytes", conn.trace_id(), read);
 
                 let stream_buf = &buf[..read];
 
-                debug!(
+                trace!(
                     "{} stream {} has {} bytes (fin? {})",
                     conn.trace_id(),
                     s,
@@ -492,7 +492,7 @@ impl HttpConn for Http09Conn {
         &mut self, conn: &mut std::pin::Pin<Box<quiche::Connection>>,
         partial_responses: &mut HashMap<u64, PartialResponse>, stream_id: u64,
     ) {
-        debug!("{} stream {} is writable", conn.trace_id(), stream_id);
+        trace!("{} stream {} is writable", conn.trace_id(), stream_id);
 
         if !partial_responses.contains_key(&stream_id) {
             return;


### PR DESCRIPTION
Follow-up to 8a1aff78fe0b484ff14ad2cb67627b7696c77eaf.

The idea is to basically downgrade logs that were previously DEBUG, to
TRACE, so we can actually see the logs that were originally INFO but are
now DEBUG.