### PR TITLE
apps: handling h3::Error::Done

### DIFF
--- a/tools/apps/src/lib.rs
+++ b/tools/apps/src/lib.rs
@@ -955,6 +955,8 @@ impl HttpConn for Http3Conn {
                     {
                         Ok(v) => v,
 
+                        Err(quiche::h3::Error::Done) => 0,
+
                         Err(e) => {
                             error!(
                                 "{} stream send failed {:?}",
@@ -1035,6 +1037,10 @@ impl HttpConn for Http3Conn {
 
         let written = match self.h3_conn.send_body(conn, stream_id, body, true) {
             Ok(v) => v,
+
+            Err(quiche::h3::Error::Done) => {
+                return;
+            },
 
             Err(e) => {
                 error!("{} stream send failed {:?}", conn.trace_id(), e);


### PR DESCRIPTION
When running quiche-server I got the following message pretty often
when the session hit the bandwidth limit.

```
[2020-05-19T06:34:28.655009788Z ERROR quiche_apps] 8e01440c13c8788bacc6b0c12265cc4210bafc05 stream send failed Done
```

However, all transfer was normal and this seems not an actual error,
so I think it's safe to ignore this error(`quiche::h3::Error::Done`).