### PR TITLE
stream: only validate stream id of new streams if they never existed

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -158,13 +158,13 @@ impl StreamMap {
     ) -> Result<&mut Stream> {
         let stream = match self.streams.entry(id) {
             hash_map::Entry::Vacant(v) => {
-                if local != is_local(id, is_server) {
-                    return Err(Error::InvalidStreamState);
-                }
-
                 // Stream has already been closed and garbage collected.
                 if self.collected.contains(&id) {
                     return Err(Error::Done);
+                }
+
+                if local != is_local(id, is_server) {
+                    return Err(Error::InvalidStreamState);
                 }
 
                 let (max_rx_data, max_tx_data) = match (local, is_bidi(id)) {


### PR DESCRIPTION
When a STREAM frame is received and `get_or_create()` is called, we
assume that the stream was not created locally.

However it can happen that a locally-created stream was already
collected and then duplicated data for it is received.

This means that we should check whether the stream was destroyed, before
validating the stream ID.