### PR TITLE
H3 stream priority

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -480,10 +480,16 @@ int64_t quiche_h3_send_request(quiche_h3_conn *conn, quiche_conn *quic_conn,
                                quiche_h3_header *headers, size_t headers_len,
                                bool fin);
 
-// Sends an HTTP/3 response on the specified stream.
+// Sends an HTTP/3 response on the specified stream with default priority.
 int quiche_h3_send_response(quiche_h3_conn *conn, quiche_conn *quic_conn,
                             uint64_t stream_id, quiche_h3_header *headers,
                             size_t headers_len, bool fin);
+
+// Sends an HTTP/3 response on the specified stream with specified priority.
+int quiche_h3_send_response_with_priority(quiche_h3_conn *conn,
+                            quiche_conn *quic_conn, uint64_t stream_id,
+                            quiche_h3_header *headers, size_t headers_len,
+                            const char *priority, bool fin);
 
 // Sends an HTTP/3 body chunk on the given stream.
 ssize_t quiche_h3_send_body(quiche_h3_conn *conn, quiche_conn *quic_conn,


### PR DESCRIPTION
This replaces #465.

It builds on top of #513, adding APIs to the H3 layer and setting the priority of the stream prior to sending any data on it. I've included the quiche commit from #465 so that the CI can run properly and allow anyone interested to test it out.

The quiche-client and quiche-server applications have been updated
to test this out. quiche-client can be run with e.g.
`-H "Priority:u=4,i"` to send a priority signal. quiche-server
process the Priority header (or assumes the default if none is
provided). It also supports a special query string syntax that
takes precedence over the header. For example, a client can send
`https://example.com?u=4&i=1` to indicate the priority as `u=1,i`. In this way,
multiple requests can be issued with different priorities, which makes for more
interesting test cases.