### PR TITLE
Cargo: remove other mentions of benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,3 @@ debug = true
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]
-
-[[bench]]
-name = "benches"
-harness = false
-required-features = ["bench"]


### PR DESCRIPTION
Follow-up to 6a9fddd4e67165a6ba63eeb95ee6d90b28f503fa.