### PR TITLE
qlog: add HANDSHAKE_DONE frame

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ log = { version = "0.4", features = ["std"] }
 libc = "0.2"
 ring = "0.16"
 lazy_static = "1"
-qlog = { version = "0.2", optional = true }
+qlog = { version = "0.2", path = "tools/qlog", optional = true }
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3", features = ["wincrypt"] }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -834,7 +834,7 @@ impl Frame {
                            * frame type */
                 ),
 
-            _ => qlog::QuicFrame::unknown(std::u64::MAX),
+            Frame::HandshakeDone => qlog::QuicFrame::handshake_done(),
         }
     }
 }

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -514,7 +514,7 @@ impl std::convert::From<std::io::Error> for Error {
     }
 }
 
-pub const QLOG_VERSION: &str = "draft-01";
+pub const QLOG_VERSION: &str = "draft-02-wip";
 
 /// A specialized [`Result`] type for quiche qlog operations.
 ///

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -73,9 +73,9 @@
 //! ## Writing out logs
 //! As events occur during the connection, the application appends them to the
 //! trace. The qlog crate supports two modes of writing logs: the buffered mode
-//! stores everything in memory and requires the application to serialize and write
-//! the output, the streaming mode progressively writes serialized JSON output to a
-//! writer designated by the application.
+//! stores everything in memory and requires the application to serialize and
+//! write the output, the streaming mode progressively writes serialized JSON
+//! output to a writer designated by the application.
 //!
 //! ### Creating a Trace
 //!
@@ -378,7 +378,6 @@
 //! );
 //!
 //! streamer.add_event(event).ok();
-//!
 //! ```
 //!
 //! In this example, the frames contained in the QUIC packet
@@ -420,7 +419,6 @@
 //! streamer.add_frame(padding, false).ok();
 //!
 //! streamer.finish_frames().ok();
-//!
 //! ```
 //!
 //! Once all events have have been written, the log

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -1648,6 +1648,7 @@ pub enum QuicFrameTypeName {
     PathResponse,
     ConnectionClose,
     ApplicationClose,
+    HandshakeDone,
     Unknown,
 }
 
@@ -1958,6 +1959,10 @@ pub enum QuicFrame {
         trigger_frame_type: Option<String>,
     },
 
+    HandshakeDone {
+        frame_type: QuicFrameTypeName,
+    },
+
     Unknown {
         frame_type: QuicFrameTypeName,
         raw_frame_type: u64,
@@ -2132,6 +2137,12 @@ impl QuicFrame {
             raw_error_code,
             reason,
             trigger_frame_type,
+        }
+    }
+
+    pub fn handshake_done() -> Self {
+        QuicFrame::HandshakeDone {
+            frame_type: QuicFrameTypeName::HandshakeDone,
         }
     }
 


### PR DESCRIPTION
This adds the HANDSHAKE_DONE frame to qlog, and makes quiche log it.

This also removes the "unknown frame" case in the Frame::to_qlog()
method, as there can't be unknown frames, and it hides missing frame
types conversions.