### PR TITLE
Added C ffi function to make set_qlog compatible with Windows

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -218,6 +218,10 @@ quiche_conn *quiche_conn_new_with_tls(const uint8_t *scid, size_t scid_len,
                                       quiche_config *config, void *ssl,
                                       bool is_server);
 
+// Enables qlog to the specified file path. Returns true on success.
+bool quiche_conn_set_qlog(quiche_conn *conn, const char * path,
+                          const char * log_title, const char * log_desc);
+
 // Enables qlog to the specified file descriptor. Unix only.
 void quiche_conn_set_qlog_fd(quiche_conn *conn, int fd, const char * log_title,
                              const char * log_desc);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -219,8 +219,8 @@ quiche_conn *quiche_conn_new_with_tls(const uint8_t *scid, size_t scid_len,
                                       bool is_server);
 
 // Enables qlog to the specified file path. Returns true on success.
-bool quiche_conn_set_qlog(quiche_conn *conn, const char * path,
-                          const char * log_title, const char * log_desc);
+bool quiche_conn_set_qlog_path(quiche_conn *conn, const char *path,
+                          const char *log_title, const char *log_desc);
 
 // Enables qlog to the specified file descriptor. Unix only.
 void quiche_conn_set_qlog_fd(quiche_conn *conn, int fd, const char * log_title,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -236,7 +236,7 @@ pub extern fn quiche_config_set_cc_algorithm(
 
 #[no_mangle]
 #[cfg(feature = "qlog")]
-pub extern fn quiche_conn_set_qlog(
+pub extern fn quiche_conn_set_qlog_path(
     conn: &mut Connection, path: *const c_char, log_title: *const c_char,
     log_desc: *const c_char,
 ) -> bool {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -243,7 +243,8 @@ pub extern fn quiche_conn_set_qlog(
     let filename = unsafe { ffi::CStr::from_ptr(path).to_str().unwrap() };
 
     let file_res = std::fs::OpenOptions::new()
-        .write(true).create_new(true)
+        .write(true)
+        .create_new(true)
         .open(filename);
 
     let writer = match file_res {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -235,6 +235,35 @@ pub extern fn quiche_config_set_cc_algorithm(
 }
 
 #[no_mangle]
+#[cfg(feature = "qlog")]
+pub extern fn quiche_conn_set_qlog(
+    conn: &mut Connection, path: *const c_char, log_title: *const c_char,
+    log_desc: *const c_char,
+) -> bool {
+    let filename = unsafe { ffi::CStr::from_ptr(path).to_str().unwrap() };
+
+    let file_res = std::fs::OpenOptions::new()
+        .write(true).create_new(true)
+        .open(filename);
+
+    let writer = match file_res {
+        Ok(f) => std::io::BufWriter::new(f),
+        Err(_) => return false,
+    };
+
+    let title = unsafe { ffi::CStr::from_ptr(log_title).to_str().unwrap() };
+    let description = unsafe { ffi::CStr::from_ptr(log_desc).to_str().unwrap() };
+
+    conn.set_qlog(
+        std::boxed::Box::new(writer),
+        title.to_string(),
+        format!("{} id={}", description, conn.trace_id),
+    );
+
+    true
+}
+
+#[no_mangle]
 #[cfg(all(unix, feature = "qlog"))]
 pub extern fn quiche_conn_set_qlog_fd(
     conn: &mut Connection, fd: c_int, log_title: *const c_char,


### PR DESCRIPTION
Adds a ffi function `quiche_conn_set_qlog` to call `Connection::set_qlog` from C.

Work heavily based on the implementation of `quiche_conn_set_qlog_fd`, but taking a file path as an input instead of a file descriptor, and being, in this way, compatible with non posix OSs (i.e. Windows).

Tested on Windows, Linux and MacOS.