### PR TITLE
retransmit MAX_STREAM_DATA frame if lost

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1875,7 +1875,7 @@ impl Connection {
                     self.handshake_done_sent = false;
                 },
 
-                frame::Frame::MaxStreamData { stream_id, max: _ } => {
+                frame::Frame::MaxStreamData { stream_id, .. } => {
                     if self.streams.get(stream_id).is_some() {
                         self.streams.mark_almost_full(stream_id, true);
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1875,6 +1875,12 @@ impl Connection {
                     self.handshake_done_sent = false;
                 },
 
+                frame::Frame::MaxStreamData { stream_id, max: _ } => {
+                    if self.streams.get_mut(stream_id).is_some() {
+                        self.streams.mark_almost_full(stream_id, true);
+                    }
+                },
+
                 _ => (),
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1876,7 +1876,7 @@ impl Connection {
                 },
 
                 frame::Frame::MaxStreamData { stream_id, max: _ } => {
-                    if self.streams.get_mut(stream_id).is_some() {
+                    if self.streams.get(stream_id).is_some() {
                         self.streams.mark_almost_full(stream_id, true);
                     }
                 },


### PR DESCRIPTION
Currently we are not retransmitting MAX_STREAM_DATA frame so
when the client lost the packet containing MAX_STREAM_DATA,
the server doesn't know it can read more when it hits the
flow limit. In this case we can't transfer more on this
stream.

[quic-transport draft 13.3](https://www.ietf.org/id/draft-ietf-quic-transport-27.html#name-retransmission-of-informati) says that MAX_STREAM_DATA need to be
sent with updated value when the frame is lost.

In this PR we only cares about MAX_STREAM_DATA frame but
it seems like many frame types are not retransmitted properly.

Losing MAX_STREAM_DATA frame is more problematic than other
frames such as MAX_DATA because it's stream specific so when
we lost it there is no chance for the server to know unless
retransmitted.

For example MAX_DATA is frequently updated with other streams,
so there is more chance for the server to know when it was
bundled with other packet.

How to reproduce: I am able to reproduce with the following
environment:
- Server: `cargo run --release --bin quiche-server -- --root . --listen 0.0.0.0:4433`
- Client: `cargo run --release --bin quiche-client -- --no-verify --dump-responses tmp/ -n 80`

Client is MacOS Host and Server is linux VM in the same machine.