### PR TITLE
recovery: retransmit frames from 2 oldest unacked packets on PTO

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2073,6 +2073,7 @@ impl Connection {
 
         let mut ack_eliciting = false;
         let mut in_flight = false;
+        let mut has_data = false;
 
         let mut payload_len = 0;
 
@@ -2277,6 +2278,7 @@ impl Connection {
             if push_frame_to_pkt!(frames, frame, payload_len, left) {
                 ack_eliciting = true;
                 in_flight = true;
+                has_data = true;
             }
         }
 
@@ -2322,6 +2324,7 @@ impl Connection {
                 if push_frame_to_pkt!(frames, frame, payload_len, left) {
                     ack_eliciting = true;
                     in_flight = true;
+                    has_data = true;
                 }
 
                 // If the stream is still flushable, push it to the back of the
@@ -2340,45 +2343,6 @@ impl Connection {
                 }
 
                 break;
-            }
-        }
-
-        // Try to retransmit old frames on PTO, if there is space left.
-        if self.recovery.loss_probes[epoch] > 0 &&
-            left > cmp::min(
-                frame::MAX_CRYPTO_OVERHEAD,
-                frame::MAX_STREAM_OVERHEAD,
-            ) &&
-            !is_closing
-        {
-            let unacked_iter = self.recovery.sent[epoch]
-                .iter_mut()
-                // Skip packets that have already been acked or lost and packets
-                // that are not in-flight.
-                .filter(|p| p.in_flight && p.time_acked.is_none() && p.time_lost.is_none());
-
-            'unacked_iter: for unacked in unacked_iter {
-                for frame in &unacked.frames {
-                    // Only retransmit CRYPTO and STREAM frames.
-                    match frame {
-                        frame::Frame::Crypto { .. } |
-                        frame::Frame::Stream { .. } => (),
-
-                        _ => continue,
-                    }
-
-                    // Skip frame if it's too big.
-                    if left < frame.wire_len() {
-                        break 'unacked_iter;
-                    }
-
-                    push_frame_to_pkt!(frames, frame.clone(), payload_len, left);
-
-                    ack_eliciting = true;
-                    in_flight = true;
-
-                    break 'unacked_iter;
-                }
             }
         }
 
@@ -2518,6 +2482,7 @@ impl Connection {
             delivered_time: now,
             recent_delivered_packet_sent_time: now,
             is_app_limited: false,
+            has_data,
         };
 
         self.recovery.on_packet_sent(

--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -319,6 +319,7 @@ mod tests {
             delivered_time: now,
             recent_delivered_packet_sent_time: now,
             is_app_limited: false,
+            has_data: false,
         };
 
         // Send 5k x 4 = 20k, higher than default cwnd(~15k)
@@ -456,6 +457,7 @@ mod tests {
             delivered_time: now,
             recent_delivered_packet_sent_time: now,
             is_app_limited: false,
+            has_data: false,
         };
 
         // 1st round.

--- a/src/recovery/delivery_rate.rs
+++ b/src/recovery/delivery_rate.rs
@@ -204,6 +204,7 @@ mod tests {
             delivered_time: Instant::now(),
             recent_delivered_packet_sent_time: Instant::now(),
             is_app_limited: false,
+            has_data: false,
         };
 
         recovery
@@ -227,6 +228,7 @@ mod tests {
             delivered_time: Instant::now(),
             recent_delivered_packet_sent_time: Instant::now(),
             is_app_limited: false,
+            has_data: false,
         };
 
         recovery
@@ -259,6 +261,7 @@ mod tests {
             delivered_time: Instant::now(),
             recent_delivered_packet_sent_time: Instant::now(),
             is_app_limited: false,
+            has_data: false,
         };
 
         recvry
@@ -280,6 +283,7 @@ mod tests {
             delivered_time: Instant::now(),
             recent_delivered_packet_sent_time: Instant::now(),
             is_app_limited: false,
+            has_data: false,
         };
 
         recvry.app_limited = true;

--- a/src/recovery/reno.rs
+++ b/src/recovery/reno.rs
@@ -171,6 +171,7 @@ mod tests {
             delivered_time: std::time::Instant::now(),
             recent_delivered_packet_sent_time: std::time::Instant::now(),
             is_app_limited: false,
+            has_data: false,
         };
 
         // Send 5k x 4 = 20k, higher than default cwnd(~15k)


### PR DESCRIPTION
In 39905083 we implemented support for retransmitting unacked data in
PTO probes if no new data is available.

However after discussion it seems that prioritizing new data is not
actually necessary, and simply retransmitting old data first might be
the better strategy (if anything it's easier to implement).

This reverts the changes from the previous commit, and simply implements
logic to reschedule the frames from the 2 oldest sent packets when the
PTO expires.

Besides having a much simpler implementation, this also has the
advantage of allowing other frames to be sent in the probe packet (e.g.
ACKs), without risking that the original data frame wouldn't fit in the
output packet, since we won't retransmit CRYPTO and STREAM frames as-is
but will go through the normal packetization procedure (including e.g.
respecting STREAM priorities).

This also means that we won't retransmit the same data in both probe
packets. Though if there aren't enough packets with data frames
available we might still end-up sending a PING frame only in the second
probe packet.