### PR TITLE
update the receiver flow control

### DIFF
--- a/src/flowcontrol.rs
+++ b/src/flowcontrol.rs
@@ -1,0 +1,202 @@
+// Copyright (C) 2020, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::time::Duration;
+use std::time::Instant;
+
+// When autotune the receiver window, how much we increase the window.
+const WINDOW_INCREASE_FACTOR: u64 = 2;
+
+// When autotune the receiver window, check if the last update is within RTT *
+// this constant.
+const WINDOW_TRIGGER_FACTOR: u32 = 2;
+
+#[derive(Default, Debug)]
+pub struct FlowControl {
+    /// Flow control limit.
+    max_data: u64,
+
+    /// The maximum receive window. This value is used for updating
+    /// flow control limit.
+    window: u64,
+
+    /// Last update time of max_data for autotuning the window.
+    last_update: Option<Instant>,
+}
+
+impl FlowControl {
+    pub fn new(max_data: u64, window: u64) -> Self {
+        Self {
+            max_data,
+
+            window,
+
+            last_update: None,
+        }
+    }
+
+    /// Returns the current window.
+    pub fn window(&self) -> u64 {
+        self.window
+    }
+
+    /// Returns the current max_data limit.
+    pub fn max_data(&self) -> u64 {
+        self.max_data
+    }
+
+    /// Returns true if the flow control needs to update max_data.
+    ///
+    /// This happens when the available window is smaller than the half
+    /// of the current window.
+    pub fn should_update_max_data(&self, consumed: u64) -> bool {
+        let available_window = self.max_data - consumed;
+
+        available_window < (self.window / 2)
+    }
+
+    /// Returns the new max_data limit.
+    pub fn max_data_next(&mut self, consumed: u64) -> u64 {
+        let available_window = self.max_data - consumed;
+
+        self.max_data + (self.window - available_window)
+    }
+
+    /// Commits the new max_data limit.
+    pub fn update_max_data(&mut self, consumed: u64, now: Instant) {
+        self.max_data = self.max_data_next(consumed);
+        self.last_update = Some(now);
+    }
+
+    /// Make sure the lower bound of the current window.
+    /// Returns true if the current window changed.
+    pub fn ensure_window_lower_bound(&mut self, min_window: u64) -> bool {
+        if min_window > self.window {
+            self.window = min_window;
+
+            return true;
+        }
+
+        false
+    }
+
+    /// Autotune the window size. When there is an another update
+    /// within RTT x 2, bump connection window x 1.5, capped by
+    /// max(stream window).
+    pub fn autotune_window(
+        &mut self, now: Instant, rtt: Duration, max_window: u64,
+    ) {
+        if let Some(last_update) = self.last_update {
+            if now - last_update < rtt * WINDOW_TRIGGER_FACTOR {
+                self.window = std::cmp::min(
+                    self.window * WINDOW_INCREASE_FACTOR,
+                    max_window,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_data() {
+        let fc = FlowControl::new(100, 20);
+
+        assert_eq!(fc.max_data(), 100);
+    }
+
+    #[test]
+    fn should_update_max_data() {
+        let fc = FlowControl::new(100, 20);
+
+        assert_eq!(fc.should_update_max_data(85), false);
+        assert_eq!(fc.should_update_max_data(95), true);
+    }
+
+    #[test]
+    fn max_data_next() {
+        let mut fc = FlowControl::new(100, 20);
+        let consumed = 95;
+
+        assert_eq!(fc.should_update_max_data(consumed), true);
+        assert_eq!(fc.max_data_next(consumed), consumed + 20);
+    }
+
+    #[test]
+    fn update_max_data() {
+        let mut fc = FlowControl::new(100, 20);
+        let consumed = 95;
+
+        assert_eq!(fc.should_update_max_data(consumed), true);
+
+        let max_data_next = fc.max_data_next(consumed);
+        assert_eq!(max_data_next, consumed + 20);
+
+        fc.update_max_data(consumed, Instant::now());
+        assert_eq!(fc.max_data(), max_data_next);
+    }
+
+    #[test]
+    fn ensure_window_lower_bound() {
+        let w = 20;
+        let mut fc = FlowControl::new(100, w);
+
+        // Lower than current window x 1.5 (30).
+        assert_eq!(fc.ensure_window_lower_bound(w), false);
+
+        // Higher than current window x 1.5 (30).
+        assert_eq!(fc.ensure_window_lower_bound(w * 2), true);
+    }
+
+    #[test]
+    fn autotune_window() {
+        let w = 20;
+        let mut fc = FlowControl::new(100, w);
+        let consumed = 95;
+
+        assert_eq!(fc.should_update_max_data(consumed), true);
+
+        let max_data_next = fc.max_data_next(consumed);
+        assert_eq!(max_data_next, consumed + w);
+
+        fc.update_max_data(consumed, Instant::now());
+        assert_eq!(fc.max_data(), max_data_next);
+
+        // Window size should be doubled.
+        fc.autotune_window(Instant::now(), Duration::from_millis(100), 100);
+
+        let w = w * 2;
+        let consumed = 110;
+
+        assert_eq!(fc.should_update_max_data(consumed), true);
+
+        let max_data_next = fc.max_data_next(consumed);
+        assert_eq!(max_data_next, consumed + w);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,6 +313,16 @@ const DEFAULT_MAX_DGRAM_QUEUE_LEN: usize = 0;
 // frames size. We enforce the recommendation for forward compatibility.
 const MAX_DGRAM_FRAME_SIZE: u64 = 65536;
 
+// The default size of the receiver connection flow control window.
+const DEFAULT_CONNECTION_WINDOW: u64 = 48 * 1024;
+
+// The maximum size of the receiver connection flow control window.
+const MAX_CONNECTION_WINDOW: u64 = 24 * 1024 * 1024;
+
+// How much larger the connection flow control window need to be larger than
+// the stream flow control window.
+const CONNECTION_WINDOW_FACTOR: f64 = 1.5;
+
 /// A specialized [`Result`] type for quiche operations.
 ///
 /// This type is used throughout quiche's public API for any operation that
@@ -812,12 +822,11 @@ pub struct Connection {
     /// Total number of bytes received from the peer.
     rx_data: u64,
 
-    /// Local flow control limit for the connection.
-    max_rx_data: u64,
+    /// Total number of bytes read from the application.
+    rx_data_consumed: u64,
 
-    /// Updated local flow control limit for the connection. This is used to
-    /// trigger sending MAX_DATA frames after a certain threshold.
-    max_rx_data_next: u64,
+    /// Receiver flow controller.
+    flow_control: flowcontrol::FlowControl,
 
     /// Whether we send MAX_DATA frame.
     almost_full: bool,
@@ -1160,8 +1169,11 @@ impl Connection {
             sent_count: 0,
 
             rx_data: 0,
-            max_rx_data,
-            max_rx_data_next: max_rx_data,
+            rx_data_consumed: 0,
+            flow_control: flowcontrol::FlowControl::new(
+                max_rx_data,
+                cmp::min(max_rx_data, DEFAULT_CONNECTION_WINDOW),
+            ),
             almost_full: false,
 
             tx_data: 0,
@@ -2174,36 +2186,9 @@ impl Connection {
                 }
             }
 
-            // Create MAX_DATA frame as needed.
-            if self.almost_full {
-                let frame = frame::Frame::MaxData {
-                    max: self.max_rx_data_next,
-                };
-
-                if push_frame_to_pkt!(frames, frame, payload_len, left) {
-                    self.almost_full = false;
-
-                    // Commits the new max_rx_data limit.
-                    self.max_rx_data = self.max_rx_data_next;
-
-                    ack_eliciting = true;
-                    in_flight = true;
-                }
-            }
-
-            // Create DATA_BLOCKED frame.
-            if let Some(limit) = self.blocked_limit {
-                let frame = frame::Frame::DataBlocked { limit };
-
-                if push_frame_to_pkt!(frames, frame, payload_len, left) {
-                    self.blocked_limit = None;
-
-                    ack_eliciting = true;
-                    in_flight = true;
-                }
-            }
-
             // Create MAX_STREAM_DATA frames as needed.
+            // MAX_DATA may need to be sent when updating MAX_STREAM_DATA,
+            // so we send update MAX_STREAM_DATA before MAX_DATA.
             for stream_id in self.streams.almost_full() {
                 let stream = match self.streams.get_mut(stream_id) {
                     Some(v) => v,
@@ -2216,6 +2201,9 @@ impl Connection {
                     },
                 };
 
+                // Autotune the stream window size.
+                stream.recv.autotune_window(now, self.recovery.rtt());
+
                 let frame = frame::Frame::MaxStreamData {
                     stream_id,
                     max: stream.recv.max_data_next(),
@@ -2224,7 +2212,43 @@ impl Connection {
                 if push_frame_to_pkt!(frames, frame, payload_len, left) {
                     stream.recv.update_max_data();
 
+                    // Make sure the connection window always has some
+                    // room compared to the stream window. If MAX_DATA
+                    // update is necessary, send a new one.
+                    if self.flow_control.ensure_window_lower_bound(
+                        (stream.recv.window() as f64 * CONNECTION_WINDOW_FACTOR)
+                            as u64,
+                    ) && self
+                        .flow_control
+                        .should_update_max_data(self.rx_data_consumed)
+                    {
+                        self.almost_full = true;
+                    }
+
                     self.streams.mark_almost_full(stream_id, false);
+
+                    ack_eliciting = true;
+                    in_flight = true;
+                }
+            }
+
+            // Create MAX_DATA frame as needed.
+            if self.almost_full {
+                // Autotune the maximum window size.
+                self.flow_control.autotune_window(
+                    now,
+                    self.recovery.rtt(),
+                    MAX_CONNECTION_WINDOW,
+                );
+
+                let frame = frame::Frame::MaxData {
+                    max: self.flow_control.max_data_next(self.rx_data_consumed),
+                };
+
+                if push_frame_to_pkt!(frames, frame, payload_len, left) {
+                    self.flow_control
+                        .update_max_data(self.rx_data_consumed, now);
+                    self.almost_full = false;
 
                     ack_eliciting = true;
                     in_flight = true;
@@ -2242,6 +2266,18 @@ impl Connection {
 
                 if push_frame_to_pkt!(frames, frame, payload_len, left) {
                     self.streams.mark_blocked(stream_id, false, 0);
+
+                    ack_eliciting = true;
+                    in_flight = true;
+                }
+            }
+
+            // Create DATA_BLOCKED frame as needed.
+            if let Some(limit) = self.blocked_limit {
+                let frame = frame::Frame::DataBlocked { limit };
+
+                if push_frame_to_pkt!(frames, frame, payload_len, left) {
+                    self.blocked_limit = None;
 
                     ack_eliciting = true;
                     in_flight = true;
@@ -2667,7 +2703,7 @@ impl Connection {
 
         let (read, fin) = stream.recv.pop(out)?;
 
-        self.max_rx_data_next = self.max_rx_data_next.saturating_add(read as u64);
+        self.rx_data_consumed = self.rx_data_consumed.saturating_add(read as u64);
 
         let readable = stream.is_readable();
 
@@ -2687,6 +2723,13 @@ impl Connection {
             self.streams.collect(stream_id, local);
         }
 
+        if self
+            .flow_control
+            .should_update_max_data(self.rx_data_consumed)
+        {
+            self.almost_full = true;
+        }
+
         qlog_with!(self.qlog_streamer, q, {
             let ev = qlog::event::Event::h3_data_moved(
                 stream_id.to_string(),
@@ -2698,10 +2741,6 @@ impl Connection {
             );
             q.add_event(ev).ok();
         });
-
-        if self.should_update_max_data() {
-            self.almost_full = true;
-        }
 
         Ok((read, fin))
     }
@@ -3622,7 +3661,7 @@ impl Connection {
 
                 self.rx_data += stream.recv.reset(final_size)? as u64;
 
-                if self.rx_data > self.max_rx_data {
+                if self.rx_data > self.flow_control.max_data() {
                     return Err(Error::FlowControl);
                 }
             },
@@ -3752,13 +3791,6 @@ impl Connection {
                     return Err(Error::InvalidStreamState);
                 }
 
-                // Check for flow control limits.
-                let data_len = data.len() as u64;
-
-                if self.rx_data + data_len > self.max_rx_data {
-                    return Err(Error::FlowControl);
-                }
-
                 // Get existing stream or create a new one, but if the stream
                 // has already been closed and collected, ignore the frame.
                 //
@@ -3777,13 +3809,18 @@ impl Connection {
                     Err(e) => return Err(e),
                 };
 
-                stream.recv.push(data)?;
+                let rx_inc = stream.recv.push(data)?;
 
                 if stream.is_readable() {
                     self.streams.mark_readable(stream_id, true);
                 }
 
-                self.rx_data += data_len;
+                // Check for the connection flow control limits.
+                if self.rx_data + rx_inc > self.flow_control.max_data() {
+                    return Err(Error::FlowControl);
+                }
+
+                self.rx_data = self.rx_data.saturating_add(rx_inc);
             },
 
             frame::Frame::MaxData { max } => {
@@ -3929,15 +3966,6 @@ impl Connection {
         );
 
         trace!("{} dropped epoch {} state", self.trace_id, epoch);
-    }
-
-    /// Returns true if the connection-level flow control needs to be updated.
-    ///
-    /// This happens when the new max data limit is at least double the amount
-    /// of data that can be received before blocking.
-    fn should_update_max_data(&self) -> bool {
-        self.max_rx_data_next != self.max_rx_data &&
-            self.max_rx_data_next / 2 > self.max_rx_data - self.rx_data
     }
 
     /// Returns the idle timeout value.
@@ -5207,6 +5235,14 @@ mod tests {
         // Ignore ACK.
         iter.next().unwrap();
 
+        // MAX_STREAM_DATA comes first and MAX_DATA comes later.
+        assert_eq!(
+            iter.next(),
+            Some(&frame::Frame::MaxStreamData {
+                stream_id: 4,
+                max: 30
+            })
+        );
         assert_eq!(iter.next(), Some(&frame::Frame::MaxData { max: 46 }));
     }
 
@@ -5260,7 +5296,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"aaaaaaa", 0, false),
+            data: stream::RangeBuf::from(b"aaaaaaaaa", 0, false),
         }];
 
         let pkt_type = packet::Type::Short;
@@ -5271,7 +5307,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"a", 7, false),
+            data: stream::RangeBuf::from(b"a", 9, false),
         }];
 
         let len = pipe
@@ -5291,7 +5327,7 @@ mod tests {
             iter.next(),
             Some(&frame::Frame::MaxStreamData {
                 stream_id: 4,
-                max: 22,
+                max: 24,
             })
         );
     }
@@ -7724,6 +7760,7 @@ pub use crate::stream::StreamIter;
 mod crypto;
 mod dgram;
 mod ffi;
+mod flowcontrol;
 mod frame;
 pub mod h3;
 mod minmax;


### PR DESCRIPTION
This PR is to adopt [Chromium's approach](https://docs.google.com/document/d/1F2YfdDXKpy20WVKJueEf4abn_LVZHhMUMS5gX6Pgjl4/edit?usp=sharing) for the receiver flow control.

### Problem

Currently we tend to send too many `MAX_DATA` and `MAX_STREAM_DATA` after
receiving multiple megabytes.
We use `should_update_max_data()` for deciding whether to send `MAX_DATA`.
However when `max_rx_data_next` is getting bigger, `max_rx_data - rx_data`
is close to BDP (constant), so this function will return true
for most of the time later in the connection. `MAX_STREAM_DATA` has
same problem. You can compare the behavior with other implementations
[here](https://qlog.edm.uhasselt.be/epiq/).

### Fix

`flowcontrol.rs` contains a common framework for flow control updates.

Basically, the concept is to keep a `window` / 2 between the consumed
data offset and `max_data`. When the gap is smaller than window / 2,
we update `MAX_DATA` frame. Same applies to the stream updating
`MAX_STREAM_DATA`.

Auto-tuning of the window is also implemented. When `window`
update keeps happening within 2 x rtt, double `window` value.
By this `window` will be close to the actual BDP. Note that
the window only grows, not shrinks.

Also, make sure the connection window is always 1.5x higher
than any of the stream window. This is for making sure that
the connection flow limit is not a blocker for the stream
to grow. This is from [Chromium code](https://source.chromium.org/chromium/chromium/src/+/master:net/third_party/quiche/src/quic/core/quic_flow_controller.h;bpv=1;bpt=1;l=142?q=flowcontrol&ss=chromium%2Fchromium%2Fsrc&originalUrl=https:%2F%2Fcs.chromium.org%2F).

`RecvBuf.push()` now returns the increased size of the last offset,
which will be used for updating `rx_data`. This is actually a bug fix.
Previously we increased `rx_data` by the size of the data received,
however when the data has an overlap (e.g. duplicate packet) or
a hole in the receive buffer (server send "12345" and client received "5" and "2")
we should not increase `rx_data`. Also `rx_data_consumed` is added for
tracking `rx_data` offset consumed by the application.

### Result

#### 5 Mbytes x 10 requests

While no error in flow control, here is the number of
`MAX_DATA` and `MAX_STREAM_DATA` frame sent during the connection with
5 Mbytes x 10 requests (`quiche-client -n 10 https://.../5MB.png`):

- master branch
  - MAX_DATA 9955
  - MAX_STREAM_DATA 31695
- This branch
  - MAX_DATA 21
  - MAX_STREAM_DATA 385

This PR can reduce the flow control updates -- almost 1/100 of master branch.

#### 16 Mbytes x 1 request

Also when you take qvis, you can see the difference of the flow control update. This is 16Mbytes test in the [blog post](https://blog.cloudflare.com/cubic-and-hystart-support-in-quiche/).

Frames sent:
- master branch
  - MAX_DATA 6484
  - MAX_STREAM_DATA 15195
- This branch
  - MAX_DATA 19
  - MAX_STREAM_DATA 73

qvis:
master branch: `MAX_DATA` grows too fast and `MAX_STREAM_DATA` updates more often.
![cubic-hs-master](https://blog-cloudflare-com-assets.storage.googleapis.com/2020/05/cubic-hs.png)

This branch: `MAX_DATA` and `MAX_STREAM_DATA` only start to grow when passing its default value and follows the data received. Also it increases like the staircase.
![cubic-hs-829](https://user-images.githubusercontent.com/1229714/82389752-cafd7e00-99f1-11ea-8892-9e681d2ab0e1.png)

