### PR TITLE
qns: explicitly enable ChaCha20 test on the server

### DIFF
--- a/tools/qns/run_endpoint.sh
+++ b/tools/qns/run_endpoint.sh
@@ -31,6 +31,15 @@ check_testcase () {
         echo "supported"
         RUST_LOG="info"
         ;;
+    chacha20 )
+        if [ "$ROLE" == "client" ]; then
+            # We don't support selecting a cipher on the client-side.
+            echo "unsupported"
+            exit 127
+        elif [ "$ROLE" == "server" ]; then
+            echo "supported"
+        fi
+        ;;
     resumption | zerortt )
         if [ "$ROLE" == "client" ]; then
             # We don't support session resumption on the client-side yet.


### PR DESCRIPTION
This is required since https://github.com/marten-seemann/quic-interop-runner/pull/221.