### PR TITLE
Fix invalid_initial() and invalid_packet() tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5101,7 +5101,7 @@ mod tests {
         // Corrupt the packets's last byte to make decryption fail (the last
         // byte is part of the AEAD tag, so changing it means that the packet
         // cannot be authenticated during decryption).
-        buf[written - 1] = 0;
+        buf[written - 1] = !buf[written - 1];
 
         assert_eq!(pipe.server.timeout(), None);
 
@@ -5132,7 +5132,7 @@ mod tests {
         // Corrupt the packets's last byte to make decryption fail (the last
         // byte is part of the AEAD tag, so changing it means that the packet
         // cannot be authenticated during decryption).
-        buf[written - 1] = 0;
+        buf[written - 1] = !buf[written - 1];
 
         assert_eq!(pipe.server.recv(&mut buf[..written]), Err(Error::Done));
 


### PR DESCRIPTION
When it tries to corrupt buf[], there is a 1/256 chance of test
failure when buf[written - 1] = 0. Try to have always different value
by inverting bits.