### PR TITLE
bubble up STOP_SENDING frame to H3 event

### DIFF
--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -265,6 +265,27 @@ fn main() {
                         info!("GOAWAY id={}", goaway_id);
                     },
 
+                    Ok((
+                        stream_id,
+                        quiche::h3::Event::StopSending { error_code },
+                    )) => {
+                        info!(
+                            "StopSending received for stream {}, error_code {}",
+                            stream_id, error_code
+                        );
+                    },
+
+                    Ok((
+                        stream_id,
+                        quiche::h3::Event::ResetStream {
+                            error_code,
+                            final_size,
+                        },
+                    )) => {
+                        info!("ResetStream received for stream {}, error_code {}, final_size {}",
+                              stream_id, error_code, final_size);
+                    },
+
                     Err(quiche::h3::Error::Done) => {
                         break;
                     },

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -362,6 +362,25 @@ fn main() {
 
                         Ok((_goaway_id, quiche::h3::Event::GoAway)) => (),
 
+                        Ok((
+                            stream_id,
+                            quiche::h3::Event::StopSending { error_code },
+                        )) => {
+                            info!("StopSending received for stream {}, error_code {}",
+                                  stream_id, error_code);
+                        },
+
+                        Ok((
+                            stream_id,
+                            quiche::h3::Event::ResetStream {
+                                error_code,
+                                final_size,
+                            },
+                        )) => {
+                            info!("ResetStream received for stream {}, error_code {}, final_size {}",
+                                  stream_id, error_code, final_size);
+                        },
+
                         Err(quiche::h3::Error::Done) => {
                             break;
                         },

--- a/src/h3/ffi.rs
+++ b/src/h3/ffi.rs
@@ -115,6 +115,10 @@ pub extern fn quiche_h3_event_type(ev: &h3::Event) -> u32 {
         h3::Event::Datagram { .. } => 3,
 
         h3::Event::GoAway { .. } => 4,
+
+        h3::Event::StopSending { .. } => 5,
+
+        h3::Event::ResetStream { .. } => 6,
     }
 }
 

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -121,7 +121,7 @@ pub struct Stream {
 
     /// The write offset in the state buffer, that is, how many bytes have
     /// already been read from the transport for the current state. When
-    /// it reaches `stream_len` the state can be completed.
+    /// it reaches `state_len` the state can be completed.
     state_off: usize,
 
     /// The type of the frame currently being parsed.
@@ -176,6 +176,10 @@ impl Stream {
 
     pub fn state(&self) -> State {
         self.state
+    }
+
+    pub fn ty(&self) -> Option<Type> {
+        self.ty
     }
 
     /// Sets the stream's type and transitions to the next state.

--- a/tools/apps/src/lib.rs
+++ b/tools/apps/src/lib.rs
@@ -1255,6 +1255,31 @@ impl HttpConn for Http3Conn {
                     );
                 },
 
+                Ok((
+                    stream_id,
+                    quiche::h3::Event::StopSending { error_code },
+                )) => {
+                    info!(
+                        "Received STOP_SENDING stream_id={} error_code={}",
+                        stream_id, error_code
+                    );
+                },
+
+                Ok((
+                    stream_id,
+                    quiche::h3::Event::ResetStream {
+                        error_code,
+                        final_size,
+                    },
+                )) => {
+                    info!(
+                        "Received RESET_STREAM stream_id={} error_code={} final_size={}",
+                        stream_id,
+                        error_code,
+                        final_size
+                    );
+                },
+
                 Err(quiche::h3::Error::Done) => {
                     break;
                 },
@@ -1403,6 +1428,31 @@ impl HttpConn for Http3Conn {
                     );
                     self.h3_conn
                         .send_goaway(conn, self.largest_processed_request)?;
+                },
+
+                Ok((
+                    stream_id,
+                    quiche::h3::Event::StopSending { error_code },
+                )) => {
+                    info!(
+                        "Received STOP_SENDING stream_id={} error_code={}",
+                        stream_id, error_code
+                    );
+                },
+
+                Ok((
+                    stream_id,
+                    quiche::h3::Event::ResetStream {
+                        error_code,
+                        final_size,
+                    },
+                )) => {
+                    info!(
+                        "Received RESET_STREAM stream_id={} error_code={} final_size={}",
+                        stream_id,
+                        error_code,
+                        final_size
+                    );
                 },
 
                 Err(quiche::h3::Error::Done) => {

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -277,6 +277,29 @@ pub fn run(
 
                     Ok((_goaway_id, quiche::h3::Event::GoAway)) => (),
 
+                    Ok((
+                        stream_id,
+                        quiche::h3::Event::StopSending { error_code },
+                    )) => {
+                        info!(
+                            "StopSending received for stream {} error_code {}",
+                            stream_id, error_code
+                        );
+                    },
+
+                    Ok((
+                        stream_id,
+                        quiche::h3::Event::ResetStream {
+                            error_code,
+                            final_size,
+                        },
+                    )) => {
+                        info!(
+                            "ResetStream received from stream {} error_code {} final_size {}",
+                            stream_id, error_code, final_size
+                        );
+                    },
+
                     Err(quiche::h3::Error::Done) => {
                         break;
                     },


### PR DESCRIPTION
This is trying to address issue #585. The QUIC frame STOP_SENDING triggers a H3 event of `StopSending`, so that the application can react accordingly.
 
Update:

- Handled `TODO` items in `stream_shutdown` to send out `STOP_SENDING` and `RESET_STREAM` frames.
- Reply `RESET_STREAM` frame when received `STOP_SENDING` frame.
- Bubble up `StopSending` and `ResetStream` H3 events only for user request streams.