### PR TITLE
HyStart++

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -172,6 +172,9 @@ enum quiche_cc_algorithm {
 // Sets the congestion control algorithm used.
 void quiche_config_set_cc_algorithm(quiche_config *config, enum quiche_cc_algorithm algo);
 
+// Configures whether to use HyStart++.
+void quiche_config_set_hystart(quiche_config *config, bool v);
+
 // Frees the config object.
 void quiche_config_free(quiche_config *config);
 

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -173,7 +173,7 @@ enum quiche_cc_algorithm {
 void quiche_config_set_cc_algorithm(quiche_config *config, enum quiche_cc_algorithm algo);
 
 // Configures whether to use HyStart++.
-void quiche_config_set_hystart(quiche_config *config, bool v);
+void quiche_config_enable_hystart(quiche_config *config, bool v);
 
 // Frees the config object.
 void quiche_config_free(quiche_config *config);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -254,6 +254,11 @@ pub extern fn quiche_conn_set_qlog_fd(
 }
 
 #[no_mangle]
+pub extern fn quiche_config_set_hystart(config: &mut Config, v: bool) {
+    config.set_hystart(v);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_free(config: *mut Config) {
     unsafe { Box::from_raw(config) };
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -254,8 +254,8 @@ pub extern fn quiche_conn_set_qlog_fd(
 }
 
 #[no_mangle]
-pub extern fn quiche_config_set_hystart(config: &mut Config, v: bool) {
-    config.set_hystart(v);
+pub extern fn quiche_config_enable_hystart(config: &mut Config, v: bool) {
+    config.enable_hystart(v);
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -729,7 +729,7 @@ impl Config {
     /// Configures whether to enable HyStart++.
     ///
     /// The default value is `true`.
-    pub fn set_hystart(&mut self, v: bool) {
+    pub fn enable_hystart(&mut self, v: bool) {
         self.hystart = v;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,6 +421,8 @@ pub struct Config {
     grease: bool,
 
     cc_algorithm: CongestionControlAlgorithm,
+
+    hystart: bool,
 }
 
 impl Config {
@@ -442,6 +444,7 @@ impl Config {
             application_protos: Vec::new(),
             grease: true,
             cc_algorithm: CongestionControlAlgorithm::CUBIC,
+            hystart: true,
         })
     }
 
@@ -721,6 +724,13 @@ impl Config {
     /// The default value is `CongestionControlAlgorithm::CUBIC`.
     pub fn set_cc_algorithm(&mut self, algo: CongestionControlAlgorithm) {
         self.cc_algorithm = algo;
+    }
+
+    /// Configures whether to enable HyStart++.
+    ///
+    /// The default value is `true`.
+    pub fn set_hystart(&mut self, v: bool) {
+        self.hystart = v;
     }
 }
 

--- a/src/recovery/hystart.rs
+++ b/src/recovery/hystart.rs
@@ -1,0 +1,340 @@
+// Copyright (C) 2020, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! HyStart++
+//!
+//! This implementation is based on the following I-D:
+//!
+//! https://tools.ietf.org/html/draft-balasubramanian-tcpm-hystartplusplus-02
+
+use std::cmp;
+use std::time::Duration;
+
+use crate::recovery;
+
+/// Constants from I-D.
+const LOW_CWND: usize = 16;
+
+const MIN_RTT_THRESH: Duration = Duration::from_millis(4);
+
+const MAX_RTT_THRESH: Duration = Duration::from_millis(16);
+
+const LSS_DIVISOR: f64 = 0.25;
+
+const N_RTT_SAMPLE: usize = 8;
+
+#[derive(Default)]
+pub struct Hystart {
+    enabled: bool,
+
+    window_end: Option<u64>,
+
+    last_round_min_rtt: Option<Duration>,
+
+    current_round_min_rtt: Option<Duration>,
+
+    rtt_sample_count: usize,
+
+    lss: bool,
+}
+
+impl std::fmt::Debug for Hystart {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "window_end={:?} ", self.window_end)?;
+        write!(f, "last_round_min_rtt={:?} ", self.last_round_min_rtt)?;
+        write!(f, "current_round_min_rtt={:?} ", self.current_round_min_rtt)?;
+        write!(f, "rtt_sample_count={:?} ", self.rtt_sample_count)?;
+        write!(f, "lss={:?} ", self.lss)?;
+
+        Ok(())
+    }
+}
+
+impl Hystart {
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+
+            ..Default::default()
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn in_lss(&self) -> bool {
+        self.lss
+    }
+
+    pub fn start_round(&mut self, pkt_num: u64) {
+        if self.window_end.is_none() {
+            *self = Hystart {
+                enabled: self.enabled,
+
+                window_end: Some(pkt_num),
+
+                last_round_min_rtt: self.current_round_min_rtt,
+
+                current_round_min_rtt: None,
+
+                rtt_sample_count: 0,
+
+                lss: false,
+            };
+        }
+    }
+
+    // Returns a new (ssthresh, cwnd) during slow start.
+    pub fn on_packet_acked(
+        &mut self, packet: &recovery::Sent, rtt: Duration, cwnd: usize,
+        ssthresh: usize,
+    ) -> (usize, usize) {
+        let mut ssthresh = ssthresh;
+        let mut cwnd = cwnd;
+
+        if !self.lss {
+            // Reno Slow Start.
+            cwnd += packet.size;
+
+            if let Some(current_round_min_rtt) = self.current_round_min_rtt {
+                self.current_round_min_rtt =
+                    Some(cmp::min(current_round_min_rtt, rtt));
+            } else {
+                self.current_round_min_rtt = Some(rtt);
+            }
+
+            self.rtt_sample_count += 1;
+
+            if cwnd >= (LOW_CWND * recovery::MAX_DATAGRAM_SIZE) &&
+                self.rtt_sample_count >= N_RTT_SAMPLE &&
+                self.current_round_min_rtt.is_some() &&
+                self.last_round_min_rtt.is_some()
+            {
+                // clamp(min_rtt_thresh, last_round_min_rtt/8,
+                // max_rtt_thresh)
+                let rtt_thresh = cmp::max(
+                    self.last_round_min_rtt.unwrap() / 8,
+                    MIN_RTT_THRESH,
+                );
+                let rtt_thresh = cmp::min(rtt_thresh, MAX_RTT_THRESH);
+
+                // Check if we can exit to LSS.
+                if self.current_round_min_rtt.unwrap() >=
+                    (self.last_round_min_rtt.unwrap() + rtt_thresh)
+                {
+                    ssthresh = cwnd;
+
+                    self.lss = true;
+                }
+            }
+
+            // Check if we reached the end of the round.
+            if let Some(end_pkt_num) = self.window_end {
+                if packet.pkt_num >= end_pkt_num {
+                    // Start of a new round.
+                    self.window_end = None;
+                }
+            }
+        } else {
+            // LSS (Limited Slow Start).
+            let k = cwnd as f64 / (LSS_DIVISOR * ssthresh as f64);
+
+            cwnd += (packet.size as f64 / k) as usize;
+        }
+
+        (cwnd, ssthresh)
+    }
+
+    // Exit HyStart++ when entering congestion avoidance.
+    pub fn congestion_event(&mut self) {
+        if self.window_end.is_some() {
+            self.window_end = None;
+
+            self.lss = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn start_round() {
+        let mut hspp = Hystart::default();
+        let pkt_num = 100;
+
+        hspp.start_round(pkt_num);
+
+        assert_eq!(hspp.window_end, Some(pkt_num));
+        assert_eq!(hspp.current_round_min_rtt, None);
+    }
+
+    #[test]
+    fn reno_slow_start() {
+        let mut hspp = Hystart::default();
+        let pkt_num = 100;
+        let size = 1000;
+        let now = Instant::now();
+
+        hspp.start_round(pkt_num);
+
+        assert_eq!(hspp.window_end, Some(pkt_num));
+
+        let p = recovery::Sent {
+            pkt_num,
+            frames: vec![],
+            time_sent: now + Duration::from_millis(10),
+            size,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            recent_delivered_packet_sent_time: now,
+            is_app_limited: false,
+        };
+
+        let init_cwnd = 30000;
+        let init_ssthresh = 1000000;
+
+        let (cwnd, ssthresh) = hspp.on_packet_acked(
+            &p,
+            Duration::from_millis(10),
+            init_cwnd,
+            init_ssthresh,
+        );
+
+        // Expecting Reno slow start.
+        assert_eq!(hspp.lss, false);
+        assert_eq!((cwnd, ssthresh), (init_cwnd + size, init_ssthresh));
+    }
+
+    #[test]
+    fn limited_slow_start() {
+        let mut hspp = Hystart::default();
+        let size = 1000;
+        let now = Instant::now();
+
+        // 1st round rtt = 50ms
+        let rtt_1st = 50;
+
+        // end of 1st round
+        let pkt_1st = N_RTT_SAMPLE as u64;
+
+        hspp.start_round(pkt_1st);
+
+        assert_eq!(hspp.window_end, Some(pkt_1st));
+
+        let (mut cwnd, mut ssthresh) = (30000, 1000000);
+        let mut pkt_num = 0;
+
+        // 1st round.
+        for _ in 0..N_RTT_SAMPLE + 1 {
+            let p = recovery::Sent {
+                pkt_num,
+                frames: vec![],
+                time_sent: now + Duration::from_millis(pkt_num),
+                size,
+                ack_eliciting: true,
+                in_flight: true,
+                delivered: 0,
+                delivered_time: now,
+                recent_delivered_packet_sent_time: now,
+                is_app_limited: false,
+            };
+
+            // We use a fixed rtt for 1st round.
+            let rtt = Duration::from_millis(rtt_1st);
+
+            let (new_cwnd, new_ssthresh) =
+                hspp.on_packet_acked(&p, rtt, cwnd, ssthresh);
+
+            cwnd = new_cwnd;
+            ssthresh = new_ssthresh;
+
+            pkt_num += 1;
+        }
+
+        // 2nd round. rtt = 100ms to trigger LSS.
+        let rtt_2nd = 100;
+
+        hspp.start_round(pkt_1st * 2 + 1);
+
+        for _ in 0..N_RTT_SAMPLE + 1 {
+            let p = recovery::Sent {
+                pkt_num,
+                frames: vec![],
+                time_sent: now + Duration::from_millis(pkt_num),
+                size,
+                ack_eliciting: true,
+                in_flight: true,
+                delivered: 0,
+                delivered_time: now,
+                recent_delivered_packet_sent_time: now,
+                is_app_limited: false,
+            };
+
+            // Keep increasing rtt to simulate buffer queueing delay
+            // This is to exit from slow slart to LSS.
+            let rtt = Duration::from_millis(rtt_2nd + pkt_num * 4);
+
+            let (new_cwnd, new_ssthresh) =
+                hspp.on_packet_acked(&p, rtt, cwnd, ssthresh);
+
+            cwnd = new_cwnd;
+            ssthresh = new_ssthresh;
+
+            pkt_num += 1;
+        }
+
+        // At this point, cwnd exits to LSS mode.
+        assert_eq!(hspp.lss, true);
+
+        // Check if current cwnd is in LSS.
+        let cur_ssthresh = 47000;
+        let k = cur_ssthresh as f64 / (LSS_DIVISOR * cur_ssthresh as f64);
+        let lss_cwnd = cur_ssthresh as f64 + size as f64 / k;
+
+        assert_eq!((cwnd, ssthresh), (lss_cwnd as usize, cur_ssthresh));
+    }
+
+    #[test]
+    fn congestion_event() {
+        let mut hspp = Hystart::default();
+        let pkt_num = 100;
+
+        hspp.start_round(pkt_num);
+
+        assert_eq!(hspp.window_end, Some(pkt_num));
+
+        // When moving into CA mode, window_end should be cleared.
+        hspp.congestion_event();
+
+        assert_eq!(hspp.window_end, None);
+    }
+}

--- a/tools/apps/src/bin/quiche-client.rs
+++ b/tools/apps/src/bin/quiche-client.rs
@@ -136,7 +136,7 @@ fn main() {
     }
 
     if conn_args.disable_hystart {
-        config.set_hystart(false);
+        config.enable_hystart(false);
     }
 
     let mut http_conn: Option<Box<dyn HttpConn>> = None;

--- a/tools/apps/src/bin/quiche-client.rs
+++ b/tools/apps/src/bin/quiche-client.rs
@@ -55,6 +55,7 @@ Options:
   --no-verify              Don't verify server's certificate.
   --no-grease              Don't send GREASE.
   --cc-algorithm NAME      Specify which congestion control algorithm to use [default: cubic].
+  --disable-hystart        Disable HyStart++.
   -H --header HEADER ...   Add a request header.
   -n --requests REQUESTS   Send the given number of identical requests [default: 1].
   -h --help                Show this screen.
@@ -132,6 +133,10 @@ fn main() {
 
     if std::env::var_os("SSLKEYLOGFILE").is_some() {
         config.log_keys();
+    }
+
+    if conn_args.disable_hystart {
+        config.set_hystart(false);
     }
 
     let mut http_conn: Option<Box<dyn HttpConn>> = None;

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -128,7 +128,7 @@ fn main() {
         .unwrap();
 
     if conn_args.disable_hystart {
-        config.set_hystart(false);
+        config.enable_hystart(false);
     }
 
     let rng = SystemRandom::new();

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -60,6 +60,7 @@ Options:
   --no-grease                 Don't send GREASE.
   --http-version VERSION      HTTP version to use [default: all].
   --cc-algorithm NAME         Specify which congestion control algorithm to use [default: cubic].
+  --disable-hystart           Disable HyStart++.
   -h --help                   Show this screen.
 ";
 
@@ -125,6 +126,10 @@ fn main() {
     config
         .set_cc_algorithm_name(&conn_args.cc_algorithm)
         .unwrap();
+
+    if conn_args.disable_hystart {
+        config.set_hystart(false);
+    }
 
     let rng = SystemRandom::new();
     let conn_id_seed =

--- a/tools/apps/src/lib.rs
+++ b/tools/apps/src/lib.rs
@@ -81,20 +81,22 @@ pub struct CommonArgs {
     pub dump_packet_path: Option<String>,
     pub no_grease: bool,
     pub cc_algorithm: String,
+    pub disable_hystart: bool,
 }
 
 /// Creates a new `CommonArgs` structure using the provided [`Docopt`].
 ///
 /// The `Docopt` usage String needs to include the following:
 ///
-/// --http-version VERSION   HTTP version to use
-/// --max-data BYTES         Connection-wide flow control limit.
-/// --max-stream-data BYTES  Per-stream flow control limit.
+/// --http-version VERSION      HTTP version to use
+/// --max-data BYTES            Connection-wide flow control limit.
+/// --max-stream-data BYTES     Per-stream flow control limit.
 /// --max-streams-bidi STREAMS  Number of allowed concurrent streams.
 /// --max-streams-uni STREAMS   Number of allowed concurrent streams.
 /// --dump-packets PATH         Dump the incoming packets in PATH.
 /// --no-grease                 Don't send GREASE.
 /// --cc-algorithm NAME         Set a congestion control algorithm.
+/// --disable-hystart           Disable HyStart++.
 ///
 /// [`Docopt`]: https://docs.rs/docopt/1.1.0/docopt/
 impl Args for CommonArgs {
@@ -138,6 +140,8 @@ impl Args for CommonArgs {
 
         let cc_algorithm = args.get_str("--cc-algorithm");
 
+        let disable_hystart = args.get_bool("--disable-hystart");
+
         CommonArgs {
             alpns,
             max_data,
@@ -147,6 +151,7 @@ impl Args for CommonArgs {
             dump_packet_path,
             no_grease,
             cc_algorithm: cc_algorithm.to_string(),
+            disable_hystart,
         }
     }
 }


### PR DESCRIPTION
**Note that it's based on #475 since this PR includes changes for CUBIC as well.**

Implements Hystart++ based on IETF draft:
  https://tools.ietf.org/html/draft-balasubramanian-tcpm-hystartplusplus-02

HyStart++ is an improved version of original Hystart. It can be used
with Reno and CUBIC (or possibly other loss based congestion control).
It's enabled by default. You can disable it by calling config API provided.

Config APIs:
- C: quiche_config_set_hystart()
- Rust: Config.set_hystart()

API Changes:
- CongestionControlOps API: `epoch` is added to on_packet_acked()
  and congestion_event()

Tools Update:
- tools/apps/quiche-{client,server}: added --disable-hystart
  command line option

Different from TCP: TCP implementation uses sequence number to
check a start of the round. In QUIC, current implementation uses
packet number instead. However packet number space is unique
per epoch but Initial and Handshake epoch is short, so only
applies HyStart++ to Application epoch.

In TCP, sequence number is reused for retransmitted packets
but QUIC will use a new packet number for retransmit so
this is not exactly same. But it should be fine because this is
only for the slow start episode and when QUIC connection sees a
packet loss, it enters into recovery episode and exits from slow
start, so retransmitted packet number is not used during HyStart++
slow start.