### PR TITLE
travis: pin Rust nightly version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
       - make docker-build
    - name: "nightly Linux x86_64"
      language: rust
-     rust: nightly
+     rust: nightly-2020-06-10
      addons:
        apt:
          packages:


### PR DESCRIPTION
rustfmt is yet again broken in the latest nightly, so pin the rust
version to the last known good one.

Can revert once https://github.com/rust-lang/rust/issues/73200 is fixed.