### PR TITLE
build: remove 32bit iOS support

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -33,14 +33,6 @@ const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
         ("CMAKE_OSX_ARCHITECTURES", "arm64"),
         ("CMAKE_OSX_SYSROOT", "iphoneos"),
     ]),
-    ("arm", &[
-        ("CMAKE_OSX_ARCHITECTURES", "arm"),
-        ("CMAKE_OSX_SYSROOT", "iphoneos"),
-    ]),
-    ("x86", &[
-        ("CMAKE_OSX_ARCHITECTURES", "x86"),
-        ("CMAKE_OSX_SYSROOT", "iphonesimulator"),
-    ]),
     ("x86_64", &[
         ("CMAKE_OSX_ARCHITECTURES", "x86_64"),
         ("CMAKE_OSX_SYSROOT", "iphonesimulator"),


### PR DESCRIPTION
32bit iOS target is demoted.

https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html