### PR TITLE
qns: actually enable 0-RTT in resumption/zerortt tests

### DIFF
--- a/extras/docker/qns/run_endpoint.sh
+++ b/extras/docker/qns/run_endpoint.sh
@@ -38,6 +38,7 @@ check_testcase () {
             exit 127
         elif [ "$ROLE" == "server" ]; then
             echo "supported"
+            QUICHE_SERVER_OPT="$QUICHE_SERVER_OPT --early-data"
         fi
         ;;
     retry )


### PR DESCRIPTION
Follow-up to 77f9f8bf16461db361d0052d7c7cae4d8dae2b1c.

Forgot about this in the previous PR :man_facepalming: 