### PR TITLE
Qlog data moved

### DIFF
--- a/tools/qlog/src/event.rs
+++ b/tools/qlog/src/event.rs
@@ -704,8 +704,9 @@ impl Event {
     /// * `EventType`=`Http3EventType::DataMoved`
     /// * `EventData`=`H3DataMoved`.
     pub fn h3_data_moved(
-        stream_id: String, offset: Option<String>, from: Option<H3DataRecipient>,
-        to: Option<H3DataRecipient>, raw: Option<String>,
+        stream_id: String, offset: Option<String>, length: Option<u64>,
+        from: Option<H3DataRecipient>, to: Option<H3DataRecipient>,
+        raw: Option<String>,
     ) -> Self {
         Event {
             category: EventCategory::Http,
@@ -713,6 +714,7 @@ impl Event {
             data: EventData::H3DataMoved {
                 stream_id,
                 offset,
+                length,
                 from,
                 to,
                 raw,
@@ -721,7 +723,7 @@ impl Event {
     }
 
     pub fn h3_data_moved_min(stream_id: String) -> Self {
-        Event::h3_data_moved(stream_id, None, None, None, None)
+        Event::h3_data_moved(stream_id, None, None, None, None, None)
     }
 
     /// Returns:

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -1456,6 +1456,7 @@ pub enum EventData {
     H3DataMoved {
         stream_id: String,
         offset: Option<String>,
+        length: Option<u64>,
 
         from: Option<H3DataRecipient>,
         to: Option<H3DataRecipient>,


### PR DESCRIPTION
Opening mainly to get some eyes on.

Qlog draft 02 has a data_moved event that allows logging when stream data is moved into or out of the transport. Logging this information allows us in the qvis multiplexing tool to see how the quiche-client reads data from the transport layer.

Our definition of data_moved is bit old, so this change tweaks it to contain the length. In testing I found that `SendBuf.off()` always returned `0` while the qvis expects the offset to move along at the stream offset grows. That is why I added the `cumulative_offset()` function as a hack. Happy to hear a better solution to this.

Right now data_moved is in the category HTTP/3 but that will change to be transport soon. So we can rename things in a separate followup PR.