### PR TITLE
recovery: update calculation of PTO and loss timeout

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -757,6 +757,10 @@ impl PktNumSpace {
     pub fn ready(&self) -> bool {
         self.crypto_stream.is_flushable() || self.ack_elicited
     }
+
+    pub fn has_keys(&self) -> bool {
+        self.crypto_open.is_some() && self.crypto_seal.is_some()
+    }
 }
 
 #[derive(Clone, Copy, Default)]


### PR DESCRIPTION
This updates how PTO and loss timeout are calculated based on the latest
recovery draft. It also fills in some gaps we had, notably arming PTO
when the peer has not completed address validation to prevent deadlocks
during handshake.