### PR TITLE
recovery: refactor sent packets tracking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2413,6 +2413,8 @@ impl Connection {
             pkt_num: pn,
             frames,
             time_sent: now,
+            time_acked: None,
+            time_lost: None,
             size: if ack_eliciting { written } else { 0 },
             ack_eliciting,
             in_flight,

--- a/src/recovery/delivery_rate.rs
+++ b/src/recovery/delivery_rate.rs
@@ -68,7 +68,7 @@ impl Rate {
         pkt.is_app_limited = self.app_limited_at_pkt > 0;
     }
 
-    pub fn on_ack_received(&mut self, pkt: Sent, now: Instant) {
+    pub fn on_packet_acked(&mut self, pkt: &Sent, now: Instant) {
         self.rate_sample.prior_time = Some(pkt.delivered_time);
 
         self.delivered += pkt.size;
@@ -195,6 +195,8 @@ mod tests {
             pkt_num: 0,
             frames: vec![],
             time_sent: Instant::now(),
+            time_acked: None,
+            time_lost: None,
             size: 1200,
             ack_eliciting: true,
             in_flight: true,
@@ -210,12 +212,14 @@ mod tests {
         std::thread::sleep(Duration::from_millis(50));
         recovery
             .delivery_rate
-            .on_ack_received(pkt_1, Instant::now());
+            .on_packet_acked(&pkt_1, Instant::now());
 
         let mut pkt_2 = Sent {
             pkt_num: 1,
             frames: vec![],
             time_sent: Instant::now(),
+            time_acked: None,
+            time_lost: None,
             size: 1200,
             ack_eliciting: true,
             in_flight: true,
@@ -231,7 +235,7 @@ mod tests {
         std::thread::sleep(Duration::from_millis(50));
         recovery
             .delivery_rate
-            .on_ack_received(pkt_2, Instant::now());
+            .on_packet_acked(&pkt_2, Instant::now());
         recovery.delivery_rate.estimate();
 
         assert!(recovery.delivery_rate() > 0);
@@ -246,6 +250,8 @@ mod tests {
             pkt_num: 0,
             frames: vec![],
             time_sent: Instant::now(),
+            time_acked: None,
+            time_lost: None,
             size: 1200,
             ack_eliciting: true,
             in_flight: true,
@@ -259,12 +265,14 @@ mod tests {
             .delivery_rate
             .on_packet_sent(&mut pkt_1, Instant::now());
         std::thread::sleep(Duration::from_millis(50));
-        recvry.delivery_rate.on_ack_received(pkt_1, Instant::now());
+        recvry.delivery_rate.on_packet_acked(&pkt_1, Instant::now());
 
         let mut pkt_2 = Sent {
             pkt_num: 1,
             frames: vec![],
             time_sent: Instant::now(),
+            time_acked: None,
+            time_lost: None,
             size: 1200,
             ack_eliciting: true,
             in_flight: true,
@@ -282,7 +290,7 @@ mod tests {
             .delivery_rate
             .on_packet_sent(&mut pkt_2, Instant::now());
         std::thread::sleep(Duration::from_millis(50));
-        recvry.delivery_rate.on_ack_received(pkt_2, Instant::now());
+        recvry.delivery_rate.on_packet_acked(&pkt_2, Instant::now());
         recvry.delivery_rate.estimate();
 
         assert_eq!(recvry.delivery_rate.app_limited_at_pkt, 0);

--- a/src/recovery/hystart.rs
+++ b/src/recovery/hystart.rs
@@ -111,7 +111,7 @@ impl Hystart {
 
     // Returns a new (ssthresh, cwnd) during slow start.
     pub fn on_packet_acked(
-        &mut self, packet: &recovery::Sent, rtt: Duration, cwnd: usize,
+        &mut self, packet: &recovery::Acked, rtt: Duration, cwnd: usize,
         ssthresh: usize, now: Instant,
     ) -> (usize, usize) {
         let mut ssthresh = ssthresh;
@@ -206,17 +206,10 @@ mod tests {
 
         assert_eq!(hspp.window_end, Some(pkt_num));
 
-        let p = recovery::Sent {
+        let p = recovery::Acked {
             pkt_num,
-            frames: vec![],
             time_sent: now + Duration::from_millis(10),
             size,
-            ack_eliciting: true,
-            in_flight: true,
-            delivered: 0,
-            delivered_time: now,
-            recent_delivered_packet_sent_time: now,
-            is_app_limited: false,
         };
 
         let init_cwnd = 30000;
@@ -256,17 +249,10 @@ mod tests {
 
         // 1st round.
         for _ in 0..N_RTT_SAMPLE + 1 {
-            let p = recovery::Sent {
+            let p = recovery::Acked {
                 pkt_num,
-                frames: vec![],
                 time_sent: now + Duration::from_millis(pkt_num),
                 size,
-                ack_eliciting: true,
-                in_flight: true,
-                delivered: 0,
-                delivered_time: now,
-                recent_delivered_packet_sent_time: now,
-                is_app_limited: false,
             };
 
             // We use a fixed rtt for 1st round.
@@ -287,17 +273,10 @@ mod tests {
         hspp.start_round(pkt_1st * 2 + 1);
 
         for _ in 0..N_RTT_SAMPLE + 1 {
-            let p = recovery::Sent {
+            let p = recovery::Acked {
                 pkt_num,
-                frames: vec![],
                 time_sent: now + Duration::from_millis(pkt_num),
                 size,
-                ack_eliciting: true,
-                in_flight: true,
-                delivered: 0,
-                delivered_time: now,
-                recent_delivered_packet_sent_time: now,
-                is_app_limited: false,
             };
 
             // Keep increasing rtt to simulate buffer queueing delay


### PR DESCRIPTION
Instead of using a BTreeMap, use a VecDeque to track sent packets, which
makes it easier to keep track of acked and lost packets for a short time
after they have been acked or declared lost instead of immediately
removing them from the list, which in turn will allow detecting things
like DSACKs and spurious losses.

Similarly to how the BTreeMap was used, sent packets are appended to the
back of the queue (so they end up being sorted by packet number / sent
time). Access now happen by iterating over the queue from the start
rather than looking up specific packets by packet number. When acked or
declared lost, the packets are simply marked accordingly _without_ being
removed from the queue.

At predefined times, the semt packets marked as acked or lost are then
removed from the start of the queue in contiguous blocks, in order to
avoid having to copy elements around to cover gaps in the queue caused
by removed elements. Later this can be changed to e.g. delay cleaning of
lost packets for 1 RTT after they were marked as lost.

This new strcture also allows us to follow the -recovery draft
pseudo-code somewhat more closely, and as a side-effect, there are no
more potentially expensive BTreeMap lookups in hot codepaths, which
might help reduce CPU usage when e.g. processing ACK frames (flamegraphs
generated on my laptop show that the time spent inside
Recovery::on_ack_received() is cut in half).

---

This is based on https://github.com/cloudflare/quiche/pull/468. Note that before merging we should do more testing in the lab to make sure this doesn't have any adverse side-effects.