### PR TITLE
packet: support Retry with older versions too

### DIFF
--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -290,7 +290,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                                                dcid, dcid_len,
                                                dcid, dcid_len,
                                                token, token_len,
-                                               out, sizeof(out));
+                                               version, out, sizeof(out));
 
                 if (written < 0) {
                     fprintf(stderr, "failed to create retry packet: %zd\n",

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -219,9 +219,15 @@ fn main() {
                     let new_token = mint_token(&hdr, &src);
 
                     let len = quiche::retry(
-                        &hdr.scid, &hdr.dcid, &scid, &new_token, &mut out,
+                        &hdr.scid,
+                        &hdr.dcid,
+                        &scid,
+                        &new_token,
+                        hdr.version,
+                        &mut out,
                     )
                     .unwrap();
+
                     let out = &out[..len];
 
                     if let Err(e) = socket.send_to(out, &src) {

--- a/examples/server.c
+++ b/examples/server.c
@@ -278,7 +278,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                                                dcid, dcid_len,
                                                dcid, dcid_len,
                                                token, token_len,
-                                               out, sizeof(out));
+                                               version, out, sizeof(out));
 
                 if (written < 0) {
                     fprintf(stderr, "failed to create retry packet: %zd\n",

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -213,7 +213,12 @@ fn main() {
                     let new_token = mint_token(&hdr, &src);
 
                     let len = quiche::retry(
-                        &hdr.scid, &hdr.dcid, &scid, &new_token, &mut out,
+                        &hdr.scid,
+                        &hdr.dcid,
+                        &scid,
+                        &new_token,
+                        hdr.version,
+                        &mut out,
                     )
                     .unwrap();
 

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -216,7 +216,7 @@ ssize_t quiche_retry(const uint8_t *scid, size_t scid_len,
                      const uint8_t *dcid, size_t dcid_len,
                      const uint8_t *new_scid, size_t new_scid_len,
                      const uint8_t *token, size_t token_len,
-                     uint8_t *out, size_t out_len);
+                     uint32_t version, uint8_t *out, size_t out_len);
 
 // Returns true if the given protocol version is supported.
 bool quiche_version_is_supported(uint32_t version);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -376,7 +376,7 @@ pub extern fn quiche_version_is_supported(version: u32) -> bool {
 pub extern fn quiche_retry(
     scid: *const u8, scid_len: size_t, dcid: *const u8, dcid_len: size_t,
     new_scid: *const u8, new_scid_len: size_t, token: *const u8,
-    token_len: size_t, out: *mut u8, out_len: size_t,
+    token_len: size_t, version: u32, out: *mut u8, out_len: size_t,
 ) -> ssize_t {
     let scid = unsafe { slice::from_raw_parts(scid, scid_len) };
     let dcid = unsafe { slice::from_raw_parts(dcid, dcid_len) };
@@ -384,7 +384,7 @@ pub extern fn quiche_retry(
     let token = unsafe { slice::from_raw_parts(token, token_len) };
     let out = unsafe { slice::from_raw_parts_mut(out, out_len) };
 
-    match retry(scid, dcid, new_scid, token, out) {
+    match retry(scid, dcid, new_scid, token, version, out) {
         Ok(v) => v as ssize_t,
 
         Err(e) => e.to_c(),

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -266,9 +266,15 @@ fn main() {
                         let new_token = mint_token(&hdr, &src);
 
                         let len = quiche::retry(
-                            &hdr.scid, &hdr.dcid, &scid, &new_token, &mut out,
+                            &hdr.scid,
+                            &hdr.dcid,
+                            &scid,
+                            &new_token,
+                            hdr.version,
+                            &mut out,
                         )
                         .unwrap();
+
                         let out = &out[..len];
 
                         if let Err(e) = socket.send_to(out, &src) {


### PR DESCRIPTION
I realized that until other implementations update to draft-29 we will
fail the Retry tests, so we might as well do this now.

It's mostly just a matter of propagating the version from the public API
exposed to applications, down to where the retry integrity tag is
generated.