### PR TITLE
qlog: fix qlog metrics_updated on recv

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1643,6 +1643,11 @@ impl Connection {
             q.finish_frames().ok();
         });
 
+        qlog_with!(self.qlog_streamer, q, {
+            let ev = self.recovery.to_qlog();
+            q.add_event(ev).ok();
+        });
+
         // Only log the remote transport parameters once the connection is
         // established (i.e. after frames have been fully parsed) and only
         // once per connection.
@@ -3040,11 +3045,6 @@ impl Connection {
                     now,
                     &self.trace_id,
                 )?;
-
-                qlog_with!(self.qlog_streamer, q, {
-                    let ev = self.recovery.to_qlog();
-                    q.add_event(ev).ok();
-                });
 
                 // When we receive an ACK for a 1-RTT packet after handshake
                 // completion, it means the handshake has been confirmed.


### PR DESCRIPTION
Previously we would attempt to write a qlog metrics_updated
event while processing frames in a received packet. This would
silently fail because qlog was in the middle of writing a
packet_received event.

This change moves metrics_updated writing to the point after
the packet_received event is complete. This might cause a slight
inaccuracy in the event's reported time but it is better than no
event at all.

Anecdotal test against cloudlare-quic.com:

before = 15 metrics_updated events
after = 27 metics_updated events