### PR TITLE
tls: write SSLKEYLOGFILE line in one syscall

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -758,10 +758,10 @@ extern fn keylog(_: *mut SSL, line: *const c_char) {
 
         if let Ok(mut file) = file {
             let data = unsafe { ffi::CStr::from_ptr(line).to_bytes() };
-
-            file.write_all(b"QUIC_").unwrap_or(());
-            file.write_all(data).unwrap_or(());
-            file.write_all(b"\n").unwrap_or(());
+            let mut full_line = Vec::with_capacity(data.len() + 1);
+            full_line.extend_from_slice(data);
+            full_line.push(b'\n');
+            file.write_all(&full_line[..]).unwrap_or(());
         }
     }
 }


### PR DESCRIPTION
 * Write the key log line and LF in one go to avoid problems with
   multiple interleaving applications.
 * Drop the "QUIC_" prefix, since draft-ietf-quic-tls-17 the same HKDF
   label from TLS 1.3 is in use. Wireshark v3.1.0rc0-836-gcc50ec3634
   supports both, but the "QUIC_" variant is deprecated.