### PR TITLE
Make Connection Send

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2588,7 +2588,7 @@ impl Connection {
     /// method will return [`Done`].
     ///
     /// [`Done`]: enum.Error.html#variant.Done
-    pub fn stream_init_application_data<T>(
+    pub fn stream_init_application_data<T: Send>(
         &mut self, stream_id: u64, data: T,
     ) -> Result<()>
     where
@@ -5720,6 +5720,14 @@ mod tests {
 
         let hdr = Header::from_slice(&mut buf[..len], MAX_CONN_ID_LEN).unwrap();
         assert_eq!(&hdr.token.unwrap(), token);
+    }
+
+    fn check_send(_: &mut impl Send) {}
+
+    #[test]
+    fn connection_must_be_send() {
+        let mut pipe = testing::Pipe::default().unwrap();
+        check_send(&mut pipe.client);
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -405,7 +405,7 @@ pub struct Stream {
     pub local: bool,
 
     /// Application data.
-    pub data: Option<Box<dyn std::any::Any>>,
+    pub data: Option<Box<dyn Send + std::any::Any>>,
 }
 
 impl Stream {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -528,6 +528,8 @@ impl Handshake {
     }
 }
 
+unsafe impl std::marker::Send for Handshake {}
+
 impl Drop for Handshake {
     fn drop(&mut self) {
         unsafe { SSL_free(self.as_ptr()) }


### PR DESCRIPTION
This PR addresses comments in #32 which taken together imply that Connection could be Send (but not Sync). Doing so would greatly ease integration in a project I'm working on, so I thought I'd see what the maintainers think.