### PR TITLE
build: add soname to libquiche.so in android build

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -222,6 +222,10 @@ fn main() {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-undefined,dynamic_lookup");
     }
 
+    if cfg!(target_os = "android") {
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,libquiche.so");
+    }
+
     if cfg!(feature = "pkg-config-meta") {
         write_pkg_config();
     }


### PR DESCRIPTION
Suggested by #598. Probably beneficial for other platform
build but currently only for android build.