### PR TITLE
Refactor CongestionControl and Reno

### DIFF
--- a/src/cc/mod.rs
+++ b/src/cc/mod.rs
@@ -67,50 +67,157 @@ impl FromStr for Algorithm {
 }
 
 /// Congestion control algorithm.
-pub trait CongestionControl
+pub trait CongestionControl:
+    CCCommon + CCOnPacketSent + CCOnPacketAcked + CCCongestionEvent
 where
     Self: std::fmt::Debug,
 {
     fn new() -> Self
     where
         Self: Sized;
+}
 
+/// Congestion Control Hook OnPacketSentCC().
+pub trait CCOnPacketSent {
+    fn on_packet_sent_cc(
+        &mut self, bytes_sent: usize, now: Instant, trace_id: &str,
+    );
+}
+
+/// Congestion Control Hook OnPacketAckedCC().
+pub trait CCOnPacketAcked {
+    fn on_packet_acked_cc(
+        &mut self, packet: &Sent, srtt: Duration, min_rtt: Duration,
+        app_limited: bool, now: Instant, trace_id: &str,
+    );
+}
+
+/// Congestion Control Hook CongestionEvent().
+pub trait CCCongestionEvent {
+    fn congestion_event(
+        &mut self, time_sent: Instant, now: Instant, trace_id: &str,
+    );
+}
+
+/// Commonly used methods in Congestion Control.
+pub trait CCCommon {
     fn cwnd(&self) -> usize;
 
     fn bytes_in_flight(&self) -> usize;
 
     fn decrease_bytes_in_flight(&mut self, bytes_in_flight: usize);
 
+    /// Returns when the current recovery episode started.
+    /// None if currently not in the recovery.
     fn congestion_recovery_start_time(&self) -> Option<Instant>;
 
     /// Resets the congestion window to the minimum size.
     fn collapse_cwnd(&mut self);
 
-    /// OnPacketSentCC(bytes_sent)
-    fn on_packet_sent_cc(
-        &mut self, bytes_sent: usize, now: Instant, trace_id: &str,
-    );
+    /// Returns true if currently in the recovery episode.
+    fn in_congestion_recovery(&self, sent_time: Instant) -> bool;
+}
 
-    /// InCongestionRecovery(sent_time)
-    fn in_congestion_recovery(&self, sent_time: Instant) -> bool {
-        match self.congestion_recovery_start_time() {
-            Some(congestion_recovery_start_time) =>
-                sent_time <= congestion_recovery_start_time,
+macro_rules! impl_cc_common {
+    ($name:ident) => {
+        impl cc::CCCommon for $name {
+            fn cwnd(&self) -> usize {
+                self.congestion_window
+            }
 
-            None => false,
+            fn bytes_in_flight(&self) -> usize {
+                self.bytes_in_flight
+            }
+
+            fn decrease_bytes_in_flight(&mut self, bytes_in_flight: usize) {
+                self.bytes_in_flight =
+                    self.bytes_in_flight.saturating_sub(bytes_in_flight);
+            }
+
+            fn congestion_recovery_start_time(&self) -> Option<Instant> {
+                self.congestion_recovery_start_time
+            }
+
+            fn collapse_cwnd(&mut self) {
+                self.congestion_window = cc::MINIMUM_WINDOW;
+            }
+
+            fn in_congestion_recovery(&self, sent_time: Instant) -> bool {
+                match self.congestion_recovery_start_time() {
+                    Some(congestion_recovery_start_time) =>
+                        sent_time <= congestion_recovery_start_time,
+
+                    None => false,
+                }
+            }
         }
-    }
+    };
+}
 
-    /// OnPacketAckedCC(packet)
-    fn on_packet_acked_cc(
-        &mut self, packet: &Sent, srtt: Duration, min_rtt: Duration,
-        app_limited: bool, now: Instant, trace_id: &str,
-    );
+macro_rules! impl_cc_on_packet_sent_reno {
+    ($name:ident) => {
+        impl cc::CCOnPacketSent for $name {
+            fn on_packet_sent_cc(
+                &mut self, bytes_sent: usize, _now: Instant, _trace_id: &str,
+            ) {
+                self.bytes_in_flight += bytes_sent;
+            }
+        }
+    };
+}
 
-    /// CongestionEvent(time_sent)
-    fn congestion_event(
-        &mut self, time_sent: Instant, now: Instant, trace_id: &str,
-    );
+macro_rules! impl_cc_on_packet_acked_reno {
+    ($name:ident) => {
+        impl cc::CCOnPacketAcked for $name {
+            fn on_packet_acked_cc(
+                &mut self, packet: &Sent, _srtt: Duration, _min_rtt: Duration,
+                app_limited: bool, _now: Instant, _trace_id: &str,
+            ) {
+                self.bytes_in_flight -= packet.size;
+
+                if self.in_congestion_recovery(packet.time) {
+                    return;
+                }
+
+                if app_limited {
+                    return;
+                }
+
+                if self.congestion_window < self.ssthresh {
+                    // Slow start.
+                    self.congestion_window += packet.size;
+                } else {
+                    // Congestion avoidance.
+                    self.congestion_window += (cc::MAX_DATAGRAM_SIZE *
+                        packet.size) /
+                        self.congestion_window;
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_cc_congestion_event_reno {
+    ($name:ident) => {
+        impl cc::CCCongestionEvent for $name {
+            fn congestion_event(
+                &mut self, time_sent: Instant, now: Instant, _trace_id: &str,
+            ) {
+                // Start a new congestion event if packet was sent after the
+                // start of the previous congestion recovery period.
+                if !self.in_congestion_recovery(time_sent) {
+                    self.congestion_recovery_start_time = Some(now);
+
+                    self.congestion_window = (self.congestion_window as f64 *
+                        cc::LOSS_REDUCTION_FACTOR)
+                        as usize;
+                    self.congestion_window =
+                        std::cmp::max(self.congestion_window, cc::MINIMUM_WINDOW);
+                    self.ssthresh = self.congestion_window;
+                }
+            }
+        }
+    };
 }
 
 /// Instances a congestion control implementation based on the CC algorithm ID.


### PR DESCRIPTION
- Split CongestionControl trait into multiple traits
- Redefine Reno using macro for future reuse

In this way, other congestion control can be simplified
without repeating same function again. mod.rs includes
Reno implementation using macros, so reno.rs is now
very simple.

If other cc algorithm want to use same hook, use one
of impl_cc_*!() for reusing Reno implementation.

It also enables to add a common feature for all CC
algorithms easily.

e.g. if CC Foo is added and want to reuse on_packet_sent() and
congestion_event() but want to define its own on_packet_acked():

    pub struct Foo {
        ...
    }

    impl cc::CongestionControl for Foo {
        ...
    }

    // Reuse Reno hooks
    impl_cc_common!(Foo);
    impl_cc_on_packet_sent_reno!(Foo);
    impl_cc_congestion_event_reno!(Foo);

    // Redefine only on_packet_acked() hook
    impl cc::CCOnPacketAcked for Foo {
        ...
    }