### PR TITLE
lib: finish qlog events even on frame error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1727,7 +1727,14 @@ impl Connection {
                 ack_elicited = true;
             }
 
-            self.process_frame(frame, epoch, now)?;
+            if let Err(e) = self.process_frame(frame, epoch, now) {
+                qlog_with!(self.qlog_streamer, q, {
+                    // Always conclude frame writing on error.
+                    q.finish_frames().ok();
+                });
+
+                return Err(e);
+            }
         }
 
         qlog_with!(self.qlog_streamer, q, {


### PR DESCRIPTION
There might be occasions when the frame parsing fails and then we end up leaving the qlog streamer in a state that causes the next packet's frames to be recorded in the wrong event.