### PR TITLE
drop support for old draft versions

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -240,7 +240,7 @@ int main(int argc, char *argv[]) {
     }
 
     quiche_config_set_application_protos(config,
-        (uint8_t *) "\x05hq-27\x05hq-25\x05hq-24\x05hq-23\x08http/0.9", 15);
+        (uint8_t *) "\x05hq-27\x08http/0.9", 15);
 
     quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -87,9 +87,7 @@ fn main() {
     config.verify_peer(false);
 
     config
-        .set_application_protos(
-            b"\x05hq-27\x05hq-25\x05hq-24\x05hq-23\x08http/0.9",
-        )
+        .set_application_protos(b"\x05hq-27\x08http/0.9")
         .unwrap();
 
     config.set_max_idle_timeout(5000);

--- a/examples/server.c
+++ b/examples/server.c
@@ -438,7 +438,7 @@ int main(int argc, char *argv[]) {
     quiche_config_load_priv_key_from_pem_file(config, "./cert.key");
 
     quiche_config_set_application_protos(config,
-        (uint8_t *) "\x05hq-27\x05hq-25\x05hq-24\x05hq-23\x08http/0.9", 21);
+        (uint8_t *) "\x05hq-27\x08http/0.9", 15);
 
     quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_packet_size(config, MAX_DATAGRAM_SIZE);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -90,9 +90,7 @@ fn main() {
         .unwrap();
 
     config
-        .set_application_protos(
-            b"\x05hq-27\x05hq-25\x05hq-24\x05hq-23\x08http/0.9",
-        )
+        .set_application_protos(b"\x05hq-27\x08http/0.9")
         .unwrap();
 
     config.set_max_idle_timeout(5000);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -339,7 +339,7 @@ void quiche_conn_free(quiche_conn *conn);
 //
 
 // List of ALPN tokens of supported HTTP/3 versions.
-#define QUICHE_H3_APPLICATION_PROTOCOL "\x05h3-27\x05h3-25\x05h3-24\x05h3-23"
+#define QUICHE_H3_APPLICATION_PROTOCOL "\x05h3-27"
 
 enum quiche_h3_error {
     /// There is no error or no work to do

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -258,7 +258,7 @@ use crate::octets;
 ///
 /// [`Config::set_application_protos()`]:
 /// ../struct.Config.html#method.set_application_protos
-pub const APPLICATION_PROTOCOL: &[u8] = b"\x05h3-27\x05h3-25\x05h3-24\x05h3-23";
+pub const APPLICATION_PROTOCOL: &[u8] = b"\x05h3-27";
 
 /// A specialized [`Result`] type for quiche HTTP/3 operations.
 ///

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -590,8 +590,6 @@ pub fn negotiate_version(
     b.put_u8(dcid.len() as u8)?;
     b.put_bytes(&dcid)?;
     b.put_u32(crate::PROTOCOL_VERSION)?;
-    b.put_u32(crate::PROTOCOL_VERSION_DRAFT24)?;
-    b.put_u32(crate::PROTOCOL_VERSION_DRAFT23)?;
 
     Ok(b.off())
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -329,7 +329,6 @@ impl Handshake {
 
         let raw_params = TransportParams::encode(
             &conn.local_transport_params,
-            conn.version,
             conn.is_server,
             &mut raw_params,
         )?;

--- a/tools/apps/src/lib.rs
+++ b/tools/apps/src/lib.rs
@@ -50,10 +50,8 @@ pub fn hex_dump(buf: &[u8]) -> String {
 ///
 /// This module contains constants and functions for working with ALPN.
 pub mod alpns {
-    pub const HTTP_09: [&str; 5] =
-        ["hq-27", "hq-25", "hq-24", "hq-23", "http/0.9"];
-
-    pub const HTTP_3: [&str; 4] = ["h3-27", "h3-25", "h3-24", "h3-23"];
+    pub const HTTP_09: [&str; 2] = ["hq-27", "http/0.9"];
+    pub const HTTP_3: [&str; 1] = ["h3-27"];
 
     pub fn length_prefixed(alpns: &[&str]) -> Vec<u8> {
         let mut out = Vec::new();


### PR DESCRIPTION
This mostly just simplifies how transport parameters are encoded and
decoded, by removing the intermediate buffer required for older draft
versions.

---

I just realized that the C hq client and server have been using a truncated ALPN value....