### PR TITLE
Fix the compiling for rust 1.39.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,38 @@ matrix:
       - RUSTFLAGS="-D warnings" cargo build --target=$TARGET_32
       # docker
       - make docker-build
+   - name: "1.39.0 Linux x86_64/x86"
+     language: rust
+     rust: 1.39.0
+     env:
+       DEPLOY_BUILD=yes
+       TARGET_32=i686-unknown-linux-gnu
+     addons:
+       apt:
+         packages:
+         - [*linux_deps, gcc-multilib, g++-multilib]
+     install:
+      - rustup component add clippy
+      - rustup target add $TARGET_32
+     script:
+      - RUSTFLAGS="-D warnings" cargo test --verbose
+      - RUSTFLAGS="-D warnings" cargo package --verbose --allow-dirty
+      - cargo clippy --examples -- -D warnings
+      - cargo doc --no-deps
+      - make -C examples
+      # http3_test
+      - RUSTFLAGS="-D warnings" cargo test --no-run --verbose --manifest-path tools/http3_test/Cargo.toml
+      - cargo clippy --manifest-path tools/http3_test/Cargo.toml -- -D warnings
+      # qlog
+      - RUSTFLAGS="-D warnings" cargo test --verbose --manifest-path tools/qlog/Cargo.toml
+      - cargo clippy --manifest-path tools/qlog/Cargo.toml -- -D warnings
+      # quiche-apps
+      - RUSTFLAGS="-D warnings" cargo build --verbose --manifest-path tools/apps/Cargo.toml
+      - cargo clippy --manifest-path tools/apps/Cargo.toml -- -D warnings
+      # x86 cross build
+      - RUSTFLAGS="-D warnings" cargo build --target=$TARGET_32
+      # docker
+      - make docker-build
    - name: "nightly Linux x86_64"
      language: rust
      rust: nightly-2020-10-25

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ libm = "0.2"
 ring = "0.16"
 lazy_static = "1"
 qlog = { version = "0.3", path = "tools/qlog", optional = true }
+matches = "0.1.8"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3", features = ["wincrypt"] }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -37,6 +37,8 @@ pub const MAX_DGRAM_OVERHEAD: usize = 2;
 pub const MAX_STREAM_OVERHEAD: usize = 12;
 pub const MAX_STREAM_SIZE: u64 = 1 << 62;
 
+use matches::matches;
+
 #[derive(Clone, PartialEq)]
 pub enum Frame {
     Padding {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,9 @@
 #[macro_use]
 extern crate log;
 
+#[macro_use]
+extern crate matches;
+
 use std::cmp;
 use std::time;
 

--- a/tools/qlog/Cargo.toml
+++ b/tools/qlog/Cargo.toml
@@ -15,3 +15,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 serde_derive = "1.0"
 serde_with = "1.3.1"
+matches = "0.1.8"

--- a/tools/qlog/src/event.rs
+++ b/tools/qlog/src/event.rs
@@ -32,6 +32,7 @@
 //! verbosity of using the raw data structures.
 
 use super::*;
+use matches::matches;
 
 /// A representation of qlog events that couple EventCategory, EventType and
 /// EventData.


### PR DESCRIPTION
Rust 1.39.0 has no `matches!` macro in std lib. 