### PR TITLE
lib: limiting a burst of outgoing packets

### DIFF
--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -92,6 +92,11 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
     while (1) {
         ssize_t written = quiche_conn_send(conn_io->conn, out, sizeof(out));
 
+        if (written == QUICHE_ERR_AGAIN) {
+            fprintf(stderr, "try again writing\n");
+            continue;
+        }
+
         if (written == QUICHE_ERR_DONE) {
             fprintf(stderr, "done writing\n");
             break;

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -386,6 +386,11 @@ fn main() {
                 let write = match client.conn.send(&mut out) {
                     Ok(v) => v,
 
+                    Err(quiche::Error::Again) => {
+                        debug!("{} try again writing", client.conn.trace_id());
+                        continue;
+                    },
+
                     Err(quiche::Error::Done) => {
                         debug!("{} done writing", client.conn.trace_id());
                         break;

--- a/examples/server.c
+++ b/examples/server.c
@@ -89,6 +89,11 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
     while (1) {
         ssize_t written = quiche_conn_send(conn_io->conn, out, sizeof(out));
 
+        if (written == QUICHE_ERR_AGAIN) {
+            fprintf(stderr, "try again writing\n");
+            continue;
+        }
+
         if (written == QUICHE_ERR_DONE) {
             fprintf(stderr, "done writing\n");
             break;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -329,6 +329,11 @@ fn main() {
                 let write = match client.conn.send(&mut out) {
                     Ok(v) => v,
 
+                    Err(quiche::Error::Again) => {
+                        debug!("{} try again writing", client.conn.trace_id());
+                        continue;
+                    },
+
                     Err(quiche::Error::Done) => {
                         debug!("{} done writing", client.conn.trace_id());
                         break;

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -102,6 +102,9 @@ enum quiche_error {
 
     // Error in congestion control.
     QUICHE_ERR_CONGESTION_CONTROL = -14,
+
+    // There is more work to do. Need to call it again.
+    QUICHE_ERR_AGAIN = -16,
 };
 
 // Returns a human readable string with the quiche version number.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,11 @@
 //!     let write = match conn.send(&mut out) {
 //!         Ok(v) => v,
 //!
+//!         Err(quiche::Error::Again) => {
+//!             // Send packets into the network and continue.
+//!             continue;
+//!         },
+//!
 //!         Err(quiche::Error::Done) => {
 //!             // Done writing.
 //!             break;
@@ -155,6 +160,11 @@
 //! loop {
 //!     let write = match conn.send(&mut out) {
 //!         Ok(v) => v,
+//!
+//!         Err(quiche::Error::Again) => {
+//!             // Send packets into the network and continue.
+//!             continue;
+//!         },
 //!
 //!         Err(quiche::Error::Done) => {
 //!             // Done writing.
@@ -382,6 +392,9 @@ pub enum Error {
 
     /// Error in congestion control.
     CongestionControl,
+
+    /// There is more work to do, need to call it again.
+    Again,
 }
 
 impl Error {
@@ -415,6 +428,7 @@ impl Error {
             Error::FinalSize => -13,
             Error::CongestionControl => -14,
             Error::StreamStopped { .. } => -15,
+            Error::Again => -16,
         }
     }
 }
@@ -869,6 +883,12 @@ pub struct Connection {
     /// Total number of sent packets.
     sent_count: usize,
 
+    /// Total number of sent bytes without calling recv().
+    sent_bytes_burst: usize,
+
+    /// Max number of sent bytes without calling recv().
+    sent_bytes_max_burst: usize,
+
     /// Total number of bytes received from the peer.
     rx_data: u64,
 
@@ -1231,6 +1251,10 @@ impl Connection {
             recv_count: 0,
             sent_count: 0,
 
+            sent_bytes_burst: 0,
+            sent_bytes_max_burst: config.max_send_udp_payload_size *
+                recovery::INITIAL_WINDOW_PACKETS,
+
             rx_data: 0,
             max_rx_data,
             max_rx_data_next: max_rx_data,
@@ -1496,6 +1520,8 @@ impl Connection {
             done += read;
             left -= read;
         }
+
+        self.sent_bytes_burst = 0;
 
         Ok(done)
     }
@@ -1991,6 +2017,12 @@ impl Connection {
     /// On success the number of bytes written to the output buffer is
     /// returned, or [`Done`] if there was nothing to write.
     ///
+    /// It may return [`Again`] which indicates trying to send too much
+    /// data at once. The application may send those packets to the network
+    /// and continue calling `send()`. There may be still data to write,
+    /// so `send()` should be called again until [`Done`].
+    /// This is to prevent from bursting outgoing packets.
+    ///
     /// The application should call `send()` multiple times until [`Done`] is
     /// returned, indicating that there are no more packets to send. It is
     /// recommended that `send()` be called in the following cases:
@@ -2005,6 +2037,7 @@ impl Connection {
     ///    [`stream_send()`] or [`stream_shutdown()`] are called).
     ///
     /// [`Done`]: enum.Error.html#variant.Done
+    /// [`Again`]: enum.Error.html#variant.Again
     /// [`recv()`]: struct.Connection.html#method.recv
     /// [`on_timeout()`]: struct.Connection.html#method.on_timeout
     /// [`stream_send()`]: struct.Connection.html#method.stream_send
@@ -2022,6 +2055,11 @@ impl Connection {
     ///     let write = match conn.send(&mut out) {
     ///         Ok(v) => v,
     ///
+    ///         Err(quiche::Error::Again) => {
+    ///             // Send packets into the network and continue.
+    ///             continue;
+    ///         },
+    ///
     ///         Err(quiche::Error::Done) => {
     ///             // Done writing.
     ///             break;
@@ -2038,6 +2076,13 @@ impl Connection {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn send(&mut self, out: &mut [u8]) -> Result<usize> {
+        // Burst protection: don't send more than `sent_bytes_max_burst`
+        // bytes when calling send() consecutively.
+        if self.sent_bytes_burst > self.sent_bytes_max_burst {
+            self.sent_bytes_burst = 0;
+            return Err(Error::Again);
+        }
+
         let now = time::Instant::now();
 
         if out.is_empty() {
@@ -2827,6 +2872,8 @@ impl Connection {
         if ack_eliciting {
             self.ack_eliciting_sent = true;
         }
+
+        self.sent_bytes_burst += written;
 
         Ok(written)
     }
@@ -5003,6 +5050,8 @@ pub mod testing {
                 Ok(write) => off += write,
 
                 Err(Error::Done) => break,
+
+                Err(Error::Again) => continue,
 
                 Err(e) => return Err(e),
             }

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -58,7 +58,7 @@ const RTT_WINDOW: Duration = Duration::from_secs(300);
 const MAX_PTO_PROBES_COUNT: usize = 2;
 
 // Congestion Control
-const INITIAL_WINDOW_PACKETS: usize = 10;
+pub const INITIAL_WINDOW_PACKETS: usize = 10;
 
 const MINIMUM_WINDOW_PACKETS: usize = 2;
 
@@ -341,6 +341,10 @@ impl Recovery {
         self.detect_lost_packets(epoch, now, trace_id);
 
         self.on_packets_acked(newly_acked, epoch, now);
+
+        // Update app_limited. If next incoming packet is also ACK,
+        // this value need to be updated for proper cwnd updates.
+        self.app_limited = self.bytes_in_flight < self.congestion_window;
 
         self.pto_count = 0;
 

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -448,6 +448,11 @@ fn main() {
                 let write = match client.conn.send(&mut out) {
                     Ok(v) => v,
 
+                    Err(quiche::Error::Again) => {
+                        trace!("{} need to try again", client.conn.trace_id());
+                        break;
+                    },
+
                     Err(quiche::Error::Done) => {
                         trace!("{} done writing", client.conn.trace_id());
                         break;


### PR DESCRIPTION
"QUIC draft-32 7.7" says:
>     Sending multiple packets into the network without any delay between
>     them creates a packet burst that might cause short-term congestion
>     and losses.  Senders MUST either use pacing or limit such bursts.
>     Senders SHOULD limit bursts to the initial congestion window; see
>     Section 7.2.  A sender with knowledge that the network path to the
>     receiver can absorb larger bursts MAY use a higher limit.

When I test quiche in a high bandwidth/low rtt environment such as localhost,
cwnd can grow very quickly and can create a lot of packet sent
when 1) many sender packets are acked on once 2) try to recover many losses.

This PR implements limiting outgoing packet burst as recommended in the
draft. Here we limit total number of outgoing packets in a single send() loop
to the initial congestion window. When send() reaches a burst limit,
now `Error::Again` will be returned, so it's up to application to flush
current packets and check if there is incoming packets, or can continue
to allow bursting.

Also note that I added the limit on the send(). Such limiting burst
can be done in the application itself, but it provides more general
support and all quiche application can use same burst limiting.