### PR TITLE
CI: disable nightly rustfmt (tmp)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,28 +62,28 @@ matrix:
       - eval "$(gimme stable)"
       - gimme --list
      install:
-      - rustup component add rustfmt
+      #- rustup component add rustfmt
       - cargo install cargo-fuzz
      script:
       - RUSTFLAGS="-D warnings" cargo test --verbose
       - RUSTFLAGS="-D warnings" cargo package --verbose --allow-dirty
-      - cargo fmt -- --check
+      #- cargo fmt -- --check
       - cargo doc --no-deps
       - make -C examples
       # fuzzers
       - RUSTFLAGS="-D warnings" cargo fuzz run packet_recv_client -- -runs=1
       - RUSTFLAGS="-D warnings" cargo fuzz run packet_recv_server -- -runs=1
       - RUSTFLAGS="-D warnings" cargo fuzz run qpack_decode -- -runs=1
-      - cargo fmt --manifest-path fuzz/Cargo.toml -- --check
+      #- cargo fmt --manifest-path fuzz/Cargo.toml -- --check
       # http3_test
       - RUSTFLAGS="-D warnings" cargo test --no-run --verbose --manifest-path tools/http3_test/Cargo.toml
-      - cargo fmt --manifest-path tools/http3_test/Cargo.toml -- --check
+      #- cargo fmt --manifest-path tools/http3_test/Cargo.toml -- --check
       # qlog
       - RUSTFLAGS="-D warnings" cargo test --verbose --manifest-path tools/qlog/Cargo.toml
-      - cargo fmt --manifest-path tools/qlog/Cargo.toml -- --check
+      #- cargo fmt --manifest-path tools/qlog/Cargo.toml -- --check
       # quiche-apps
       - RUSTFLAGS="-D warnings" cargo build --verbose --manifest-path tools/apps/Cargo.toml
-      - cargo fmt --manifest-path tools/apps/Cargo.toml -- --check
+      #- cargo fmt --manifest-path tools/apps/Cargo.toml -- --check
    - name: "stable macOS + iOS"
      language: rust
      rust: stable


### PR DESCRIPTION
Since nightly rustfmt is not coming back a week, disable it
temporarily.

https://rust-lang.github.io/rustup-components-history/