### PR TITLE
encode generic CryptoFail and TlsFail errors as PROTOCOL_VIOLATION

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,8 +364,6 @@ impl Error {
             Error::InvalidFrame => 0x7,
             Error::InvalidStreamState => 0x5,
             Error::InvalidTransportParam => 0x8,
-            Error::CryptoFail => 0x100,
-            Error::TlsFail => 0x100,
             Error::FlowControl => 0x3,
             Error::StreamLimit => 0x4,
             Error::FinalSize => 0x6,


### PR DESCRIPTION
The 0x100 error space is reserved for TLS alerts, so if we encode
generic CryptoFail and TlsFail as 0x100 the peer might interpret it as a
close_notify alert,  but that is not the intention.

TLS alerts are handled separately so this change doesn't affect that.