### PR TITLE
HANDSHAKE_DONE is also ack-eliciting and in-flight

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1808,6 +1808,9 @@ impl Connection {
 
                 if push_frame_to_pkt!(frames, frame, payload_len, left) {
                     self.handshake_done_sent = true;
+
+                    ack_eliciting = true;
+                    in_flight = true;
                 }
             }
 


### PR DESCRIPTION
Make sure the packet is marked as ack-eliciting and in-flight when
HANDSHAKE_DONE is sent. In practice the packet is marked properly in
most cases due to other frames (e.g. CRYPTO), but this ensures that it
is.

---

This is based on https://github.com/cloudflare/quiche/pull/407.