### PR TITLE
lib: send MAX_DATA when MAX_STREAM_DATA is sent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2255,23 +2255,6 @@ impl Connection {
                 }
             }
 
-            // Create MAX_DATA frame as needed.
-            if self.almost_full {
-                let frame = frame::Frame::MaxData {
-                    max: self.max_rx_data_next,
-                };
-
-                if push_frame_to_pkt!(b, frames, frame, left) {
-                    self.almost_full = false;
-
-                    // Commits the new max_rx_data limit.
-                    self.max_rx_data = self.max_rx_data_next;
-
-                    ack_eliciting = true;
-                    in_flight = true;
-                }
-            }
-
             // Create DATA_BLOCKED frame.
             if let Some(limit) = self.blocked_limit {
                 let frame = frame::Frame::DataBlocked { limit };
@@ -2306,6 +2289,27 @@ impl Connection {
                     stream.recv.update_max_data();
 
                     self.streams.mark_almost_full(stream_id, false);
+
+                    ack_eliciting = true;
+                    in_flight = true;
+
+                    // Also send MAX_DATA when MAX_STREAM_DATA is sent, to avoid a
+                    // potential race condition.
+                    self.almost_full = true;
+                }
+            }
+
+            // Create MAX_DATA frame as needed.
+            if self.almost_full && self.max_rx_data < self.max_rx_data_next {
+                let frame = frame::Frame::MaxData {
+                    max: self.max_rx_data_next,
+                };
+
+                if push_frame_to_pkt!(b, frames, frame, left) {
+                    self.almost_full = false;
+
+                    // Commits the new max_rx_data limit.
+                    self.max_rx_data = self.max_rx_data_next;
 
                     ack_eliciting = true;
                     in_flight = true;
@@ -5464,6 +5468,13 @@ mod tests {
         // Ignore ACK.
         iter.next().unwrap();
 
+        assert_eq!(
+            iter.next(),
+            Some(&frame::Frame::MaxStreamData {
+                stream_id: 4,
+                max: 30
+            })
+        );
         assert_eq!(iter.next(), Some(&frame::Frame::MaxData { max: 46 }));
     }
 


### PR DESCRIPTION
Let's think the following scenario:

- starting default of stream and connection flow limit

stream#1 limit=100, want to write 150 bytes in total
stream#2 limit=100, want to write 150 bytes in total
stream#3 limit=100, want to write 150 bytes in total
connection limit=300

And let's say server want to write 150 bytes each in the stream.
And all stream has a same priority: each stream data need to be delivered FIFO, which means
we should deliver 150 bytes in stream#1 full and 150 bytes in stream#2, and so on.

- Current behavior

server stream_send() stream#1 100 bytes (stream#1 reach limit = 100)
server stream_send() stream#2 100 bytes (stream#2 reach limit = 100)
server stream_send() stream#3 100 bytes (stream#1 reach limit = 100) (connection reached limit = 300)

server send() stream#1 100 bytes
client recv() 100 bytes from stream#1 and send() ACK + MAX_STREAM_DATA(stream#1, 200)
**client: MAX_DATA is not sent because should_update_max_data() returns false at this point**

_server receives ACK and update stream#1 limit to 200_
_server want to write more on stream#1, but cannot due to connection limit (300)_ --> this is a problem breaking FIFO

server send stream#2 100 bytes
client recv() 100 bytes from stream#1 and send() ACK + MAX_DATA(500)
server send stream#2 50 bytes + fin
...

Eventually MAX_DATA will be sent but it arrives later, so FIFO delivery start to break and there is a race condition
where the sender can't write more until MAX_DATA arrives. To solve the issue, when MAX_STREAM_DATA is sent,
and MAX_DATA if increased from the previously sent value. This will unblock the sender to write on the right stream
early.


- This PR's behavior

server stream_send() stream#1 100 bytes (stream#1 reach limit = 100)
server stream_send() stream#2 100 bytes (stream#2 reach limit = 100)
server stream_send() stream#3 100 bytes (stream#1 reach limit = 100) (connection reached limit = 300)

server send() stream#1 100 bytes
client recv() 100 bytes from stream#1 and send() ACK + MAX_STREAM_DATA(stream#1, 200) + **MAX_DATA(400)**
**client send MAX_DATA with MAX_STREAM_DATA, regardless of should_update_max_data()**

_server receives ACK and updates connection limit to 400 and stream#1 limit to 200_

server send() stream#1 50 bytes + fin --> FIFO works
client recv() 50 bytes from stream#1 and send() ACK + MAX_DATA(450)

server send stream#1 100 bytes
...