### PR TITLE
try to retransmit old frames on PTO

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2340,7 +2340,46 @@ impl Connection {
             }
         }
 
-        // Create PING for PTO probe.
+        // Try to retransmit old frames on PTO, if there is space left.
+        if self.recovery.loss_probes[epoch] > 0 &&
+            left > cmp::min(
+                frame::MAX_CRYPTO_OVERHEAD,
+                frame::MAX_STREAM_OVERHEAD,
+            ) &&
+            !is_closing
+        {
+            let unacked_iter = self.recovery.sent[epoch]
+                .iter_mut()
+                // Skip packets that have already been acked or lost and packets
+                // that are not in-flight.
+                .filter(|p| p.in_flight && p.time_acked.is_none() && p.time_lost.is_none());
+
+            'unacked_iter: for unacked in unacked_iter {
+                for frame in &unacked.frames {
+                    // Only retransmit CRYPTO and STREAM frames.
+                    match frame {
+                        frame::Frame::Crypto { .. } |
+                        frame::Frame::Stream { .. } => (),
+
+                        _ => continue,
+                    }
+
+                    // Skip frame if it's too big.
+                    if left < frame.wire_len() {
+                        break 'unacked_iter;
+                    }
+
+                    push_frame_to_pkt!(frames, frame.clone(), payload_len, left);
+
+                    ack_eliciting = true;
+                    in_flight = true;
+
+                    break 'unacked_iter;
+                }
+            }
+        }
+
+        // Create PING for PTO probe if no other ack-elicitng frame is sent.
         if self.recovery.loss_probes[epoch] > 0 &&
             !ack_eliciting &&
             left >= 1 &&
@@ -6881,6 +6920,49 @@ mod tests {
         );
 
         assert_eq!(pipe.server.send(&mut buf), Err(Error::Done));
+    }
+
+    #[test]
+    /// Tests that old data is retransmitted on PTO.
+    fn early_retransmit() {
+        let mut buf = [0; 65535];
+
+        let mut pipe = testing::Pipe::default().unwrap();
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+
+        // Client sends stream data.
+        assert_eq!(pipe.client.stream_send(0, b"a", false), Ok(1));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        // Client sends more stream data, but packet is lost
+        assert_eq!(pipe.client.stream_send(4, b"b", false), Ok(1));
+        assert!(pipe.client.send(&mut buf).is_ok());
+
+        // Wait until PTO expires. Since the RTT is very low, wait a bit more.
+        let timer = pipe.client.timeout().unwrap();
+        std::thread::sleep(timer + time::Duration::from_millis(1));
+
+        pipe.client.on_timeout();
+
+        let epoch = packet::EPOCH_APPLICATION;
+        assert_eq!(pipe.client.recovery.loss_probes[epoch], 2);
+
+        // Client retransmits stream data in PTO probe.
+        let len = pipe.client.send(&mut buf).unwrap();
+
+        let epoch = packet::EPOCH_APPLICATION;
+        assert_eq!(pipe.client.recovery.loss_probes[epoch], 1);
+
+        let frames =
+            testing::decode_pkt(&mut pipe.server, &mut buf, len).unwrap();
+
+        assert_eq!(
+            frames.iter().next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 4,
+                data: stream::RangeBuf::from(b"b", 0, false),
+            })
+        );
     }
 }
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -91,7 +91,7 @@ pub struct Recovery {
 
     loss_time: [Option<Instant>; packet::EPOCH_COUNT],
 
-    sent: [VecDeque<Sent>; packet::EPOCH_COUNT],
+    pub sent: [VecDeque<Sent>; packet::EPOCH_COUNT],
 
     pub lost: [Vec<frame::Frame>; packet::EPOCH_COUNT],
 


### PR DESCRIPTION
Currently when sending a PTO probe we either include new data frames or
a PING frame in the packet to make sure that the probe is ack-eliciting.
However if no new data is availabe, we should try to include old data
that has not been marked as lost yet if there is any, instead of just
sending a PING.

This changes that by iterating over old sent packets (that have not been
acked or lost yet) and copying CRYPTO and STREAM frames into the outgoing
packet when creating PTO probes.

This requires cloning the frames, which is somewhat unfortunate, but it
should only happen when PTO expires, which has exponential backoff so it
shouldn't be possible to use this as a DoS vector.