### PR TITLE
qlog: fix flappy test

### DIFF
--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -2870,7 +2870,10 @@ mod tests {
         });
 
         // Some events hold frames, can't write any more events until frame
-        // writing is concluded.
+        // writing is concluded. Store event add time so that we can substitute
+        // it back into the qlog test output and avoid time-base flappiness.
+        let event_add_time =
+            format!("\"{}\"", s.start_time.elapsed().as_millis().to_string());
         assert!(match s.add_event(event2.clone()) {
             Ok(true) => true,
             _ => false,
@@ -2903,8 +2906,8 @@ mod tests {
         let r = s.writer();
         let w: &Box<std::io::Cursor<Vec<u8>>> = unsafe { std::mem::transmute(r) };
 
-        let log_string = r#"{"qlog_version":"version","title":"title","description":"description","traces":[{"vantage_point":{"type":"server"},"title":"Quiche qlog trace","description":"Quiche qlog trace description","configuration":{"time_units":"ms","time_offset":"0"},"event_fields":["relative_time","category","event","data"],"events":[["0","transport","packet_sent",{"packet_type":"handshake","header":{"packet_number":"0","packet_size":1251,"payload_length":1224,"version":"ff000018","scil":"8","dcil":"8","scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"frames":[{"frame_type":"stream","stream_id":"40","offset":"40","length":"400","fin":true}]}],["0","transport","packet_sent",{"packet_type":"initial","header":{"packet_number":"0","packet_size":1251,"payload_length":1224,"version":"ff000018","scil":"8","dcil":"8","scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"frames":[{"frame_type":"stream","stream_id":"0","offset":"0","length":"100","fin":true}]}]]}]}"#;
-
+        let log_string = r#"{"qlog_version":"version","title":"title","description":"description","traces":[{"vantage_point":{"type":"server"},"title":"Quiche qlog trace","description":"Quiche qlog trace description","configuration":{"time_units":"ms","time_offset":"0"},"event_fields":["relative_time","category","event","data"],"events":[["0","transport","packet_sent",{"packet_type":"handshake","header":{"packet_number":"0","packet_size":1251,"payload_length":1224,"version":"ff000018","scil":"8","dcil":"8","scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"frames":[{"frame_type":"stream","stream_id":"40","offset":"40","length":"400","fin":true}]}],[event_add_time,"transport","packet_sent",{"packet_type":"initial","header":{"packet_number":"0","packet_size":1251,"payload_length":1224,"version":"ff000018","scil":"8","dcil":"8","scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"frames":[{"frame_type":"stream","stream_id":"0","offset":"0","length":"100","fin":true}]}]]}]}"#;
+        let log_string = log_string.replace("event_add_time", &event_add_time);
         let written_string = std::str::from_utf8(w.as_ref().get_ref()).unwrap();
 
         assert_eq!(log_string, written_string);


### PR DESCRIPTION
The CI builds sometimes fail due to timing issues in the qlog tests.

The qlog serializer generates a relative event time when `add_event()` succeeds. I guess it takes the CI slightly longer to run through the test steps, which causes the event time to be greater than the expected value in the `log_string` variable.

The simplest solution is to sample the time just before the successful `add_event` call and hope it doesn't take 1 millisecond to run 2 lines of code. Then substitute the sample time back into the expect log string before the comarison with the generated log.