### PR TITLE
Make minmax filter implementation generic

### DIFF
--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -305,7 +305,6 @@ mod tests {
         assert_eq!(f.estimate[2].value, bw_200);
     }
 
-
     #[test]
     fn get_windowed_min_estimates_rtt() {
         let mut f = Minmax::new(Duration::new(0, 0));
@@ -370,7 +369,6 @@ mod tests {
         assert_eq!(f.estimate[2].value, bw_200);
     }
 
-
     #[test]
     fn get_windowed_max_estimates_rtt() {
         let mut f = Minmax::new(Duration::new(0, 0));
@@ -433,5 +431,5 @@ mod tests {
         assert_eq!(bw_max, bw_600);
         assert_eq!(f.estimate[1].value, bw_600);
         assert_eq!(f.estimate[2].value, bw_600);
-   }
+    }
 }

--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -56,27 +56,27 @@ use std::time::Duration;
 use std::time::Instant;
 
 #[derive(Copy, Clone)]
-struct MinmaxSample {
+struct MinmaxSample<T> {
     time: Instant,
-    value: Duration,
+    value: T,
 }
 
-pub struct Minmax {
-    estimate: [MinmaxSample; 3],
+pub struct Minmax<T> {
+    estimate: [MinmaxSample<T>; 3],
 }
 
-impl Minmax {
-    pub fn new() -> Self {
+impl<T: PartialOrd + Copy> Minmax<T> {
+    pub fn new(val: T) -> Self {
         Minmax {
             estimate: [MinmaxSample {
                 time: Instant::now(),
-                value: Duration::new(0, 0),
+                value: val,
             }; 3],
         }
     }
 
     /// Resets the estimates to the given value.
-    pub fn reset(&mut self, time: Instant, meas: Duration) -> Duration {
+    pub fn reset(&mut self, time: Instant, meas: T) -> T {
         let val = MinmaxSample { time, value: meas };
 
         for i in self.estimate.iter_mut() {
@@ -87,9 +87,7 @@ impl Minmax {
     }
 
     /// Updates the min estimate based on the given measurement, and returns it.
-    pub fn running_min(
-        &mut self, win: Duration, time: Instant, meas: Duration,
-    ) -> Duration {
+    pub fn running_min(&mut self, win: Duration, time: Instant, meas: T) -> T {
         let val = MinmaxSample { time, value: meas };
 
         let delta_time = time.duration_since(self.estimate[2].time);
@@ -110,9 +108,7 @@ impl Minmax {
     }
 
     /// Updates the max estimate based on the given measurement, and returns it.
-    pub fn _running_max(
-        &mut self, win: Duration, time: Instant, meas: Duration,
-    ) -> Duration {
+    pub fn _running_max(&mut self, win: Duration, time: Instant, meas: T) -> T {
         let val = MinmaxSample { time, value: meas };
 
         let delta_time = time.duration_since(self.estimate[2].time);
@@ -133,9 +129,7 @@ impl Minmax {
     }
 
     /// As time advances, update the 1st, 2nd and 3rd estimates.
-    fn subwin_update(
-        &mut self, win: Duration, time: Instant, meas: Duration,
-    ) -> Duration {
+    fn subwin_update(&mut self, win: Duration, time: Instant, meas: T) -> T {
         let val = MinmaxSample { time, value: meas };
 
         let delta_time = time.duration_since(self.estimate[0].time);
@@ -178,8 +172,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn reset_filter() {
-        let mut f = Minmax::new();
+    fn reset_filter_rtt() {
+        let mut f = Minmax::new(Duration::new(0, 0));
         let now = Instant::now();
         let rtt = Duration::from_millis(50);
 
@@ -197,8 +191,27 @@ mod tests {
     }
 
     #[test]
-    fn get_windowed_min() {
-        let mut f = Minmax::new();
+    fn reset_filter_bandwidth() {
+        let mut f = Minmax::new(0);
+        let now = Instant::now();
+        let bw = 2000;
+
+        let bw_min = f.reset(now, bw);
+        assert_eq!(bw_min, bw);
+
+        assert_eq!(f.estimate[0].time, now);
+        assert_eq!(f.estimate[0].value, bw);
+
+        assert_eq!(f.estimate[1].time, now);
+        assert_eq!(f.estimate[1].value, bw);
+
+        assert_eq!(f.estimate[2].time, now);
+        assert_eq!(f.estimate[2].value, bw);
+    }
+
+    #[test]
+    fn get_windowed_min_rtt() {
+        let mut f = Minmax::new(Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let win = Duration::from_millis(500);
@@ -221,8 +234,32 @@ mod tests {
     }
 
     #[test]
-    fn get_windowed_max() {
-        let mut f = Minmax::new();
+    fn get_windowed_min_bandwidth() {
+        let mut f = Minmax::new(0);
+        let bw_200 = 200;
+        let bw_500 = 500;
+        let win = Duration::from_millis(500);
+        let mut time = Instant::now();
+
+        let mut bw_min = f.reset(time, bw_500);
+        assert_eq!(bw_min, bw_500);
+
+        time += Duration::from_millis(250);
+        bw_min = f.running_min(win, time, bw_200);
+        assert_eq!(bw_min, bw_200);
+        assert_eq!(f.estimate[1].value, bw_200);
+        assert_eq!(f.estimate[2].value, bw_200);
+
+        time += Duration::from_millis(600);
+        bw_min = f.running_min(win, time, bw_500);
+        assert_eq!(bw_min, bw_500);
+        assert_eq!(f.estimate[1].value, bw_500);
+        assert_eq!(f.estimate[2].value, bw_500);
+    }
+
+    #[test]
+    fn get_windowed_max_rtt() {
+        let mut f = Minmax::new(Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let win = Duration::from_millis(500);
@@ -245,8 +282,33 @@ mod tests {
     }
 
     #[test]
-    fn get_windowed_min_estimates() {
-        let mut f = Minmax::new();
+    fn get_windowed_max_bandwidth() {
+        let mut f = Minmax::new(0);
+        let bw_200 = 200;
+        let bw_500 = 500;
+        let win = Duration::from_millis(500);
+        let mut time = Instant::now();
+
+        let mut bw_max = f.reset(time, bw_200);
+        assert_eq!(bw_max, bw_200);
+
+        time += Duration::from_millis(5000);
+        bw_max = f._running_max(win, time, bw_500);
+        assert_eq!(bw_max, bw_500);
+        assert_eq!(f.estimate[1].value, bw_500);
+        assert_eq!(f.estimate[2].value, bw_500);
+
+        time += Duration::from_millis(600);
+        bw_max = f._running_max(win, time, bw_200);
+        assert_eq!(bw_max, bw_200);
+        assert_eq!(f.estimate[1].value, bw_200);
+        assert_eq!(f.estimate[2].value, bw_200);
+    }
+
+
+    #[test]
+    fn get_windowed_min_estimates_rtt() {
+        let mut f = Minmax::new(Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let rtt_23 = Duration::from_millis(23);
@@ -277,8 +339,41 @@ mod tests {
     }
 
     #[test]
-    fn get_windowed_max_estimates() {
-        let mut f = Minmax::new();
+    fn get_windowed_min_estimates_bandwidth() {
+        let mut f = Minmax::new(0);
+        let bw_500 = 500;
+        let bw_400 = 400;
+        let bw_300 = 300;
+        let bw_200 = 200;
+        let win = Duration::from_secs(1);
+        let mut time = Instant::now();
+
+        let mut bw_min = f.reset(time, bw_300);
+        assert_eq!(bw_min, bw_300);
+
+        time += Duration::from_millis(300);
+        bw_min = f.running_min(win, time, bw_400);
+        assert_eq!(bw_min, bw_300);
+        assert_eq!(f.estimate[1].value, bw_400);
+        assert_eq!(f.estimate[2].value, bw_400);
+
+        time += Duration::from_millis(300);
+        bw_min = f.running_min(win, time, bw_500);
+        assert_eq!(bw_min, bw_300);
+        assert_eq!(f.estimate[1].value, bw_400);
+        assert_eq!(f.estimate[2].value, bw_500);
+
+        time += Duration::from_millis(300);
+        bw_min = f.running_min(win, time, bw_200);
+        assert_eq!(bw_min, bw_200);
+        assert_eq!(f.estimate[1].value, bw_200);
+        assert_eq!(f.estimate[2].value, bw_200);
+    }
+
+
+    #[test]
+    fn get_windowed_max_estimates_rtt() {
+        let mut f = Minmax::new(Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let rtt_23 = Duration::from_millis(23);
@@ -307,4 +402,36 @@ mod tests {
         assert_eq!(f.estimate[1].value, rtt_26);
         assert_eq!(f.estimate[2].value, rtt_26);
     }
+
+    #[test]
+    fn get_windowed_max_estimates_bandwidth() {
+        let mut f = Minmax::new(0);
+        let bw_500 = 500;
+        let bw_400 = 400;
+        let bw_300 = 300;
+        let bw_600 = 600;
+        let win = Duration::from_secs(1);
+        let mut time = Instant::now();
+
+        let mut bw_max = f.reset(time, bw_500);
+        assert_eq!(bw_max, bw_500);
+
+        time += Duration::from_millis(300);
+        bw_max = f._running_max(win, time, bw_400);
+        assert_eq!(bw_max, bw_500);
+        assert_eq!(f.estimate[1].value, bw_400);
+        assert_eq!(f.estimate[2].value, bw_400);
+
+        time += Duration::from_millis(300);
+        bw_max = f._running_max(win, time, bw_300);
+        assert_eq!(bw_max, bw_500);
+        assert_eq!(f.estimate[1].value, bw_400);
+        assert_eq!(f.estimate[2].value, bw_300);
+
+        time += Duration::from_millis(300);
+        bw_max = f._running_max(win, time, bw_600);
+        assert_eq!(bw_max, bw_600);
+        assert_eq!(f.estimate[1].value, bw_600);
+        assert_eq!(f.estimate[2].value, bw_600);
+   }
 }

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -83,7 +83,7 @@ pub struct Recovery {
 
     rttvar: Duration,
 
-    minmax_filter: minmax::Minmax,
+    minmax_filter: minmax::Minmax<Duration>,
 
     min_rtt: Duration,
 
@@ -139,7 +139,7 @@ impl Recovery {
 
             smoothed_rtt: None,
 
-            minmax_filter: minmax::Minmax::new(),
+            minmax_filter: minmax::Minmax::new(Duration::new(0, 0)),
 
             min_rtt: Duration::new(0, 0),
 


### PR DESCRIPTION
Making this minmax filter implementation generic so that it can be used to get filtered minmax bandwidth for BBR implementation.