### PR TITLE
nginx: disable request buffering in config example

### DIFF
--- a/extras/nginx/README.md
+++ b/extras/nginx/README.md
@@ -88,6 +88,9 @@ http {
         # Enable all TLS versions (TLSv1.3 is required for QUIC).
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
 
+        # Request buffering in not currently supported for HTTP/3.
+        proxy_request_buffering off;
+
         # Add Alt-Svc header to negotiate HTTP/3.
         add_header alt-svc 'h3-27=":443"; ma=86400';
     }


### PR DESCRIPTION
The HTTP/3 code does not support request buffering right now, so
enabling proxy_request_buffering will break POST requests.