### PR TITLE
qpack: don't lower-case incoming header names

### DIFF
--- a/src/h3/qpack/decoder.rs
+++ b/src/h3/qpack/decoder.rs
@@ -144,16 +144,13 @@ impl Decoder {
                     let mut name = b.get_bytes(name_len)?;
 
                     let name = if name_huff {
-                        let name = super::huffman::decode(&mut name, true)?;
-
-                        String::from_utf8(name)
-                            .map_err(|_| Error::InvalidHeaderValue)?
+                        super::huffman::decode(&mut name)?
                     } else {
-                        let name = std::str::from_utf8(name.as_ref())
-                            .map_err(|_| Error::InvalidHeaderValue)?;
-
-                        name.to_ascii_lowercase()
+                        name.to_vec()
                     };
+
+                    let name = String::from_utf8(name)
+                        .map_err(|_| Error::InvalidHeaderValue)?;
 
                     let value = decode_str(&mut b)?;
 
@@ -267,7 +264,7 @@ fn decode_str<'a>(b: &'a mut octets::Octets) -> Result<String> {
     let mut val = b.get_bytes(len)?;
 
     let val = if huff {
-        super::huffman::decode(&mut val, false)?
+        super::huffman::decode(&mut val)?
     } else {
         val.to_vec()
     };

--- a/src/h3/qpack/huffman/mod.rs
+++ b/src/h3/qpack/huffman/mod.rs
@@ -32,7 +32,7 @@ use super::Result;
 use self::table::DECODE_TABLE;
 use self::table::ENCODE_TABLE;
 
-pub fn decode(b: &mut octets::Octets, low: bool) -> Result<Vec<u8>> {
+pub fn decode(b: &mut octets::Octets) -> Result<Vec<u8>> {
     // Max compression ratio is >= 0.5
     let mut out = Vec::with_capacity(b.len() << 1);
 
@@ -42,12 +42,10 @@ pub fn decode(b: &mut octets::Octets, low: bool) -> Result<Vec<u8>> {
         let byte = b.get_u8()?;
 
         if let Some(b) = decoder.decode4(byte >> 4)? {
-            let b = if low { b.to_ascii_lowercase() } else { b };
             out.push(b);
         }
 
         if let Some(b) = decoder.decode4(byte & 0xf)? {
-            let b = if low { b.to_ascii_lowercase() } else { b };
             out.push(b);
         }
     }


### PR DESCRIPTION
This is a violation of the HTTP/3 spec, as upper-case header names MUST
be treated as invalid. However we delegate this check to the aplication.

This partially reverts 0812aa2aa8083b7fe14178c11e9fa185eb6ba9b7.