### PR TITLE
immediately mark connection as closed when receiving an invalid first packet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2871,6 +2871,11 @@ impl Connection {
             self.error = Some(err);
         }
 
+        // When no packet was successfully processed close connection immediately.
+        if self.recv_count == 0 {
+            self.closed = true;
+        }
+
         Ok(())
     }
 
@@ -5435,6 +5440,8 @@ mod tests {
             pipe.server.recv(&mut buf[..written]),
             Err(Error::CryptoFail)
         );
+
+        assert!(pipe.server.is_closed());
     }
 
     #[test]


### PR DESCRIPTION
When an invalid first packet is received the connection is correctly
marked as closing, however due to the anti-amplification mechanism it is
prevented from actually sending anything.

Since the draining timeout is armed only when `CONNECTION_CLOSE` is
actually sent, and the idle timeout is armed when a packet is processed
successfully, the connection ends up never being closed.