### PR TITLE
apps: make 'qlog' feature really optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,9 +271,6 @@ use std::time;
 use std::pin::Pin;
 use std::str::FromStr;
 
-#[cfg(feature = "qlog")]
-use qlog::event::Event;
-
 /// The current QUIC wire version.
 pub const PROTOCOL_VERSION: u32 = PROTOCOL_VERSION_DRAFT27;
 
@@ -1600,7 +1597,7 @@ impl Connection {
                 Some(&hdr.dcid),
             );
 
-            q.add_event(Event::packet_received(
+            q.add_event(qlog::event::Event::packet_received(
                 hdr.ty.to_qlog(),
                 qlog_pkt_hdr,
                 Some(Vec::new()),
@@ -2270,7 +2267,7 @@ impl Connection {
                 Some(&hdr.dcid),
             );
 
-            let packet_sent_ev = Event::packet_sent_min(
+            let packet_sent_ev = qlog::event::Event::packet_sent_min(
                 hdr.ty.to_qlog(),
                 qlog_pkt_hdr,
                 Some(Vec::new()),
@@ -3780,7 +3777,7 @@ impl TransportParams {
         let stateless_reset_token =
             qlog::HexSlice::maybe_string(self.stateless_reset_token.as_ref());
 
-        Event::transport_parameters_set(
+        qlog::event::Event::transport_parameters_set(
             Some(owner),
             None, // resumption
             None, // early data

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -33,9 +33,6 @@ use std::time::Instant;
 
 use std::collections::BTreeMap;
 
-#[cfg(feature = "qlog")]
-use qlog::event::Event;
-
 use crate::Config;
 use crate::Error;
 use crate::Result;
@@ -735,7 +732,7 @@ impl Recovery {
     #[cfg(feature = "qlog")]
     pub fn to_qlog(&self) -> qlog::event::Event {
         // QVis can't use all these fields and they can be large.
-        Event::metrics_updated(
+        qlog::event::Event::metrics_updated(
             Some(self.min_rtt.as_millis() as u64),
             Some(self.rtt().as_millis() as u64),
             Some(self.latest_rtt.as_millis() as u64),

--- a/tools/apps/Cargo.toml
+++ b/tools/apps/Cargo.toml
@@ -9,6 +9,9 @@ publish = false
 # Enable quiche's fuzzing mode.
 fuzzing = ["quiche/fuzzing"]
 
+# Enable qlog support.
+qlog = ["quiche/qlog"]
+
 [dependencies]
 docopt = "1"
 env_logger = "0.6"
@@ -16,8 +19,7 @@ mio = "0.6"
 url = "1"
 log = "0.4"
 ring = "0.16"
-quiche = { path = "../../", features=["qlog"] }
-qlog = { version = "0.2", optional = true }
+quiche = { path = "../../" }
 
 [profile.release]
 debug = true


### PR DESCRIPTION
Both the apps crate and quiche itself optionally depend on the qlog
crate, however the apps crate enables quiche's qlog feature
unconditionally. This means that even if the qlog feature of the apps
crate is disabled, the qlog crate will still be built.

However the apps crate doesn't need to depend on the qlog crate at all,
as it doesn't use it directly. This change removes the dependency, and
turns the qlog feature into an explicit feature that only enables
quiche's qlog feature when enabled.

---

Also, we might want to enable the `qlog` feature in the apps crate by default.