### PR TITLE
nginx: ngx_msec_t is 32bit in 32bit platform

### DIFF
--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -645,7 +645,7 @@ index 000000000..9f8b2cb98
 +ngx_quic_write_handler(ngx_event_t *wev)
 +{
 +    ngx_connection_t   *c;
-+    ngx_msec_t          expiry;
++    uint64_t            expiry;
 +    static uint8_t      out[MAX_DATAGRAM_SIZE];
 +
 +    c = wev->data;
@@ -709,7 +709,7 @@ index 000000000..9f8b2cb98
 +     * should be unset (this would be equvalent to returning Option::None in
 +     * Rust). To avoid overflow we need to explicitly check for this value. */
 +    if (expiry != UINT64_MAX) {
-+        ngx_add_timer(wev, expiry);
++        ngx_add_timer(wev, (ngx_msec_t)expiry);
 +    }
 +}
 +


### PR DESCRIPTION
`ngx_msec_t` is `uint_t` and it's 32bit in 32bit platform. However
`quiche_conn_timeout_as_millis()` returns `uint64_t` and comparing
`ngx_msec_t` with `UINT64_MAX` is not meaningful. (compiler
gives a warning)

Fix here is we check the return value of `quiche_conn_timeout_as_millis()`
first and cast to `ngx_msec_t`. In 64bit platform `ngx_msec_t` is
`uint64_t`, so no casting there.

Fix #648 