### PR TITLE
build: rustfmt missing since 2020-10-26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
       - make docker-build
    - name: "nightly Linux x86_64"
      language: rust
-     rust: nightly
+     rust: nightly-2020-10-25
      addons:
        apt:
          packages:


### PR DESCRIPTION
https://rust-lang.github.io/rustup-components-history/
pin to 2020-10-25.