### PR TITLE
fixed certificate and key path in .c examples

### DIFF
--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -499,8 +499,8 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    quiche_config_load_cert_chain_from_pem_file(config, "examples/cert.crt");
-    quiche_config_load_priv_key_from_pem_file(config, "examples/cert.key");
+    quiche_config_load_cert_chain_from_pem_file(config, "./cert.crt");
+    quiche_config_load_priv_key_from_pem_file(config, "./cert.key");
 
     quiche_config_set_application_protos(config,
         (uint8_t *) QUICHE_H3_APPLICATION_PROTOCOL,

--- a/examples/server.c
+++ b/examples/server.c
@@ -434,8 +434,8 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    quiche_config_load_cert_chain_from_pem_file(config, "examples/cert.crt");
-    quiche_config_load_priv_key_from_pem_file(config, "examples/cert.key");
+    quiche_config_load_cert_chain_from_pem_file(config, "./cert.crt");
+    quiche_config_load_priv_key_from_pem_file(config, "./cert.key");
 
     quiche_config_set_application_protos(config,
         (uint8_t *) "\x05hq-27\x05hq-25\x05hq-24\x05hq-23\x08http/0.9", 21);


### PR DESCRIPTION
Fixed the path for the certificate and key files in server.c file in examples.
With the existing path, it leads to -
 **`quiche::tls: error:100000ae:SSL routines:OPENSSL_internal:NO_CERTIFICATE_SET`**