### PR TITLE
examples: align retry mechanism with Rust examples

### DIFF
--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -156,7 +156,7 @@ static bool validate_token(const uint8_t *token, size_t token_len,
     return true;
 }
 
-static uint8_t* gen_cid(uint8_t* cid, size_t cid_len) {
+static uint8_t *gen_cid(uint8_t *cid, size_t cid_len) {
     int rng = open("/dev/urandom", O_RDONLY);
     if (rng < 0) {
         perror("failed to open /dev/urandom");

--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -156,24 +156,35 @@ static bool validate_token(const uint8_t *token, size_t token_len,
     return true;
 }
 
-static struct conn_io *create_conn(uint8_t *odcid, size_t odcid_len) {
-    struct conn_io *conn_io = calloc(1, sizeof(*conn_io));
-    if (conn_io == NULL) {
-        fprintf(stderr, "failed to allocate connection IO\n");
-        return NULL;
-    }
-
+static uint8_t* gen_cid(uint8_t* cid, size_t cid_len) {
     int rng = open("/dev/urandom", O_RDONLY);
     if (rng < 0) {
         perror("failed to open /dev/urandom");
         return NULL;
     }
 
-    ssize_t rand_len = read(rng, conn_io->cid, LOCAL_CONN_ID_LEN);
+    ssize_t rand_len = read(rng, cid, cid_len);
     if (rand_len < 0) {
         perror("failed to create connection ID");
         return NULL;
     }
+
+    return cid;
+}
+
+static struct conn_io *create_conn(uint8_t *scid, size_t scid_len,
+                                   uint8_t *odcid, size_t odcid_len) {
+    struct conn_io *conn_io = calloc(1, sizeof(*conn_io));
+    if (conn_io == NULL) {
+        fprintf(stderr, "failed to allocate connection IO\n");
+        return NULL;
+    }
+
+    if (scid_len != LOCAL_CONN_ID_LEN) {
+        fprintf(stderr, "failed, scid length too short\n");
+    }
+
+    memcpy(conn_io->cid, scid, LOCAL_CONN_ID_LEN);
 
     quiche_conn *conn = quiche_accept(conn_io->cid, LOCAL_CONN_ID_LEN,
                                       odcid, odcid_len, config);
@@ -286,9 +297,15 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                 mint_token(dcid, dcid_len, &peer_addr, peer_addr_len,
                            token, &token_len);
 
+                uint8_t new_cid[LOCAL_CONN_ID_LEN];
+
+                if (gen_cid(new_cid, LOCAL_CONN_ID_LEN) == NULL) {
+                    continue;
+                }
+
                 ssize_t written = quiche_retry(scid, scid_len,
                                                dcid, dcid_len,
-                                               dcid, dcid_len,
+                                               new_cid, LOCAL_CONN_ID_LEN,
                                                token, token_len,
                                                version, out, sizeof(out));
 
@@ -317,7 +334,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                 continue;
             }
 
-            conn_io = create_conn(odcid, odcid_len);
+            conn_io = create_conn(dcid, dcid_len, odcid, odcid_len);
             if (conn_io == NULL) {
                 continue;
             }

--- a/examples/server.c
+++ b/examples/server.c
@@ -153,24 +153,31 @@ static bool validate_token(const uint8_t *token, size_t token_len,
     return true;
 }
 
-static struct conn_io *create_conn(uint8_t *odcid, size_t odcid_len) {
-    struct conn_io *conn_io = malloc(sizeof(*conn_io));
-    if (conn_io == NULL) {
-        fprintf(stderr, "failed to allocate connection IO\n");
-        return NULL;
-    }
-
+static uint8_t* gen_cid(uint8_t* cid, size_t cid_len) {
     int rng = open("/dev/urandom", O_RDONLY);
     if (rng < 0) {
         perror("failed to open /dev/urandom");
         return NULL;
     }
 
-    ssize_t rand_len = read(rng, conn_io->cid, LOCAL_CONN_ID_LEN);
+    ssize_t rand_len = read(rng, cid, cid_len);
     if (rand_len < 0) {
         perror("failed to create connection ID");
         return NULL;
     }
+
+    return cid;
+}
+
+static struct conn_io *create_conn(uint8_t *dcid, size_t dcid_len, uint8_t *odcid,
+                                   size_t odcid_len) {
+    struct conn_io *conn_io = malloc(sizeof(*conn_io));
+    if (conn_io == NULL) {
+        fprintf(stderr, "failed to allocate connection IO\n");
+        return NULL;
+    }
+
+    memcpy(conn_io->cid, dcid, LOCAL_CONN_ID_LEN);
 
     quiche_conn *conn = quiche_accept(conn_io->cid, LOCAL_CONN_ID_LEN,
                                       odcid, odcid_len, config);
@@ -274,9 +281,15 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                 mint_token(dcid, dcid_len, &peer_addr, peer_addr_len,
                            token, &token_len);
 
+                uint8_t new_cid[LOCAL_CONN_ID_LEN];
+
+                if (gen_cid(new_cid, LOCAL_CONN_ID_LEN) == NULL) {
+                    continue;
+                }
+
                 ssize_t written = quiche_retry(scid, scid_len,
                                                dcid, dcid_len,
-                                               dcid, dcid_len,
+                                               new_cid, LOCAL_CONN_ID_LEN,
                                                token, token_len,
                                                version, out, sizeof(out));
 
@@ -305,7 +318,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                 continue;
             }
 
-            conn_io = create_conn(odcid, odcid_len);
+            conn_io = create_conn(dcid, dcid_len, odcid, odcid_len);
             if (conn_io == NULL) {
                 continue;
             }

--- a/examples/server.c
+++ b/examples/server.c
@@ -153,7 +153,7 @@ static bool validate_token(const uint8_t *token, size_t token_len,
     return true;
 }
 
-static uint8_t* gen_cid(uint8_t* cid, size_t cid_len) {
+static uint8_t *gen_cid(uint8_t *cid, size_t cid_len) {
     int rng = open("/dev/urandom", O_RDONLY);
     if (rng < 0) {
         perror("failed to open /dev/urandom");


### PR DESCRIPTION
fixes #566. Replaces #582

Previously, when doing stateless retry the C example server would
reuse the dcid for new_scid. Once a client sent back the token
and we validated it, a new connection ID would be generated and
sent back to the client as part of the handshake. The client would
detect an error when validating retry_source_connection_id and
close the connection.

This change aligns the C examples to the Rust examples. A new
connection ID is generated and sent in the retry. Once a client
sends back the toked and we validate it, we use the information
at hand instead of generating anything again.