### PR TITLE
Mutable and immutable variants of Octets

### DIFF
--- a/examples/qpack-decode.rs
+++ b/examples/qpack-decode.rs
@@ -74,7 +74,7 @@ fn main() {
             continue;
         }
 
-        for hdr in dec.decode(&mut data[..len], std::u64::MAX).unwrap() {
+        for hdr in dec.decode(&data[..len], std::u64::MAX).unwrap() {
             println!("{}\t{}", hdr.name(), hdr.value());
         }
 

--- a/fuzz/src/qpack_decode.rs
+++ b/fuzz/src/qpack_decode.rs
@@ -21,7 +21,7 @@ fuzz_target!(|data: &[u8]| {
     let encoded_size = encoder.encode(&hdrs, &mut encoded_hdrs).unwrap();
 
     let decoded_hdrs = decoder
-        .decode(&mut encoded_hdrs[..encoded_size], std::u64::MAX)
+        .decode(&encoded_hdrs[..encoded_size], std::u64::MAX)
         .unwrap();
 
     assert_eq!(hdrs, decoded_hdrs)

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -142,7 +142,7 @@ pub enum Frame {
 
 impl Frame {
     pub fn from_bytes(
-        b: &mut octets::OctetsMut, pkt: packet::Type,
+        b: &mut octets::Octets, pkt: packet::Type,
     ) -> Result<Frame> {
         let frame_type = b.get_varint()?;
 
@@ -977,7 +977,7 @@ impl std::fmt::Debug for Frame {
     }
 }
 
-fn parse_ack_frame(_ty: u64, b: &mut octets::OctetsMut) -> Result<Frame> {
+fn parse_ack_frame(_ty: u64, b: &mut octets::Octets) -> Result<Frame> {
     let largest_ack = b.get_varint()?;
     let ack_delay = b.get_varint()?;
     let block_count = b.get_varint()?;
@@ -1017,7 +1017,7 @@ fn parse_ack_frame(_ty: u64, b: &mut octets::OctetsMut) -> Result<Frame> {
     Ok(Frame::ACK { ack_delay, ranges })
 }
 
-fn parse_stream_frame(ty: u64, b: &mut octets::OctetsMut) -> Result<Frame> {
+fn parse_stream_frame(ty: u64, b: &mut octets::Octets) -> Result<Frame> {
     let first = ty as u8;
 
     let stream_id = b.get_varint()?;
@@ -1063,16 +1063,16 @@ mod tests {
 
         assert_eq!(wire_len, 128);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_ok());
     }
 
@@ -1090,16 +1090,16 @@ mod tests {
         assert_eq!(wire_len, 1);
         assert_eq!(&d[..wire_len], [0x01 as u8]);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_ok());
     }
 
@@ -1125,16 +1125,16 @@ mod tests {
 
         assert_eq!(wire_len, 17);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_ok());
     }
 
@@ -1155,16 +1155,16 @@ mod tests {
 
         assert_eq!(wire_len, 13);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1184,16 +1184,16 @@ mod tests {
 
         assert_eq!(wire_len, 7);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1214,16 +1214,16 @@ mod tests {
 
         assert_eq!(wire_len, 18);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_ok());
     }
 
@@ -1242,16 +1242,16 @@ mod tests {
 
         assert_eq!(wire_len, 17);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1273,16 +1273,16 @@ mod tests {
 
         assert_eq!(wire_len, 19);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1304,7 +1304,7 @@ mod tests {
 
         assert_eq!(wire_len, 23);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(
             Frame::from_bytes(&mut b, packet::Type::Short),
             Err(Error::InvalidFrame)
@@ -1324,16 +1324,16 @@ mod tests {
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1353,16 +1353,16 @@ mod tests {
 
         assert_eq!(wire_len, 7);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1379,16 +1379,16 @@ mod tests {
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1405,16 +1405,16 @@ mod tests {
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1431,16 +1431,16 @@ mod tests {
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1460,16 +1460,16 @@ mod tests {
 
         assert_eq!(wire_len, 7);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1486,16 +1486,16 @@ mod tests {
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1512,16 +1512,16 @@ mod tests {
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1543,16 +1543,16 @@ mod tests {
 
         assert_eq!(wire_len, 41);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1569,16 +1569,16 @@ mod tests {
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1597,16 +1597,16 @@ mod tests {
 
         assert_eq!(wire_len, 9);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1625,16 +1625,16 @@ mod tests {
 
         assert_eq!(wire_len, 9);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1655,16 +1655,16 @@ mod tests {
 
         assert_eq!(wire_len, 22);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_ok());
     }
 
@@ -1684,16 +1684,16 @@ mod tests {
 
         assert_eq!(wire_len, 18);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1710,16 +1710,16 @@ mod tests {
 
         assert_eq!(wire_len, 1);
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::OctetsMut::with_slice(&mut d);
+        let mut b = octets::Octets::with_slice(&d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -142,7 +142,7 @@ pub enum Frame {
 
 impl Frame {
     pub fn from_bytes(
-        b: &mut octets::Octets, pkt: packet::Type,
+        b: &mut octets::OctetsMut, pkt: packet::Type,
     ) -> Result<Frame> {
         let frame_type = b.get_varint()?;
 
@@ -294,7 +294,7 @@ impl Frame {
         Ok(frame)
     }
 
-    pub fn to_bytes(&self, b: &mut octets::Octets) -> Result<usize> {
+    pub fn to_bytes(&self, b: &mut octets::OctetsMut) -> Result<usize> {
         let before = b.cap();
 
         match self {
@@ -977,7 +977,7 @@ impl std::fmt::Debug for Frame {
     }
 }
 
-fn parse_ack_frame(_ty: u64, b: &mut octets::Octets) -> Result<Frame> {
+fn parse_ack_frame(_ty: u64, b: &mut octets::OctetsMut) -> Result<Frame> {
     let largest_ack = b.get_varint()?;
     let ack_delay = b.get_varint()?;
     let block_count = b.get_varint()?;
@@ -1017,7 +1017,7 @@ fn parse_ack_frame(_ty: u64, b: &mut octets::Octets) -> Result<Frame> {
     Ok(Frame::ACK { ack_delay, ranges })
 }
 
-fn parse_stream_frame(ty: u64, b: &mut octets::Octets) -> Result<Frame> {
+fn parse_stream_frame(ty: u64, b: &mut octets::OctetsMut) -> Result<Frame> {
     let first = ty as u8;
 
     let stream_id = b.get_varint()?;
@@ -1057,22 +1057,22 @@ mod tests {
         let frame = Frame::Padding { len: 128 };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 128);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_ok());
     }
 
@@ -1083,23 +1083,23 @@ mod tests {
         let frame = Frame::Ping;
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 1);
         assert_eq!(&d[..wire_len], [0x01 as u8]);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_ok());
     }
 
@@ -1119,22 +1119,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 17);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_ok());
     }
 
@@ -1149,22 +1149,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 13);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1178,22 +1178,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 7);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1208,22 +1208,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 18);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_ok());
     }
 
@@ -1236,22 +1236,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 17);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1267,22 +1267,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 19);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1298,13 +1298,13 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 23);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(
             Frame::from_bytes(&mut b, packet::Type::Short),
             Err(Error::InvalidFrame)
@@ -1318,22 +1318,22 @@ mod tests {
         let frame = Frame::MaxData { max: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1347,22 +1347,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 7);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1373,22 +1373,22 @@ mod tests {
         let frame = Frame::MaxStreamsBidi { max: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1399,22 +1399,22 @@ mod tests {
         let frame = Frame::MaxStreamsUni { max: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1425,22 +1425,22 @@ mod tests {
         let frame = Frame::DataBlocked { limit: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1454,22 +1454,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 7);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1480,22 +1480,22 @@ mod tests {
         let frame = Frame::StreamsBlockedBidi { limit: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1506,22 +1506,22 @@ mod tests {
         let frame = Frame::StreamsBlockedUni { limit: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1537,22 +1537,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 41);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1563,22 +1563,22 @@ mod tests {
         let frame = Frame::RetireConnectionId { seq_num: 123_213 };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1591,22 +1591,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 9);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1619,22 +1619,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 9);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1649,22 +1649,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 22);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_ok());
     }
 
@@ -1678,22 +1678,22 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 18);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_ok());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 
@@ -1704,22 +1704,22 @@ mod tests {
         let frame = Frame::HandshakeDone;
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 1);
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
     }
 }

--- a/src/h3/frame.rs
+++ b/src/h3/frame.rs
@@ -81,7 +81,7 @@ impl Frame {
     pub fn from_bytes(
         frame_type: u64, payload_length: u64, bytes: &mut [u8],
     ) -> Result<Frame> {
-        let mut b = octets::Octets::with_slice(bytes);
+        let mut b = octets::OctetsMut::with_slice(bytes);
 
         // TODO: handling of 0-length frames
         let frame = match frame_type {
@@ -117,7 +117,7 @@ impl Frame {
         Ok(frame)
     }
 
-    pub fn to_bytes(&self, b: &mut octets::Octets) -> Result<usize> {
+    pub fn to_bytes(&self, b: &mut octets::OctetsMut) -> Result<usize> {
         let before = b.cap();
 
         match self {
@@ -281,7 +281,7 @@ impl std::fmt::Debug for Frame {
 }
 
 fn parse_settings_frame(
-    b: &mut octets::Octets, settings_length: usize,
+    b: &mut octets::OctetsMut, settings_length: usize,
 ) -> Result<Frame> {
     let mut max_header_list_size = None;
     let mut qpack_max_table_capacity = None;
@@ -318,7 +318,7 @@ fn parse_settings_frame(
 }
 
 fn parse_push_promise(
-    payload_length: u64, b: &mut octets::Octets,
+    payload_length: u64, b: &mut octets::OctetsMut,
 ) -> Result<Frame> {
     let push_id = b.get_varint()?;
     let header_block_length = payload_length - octets::varint_len(push_id) as u64;
@@ -345,7 +345,7 @@ mod tests {
         let frame = Frame::Data { payload };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
@@ -373,7 +373,7 @@ mod tests {
         let frame = Frame::Headers { header_block };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
@@ -400,7 +400,7 @@ mod tests {
         let frame_header_len = 2;
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
@@ -432,7 +432,7 @@ mod tests {
         let frame_header_len = 2;
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
@@ -472,7 +472,7 @@ mod tests {
         let frame_header_len = 2;
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
@@ -504,7 +504,7 @@ mod tests {
         let frame_header_len = 2;
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
@@ -536,7 +536,7 @@ mod tests {
         let frame_header_len = 2;
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
@@ -567,7 +567,7 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
@@ -594,7 +594,7 @@ mod tests {
         let frame_header_len = 2;
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 
@@ -621,7 +621,7 @@ mod tests {
         let frame_header_len = 2;
 
         let wire_len = {
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
             frame.to_bytes(&mut b).unwrap()
         };
 

--- a/src/h3/frame.rs
+++ b/src/h3/frame.rs
@@ -79,9 +79,9 @@ pub enum Frame {
 
 impl Frame {
     pub fn from_bytes(
-        frame_type: u64, payload_length: u64, bytes: &mut [u8],
+        frame_type: u64, payload_length: u64, bytes: &[u8],
     ) -> Result<Frame> {
-        let mut b = octets::OctetsMut::with_slice(bytes);
+        let mut b = octets::Octets::with_slice(bytes);
 
         // TODO: handling of 0-length frames
         let frame = match frame_type {
@@ -281,7 +281,7 @@ impl std::fmt::Debug for Frame {
 }
 
 fn parse_settings_frame(
-    b: &mut octets::OctetsMut, settings_length: usize,
+    b: &mut octets::Octets, settings_length: usize,
 ) -> Result<Frame> {
     let mut max_header_list_size = None;
     let mut qpack_max_table_capacity = None;
@@ -318,7 +318,7 @@ fn parse_settings_frame(
 }
 
 fn parse_push_promise(
-    payload_length: u64, b: &mut octets::OctetsMut,
+    payload_length: u64, b: &mut octets::Octets,
 ) -> Result<Frame> {
     let push_id = b.get_varint()?;
     let header_block_length = payload_length - octets::varint_len(push_id) as u64;
@@ -355,7 +355,7 @@ mod tests {
             Frame::from_bytes(
                 DATA_FRAME_TYPE_ID,
                 frame_payload_len as u64,
-                &mut d[frame_header_len..]
+                &d[frame_header_len..]
             )
             .unwrap(),
             frame
@@ -383,7 +383,7 @@ mod tests {
             Frame::from_bytes(
                 HEADERS_FRAME_TYPE_ID,
                 frame_payload_len as u64,
-                &mut d[frame_header_len..]
+                &d[frame_header_len..]
             )
             .unwrap(),
             frame
@@ -410,7 +410,7 @@ mod tests {
             Frame::from_bytes(
                 CANCEL_PUSH_FRAME_TYPE_ID,
                 frame_payload_len as u64,
-                &mut d[frame_header_len..]
+                &d[frame_header_len..]
             )
             .unwrap(),
             frame
@@ -442,7 +442,7 @@ mod tests {
             Frame::from_bytes(
                 SETTINGS_FRAME_TYPE_ID,
                 frame_payload_len as u64,
-                &mut d[frame_header_len..]
+                &d[frame_header_len..]
             )
             .unwrap(),
             frame
@@ -482,7 +482,7 @@ mod tests {
             Frame::from_bytes(
                 SETTINGS_FRAME_TYPE_ID,
                 frame_payload_len as u64,
-                &mut d[frame_header_len..]
+                &d[frame_header_len..]
             )
             .unwrap(),
             frame_parsed
@@ -514,7 +514,7 @@ mod tests {
             Frame::from_bytes(
                 SETTINGS_FRAME_TYPE_ID,
                 frame_payload_len as u64,
-                &mut d[frame_header_len..]
+                &d[frame_header_len..]
             )
             .unwrap(),
             frame
@@ -546,7 +546,7 @@ mod tests {
             Frame::from_bytes(
                 SETTINGS_FRAME_TYPE_ID,
                 frame_payload_len as u64,
-                &mut d[frame_header_len..]
+                &d[frame_header_len..]
             )
             .unwrap(),
             frame
@@ -577,7 +577,7 @@ mod tests {
             Frame::from_bytes(
                 PUSH_PROMISE_FRAME_TYPE_ID,
                 frame_payload_len as u64,
-                &mut d[frame_header_len..]
+                &d[frame_header_len..]
             )
             .unwrap(),
             frame
@@ -604,7 +604,7 @@ mod tests {
             Frame::from_bytes(
                 GOAWAY_FRAME_TYPE_ID,
                 frame_payload_len as u64,
-                &mut d[frame_header_len..]
+                &d[frame_header_len..]
             )
             .unwrap(),
             frame
@@ -631,7 +631,7 @@ mod tests {
             Frame::from_bytes(
                 MAX_PUSH_FRAME_TYPE_ID,
                 frame_payload_len as u64,
-                &mut d[frame_header_len..]
+                &d[frame_header_len..]
             )
             .unwrap(),
             frame
@@ -640,11 +640,8 @@ mod tests {
 
     #[test]
     fn unknown_type() {
-        let mut d = [42; 12];
+        let d = [42; 12];
 
-        assert_eq!(
-            Frame::from_bytes(255, 12345, &mut d[..]),
-            Ok(Frame::Unknown)
-        );
+        assert_eq!(Frame::from_bytes(255, 12345, &d[..]), Ok(Frame::Unknown));
     }
 }

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -1304,7 +1304,7 @@ impl Connection {
                 };
             },
 
-            frame::Frame::Headers { mut header_block } => {
+            frame::Frame::Headers { header_block } => {
                 if Some(stream_id) == self.peer_control_stream_id {
                     conn.close(
                         true,
@@ -1324,7 +1324,7 @@ impl Connection {
 
                 let headers = self
                     .qpack_decoder
-                    .decode(&mut header_block[..], max_size)
+                    .decode(&header_block[..], max_size)
                     .map_err(|e| match e {
                         qpack::Error::HeaderListTooLarge => Error::ExcessiveLoad,
 

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -663,7 +663,7 @@ impl Connection {
         headers: &[Header], fin: bool,
     ) -> Result<()> {
         let mut d = [42; 10];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         if !self.frames_greased && conn.grease {
             self.send_grease_frames(conn, stream_id)?;
@@ -721,7 +721,7 @@ impl Connection {
         fin: bool,
     ) -> Result<usize> {
         let mut d = [42; 10];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         // Validate that it is sane to send data on the stream.
         if stream_id % 4 != 0 {
@@ -883,7 +883,7 @@ impl Connection {
         let stream_id = self.next_uni_stream_id;
 
         let mut d = [0; 8];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         conn.stream_send(stream_id, b.put_varint(ty)?, false)?;
 
@@ -944,17 +944,17 @@ impl Connection {
         trace!("{} tx frm GREASE stream={}", conn.trace_id(), stream_id);
 
         // Empty GREASE frame.
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         conn.stream_send(stream_id, b.put_varint(grease_frame1)?, false)?;
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         conn.stream_send(stream_id, b.put_varint(0)?, false)?;
 
         // GREASE frame with payload.
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         conn.stream_send(stream_id, b.put_varint(grease_frame2)?, false)?;
 
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
         conn.stream_send(stream_id, b.put_varint(18)?, false)?;
 
         conn.stream_send(stream_id, grease_payload, false)?;
@@ -1006,7 +1006,7 @@ impl Connection {
         };
 
         let mut d = [42; 128];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         frame.to_bytes(&mut b)?;
 
@@ -1696,7 +1696,7 @@ pub mod testing {
         ) -> Result<()> {
             let mut d = [42; 65535];
 
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
 
             frame.to_bytes(&mut b)?;
 
@@ -1714,7 +1714,7 @@ pub mod testing {
         ) -> Result<()> {
             let mut d = [42; 65535];
 
-            let mut b = octets::Octets::with_slice(&mut d);
+            let mut b = octets::OctetsMut::with_slice(&mut d);
 
             frame.to_bytes(&mut b)?;
 
@@ -2370,7 +2370,7 @@ mod tests {
         let stream_id = s.client.next_uni_stream_id;
 
         let mut d = [42; 8];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         s.pipe
             .client
@@ -2498,7 +2498,7 @@ mod tests {
         s.handshake().unwrap();
 
         let mut d = [42; 128];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let frame_type = b.put_varint(frame::DATA_FRAME_TYPE_ID).unwrap();
         s.pipe.client.stream_send(0, frame_type, false).unwrap();
@@ -2517,7 +2517,7 @@ mod tests {
         s.handshake().unwrap();
 
         let mut d = [42; 128];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let frame_type = b.put_varint(148_764_065_110_560_899).unwrap();
         s.pipe.client.stream_send(0, frame_type, false).unwrap();
@@ -2680,7 +2680,7 @@ mod tests {
         s.handshake().unwrap();
 
         let mut d = [42; 128];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let frame_type = b.put_varint(frame::DATA_FRAME_TYPE_ID).unwrap();
         s.pipe.client.stream_send(0, frame_type, false).unwrap();
@@ -2699,7 +2699,7 @@ mod tests {
         s.handshake().unwrap();
 
         let mut d = [42; 128];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let frame_type = b.put_varint(148_764_065_110_560_899).unwrap();
         s.pipe.client.stream_send(0, frame_type, false).unwrap();

--- a/src/h3/qpack/decoder.rs
+++ b/src/h3/qpack/decoder.rs
@@ -89,10 +89,8 @@ impl Decoder {
     }
 
     /// Decodes a QPACK header block into a list of headers.
-    pub fn decode(
-        &mut self, buf: &mut [u8], max_size: u64,
-    ) -> Result<Vec<Header>> {
-        let mut b = octets::OctetsMut::with_slice(buf);
+    pub fn decode(&mut self, buf: &[u8], max_size: u64) -> Result<Vec<Header>> {
+        let mut b = octets::Octets::with_slice(buf);
 
         let mut out = Vec::new();
 
@@ -324,7 +322,7 @@ fn lookup_static(idx: u64) -> Result<(&'static str, &'static str)> {
     Ok(hdr)
 }
 
-fn decode_int(b: &mut octets::OctetsMut, prefix: usize) -> Result<u64> {
+fn decode_int(b: &mut octets::Octets, prefix: usize) -> Result<u64> {
     let mask = 2u64.pow(prefix as u32) - 1;
 
     let mut val = u64::from(b.get_u8()?);
@@ -355,7 +353,7 @@ fn decode_int(b: &mut octets::OctetsMut, prefix: usize) -> Result<u64> {
     Err(Error::BufferTooShort)
 }
 
-fn decode_str<'a>(b: &'a mut octets::OctetsMut) -> Result<String> {
+fn decode_str<'a>(b: &'a mut octets::Octets) -> Result<String> {
     let first = b.peek_u8()?;
 
     let huff = first & 0x80 == 0x80;
@@ -383,7 +381,7 @@ mod tests {
     #[test]
     fn decode_int1() {
         let mut encoded = [0b01010, 0x02];
-        let mut b = octets::OctetsMut::with_slice(&mut encoded);
+        let mut b = octets::Octets::with_slice(&mut encoded);
 
         assert_eq!(decode_int(&mut b, 5), Ok(10));
     }
@@ -391,7 +389,7 @@ mod tests {
     #[test]
     fn decode_int2() {
         let mut encoded = [0b11111, 0b10011010, 0b00001010];
-        let mut b = octets::OctetsMut::with_slice(&mut encoded);
+        let mut b = octets::Octets::with_slice(&mut encoded);
 
         assert_eq!(decode_int(&mut b, 5), Ok(1337));
     }
@@ -399,7 +397,7 @@ mod tests {
     #[test]
     fn decode_int3() {
         let mut encoded = [0b101010];
-        let mut b = octets::OctetsMut::with_slice(&mut encoded);
+        let mut b = octets::Octets::with_slice(&mut encoded);
 
         assert_eq!(decode_int(&mut b, 8), Ok(42));
     }

--- a/src/h3/qpack/decoder.rs
+++ b/src/h3/qpack/decoder.rs
@@ -92,7 +92,7 @@ impl Decoder {
     pub fn decode(
         &mut self, buf: &mut [u8], max_size: u64,
     ) -> Result<Vec<Header>> {
-        let mut b = octets::Octets::with_slice(buf);
+        let mut b = octets::OctetsMut::with_slice(buf);
 
         let mut out = Vec::new();
 
@@ -324,7 +324,7 @@ fn lookup_static(idx: u64) -> Result<(&'static str, &'static str)> {
     Ok(hdr)
 }
 
-fn decode_int(b: &mut octets::Octets, prefix: usize) -> Result<u64> {
+fn decode_int(b: &mut octets::OctetsMut, prefix: usize) -> Result<u64> {
     let mask = 2u64.pow(prefix as u32) - 1;
 
     let mut val = u64::from(b.get_u8()?);
@@ -355,7 +355,7 @@ fn decode_int(b: &mut octets::Octets, prefix: usize) -> Result<u64> {
     Err(Error::BufferTooShort)
 }
 
-fn decode_str<'a>(b: &'a mut octets::Octets) -> Result<String> {
+fn decode_str<'a>(b: &'a mut octets::OctetsMut) -> Result<String> {
     let first = b.peek_u8()?;
 
     let huff = first & 0x80 == 0x80;
@@ -383,7 +383,7 @@ mod tests {
     #[test]
     fn decode_int1() {
         let mut encoded = [0b01010, 0x02];
-        let mut b = octets::Octets::with_slice(&mut encoded);
+        let mut b = octets::OctetsMut::with_slice(&mut encoded);
 
         assert_eq!(decode_int(&mut b, 5), Ok(10));
     }
@@ -391,7 +391,7 @@ mod tests {
     #[test]
     fn decode_int2() {
         let mut encoded = [0b11111, 0b10011010, 0b00001010];
-        let mut b = octets::Octets::with_slice(&mut encoded);
+        let mut b = octets::OctetsMut::with_slice(&mut encoded);
 
         assert_eq!(decode_int(&mut b, 5), Ok(1337));
     }
@@ -399,7 +399,7 @@ mod tests {
     #[test]
     fn decode_int3() {
         let mut encoded = [0b101010];
-        let mut b = octets::Octets::with_slice(&mut encoded);
+        let mut b = octets::OctetsMut::with_slice(&mut encoded);
 
         assert_eq!(decode_int(&mut b, 8), Ok(42));
     }

--- a/src/h3/qpack/encoder.rs
+++ b/src/h3/qpack/encoder.rs
@@ -53,7 +53,7 @@ impl Encoder {
     pub fn encode(
         &mut self, headers: &[Header], out: &mut [u8],
     ) -> Result<usize> {
-        let mut b = octets::Octets::with_slice(out);
+        let mut b = octets::OctetsMut::with_slice(out);
 
         // Request Insert Count.
         encode_int(0, 0, 8, &mut b)?;
@@ -247,7 +247,7 @@ fn lookup_static(h: &Header) -> Option<(u64, bool)> {
 }
 
 fn encode_int(
-    mut v: u64, first: u8, prefix: usize, b: &mut octets::Octets,
+    mut v: u64, first: u8, prefix: usize, b: &mut octets::OctetsMut,
 ) -> Result<()> {
     let mask = 2u64.pow(prefix as u32) - 1;
 
@@ -275,7 +275,7 @@ fn encode_int(
     Ok(())
 }
 
-fn encode_str(v: &str, prefix: usize, b: &mut octets::Octets) -> Result<()> {
+fn encode_str(v: &str, prefix: usize, b: &mut octets::OctetsMut) -> Result<()> {
     let len = super::huffman::encode_output_length(v.as_bytes())?;
 
     encode_int(len as u64, 0x80, prefix, b)?;
@@ -295,7 +295,7 @@ mod tests {
     fn encode_int1() {
         let expected = [0b01010];
         let mut encoded = [0; 1];
-        let mut b = octets::Octets::with_slice(&mut encoded);
+        let mut b = octets::OctetsMut::with_slice(&mut encoded);
 
         assert!(encode_int(10, 0, 5, &mut b).is_ok());
 
@@ -306,7 +306,7 @@ mod tests {
     fn encode_int2() {
         let expected = [0b11111, 0b10011010, 0b00001010];
         let mut encoded = [0; 3];
-        let mut b = octets::Octets::with_slice(&mut encoded);
+        let mut b = octets::OctetsMut::with_slice(&mut encoded);
 
         assert!(encode_int(1337, 0, 5, &mut b).is_ok());
 
@@ -317,7 +317,7 @@ mod tests {
     fn encode_int3() {
         let expected = [0b101010];
         let mut encoded = [0; 1];
-        let mut b = octets::Octets::with_slice(&mut encoded);
+        let mut b = octets::OctetsMut::with_slice(&mut encoded);
 
         assert!(encode_int(42, 0, 8, &mut b).is_ok());
 

--- a/src/h3/qpack/huffman/mod.rs
+++ b/src/h3/qpack/huffman/mod.rs
@@ -32,7 +32,7 @@ use super::Result;
 use self::table::DECODE_TABLE;
 use self::table::ENCODE_TABLE;
 
-pub fn decode(b: &mut octets::OctetsMut) -> Result<Vec<u8>> {
+pub fn decode(b: &mut octets::Octets) -> Result<Vec<u8>> {
     // Max compression ratio is >= 0.5
     let mut out = Vec::with_capacity(b.len() << 1);
 

--- a/src/h3/qpack/huffman/mod.rs
+++ b/src/h3/qpack/huffman/mod.rs
@@ -32,7 +32,7 @@ use super::Result;
 use self::table::DECODE_TABLE;
 use self::table::ENCODE_TABLE;
 
-pub fn decode(b: &mut octets::Octets) -> Result<Vec<u8>> {
+pub fn decode(b: &mut octets::OctetsMut) -> Result<Vec<u8>> {
     // Max compression ratio is >= 0.5
     let mut out = Vec::with_capacity(b.len() << 1);
 
@@ -57,7 +57,7 @@ pub fn decode(b: &mut octets::Octets) -> Result<Vec<u8>> {
     Ok(out)
 }
 
-pub fn encode(src: &[u8], out: &mut octets::Octets) -> Result<()> {
+pub fn encode(src: &[u8], out: &mut octets::OctetsMut) -> Result<()> {
     let mut bits: u64 = 0;
     let mut bits_left = 40;
 

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -410,7 +410,7 @@ impl Stream {
         }
 
         let varint =
-            octets::Octets::with_slice(&mut self.state_buf).get_varint()?;
+            octets::OctetsMut::with_slice(&mut self.state_buf).get_varint()?;
 
         Ok(varint)
     }
@@ -509,7 +509,7 @@ mod tests {
         assert_eq!(stream.state, State::StreamType);
 
         let mut d = vec![42; 40];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let frame = frame::Frame::Settings {
             max_header_list_size: Some(0),
@@ -564,7 +564,7 @@ mod tests {
         assert_eq!(stream.state, State::StreamType);
 
         let mut d = vec![42; 40];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let frame = frame::Frame::Settings {
             max_header_list_size: Some(0),
@@ -626,7 +626,7 @@ mod tests {
         assert_eq!(stream.state, State::StreamType);
 
         let mut d = vec![42; 40];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let goaway = frame::Frame::GoAway { stream_id: 0 };
 
@@ -667,7 +667,7 @@ mod tests {
         assert_eq!(stream.state, State::StreamType);
 
         let mut d = vec![42; 40];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let header_block = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
         let hdrs = frame::Frame::Headers { header_block };
@@ -730,7 +730,7 @@ mod tests {
         let mut stream = Stream::new(0, false);
 
         let mut d = vec![42; 128];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let header_block = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
         let payload = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
@@ -802,7 +802,7 @@ mod tests {
         let mut stream = Stream::new(2, false);
 
         let mut d = vec![42; 128];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let header_block = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
         let payload = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
@@ -895,7 +895,7 @@ mod tests {
         let mut stream = Stream::new(2, false);
 
         let mut d = vec![42; 20];
-        let mut b = octets::Octets::with_slice(&mut d);
+        let mut b = octets::OctetsMut::with_slice(&mut d);
 
         b.put_varint(33).unwrap();
 

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -409,8 +409,7 @@ impl Stream {
             return Err(Error::Done);
         }
 
-        let varint =
-            octets::OctetsMut::with_slice(&mut self.state_buf).get_varint()?;
+        let varint = octets::Octets::with_slice(&self.state_buf).get_varint()?;
 
         Ok(varint)
     }
@@ -421,7 +420,7 @@ impl Stream {
         let frame = frame::Frame::from_bytes(
             self.frame_type.unwrap(),
             self.state_len as u64,
-            &mut self.state_buf,
+            &self.state_buf,
         )?;
 
         self.state_transition(State::FrameType, 1, true)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,7 +564,7 @@ impl Config {
     pub fn set_application_protos(&mut self, protos: &[u8]) -> Result<()> {
         let mut protos = protos.to_vec();
 
-        let mut b = octets::Octets::with_slice(&mut protos);
+        let mut b = octets::OctetsMut::with_slice(&mut protos);
 
         let mut protos_list = Vec::new();
 
@@ -1343,7 +1343,7 @@ impl Connection {
             return Err(Error::Done);
         }
 
-        let mut b = octets::Octets::with_slice(buf);
+        let mut b = octets::OctetsMut::with_slice(buf);
 
         let mut hdr = Header::from_bytes(&mut b, self.scid.len())
             .map_err(|e| drop_pkt_on_err(e, self.recv_count, &self.trace_id))?;
@@ -1810,7 +1810,7 @@ impl Connection {
             self.do_handshake()?;
         }
 
-        let mut b = octets::Octets::with_slice(out);
+        let mut b = octets::OctetsMut::with_slice(out);
 
         let epoch = self.write_epoch()?;
 
@@ -3521,7 +3521,7 @@ impl TransportParams {
     fn decode(
         buf: &mut [u8], version: u32, is_server: bool,
     ) -> Result<TransportParams> {
-        let mut b = octets::Octets::with_slice(buf);
+        let mut b = octets::OctetsMut::with_slice(buf);
 
         let mut tp = TransportParams::default();
 
@@ -3656,7 +3656,7 @@ impl TransportParams {
     }
 
     fn encode_param(
-        b: &mut octets::Octets, ty: u64, len: usize, version: u32,
+        b: &mut octets::OctetsMut, ty: u64, len: usize, version: u32,
     ) -> Result<()> {
         if version < PROTOCOL_VERSION_DRAFT27 {
             b.put_u16(ty as u16)?;
@@ -3675,7 +3675,7 @@ impl TransportParams {
         let mut params = [0; 128];
 
         let params_len = {
-            let mut b = octets::Octets::with_slice(&mut params);
+            let mut b = octets::OctetsMut::with_slice(&mut params);
 
             if is_server {
                 if let Some(ref odcid) = tp.original_connection_id {
@@ -3821,7 +3821,7 @@ impl TransportParams {
         };
 
         let out_len = {
-            let mut b = octets::Octets::with_slice(out);
+            let mut b = octets::OctetsMut::with_slice(out);
 
             // TODO: once we drop support for drafts < 27, we should simplify
             // the encoding to serialize the parameters into the output buffer
@@ -4077,7 +4077,7 @@ pub mod testing {
         conn: &mut Connection, pkt_type: packet::Type, frames: &[frame::Frame],
         buf: &mut [u8],
     ) -> Result<usize> {
-        let mut b = octets::Octets::with_slice(buf);
+        let mut b = octets::OctetsMut::with_slice(buf);
 
         let epoch = pkt_type.to_epoch()?;
 
@@ -4138,7 +4138,7 @@ pub mod testing {
     pub fn decode_pkt(
         conn: &mut Connection, buf: &mut [u8], len: usize,
     ) -> Result<Vec<frame::Frame>> {
-        let mut b = octets::Octets::with_slice(&mut buf[..len]);
+        let mut b = octets::OctetsMut::with_slice(&mut buf[..len]);
 
         let mut hdr = Header::from_bytes(&mut b, conn.scid.len()).unwrap();
 
@@ -5469,7 +5469,7 @@ mod tests {
         let mut buf = [0; 65535];
         let mut pipe = testing::Pipe::default().unwrap();
 
-        let mut b = octets::Octets::with_slice(&mut buf);
+        let mut b = octets::OctetsMut::with_slice(&mut buf);
 
         let epoch = packet::Type::Initial.to_epoch().unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,9 +562,7 @@ impl Config {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn set_application_protos(&mut self, protos: &[u8]) -> Result<()> {
-        let mut protos = protos.to_vec();
-
-        let mut b = octets::OctetsMut::with_slice(&mut protos);
+        let mut b = octets::Octets::with_slice(&protos);
 
         let mut protos_list = Vec::new();
 
@@ -2975,10 +2973,10 @@ impl Connection {
         }
 
         if !self.parsed_peer_transport_params {
-            let mut raw_params = self.handshake.quic_transport_params().to_vec();
+            let raw_params = self.handshake.quic_transport_params();
 
             let peer_params = TransportParams::decode(
-                &mut raw_params,
+                &raw_params,
                 self.version,
                 self.is_server,
             )?;
@@ -3519,9 +3517,9 @@ impl Default for TransportParams {
 
 impl TransportParams {
     fn decode(
-        buf: &mut [u8], version: u32, is_server: bool,
+        buf: &[u8], version: u32, is_server: bool,
     ) -> Result<TransportParams> {
-        let mut b = octets::OctetsMut::with_slice(buf);
+        let mut b = octets::Octets::with_slice(buf);
 
         let mut tp = TransportParams::default();
 
@@ -4196,13 +4194,13 @@ mod tests {
         };
 
         let mut raw_params = [42; 256];
-        let mut raw_params =
+        let raw_params =
             TransportParams::encode(&tp, PROTOCOL_VERSION, true, &mut raw_params)
                 .unwrap();
         assert_eq!(raw_params.len(), 73);
 
         let new_tp =
-            TransportParams::decode(&mut raw_params, PROTOCOL_VERSION, false)
+            TransportParams::decode(&raw_params, PROTOCOL_VERSION, false)
                 .unwrap();
 
         assert_eq!(new_tp, tp);
@@ -4226,7 +4224,7 @@ mod tests {
         };
 
         let mut raw_params = [42; 256];
-        let mut raw_params = TransportParams::encode(
+        let raw_params = TransportParams::encode(
             &tp,
             PROTOCOL_VERSION,
             false,
@@ -4236,8 +4234,7 @@ mod tests {
         assert_eq!(raw_params.len(), 55);
 
         let new_tp =
-            TransportParams::decode(&mut raw_params, PROTOCOL_VERSION, true)
-                .unwrap();
+            TransportParams::decode(&raw_params, PROTOCOL_VERSION, true).unwrap();
 
         assert_eq!(new_tp, tp);
     }
@@ -4263,7 +4260,7 @@ mod tests {
         };
 
         let mut raw_params = [42; 256];
-        let mut raw_params = TransportParams::encode(
+        let raw_params = TransportParams::encode(
             &tp,
             PROTOCOL_VERSION_DRAFT25,
             true,
@@ -4272,12 +4269,9 @@ mod tests {
         .unwrap();
         assert_eq!(raw_params.len(), 101);
 
-        let new_tp = TransportParams::decode(
-            &mut raw_params,
-            PROTOCOL_VERSION_DRAFT25,
-            false,
-        )
-        .unwrap();
+        let new_tp =
+            TransportParams::decode(&raw_params, PROTOCOL_VERSION_DRAFT25, false)
+                .unwrap();
 
         assert_eq!(new_tp, tp);
 
@@ -4300,7 +4294,7 @@ mod tests {
         };
 
         let mut raw_params = [42; 256];
-        let mut raw_params = TransportParams::encode(
+        let raw_params = TransportParams::encode(
             &tp,
             PROTOCOL_VERSION_DRAFT25,
             false,
@@ -4309,12 +4303,9 @@ mod tests {
         .unwrap();
         assert_eq!(raw_params.len(), 81);
 
-        let new_tp = TransportParams::decode(
-            &mut raw_params,
-            PROTOCOL_VERSION_DRAFT25,
-            true,
-        )
-        .unwrap();
+        let new_tp =
+            TransportParams::decode(&raw_params, PROTOCOL_VERSION_DRAFT25, true)
+                .unwrap();
 
         assert_eq!(new_tp, tp);
     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -427,7 +427,7 @@ pub fn decrypt_hdr(
         first_buf.as_ref()[0]
     };
 
-    let mut pn_and_sample = b.peek_bytes(MAX_PKT_NUM_LEN + SAMPLE_LEN)?;
+    let mut pn_and_sample = b.peek_bytes_mut(MAX_PKT_NUM_LEN + SAMPLE_LEN)?;
 
     let (mut ciphertext, sample) =
         pn_and_sample.split_at(MAX_PKT_NUM_LEN).unwrap();
@@ -500,7 +500,7 @@ pub fn decode_pkt_num(largest_pn: u64, truncated_pn: u64, pn_len: usize) -> u64 
 pub fn decrypt_pkt<'a>(
     b: &'a mut octets::OctetsMut, pn: u64, pn_len: usize, payload_len: usize,
     aead: &crypto::Open,
-) -> Result<octets::OctetsMut<'a>> {
+) -> Result<octets::Octets<'a>> {
     let payload_offset = b.off();
 
     let (header, mut payload) = b.split_at(payload_offset)?;
@@ -509,7 +509,7 @@ pub fn decrypt_pkt<'a>(
         .checked_sub(pn_len)
         .ok_or(Error::InvalidPacket)?;
 
-    let mut ciphertext = payload.peek_bytes(payload_len)?;
+    let mut ciphertext = payload.peek_bytes_mut(payload_len)?;
 
     let payload_len =
         aead.open_with_u64_counter(pn, header.as_ref(), ciphertext.as_mut())?;

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -782,7 +782,7 @@ extern fn select_alpn(
         return 3; // SSL_TLSEXT_ERR_NOACK
     }
 
-    let mut protos = octets::Octets::with_slice(unsafe {
+    let mut protos = octets::OctetsMut::with_slice(unsafe {
         slice::from_raw_parts_mut(inp, in_len as usize)
     });
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -782,8 +782,8 @@ extern fn select_alpn(
         return 3; // SSL_TLSEXT_ERR_NOACK
     }
 
-    let mut protos = octets::OctetsMut::with_slice(unsafe {
-        slice::from_raw_parts_mut(inp, in_len as usize)
+    let mut protos = octets::Octets::with_slice(unsafe {
+        slice::from_raw_parts(inp, in_len as usize)
     });
 
     while let Ok(proto) = protos.get_bytes_with_u8_length() {


### PR DESCRIPTION
This changes the `octets` API into immutable and mutable variants of the same API. The main motivation for this is to avoid having to take mutable references to buffers when decoding read-only buffers (in most cases there's no reason to use mutable references other than the fact that the octets API forces it).

For example, when parsing transport parameters we get an immutable buffer from the BoringSSL API, so in order to use it with the octets API we currently need to clone it so that we can get a mutable reference. Though in general it's a good idea to use immutable references when the data doesn't actually need to be modified, which happens a lot.

The duplication in `octets.rs` is somewhat unfortunate, though I couldn't figure out a nice way to avoid it for now, but it can be improved later on.