### PR TITLE
lib: fix app_limited to allow cwnd growth

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -726,7 +726,7 @@ impl PktNumSpace {
         self.ack_elicited = false;
     }
 
-    pub fn overhead(&self) -> Option<usize> {
+    pub fn crypto_overhead(&self) -> Option<usize> {
         Some(self.crypto_seal.as_ref()?.alg().tag_len())
     }
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -638,6 +638,14 @@ impl Recovery {
         )
     }
 
+    pub fn update_app_limited(&mut self, v: bool) {
+        self.app_limited = v;
+    }
+
+    pub fn app_limited(&mut self) -> bool {
+        self.app_limited
+    }
+
     #[cfg(feature = "qlog")]
     pub fn to_qlog(&self) -> qlog::event::Event {
         // QVis can't use all these fields and they can be large.
@@ -739,6 +747,7 @@ impl std::fmt::Debug for Recovery {
         write!(f, "cwnd={} ", self.congestion_window)?;
         write!(f, "ssthresh={} ", self.ssthresh)?;
         write!(f, "bytes_in_flight={} ", self.bytes_in_flight)?;
+        write!(f, "app_limited={} ", self.app_limited)?;
         write!(f, "{:?} ", self.delivery_rate)?;
 
         if self.hystart.enabled() {


### PR DESCRIPTION
There is a problem when sender has some leftover data cannot be
sent as a QUIC packet, app_limited is true so cwnd doesn't
grow well, especially during congestion avoidance.

Let's think the following scenario:

- max_packet_size=1200
- at send(): cwnd=1220, flight_size=0, send a full packet, 1200 bytes
- at send(): cwnd=1220, flight_size=1200
   we are only able to send 20 bytes, but it does't fit even for
   QUIC headers (usually larger than 20 bytes) and
   send() returns Error::Done.
   In this case, flight_size < cwnd so app_limited is still true.

However the app already send as much as possible to cwnd and
can't send more. This case should be considered
as app_limited=false.

The fix is to check and update app_limited when we return Error::Done
from send(). If still considered limited by cwnd, app_limited
will be false.