### PR TITLE
Cargo: use no-default-features to disable features when building for …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ fuzzing = []
 ndk-old-gcc = []
 
 [package.metadata.docs.rs]
-default-features = false
+no-default-features = true
 
 [build-dependencies]
 cmake = "0.1"


### PR DESCRIPTION
…docs.rs

According to the docs.rs documentation "no-default-features = true" is
the correct field https://docs.rs/about#metadata

This should hopefully fix building the documentation on docs.rs.