### PR TITLE
recovery: send PTO probes based on PTO count

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6978,13 +6978,11 @@ mod tests {
         pipe.client.on_timeout();
 
         let epoch = packet::EPOCH_APPLICATION;
-        assert_eq!(pipe.client.recovery.loss_probes[epoch], 2);
+        assert_eq!(pipe.client.recovery.loss_probes[epoch], 1);
 
         // Client retransmits stream data in PTO probe.
         let len = pipe.client.send(&mut buf).unwrap();
-
-        let epoch = packet::EPOCH_APPLICATION;
-        assert_eq!(pipe.client.recovery.loss_probes[epoch], 1);
+        assert_eq!(pipe.client.recovery.loss_probes[epoch], 0);
 
         let frames =
             testing::decode_pkt(&mut pipe.server, &mut buf, len).unwrap();


### PR DESCRIPTION
Instead of always sending 2 PTO probes, we should start by sending one
probe, and increase to 2 if the previous probe was lost.

This is done by using the current PTO count to determine how many probes
should be sent (up to 2).

---

This depends on https://github.com/cloudflare/quiche/pull/571.