### PR TITLE
build: fix x86_64 iOS build on Xcode 10.1

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -118,9 +118,20 @@ fn get_boringssl_cmake_config() -> cmake::Config {
                 }
             }
 
-            // bitcode on
-            boringssl_cmake.define("CMAKE_ASM_FLAGS", "-fembed-bitcode");
-            boringssl_cmake.cflag("-fembed-bitcode");
+            // Bitcode is always on.
+            let bitcode_cflag = "-fembed-bitcode";
+
+            // Hack for Xcode 10.1.
+            let target_cflag = if arch == "x86_64" {
+                "-target x86_64-apple-ios-simulator"
+            } else {
+                ""
+            };
+
+            let cflag = format!("{} {}", bitcode_cflag, target_cflag);
+
+            boringssl_cmake.define("CMAKE_ASM_FLAGS", &cflag);
+            boringssl_cmake.cflag(&cflag);
 
             boringssl_cmake
         },


### PR DESCRIPTION
When we do `cargo lipo` on Xcode 10.1 (11.2 works fine),
it fails with the following error during BoringSSL build:

```
ld: in libcrypto.a(rdrand-x86_64.S.o), building for iOS Simulator,
but linking in object file built for iOS, for architecture x86_64
```

It looks like we need to have `-target x86_64-apple-ios-simulator`
compiler flag for both C/C++ and asm object not to confuse the linker.
This is not added by cmake so manually added in build.rs.

This hack works both Xcode 10.1 and 11.2 (confirmed by CI).
Fixes #515.