### PR TITLE
stream: fix name and documentation of method returning lowest recv offset

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2663,7 +2663,7 @@ impl Connection {
         }
 
         #[cfg(feature = "qlog")]
-        let offset = stream.recv.off_back();
+        let offset = stream.recv.off_front();
 
         let (read, fin) = stream.recv.pop(out)?;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -825,9 +825,9 @@ impl RecvBuf {
         Ok(())
     }
 
-    /// Returns the largest offset of data buffered.
+    /// Returns the lowest offset of data buffered.
     #[allow(dead_code)]
-    pub fn off_back(&self) -> u64 {
+    pub fn off_front(&self) -> u64 {
         self.off
     }
 


### PR DESCRIPTION
The documentation of this method doesn't match what it actually does.

Also rename it to be consistent with SendBuf.