### PR TITLE
Fix nginx crash at debug logging

### DIFF
--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -4102,7 +4102,7 @@ index 00000000..2e8aaa7c
 +{
 +    ngx_log_t *log = ngx_cycle->log;
 +
-+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, log, 0, line);
++    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0, "%s", line);
 +}
 +#endif
 +


### PR DESCRIPTION
When nginx is built with --with-debug, `quiche_log()` is called
for debug log. In this functino `line` is used for format
string of sprintf().  When it contains a format string such as '%d',
it expects additional parameter but we only provide one, it can crash
nginx at logging.