### PR TITLE
fix debugging when SCID length is mismatched

### DIFF
--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -510,7 +510,7 @@ index 00000000..a80998eb
 +    ngx_log_debug4(NGX_LOG_DEBUG_EVENT, c->log, 0,
 +        "new quic connection dcid:%*.s new_scid:%*.s",
 +        ngx_hex_dump(dcid_hex, dcid, dcid_len) - dcid_hex, dcid_hex,
-+        ngx_hex_dump(scid_hex, scid, scid_len) - scid_hex, scid_hex);
++        ngx_hex_dump(scid_hex, scid, sizeof(scid)) - scid_hex, scid_hex);
 +    }
 +#endif
 +


### PR DESCRIPTION
Debug lines for new QUIC connections print the server's
SCID. Previously, we mistakenly used the length the client SCID
which could cause some incorrectness. For example, Chrome sends
a 0-length SCID.

This change ensures we use the actual server SCID length.