### PR TITLE
apps: make qlog feature default

### DIFF
--- a/tools/apps/Cargo.toml
+++ b/tools/apps/Cargo.toml
@@ -12,6 +12,8 @@ fuzzing = ["quiche/fuzzing"]
 # Enable qlog support.
 qlog = ["quiche/qlog"]
 
+default = ["qlog"]
+
 [dependencies]
 docopt = "1"
 env_logger = "0.6"


### PR DESCRIPTION
The quic-interop-runner sets the `QLOGDIR` env var (https://github.com/marten-seemann/quic-interop-runner/blob/master/docker-compose.yml), so all we need to do is enable the feature in our quiche apps. Tested the interop runner locally and it seems to work fine, dumping the qlog output to `logs/qlog/{role}-{CID}.qlog`

~Note that I think this also enables the feature for both the `cloudflare/quiche` and `cloudflare/quiche-qns` images but I think that is an acceptable tradeoff. The alternative is probably a complicated branching dockerfile :nauseated_face:~