### PR TITLE
quiche.h: ensure size_t and ssize_t are defined

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -33,6 +33,14 @@ extern "C" {
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
+#ifdef __unix__
+#include <sys/types.h>
+#endif
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+#define ssize_t SSIZE_T
+#endif
 
 // QUIC transport API.
 //


### PR DESCRIPTION
Ensure that check_symbol_exists calls in CMake do not fail due to
missing headers. The minimal reproducer can be stripped down to:

    echo '#include <quiche.h>' | gcc -Iinclude -fsyntax-only -xc -

A similar (untested) fix for Windows was taken from
https://github.com/cloudflare/quiche/issues/450