### PR TITLE
nginx: refresh patch

### DIFF
--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -1,6 +1,6 @@
-From 6b265aa6ff74d0e61ca2bfd8014d02fe014f5ca6 Mon Sep 17 00:00:00 2001
+From d736db24826262e2c9887c610818532d3b6e19c1 Mon Sep 17 00:00:00 2001
 From: Alessandro Ghedini <alessandro@cloudflare.com>
-Date: Mon, 20 Jul 2020 13:26:10 +0100
+Date: Thu, 22 Oct 2020 12:28:02 +0100
 Subject: [PATCH] Initial QUIC and HTTP/3 implementation using quiche
 
 ---
@@ -26,12 +26,12 @@ Subject: [PATCH] Initial QUIC and HTTP/3 implementation using quiche
  src/http/ngx_http_request.h             |    3 +
  src/http/ngx_http_request_body.c        |   29 +
  src/http/ngx_http_upstream.c            |   13 +
- src/http/v3/ngx_http_v3.c               | 2228 +++++++++++++++++++++++
+ src/http/v3/ngx_http_v3.c               | 2234 +++++++++++++++++++++++
  src/http/v3/ngx_http_v3.h               |   77 +
  src/http/v3/ngx_http_v3_filter_module.c |   68 +
  src/http/v3/ngx_http_v3_module.c        |  286 +++
  src/http/v3/ngx_http_v3_module.h        |   34 +
- 27 files changed, 3694 insertions(+), 11 deletions(-)
+ 27 files changed, 3700 insertions(+), 11 deletions(-)
  create mode 100644 auto/lib/quiche/conf
  create mode 100644 auto/lib/quiche/make
  create mode 100644 src/event/ngx_event_quic.c
@@ -338,7 +338,7 @@ index 93ca9174d..d0441f034 100644
  #include <ngx_module.h>
 diff --git a/src/event/ngx_event_quic.c b/src/event/ngx_event_quic.c
 new file mode 100644
-index 000000000..b9cc9ec0a
+index 000000000..d9fc0b57a
 --- /dev/null
 +++ b/src/event/ngx_event_quic.c
 @@ -0,0 +1,575 @@
@@ -1556,7 +1556,7 @@ index a7391d09a..398af2797 100644
      if (ngx_event_flags & NGX_USE_KQUEUE_EVENT) {
 diff --git a/src/http/v3/ngx_http_v3.c b/src/http/v3/ngx_http_v3.c
 new file mode 100644
-index 000000000..358a36528
+index 000000000..b14af1570
 --- /dev/null
 +++ b/src/http/v3/ngx_http_v3.c
 @@ -0,0 +1,2234 @@


### PR DESCRIPTION
This simply refreshes the metadata in the patch by re-exporting it.

No functional changes.