### PR TITLE
docker: bump rust image to latest stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.39 as build
+FROM rust:1.44.1 as build
 
 WORKDIR /build
 


### PR DESCRIPTION
Some indirect dependency requires a newer Rust version to build:
https://github.com/BurntSushi/aho-corasick/issues/62