### PR TITLE
limit number of tracked packet number ranges that need to be acked

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -698,7 +698,7 @@ impl PktNumSpace {
 
             next_pkt_num: 0,
 
-            recv_pkt_need_ack: ranges::RangeSet::default(),
+            recv_pkt_need_ack: ranges::RangeSet::new(crate::MAX_ACK_RANGES),
 
             recv_pkt_num: PktNumWindow::default(),
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -228,7 +228,7 @@ impl Recovery {
         epoch: packet::Epoch, handshake_completed: bool, now: Instant,
         trace_id: &str,
     ) -> Result<()> {
-        let largest_acked = ranges.largest().unwrap();
+        let largest_acked = ranges.last().unwrap();
 
         // If the largest packet number acked exceeds any packet number we have
         // sent, then the ACK is obviously invalid, so there's no need to


### PR DESCRIPTION
This removes a potential DoS vector and it ensures that the size of
outgoing ACK frames does not get out of hand, which could cause a
deadlock in case ACK frames cannot fit in generated packets anymore.

Older packet number ranges are simply removed from the start of the
list, to keep the total list length under the limit. This will cause the
peer to spuriously retransmit the data within those packets, though that
seems better than the alternative.

Fixes #489.