### PR TITLE
check connection's send capacity when returning writable streams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2684,9 +2684,9 @@ impl Connection {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn writable(&self) -> StreamIter {
-        // If there is not enough connection-level flow control capacity, none
-        // of the streams are writable, so return an empty iterator.
-        if self.max_tx_data <= self.tx_data {
+        // If there is not enough connection-level send capacity, none of the
+        // streams are writable, so return an empty iterator.
+        if self.send_capacity() == 0 {
             return StreamIter::default();
         }
 


### PR DESCRIPTION
We currently only check for the connection's flow control limit when
passing writable streams to the application, but we should also check
for cwnd.

This prevents the application from trying to send data that might end up
being blocked later anyway.