### PR TITLE
Fixed Windows build when used as cargo dependency or building for release without debug symbols

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -47,15 +47,15 @@ const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
 fn get_boringssl_platform_output_path(lib: &str) -> String {
     if cfg!(windows) {
         // Code under this branch should match the logic in cmake-rs
-        let debug_env_var = std::env::var("DEBUG")
-            .expect("DEBUG variable not defined in env");
+        let debug_env_var =
+            std::env::var("DEBUG").expect("DEBUG variable not defined in env");
 
         let deb_info = match &debug_env_var[..] {
             "false" => false,
             "true" => true,
             unknown => {
                 panic!("Unknown DEBUG={} env var.", unknown);
-            }
+            },
         };
 
         let opt_env_var = std::env::var("OPT_LEVEL")
@@ -63,11 +63,16 @@ fn get_boringssl_platform_output_path(lib: &str) -> String {
 
         let subdir = match &opt_env_var[..] {
             "0" => "Debug",
-            "1" | "2" | "3" => if deb_info { "RelWithDebInfo" } else { "Release" },
+            "1" | "2" | "3" =>
+                if deb_info {
+                    "RelWithDebInfo"
+                } else {
+                    "Release"
+                },
             "s" | "z" => "MinSizeRel",
             unknown => {
                 panic!("Unknown OPT_LEVEL={} env var.", unknown);
-            }
+            },
         };
 
         format!("{}/{}", lib, subdir)

--- a/src/build.rs
+++ b/src/build.rs
@@ -46,11 +46,31 @@ const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
 /// See issue: https://github.com/alexcrichton/cmake-rs/issues/18
 fn get_boringssl_platform_output_path(lib: &str) -> String {
     if cfg!(windows) {
-        if cfg!(debug_assertions) {
-            format!("{}/Debug", lib)
-        } else {
-            format!("{}/RelWithDebInfo", lib)
-        }
+        // Code under this branch should match the logic in cmake-rs
+        let debug_env_var = std::env::var("DEBUG")
+            .expect("DEBUG variable not defined in env");
+
+        let deb_info = match &debug_env_var[..] {
+            "false" => false,
+            "true" => true,
+            unknown => {
+                panic!("Unknown DEBUG={} env var.", unknown);
+            }
+        };
+
+        let opt_env_var = std::env::var("OPT_LEVEL")
+            .expect("OPT_LEVEL variable not defined in env");
+
+        let subdir = match &opt_env_var[..] {
+            "0" => "Debug",
+            "1" | "2" | "3" => if deb_info { "RelWithDebInfo" } else { "Release" },
+            "s" | "z" => "MinSizeRel",
+            unknown => {
+                panic!("Unknown OPT_LEVEL={} env var.", unknown);
+            }
+        };
+
+        format!("{}/{}", lib, subdir)
     } else {
         lib.to_string()
     }


### PR DESCRIPTION
This PR fixes an issue with `--release` Windows builds of rust packages using quiche as a dependency (and quiche stand-alone, if built with custom configurations).

What happens (at least in my case) is that cargo builds the dependencies without debug symbols for release builds of a Rust package (i.e. builds with symbols only the root package).
If `quiche` is one of those deps, it gets built `--release` but without the debug symbols, and cmake-rs consistently puts boringssl in a `<somepath>/Release` directory, instead of the `<somepath>/RelWithDebInfo` directory expected by `build.rs` which then fails with the dreaded `could not find native static library 'crypto', perhaps an -L flag is missing?`.

This code synchronizes the behaviour of `build.rs` with [the one included in cmake-rs](https://github.com/alexcrichton/cmake-rs/blob/master/src/lib.rs#L553); in this way it should supposedly work with all the configurations currently supported by cmake-rs on Windows using the msvc compiler chain.
