### PR TITLE
WIP: stream: initial support for prioritization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1856,7 +1856,8 @@ impl Connection {
                     // Consider the stream flushable also when we are sending a
                     // zero-length frame that has the fin flag set.
                     if (stream.is_flushable() || empty_fin) && !was_flushable {
-                        self.streams.push_flushable(stream_id);
+                        let priority = stream.priority;
+                        self.streams.push_flushable(stream_id, priority);
                     }
                 },
 
@@ -2205,7 +2206,8 @@ impl Connection {
                 // If the stream is still flushable, push it to the back of the
                 // queue again.
                 if stream.is_flushable() {
-                    self.streams.push_flushable(stream_id);
+                    let priority = stream.priority;
+                    self.streams.push_flushable(stream_id, priority);
                 }
 
                 // When fuzzing, try to coalesce multiple STREAM frames in the
@@ -2524,6 +2526,8 @@ impl Connection {
 
         let sent = stream.send.push_slice(buf, fin)?;
 
+        let priority = stream.priority;
+
         let flushable = stream.is_flushable();
 
         let writable = stream.is_writable();
@@ -2544,7 +2548,7 @@ impl Connection {
         // Consider the stream flushable also when we are sending a zero-length
         // frame that has the fin flag set.
         if (flushable || empty_fin) && !was_flushable {
-            self.streams.push_flushable(stream_id);
+            self.streams.push_flushable(stream_id, priority);
         }
 
         if !writable {
@@ -2556,6 +2560,44 @@ impl Connection {
         self.recovery.rate_check_app_limited();
 
         Ok(sent)
+    }
+
+    /// Sets the priority for a stream.
+    ///
+    /// A stream's priority determines the order in which stream data is sent
+    /// on the wire (streams with lower priority are sent first). Streams are
+    /// created with a default priority of `127`.
+    ///
+    /// If the provided priority matches the stream's existing priority,
+    /// [`Done`] is returned. If the stream did not exist prior to calling
+    /// this method, [`InvalidStreamState`] is returned.
+    ///
+    /// [`Done`]: enum.Error.html#variant.Done
+    /// [`InvalidStreamState`]: enum.Error.html#variant.InvalidStreamState
+    pub fn stream_priority(
+        &mut self, stream_id: u64, priority: u64,
+    ) -> Result<()> {
+        // Get existing stream.
+        let stream = self
+            .streams
+            .get_mut(stream_id)
+            .ok_or(Error::InvalidStreamState)?;
+
+        if stream.priority == priority {
+            return Err(Error::Done);
+        }
+
+        let old_priority = stream.priority;
+
+        stream.priority = priority;
+
+        if stream.is_flushable() {
+            self.streams.remove_flushable(stream_id, old_priority);
+
+            self.streams.push_flushable(stream_id, priority);
+        }
+
+        Ok(())
     }
 
     /// Shuts down reading or writing from/to the specified stream.
@@ -3249,7 +3291,8 @@ impl Connection {
                 // If the stream is now flushable push it to the flushable queue,
                 // but only if it wasn't already queued.
                 if stream.is_flushable() && !was_flushable {
-                    self.streams.push_flushable(stream_id);
+                    let priority = stream.priority;
+                    self.streams.push_flushable(stream_id, priority);
                 }
 
                 if writable {
@@ -5908,6 +5951,305 @@ mod tests {
         assert_eq!(iter.next(), Some(&frame::Frame::Padding { len: 1 }));
 
         assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    /// Tests that streams are correctly scheduled based on their priority.
+    fn stream_priority() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(30);
+        config.set_initial_max_stream_data_bidi_local(15);
+        config.set_initial_max_stream_data_bidi_remote(15);
+        config.set_initial_max_stream_data_uni(0);
+        config.set_initial_max_streams_bidi(5);
+        config.set_initial_max_streams_uni(0);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(0, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(4, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(8, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(12, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        let mut b = [0; 1];
+
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.server.stream_priority(0, 255), Ok(()));
+        pipe.server.stream_send(0, b"b", false).unwrap();
+
+        pipe.server.stream_recv(12, &mut b).unwrap();
+        assert_eq!(pipe.server.stream_priority(12, 42), Ok(()));
+        pipe.server.stream_send(12, b"b", false).unwrap();
+
+        pipe.server.stream_recv(8, &mut b).unwrap();
+        assert_eq!(pipe.server.stream_priority(8, 10), Ok(()));
+        pipe.server.stream_send(8, b"b", false).unwrap();
+
+        pipe.server.stream_recv(4, &mut b).unwrap();
+        assert_eq!(pipe.server.stream_priority(4, 42), Ok(()));
+        pipe.server.stream_send(4, b"b", false).unwrap();
+
+        // First is stream 8.
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 8,
+                data: stream::RangeBuf::from(b"b", 0, false),
+            })
+        );
+
+        // Then are stream 12 and 4, with the same priority.
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 12,
+                data: stream::RangeBuf::from(b"b", 0, false),
+            })
+        );
+
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 4,
+                data: stream::RangeBuf::from(b"b", 0, false),
+            })
+        );
+
+        // Final is stream 0.
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 0,
+                data: stream::RangeBuf::from(b"b", 0, false),
+            })
+        );
+
+        assert_eq!(pipe.server.send(&mut buf), Err(Error::Done));
+
+        // Again.
+        //
+
+        pipe.server.stream_send(0, b"c", false).unwrap();
+
+        pipe.server.stream_send(12, b"c", false).unwrap();
+
+        pipe.server.stream_send(8, b"c", false).unwrap();
+
+        pipe.server.stream_send(4, b"c", false).unwrap();
+
+        // First is stream 8.
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 8,
+                data: stream::RangeBuf::from(b"b", 1, false),
+            })
+        );
+
+        // Then are stream 12 and 4, with the same priority.
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 12,
+                data: stream::RangeBuf::from(b"b", 1, false),
+            })
+        );
+
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 4,
+                data: stream::RangeBuf::from(b"b", 1, false),
+            })
+        );
+
+        // Final is stream 0.
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 0,
+                data: stream::RangeBuf::from(b"b", 1, false),
+            })
+        );
+
+        assert_eq!(pipe.server.send(&mut buf), Err(Error::Done));
+    }
+
+    #[test]
+    /// Tests that changing a stream's priority is correctly propagated.
+    fn stream_reprioritize() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(30);
+        config.set_initial_max_stream_data_bidi_local(15);
+        config.set_initial_max_stream_data_bidi_remote(15);
+        config.set_initial_max_stream_data_uni(0);
+        config.set_initial_max_streams_bidi(5);
+        config.set_initial_max_streams_uni(0);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(0, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(4, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(8, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(12, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        let mut b = [0; 1];
+
+        pipe.server.stream_recv(0, &mut b).unwrap();
+        assert_eq!(pipe.server.stream_priority(0, 255), Ok(()));
+        pipe.server.stream_send(0, b"b", false).unwrap();
+
+        pipe.server.stream_recv(12, &mut b).unwrap();
+        assert_eq!(pipe.server.stream_priority(12, 42), Ok(()));
+        pipe.server.stream_send(12, b"b", false).unwrap();
+
+        pipe.server.stream_recv(8, &mut b).unwrap();
+        assert_eq!(pipe.server.stream_priority(8, 10), Ok(()));
+        pipe.server.stream_send(8, b"b", false).unwrap();
+
+        pipe.server.stream_recv(4, &mut b).unwrap();
+        assert_eq!(pipe.server.stream_priority(4, 42), Ok(()));
+        pipe.server.stream_send(4, b"b", false).unwrap();
+
+        // Stream 0 is re-prioritized!!!
+        assert_eq!(pipe.server.stream_priority(0, 20), Ok(()));
+
+        // First is stream 8.
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 8,
+                data: stream::RangeBuf::from(b"b", 0, false),
+            })
+        );
+
+        // Then is stream 0.
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 0,
+                data: stream::RangeBuf::from(b"b", 0, false),
+            })
+        );
+
+        // Then are stream 12 and 4, with the same priority.
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 12,
+                data: stream::RangeBuf::from(b"b", 0, false),
+            })
+        );
+
+        let len = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 4,
+                data: stream::RangeBuf::from(b"b", 0, false),
+            })
+        );
+
+        assert_eq!(pipe.server.send(&mut buf), Err(Error::Done));
     }
 }
 


### PR DESCRIPTION
This implements a very simple scheme for stream prioritization at the
transport layer. Each stream can be prioritized with a number from 0 to
255 (lower is more important).

Currently priority is only used when flushing streams to the wire, but
not when streams are reported as readable or writable to the application
(yet).

Internally, instead of keeping a single queue for all scheduled streams,
an ordered map of lists is used instead. Each list holds the streams
that are scheduled at a given priority. When flushing data, the
non-empty list with the lower priority is used first. Within the same
list, streams are round-robined (so the default behavior doesn't change).

Re-prioritization is handled by removing the stream from the queue
corresponding to the old priority, and adding it to the queue of the new
pririty. However the implementation is very inefficient, due to the fact
that finding and removing the stream from the old queue requires
scanning the whole list linearly, or shifting all the elements in the
queue in the worst case scenario, or a combination of both in most
cases. So until we have a better implementation (I'm looking into it) we
might want to just ignore re-prioritization.