### PR TITLE
don't try to create ACK frames if there is nothing to ack

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2085,8 +2085,9 @@ impl Connection {
         let mut payload_len = 0;
 
         // Create ACK frame.
-        if (self.pkt_num_spaces[epoch].ack_elicited ||
-            self.recovery.loss_probes[epoch] > 0) &&
+        if self.pkt_num_spaces[epoch].recv_pkt_need_ack.len() > 0 &&
+            (self.pkt_num_spaces[epoch].ack_elicited ||
+                self.recovery.loss_probes[epoch] > 0) &&
             !is_closing
         {
             let ack_delay =


### PR DESCRIPTION
This is a regression introduced by 74458c6db64aa50b01314ac8a2fa3e2394c7965c.

We need to check that there are outstanding packets that need to be
acked before trying to create an ACK frame, otherwise a panic is
triggered when the frame is serialized.