### PR TITLE
improve keylog API

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -226,13 +226,19 @@ quiche_conn *quiche_conn_new_with_tls(const uint8_t *scid, size_t scid_len,
                                       quiche_config *config, void *ssl,
                                       bool is_server);
 
+// Enables keylog to the specified file path. Returns true on success.
+bool quiche_conn_set_keylog_path(quiche_conn *conn, const char *path);
+
+// Enables keylog to the specified file descriptor. Unix only.
+void quiche_conn_set_keylog_fd(quiche_conn *conn, int fd);
+
 // Enables qlog to the specified file path. Returns true on success.
 bool quiche_conn_set_qlog_path(quiche_conn *conn, const char *path,
                           const char *log_title, const char *log_desc);
 
 // Enables qlog to the specified file descriptor. Unix only.
-void quiche_conn_set_qlog_fd(quiche_conn *conn, int fd, const char * log_title,
-                             const char * log_desc);
+void quiche_conn_set_qlog_fd(quiche_conn *conn, int fd, const char *log_title,
+                             const char *log_desc);
 
 // Processes QUIC packets received from the peer.
 ssize_t quiche_conn_recv(quiche_conn *conn, uint8_t *buf, size_t buf_len);

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -28,8 +28,6 @@ use std::ffi;
 use std::ptr;
 use std::slice;
 
-use std::io::prelude::*;
-
 use libc::c_char;
 use libc::c_int;
 use libc::c_long;
@@ -751,20 +749,22 @@ extern fn send_alert(ssl: *mut SSL, level: crypto::Level, alert: u8) -> c_int {
     1
 }
 
-extern fn keylog(_: *mut SSL, line: *const c_char) {
-    if let Some(path) = std::env::var_os("SSLKEYLOGFILE") {
-        let file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path);
+extern fn keylog(ssl: *mut SSL, line: *const c_char) {
+    let conn =
+        match get_ex_data_from_ptr::<Connection>(ssl, *QUICHE_EX_DATA_INDEX) {
+            Some(v) => v,
 
-        if let Ok(mut file) = file {
-            let data = unsafe { ffi::CStr::from_ptr(line).to_bytes() };
-            let mut full_line = Vec::with_capacity(data.len() + 1);
-            full_line.extend_from_slice(data);
-            full_line.push(b'\n');
-            file.write_all(&full_line[..]).unwrap_or(());
-        }
+            None => return,
+        };
+
+    if let Some(keylog) = &mut conn.keylog {
+        let data = unsafe { ffi::CStr::from_ptr(line).to_bytes() };
+
+        let mut full_line = Vec::with_capacity(data.len() + 1);
+        full_line.extend_from_slice(data);
+        full_line.push(b'\n');
+
+        keylog.write_all(&full_line[..]).ok();
     }
 }
 


### PR DESCRIPTION
When an application enables key logging in the Config object, quiche
will automatically read the SSLKEYLOGFILE variable and create the
corresponding file to log to.

However this is slightly dangerous as the application is not necessarily
in control of the environment variable, so keys might accidentally end
up being logged without the application saying so. And it generally
doesn't seem to be good form for a library to depend on environment
variables.

The current API is also not very flexible, as it only allows
applications to log to files, and doesn't allow enabling/disabling
logging on a per-connection basis.

So, in addition to calling `log_keys()` on the Config object,
applications now also need to call the `set_keylog()` method on each
connection they wish to log keys for, passing the `Writer` object that
will receive the actual data from quiche.