### PR TITLE
h3: add GOAWAY API

### DIFF
--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -258,6 +258,11 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
 
                 case QUICHE_H3_EVENT_DATAGRAM:
                     break;
+                    
+                case QUICHE_H3_EVENT_GOAWAY: {
+                    fprintf(stderr, "got GOAWAY\n");
+                    break;
+                }
             }
 
             quiche_h3_event_free(ev);

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -260,6 +260,10 @@ fn main() {
 
                     Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
 
+                    Ok((goaway_id, quiche::h3::Event::GoAway)) => {
+                        info!("GOAWAY id={}", goaway_id);
+                    },
+
                     Err(quiche::h3::Error::Done) => {
                         break;
                     },

--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -427,6 +427,11 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
 
                     case QUICHE_H3_EVENT_DATAGRAM:
                         break;
+
+                    case QUICHE_H3_EVENT_GOAWAY: {
+                        fprintf(stderr, "got GOAWAY\n");
+                        break;
+                    }
                 }
 
                 quiche_h3_event_free(ev);

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -359,6 +359,8 @@ fn main() {
 
                         Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
 
+                        Ok((_goaway_id, quiche::h3::Event::GoAway)) => (),
+
                         Err(quiche::h3::Error::Done) => {
                             break;
                         },

--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -1573,7 +1573,7 @@ new file mode 100644
 index 000000000..358a36528
 --- /dev/null
 +++ b/src/http/v3/ngx_http_v3.c
-@@ -0,0 +1,2231 @@
+@@ -0,0 +1,2234 @@
 +
 +/*
 + * Copyright (C) Cloudflare, Inc.
@@ -2035,6 +2035,9 @@ index 000000000..358a36528
 +            }
 +
 +            case QUICHE_H3_EVENT_DATAGRAM:
++                break;
++
++            case QUICHE_H3_EVENT_GOAWAY:
 +                break;
 +        }
 +

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -459,6 +459,7 @@ enum quiche_h3_event_type {
     QUICHE_H3_EVENT_DATA,
     QUICHE_H3_EVENT_FINISHED,
     QUICHE_H3_EVENT_DATAGRAM,
+    QUICHE_H3_EVENT_GOAWAY,
 };
 
 typedef struct Http3Event quiche_h3_event;

--- a/src/h3/ffi.rs
+++ b/src/h3/ffi.rs
@@ -113,6 +113,8 @@ pub extern fn quiche_h3_event_type(ev: &h3::Event) -> u32 {
         h3::Event::Finished { .. } => 2,
 
         h3::Event::Datagram { .. } => 3,
+
+        h3::Event::GoAway { .. } => 4,
     }
 }
 

--- a/src/h3/frame.rs
+++ b/src/h3/frame.rs
@@ -67,7 +67,7 @@ pub enum Frame {
     },
 
     GoAway {
-        stream_id: u64,
+        id: u64,
     },
 
     MaxPushId {
@@ -104,7 +104,7 @@ impl Frame {
                 parse_push_promise(payload_length, &mut b)?,
 
             GOAWAY_FRAME_TYPE_ID => Frame::GoAway {
-                stream_id: b.get_varint()?,
+                id: b.get_varint()?,
             },
 
             MAX_PUSH_FRAME_TYPE_ID => Frame::MaxPushId {
@@ -206,11 +206,11 @@ impl Frame {
                 b.put_bytes(header_block.as_ref())?;
             },
 
-            Frame::GoAway { stream_id } => {
+            Frame::GoAway { id } => {
                 b.put_varint(GOAWAY_FRAME_TYPE_ID)?;
-                b.put_varint(octets::varint_len(*stream_id) as u64)?;
+                b.put_varint(octets::varint_len(*id) as u64)?;
 
-                b.put_varint(*stream_id)?;
+                b.put_varint(*id)?;
             },
 
             Frame::MaxPushId { push_id } => {
@@ -263,8 +263,8 @@ impl std::fmt::Debug for Frame {
                 )?;
             },
 
-            Frame::GoAway { stream_id } => {
-                write!(f, "GOAWAY stream_id={}", stream_id)?;
+            Frame::GoAway { id } => {
+                write!(f, "GOAWAY id={}", id)?;
             },
 
             Frame::MaxPushId { push_id } => {
@@ -588,7 +588,7 @@ mod tests {
     fn goaway() {
         let mut d = [42; 128];
 
-        let frame = Frame::GoAway { stream_id: 32 };
+        let frame = Frame::GoAway { id: 32 };
 
         let frame_payload_len = 1;
         let frame_header_len = 2;

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -627,7 +627,7 @@ mod tests {
         let mut d = vec![42; 40];
         let mut b = octets::OctetsMut::with_slice(&mut d);
 
-        let goaway = frame::Frame::GoAway { stream_id: 0 };
+        let goaway = frame::Frame::GoAway { id: 0 };
 
         let settings = frame::Frame::Settings {
             max_header_list_size: Some(0),

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -275,6 +275,8 @@ pub fn run(
 
                     Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
 
+                    Ok((_goaway_id, quiche::h3::Event::GoAway)) => (),
+
                     Err(quiche::h3::Error::Done) => {
                         break;
                     },


### PR DESCRIPTION
**_NB this is mostly done, I just need to have another sanity check of the API and error conditions that we CAN detect._**

Previously, quiche did some basic GOAWAY frame reception validation
internally but did not expose a method to send GOAWAY, nor an event
to inform apps that a GOAWAY had been received.

On the sending side, this change adds the `send_goaway()` method
that an application can use to send a GOAWAY frame that informs the
peer of the intention to close the connection.

On the receiving side, this change adds the `h3::Event::GoAway`
event which is returned by `poll()`.

The GOAWAY frame contains an identifier field, which affects how an
application should continue using the HTTP/3 connection. This change
is based on the draft-28 version of GOAWAY, which permits
both endpoints to send GOAWAY. If a client receives the frame, it
MUST NOT issue requests with a larger stream ID than indicated. If
a server receives the frame, it MUST NOT issue a push.

Note that applications, not the quiche library, are responsible for
processing request and response messages. Therefore the application
must ensure that GOAWAYS are issued in a semantically valid way. For
instance, a server that sends GOAWAY for stream ID 100 commits to
processing all requests up to that stream ID, unless it explicitly
cancels them or further reduces the limit. An application that
processes requests on stream IDs beyond the limit will cause
problems that cannot be detected by quiche.