### PR TITLE
don't return Error::Done from recv()

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,6 @@ loop {
     let read = match conn.recv(&mut buf[..read]) {
         Ok(v) => v,
 
-        Err(quiche::Error::Done) => {
-            // Done reading.
-            break;
-        },
-
         Err(e) => {
             // An error occurred, handle it.
             break;

--- a/examples/client.c
+++ b/examples/client.c
@@ -110,18 +110,15 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
 
         ssize_t done = quiche_conn_recv(conn_io->conn, buf, read);
 
-        if (done == QUICHE_ERR_DONE) {
-            fprintf(stderr, "done reading\n");
-            break;
-        }
-
         if (done < 0) {
             fprintf(stderr, "failed to process packet\n");
-            return;
+            continue;
         }
 
         fprintf(stderr, "recv %zd bytes\n", done);
     }
+
+    fprintf(stderr, "done reading\n");
 
     if (quiche_conn_is_closed(conn_io->conn)) {
         fprintf(stderr, "connection closed\n");

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -169,19 +169,16 @@ fn main() {
             let read = match conn.recv(&mut buf[..len]) {
                 Ok(v) => v,
 
-                Err(quiche::Error::Done) => {
-                    debug!("done reading");
-                    break;
-                },
-
                 Err(e) => {
                     error!("recv failed: {:?}", e);
-                    break 'read;
+                    continue 'read;
                 },
             };
 
             debug!("processed {} bytes", read);
         }
+
+        debug!("done reading");
 
         if conn.is_closed() {
             info!("connection closed, {:?}", conn.stats());

--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -123,18 +123,15 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
 
         ssize_t done = quiche_conn_recv(conn_io->conn, buf, read);
 
-        if (done == QUICHE_ERR_DONE) {
-            fprintf(stderr, "done reading\n");
-            break;
-        }
-
         if (done < 0) {
             fprintf(stderr, "failed to process packet: %zd\n", done);
-            return;
+            continue;
         }
 
         fprintf(stderr, "recv %zd bytes\n", done);
     }
+
+    fprintf(stderr, "done reading\n");
 
     if (quiche_conn_is_closed(conn_io->conn)) {
         fprintf(stderr, "connection closed\n");

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -187,19 +187,16 @@ fn main() {
             let read = match conn.recv(&mut buf[..len]) {
                 Ok(v) => v,
 
-                Err(quiche::Error::Done) => {
-                    debug!("done reading");
-                    break;
-                },
-
                 Err(e) => {
                     error!("recv failed: {:?}", e);
-                    break 'read;
+                    continue 'read;
                 },
             };
 
             debug!("processed {} bytes", read);
         }
+
+        debug!("done reading");
 
         if conn.is_closed() {
             info!("connection closed, {:?}", conn.stats());

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -167,7 +167,7 @@ fn main() {
 
                 Err(e) => {
                     error!("Parsing packet header failed: {:?}", e);
-                    continue;
+                    continue 'read;
                 },
             };
 
@@ -183,7 +183,7 @@ fn main() {
             {
                 if hdr.ty != quiche::Type::Initial {
                     error!("Packet is not Initial");
-                    continue;
+                    continue 'read;
                 }
 
                 if !quiche::version_is_supported(hdr.version) {
@@ -203,7 +203,7 @@ fn main() {
 
                         panic!("send() failed: {:?}", e);
                     }
-                    continue;
+                    continue 'read;
                 }
 
                 let mut scid = [0; quiche::MAX_CONN_ID_LEN];
@@ -232,7 +232,7 @@ fn main() {
 
                         panic!("send() failed: {:?}", e);
                     }
-                    continue;
+                    continue 'read;
                 }
 
                 let odcid = validate_token(&src, token);
@@ -241,12 +241,12 @@ fn main() {
                 // drop the packet.
                 if odcid == None {
                     error!("Invalid address validation token");
-                    continue;
+                    continue 'read;
                 }
 
                 if scid.len() != hdr.dcid.len() {
                     error!("Invalid destination connection ID");
-                    continue;
+                    continue 'read;
                 }
 
                 // Reuse the source connection ID we sent in the Retry
@@ -282,14 +282,9 @@ fn main() {
             let read = match client.conn.recv(pkt_buf) {
                 Ok(v) => v,
 
-                Err(quiche::Error::Done) => {
-                    debug!("{} done reading", client.conn.trace_id());
-                    break;
-                },
-
                 Err(e) => {
                     error!("{} recv failed: {:?}", client.conn.trace_id(), e);
-                    break 'read;
+                    continue 'read;
                 },
             };
 
@@ -313,7 +308,7 @@ fn main() {
 
                     Err(e) => {
                         error!("failed to create HTTP/3 connection: {}", e);
-                        break 'read;
+                        continue 'read;
                     },
                 };
 
@@ -365,7 +360,7 @@ fn main() {
                                 e
                             );
 
-                            break 'read;
+                            break;
                         },
                     }
                 }

--- a/tools/apps/src/bin/quiche-client.rs
+++ b/tools/apps/src/bin/quiche-client.rs
@@ -227,19 +227,16 @@ fn main() {
             let read = match conn.recv(&mut buf[..len]) {
                 Ok(v) => v,
 
-                Err(quiche::Error::Done) => {
-                    trace!("done reading");
-                    break;
-                },
-
                 Err(e) => {
                     error!("recv failed: {:?}", e);
-                    break 'read;
+                    continue 'read;
                 },
             };
 
             trace!("processed {} bytes", read);
         }
+
+        trace!("done reading");
 
         if conn.is_closed() {
             info!("connection closed, {:?}", conn.stats());

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -191,7 +191,7 @@ fn main() {
 
                 Err(e) => {
                     error!("Parsing packet header failed: {:?}", e);
-                    continue;
+                    continue 'read;
                 },
             };
 
@@ -207,7 +207,7 @@ fn main() {
             {
                 if hdr.ty != quiche::Type::Initial {
                     error!("Packet is not Initial");
-                    continue;
+                    continue 'read;
                 }
 
                 if !quiche::version_is_supported(hdr.version) {
@@ -227,7 +227,7 @@ fn main() {
 
                         panic!("send() failed: {:?}", e);
                     }
-                    continue;
+                    continue 'read;
                 }
 
                 let mut scid = [0; quiche::MAX_CONN_ID_LEN];
@@ -259,7 +259,7 @@ fn main() {
 
                             panic!("send() failed: {:?}", e);
                         }
-                        continue;
+                        continue 'read;
                     }
 
                     odcid = validate_token(&src, token);
@@ -273,7 +273,7 @@ fn main() {
 
                     if scid.len() != hdr.dcid.len() {
                         error!("Invalid destination connection ID");
-                        continue;
+                        continue 'read;
                     }
 
                     // Reuse the source connection ID we sent in the Retry
@@ -327,14 +327,9 @@ fn main() {
             let read = match client.conn.recv(pkt_buf) {
                 Ok(v) => v,
 
-                Err(quiche::Error::Done) => {
-                    trace!("{} done reading", client.conn.trace_id());
-                    break;
-                },
-
                 Err(e) => {
                     error!("{} recv failed: {:?}", client.conn.trace_id(), e);
-                    break 'read;
+                    continue 'read;
                 },
             };
 
@@ -385,7 +380,7 @@ fn main() {
                     )
                     .is_err()
                 {
-                    break 'read;
+                    continue 'read;
                 }
             }
         }


### PR DESCRIPTION


This changes the `recv()` public method to never return `Error::Done` to
applications, due to confusion of its meaning and misuse.

Many applications (including the quiche-apps and quiche examples) have
been interpreting the Done error as a signal to stop reading incoming
packets from a socket. However this is wrong, as applications shouldn't
stop reading incoming packets, as that might cause a deadlock where the
socket is not re-armed by the event loop and even if a connection is
closing, new packets should still be processed as the socket might be
shared among multiple connections.

Instead of `Error::Done`, `recv()` will now return an `OK(...)` value
with the full size of the incoming buffer, to mean that the entire
buffer has been processed (or ignored), which was the intended meaning
of Done.

---

This also updates the examples and quiche-apps to not stop processing incoming packets on error.