### PR TITLE
don't count dup data towards flow control limit

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -840,6 +840,11 @@ impl RecvBuf {
             self.max_data_next / 2 > self.max_data - self.len
     }
 
+    /// Returns the largest offset ever received.
+    pub fn max_off(&self) -> u64 {
+        self.len
+    }
+
     /// Returns true if the receive-side of the stream is complete.
     ///
     /// This happens when the stream's receive final size is known, and the


### PR DESCRIPTION
Currently we use the "raw" received STREAM frame length to check that
received data doesn't exceed the connection-level flow control limit.

However it can happen that the same data is received in two different
overlapping STREAM frames. In the current implementation this data ends
up being counted twice towards the flow control limit.

Instead use the difference between the frame's maximum offset and the
stream's maximum received offset.

This is consistent with §19.9 of the -transport draft:

   The sum of the final sizes on all streams - including streams in
   terminal states - MUST NOT exceed the value advertised by a receiver.