### PR TITLE
qlog: make QlogStreamer Send-able

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1191,7 +1191,7 @@ impl Connection {
     /// [`Writer`]: https://doc.rust-lang.org/std/io/trait.Write.html
     #[cfg(feature = "qlog")]
     pub fn set_qlog(
-        &mut self, writer: Box<dyn std::io::Write>, title: String,
+        &mut self, writer: Box<dyn std::io::Write + Send>, title: String,
         description: String,
     ) {
         let vp = if self.is_server {
@@ -2593,11 +2593,11 @@ impl Connection {
     /// method will return [`Done`].
     ///
     /// [`Done`]: enum.Error.html#variant.Done
-    pub fn stream_init_application_data<T: Send>(
+    pub fn stream_init_application_data<T>(
         &mut self, stream_id: u64, data: T,
     ) -> Result<()>
     where
-        T: std::any::Any,
+        T: std::any::Any + Send,
     {
         // Get existing stream.
         let stream = self.streams.get_mut(stream_id).ok_or(Error::Done)?;

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -574,7 +574,7 @@ pub enum StreamerState {
 /// [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 pub struct QlogStreamer {
     start_time: std::time::Instant,
-    writer: Box<dyn std::io::Write>,
+    writer: Box<dyn std::io::Write + Send>,
     qlog: Qlog,
     state: StreamerState,
     first_event: bool,
@@ -593,7 +593,7 @@ impl QlogStreamer {
     pub fn new(
         qlog_version: String, title: Option<String>, description: Option<String>,
         summary: Option<String>, start_time: std::time::Instant, trace: Trace,
-        writer: Box<dyn std::io::Write>,
+        writer: Box<dyn std::io::Write + Send>,
     ) -> Self {
         let qlog = Qlog {
             qlog_version,
@@ -790,7 +790,7 @@ impl QlogStreamer {
 
     /// Returns the writer.
     #[allow(clippy::borrowed_box)]
-    pub fn writer(&self) -> &Box<dyn std::io::Write> {
+    pub fn writer(&self) -> &Box<dyn std::io::Write + Send> {
         &self.writer
     }
 }


### PR DESCRIPTION
Follow-up to 2f49a25. If the qlog feature is enabled in quiche,
Connection stops being Send (and the tests fail).