### PR TITLE
apps: increase max idle timeout

### DIFF
--- a/tools/apps/src/bin/quiche-client.rs
+++ b/tools/apps/src/bin/quiche-client.rs
@@ -113,7 +113,7 @@ fn main() {
 
     config.set_application_protos(&conn_args.alpns).unwrap();
 
-    config.set_max_idle_timeout(5000);
+    config.set_max_idle_timeout(30000);
     config.set_max_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(conn_args.max_data);
     config.set_initial_max_stream_data_bidi_local(conn_args.max_stream_data);

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -101,7 +101,7 @@ fn main() {
 
     config.set_application_protos(&conn_args.alpns).unwrap();
 
-    config.set_max_idle_timeout(5000);
+    config.set_max_idle_timeout(30000);
     config.set_max_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(conn_args.max_data);
     config.set_initial_max_stream_data_bidi_local(conn_args.max_stream_data);


### PR DESCRIPTION
Other implementations running in the interop runner have higher timeouts
which kind of puts us at a disadvantage.

In the future we might want to make this configurable, but for now there
is not much point.