### PR TITLE
recovery: configurable max_datagram_size

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -243,7 +243,7 @@ int main(int argc, char *argv[]) {
         (uint8_t *) "\x05hq-29\x05hq-28\x05hq-27\x08http/0.9", 27);
 
     quiche_config_set_max_idle_timeout(config, 5000);
-    quiche_config_set_max_udp_payload_size(config, MAX_DATAGRAM_SIZE);
+    quiche_config_set_max_recv_udp_payload_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_uni(config, 1000000);

--- a/examples/client.c
+++ b/examples/client.c
@@ -244,6 +244,7 @@ int main(int argc, char *argv[]) {
 
     quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_recv_udp_payload_size(config, MAX_DATAGRAM_SIZE);
+    quiche_config_set_max_send_udp_payload_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_uni(config, 1000000);

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -92,6 +92,7 @@ fn main() {
 
     config.set_max_idle_timeout(5000);
     config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
+    config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(10_000_000);
     config.set_initial_max_stream_data_bidi_local(1_000_000);
     config.set_initial_max_stream_data_bidi_remote(1_000_000);

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -91,7 +91,7 @@ fn main() {
         .unwrap();
 
     config.set_max_idle_timeout(5000);
-    config.set_max_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(10_000_000);
     config.set_initial_max_stream_data_bidi_local(1_000_000);
     config.set_initial_max_stream_data_bidi_remote(1_000_000);

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -91,7 +91,7 @@ fn main() {
         .unwrap();
 
     config.set_max_idle_timeout(5000);
-    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(10_000_000);
     config.set_initial_max_stream_data_bidi_local(1_000_000);
     config.set_initial_max_stream_data_bidi_remote(1_000_000);

--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -339,6 +339,7 @@ int main(int argc, char *argv[]) {
 
     quiche_config_set_max_idle_timeout(config, 5000);
     quiche_config_set_max_recv_udp_payload_size(config, MAX_DATAGRAM_SIZE);
+    quiche_config_set_max_send_udp_payload_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_bidi_remote(config, 1000000);

--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -338,7 +338,7 @@ int main(int argc, char *argv[]) {
         sizeof(QUICHE_H3_APPLICATION_PROTOCOL) - 1);
 
     quiche_config_set_max_idle_timeout(config, 5000);
-    quiche_config_set_max_udp_payload_size(config, MAX_DATAGRAM_SIZE);
+    quiche_config_set_max_recv_udp_payload_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_bidi_remote(config, 1000000);

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -90,6 +90,7 @@ fn main() {
 
     config.set_max_idle_timeout(5000);
     config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
+    config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(10_000_000);
     config.set_initial_max_stream_data_bidi_local(1_000_000);
     config.set_initial_max_stream_data_bidi_remote(1_000_000);

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -89,7 +89,7 @@ fn main() {
         .unwrap();
 
     config.set_max_idle_timeout(5000);
-    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(10_000_000);
     config.set_initial_max_stream_data_bidi_local(1_000_000);
     config.set_initial_max_stream_data_bidi_remote(1_000_000);

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -89,7 +89,7 @@ fn main() {
         .unwrap();
 
     config.set_max_idle_timeout(5000);
-    config.set_max_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(10_000_000);
     config.set_initial_max_stream_data_bidi_local(1_000_000);
     config.set_initial_max_stream_data_bidi_remote(1_000_000);

--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -532,7 +532,8 @@ int main(int argc, char *argv[]) {
         sizeof(QUICHE_H3_APPLICATION_PROTOCOL) - 1);
 
     quiche_config_set_max_idle_timeout(config, 5000);
-    quiche_config_set_max_udp_payload_size(config, MAX_DATAGRAM_SIZE);
+    quiche_config_set_max_recv_udp_payload_size(config, MAX_DATAGRAM_SIZE);
+    quiche_config_set_max_send_udp_payload_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_bidi_remote(config, 1000000);

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -100,7 +100,7 @@ fn main() {
         .unwrap();
 
     config.set_max_idle_timeout(5000);
-    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(10_000_000);
     config.set_initial_max_stream_data_bidi_local(1_000_000);

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -100,7 +100,8 @@ fn main() {
         .unwrap();
 
     config.set_max_idle_timeout(5000);
-    config.set_max_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(10_000_000);
     config.set_initial_max_stream_data_bidi_local(1_000_000);
     config.set_initial_max_stream_data_bidi_remote(1_000_000);

--- a/examples/server.c
+++ b/examples/server.c
@@ -454,7 +454,8 @@ int main(int argc, char *argv[]) {
         (uint8_t *) "\x05hq-29\x05hq-28\x05hq-27\x08http/0.9", 27);
 
     quiche_config_set_max_idle_timeout(config, 5000);
-    quiche_config_set_max_udp_payload_size(config, MAX_DATAGRAM_SIZE);
+    quiche_config_set_max_recv_udp_payload_size(config, MAX_DATAGRAM_SIZE);
+    quiche_config_set_max_send_udp_payload_size(config, MAX_DATAGRAM_SIZE);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
     quiche_config_set_initial_max_stream_data_bidi_remote(config, 1000000);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -94,7 +94,7 @@ fn main() {
         .unwrap();
 
     config.set_max_idle_timeout(5000);
-    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(10_000_000);
     config.set_initial_max_stream_data_bidi_local(1_000_000);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -94,7 +94,8 @@ fn main() {
         .unwrap();
 
     config.set_max_idle_timeout(5000);
-    config.set_max_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(10_000_000);
     config.set_initial_max_stream_data_bidi_local(1_000_000);
     config.set_initial_max_stream_data_bidi_remote(1_000_000);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -145,6 +145,9 @@ void quiche_config_set_max_idle_timeout(quiche_config *config, uint64_t v);
 // Sets the `max_udp_payload_size transport` parameter.
 void quiche_config_set_max_recv_udp_payload_size(quiche_config *config, size_t v);
 
+// Sets the maximum outgoing UDP payload size.
+void quiche_config_set_max_send_udp_payload_size(quiche_config *config, size_t v);
+
 // Sets the `initial_max_data` transport parameter.
 void quiche_config_set_initial_max_data(quiche_config *config, uint64_t v);
 
@@ -187,9 +190,6 @@ void quiche_config_enable_hystart(quiche_config *config, bool v);
 void quiche_config_enable_dgram(quiche_config *config, bool enabled,
                                 size_t recv_queue_len,
                                 size_t send_queue_len);
-
-// Sets the maximum outgoing UDP payload size used in congestion control.
-void quiche_config_set_max_send_udp_payload_size(quiche_config *config, size_t v);
 
 // Frees the config object.
 void quiche_config_free(quiche_config *config);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -143,7 +143,7 @@ int quiche_config_set_application_protos(quiche_config *config,
 void quiche_config_set_max_idle_timeout(quiche_config *config, uint64_t v);
 
 // Sets the `max_udp_payload_size transport` parameter.
-void quiche_config_set_max_udp_payload_size(quiche_config *config, uint64_t v);
+void quiche_config_set_max_recv_udp_payload_size(quiche_config *config, uint64_t v);
 
 // Sets the `initial_max_data` transport parameter.
 void quiche_config_set_initial_max_data(quiche_config *config, uint64_t v);
@@ -187,6 +187,9 @@ void quiche_config_enable_hystart(quiche_config *config, bool v);
 void quiche_config_enable_dgram(quiche_config *config, bool enabled,
                                 size_t recv_queue_len,
                                 size_t send_queue_len);
+
+// Sets the maximum datagram size used by the congestion control.
+void quiche_config_set_max_send_udp_payload_size(quiche_config *config, size_t v);
 
 // Frees the config object.
 void quiche_config_free(quiche_config *config);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -143,7 +143,7 @@ int quiche_config_set_application_protos(quiche_config *config,
 void quiche_config_set_max_idle_timeout(quiche_config *config, uint64_t v);
 
 // Sets the `max_udp_payload_size transport` parameter.
-void quiche_config_set_max_recv_udp_payload_size(quiche_config *config, uint64_t v);
+void quiche_config_set_max_recv_udp_payload_size(quiche_config *config, size_t v);
 
 // Sets the `initial_max_data` transport parameter.
 void quiche_config_set_initial_max_data(quiche_config *config, uint64_t v);
@@ -188,7 +188,7 @@ void quiche_config_enable_dgram(quiche_config *config, bool enabled,
                                 size_t recv_queue_len,
                                 size_t send_queue_len);
 
-// Sets the maximum datagram size used by the congestion control.
+// Sets the maximum outgoing UDP payload size used in congestion control.
 void quiche_config_set_max_send_udp_payload_size(quiche_config *config, size_t v);
 
 // Frees the config object.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -155,7 +155,7 @@ pub extern fn quiche_config_set_max_idle_timeout(config: &mut Config, v: u64) {
 
 #[no_mangle]
 pub extern fn quiche_config_set_max_recv_udp_payload_size(
-    config: &mut Config, v: u64,
+    config: &mut Config, v: size_t,
 ) {
     config.set_max_recv_udp_payload_size(v);
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -154,10 +154,10 @@ pub extern fn quiche_config_set_max_idle_timeout(config: &mut Config, v: u64) {
 }
 
 #[no_mangle]
-pub extern fn quiche_config_set_max_udp_payload_size(
+pub extern fn quiche_config_set_max_recv_udp_payload_size(
     config: &mut Config, v: u64,
 ) {
-    config.set_max_udp_payload_size(v);
+    config.set_max_recv_udp_payload_size(v);
 }
 
 #[no_mangle]
@@ -247,6 +247,13 @@ pub extern fn quiche_config_enable_dgram(
     send_queue_len: size_t,
 ) {
     config.enable_dgram(enabled, recv_queue_len, send_queue_len);
+}
+
+#[no_mangle]
+pub extern fn quiche_config_set_max_send_udp_payload_size(
+    config: &mut Config, v: size_t,
+) {
+    config.set_max_send_udp_payload_size(v);
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,8 +306,8 @@ const MAX_ACK_RANGES: usize = 68;
 // The highest possible stream ID allowed.
 const MAX_STREAM_ID: u64 = 1 << 60;
 
-/// The default max_datagram_size in the congestion control.
-pub const MAX_DATAGRAM_SIZE: usize = 1200;
+/// The default max_datagram_size used in congestion control.
+const MAX_SEND_UDP_PAYLOAD_SIZE: usize = 1200;
 
 // The default length of DATAGRAM queues.
 const DEFAULT_MAX_DGRAM_QUEUE_LEN: usize = 0;
@@ -447,7 +447,7 @@ pub struct Config {
     dgram_recv_max_queue_len: usize,
     dgram_send_max_queue_len: usize,
 
-    max_datagram_size: usize,
+    max_send_udp_payload_size: usize,
 }
 
 impl Config {
@@ -474,7 +474,7 @@ impl Config {
             dgram_recv_max_queue_len: DEFAULT_MAX_DGRAM_QUEUE_LEN,
             dgram_send_max_queue_len: DEFAULT_MAX_DGRAM_QUEUE_LEN,
 
-            max_datagram_size: MAX_DATAGRAM_SIZE,
+            max_send_udp_payload_size: MAX_SEND_UDP_PAYLOAD_SIZE,
         })
     }
 
@@ -619,8 +619,8 @@ impl Config {
     /// Sets the `max_udp_payload_size transport` parameter.
     ///
     /// The default value is `65527`.
-    pub fn set_max_recv_udp_payload_size(&mut self, v: u64) {
-        self.local_transport_params.max_udp_payload_size = v;
+    pub fn set_max_recv_udp_payload_size(&mut self, v: usize) {
+        self.local_transport_params.max_udp_payload_size = v as u64;
     }
 
     /// Sets the `initial_max_data` transport parameter.
@@ -780,11 +780,11 @@ impl Config {
         self.dgram_send_max_queue_len = send_queue_len;
     }
 
-    /// Sets the maximum datagram size used by the congestion control.
+    /// Sets the maximum outgoing UDP payload size used in congestion control.
     ///
     /// The default and minimum value is `1200`.
     pub fn set_max_send_udp_payload_size(&mut self, v: usize) {
-        self.max_datagram_size = cmp::max(v, MAX_DATAGRAM_SIZE);
+        self.max_send_udp_payload_size = cmp::max(v, MAX_SEND_UDP_PAYLOAD_SIZE);
     }
 }
 

--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -247,7 +247,7 @@ fn on_packet_acked(
 
         // cwnd_inc can be more than 1 MSS in the late stage of max probing.
         // however QUIC recovery draft 7.4 (Congestion Avoidance) limits
-        // the increase of cwnd to 1 max packet size per cwnd acknowledged.
+        // the increase of cwnd to 1 max_datagram_size per cwnd acknowledged.
         if r.cubic_state.cwnd_inc >= r.max_datagram_size {
             r.congestion_window += r.max_datagram_size;
             r.cubic_state.cwnd_inc -= r.max_datagram_size;

--- a/src/recovery/hystart.rs
+++ b/src/recovery/hystart.rs
@@ -112,7 +112,7 @@ impl Hystart {
     // Returns a new (ssthresh, cwnd) during slow start.
     pub fn on_packet_acked(
         &mut self, packet: &recovery::Acked, rtt: Duration, cwnd: usize,
-        ssthresh: usize, now: Instant,
+        ssthresh: usize, now: Instant, max_datagram_size: usize,
     ) -> (usize, usize) {
         let mut ssthresh = ssthresh;
         let mut cwnd = cwnd;
@@ -130,7 +130,7 @@ impl Hystart {
 
             self.rtt_sample_count += 1;
 
-            if cwnd >= (LOW_CWND * recovery::MAX_DATAGRAM_SIZE) &&
+            if cwnd >= (LOW_CWND * max_datagram_size) &&
                 self.rtt_sample_count >= N_RTT_SAMPLE &&
                 self.current_round_min_rtt.is_some() &&
                 self.last_round_min_rtt.is_some()
@@ -221,6 +221,7 @@ mod tests {
             init_cwnd,
             init_ssthresh,
             now,
+            crate::MAX_DATAGRAM_SIZE,
         );
 
         // Expecting Reno slow start.
@@ -258,8 +259,14 @@ mod tests {
             // We use a fixed rtt for 1st round.
             let rtt = Duration::from_millis(rtt_1st);
 
-            let (new_cwnd, new_ssthresh) =
-                hspp.on_packet_acked(&p, rtt, cwnd, ssthresh, now);
+            let (new_cwnd, new_ssthresh) = hspp.on_packet_acked(
+                &p,
+                rtt,
+                cwnd,
+                ssthresh,
+                now,
+                crate::MAX_DATAGRAM_SIZE,
+            );
 
             cwnd = new_cwnd;
             ssthresh = new_ssthresh;
@@ -283,8 +290,14 @@ mod tests {
             // This is to exit from slow slart to LSS.
             let rtt = Duration::from_millis(rtt_2nd + pkt_num * 4);
 
-            let (new_cwnd, new_ssthresh) =
-                hspp.on_packet_acked(&p, rtt, cwnd, ssthresh, now);
+            let (new_cwnd, new_ssthresh) = hspp.on_packet_acked(
+                &p,
+                rtt,
+                cwnd,
+                ssthresh,
+                now,
+                crate::MAX_DATAGRAM_SIZE,
+            );
 
             cwnd = new_cwnd;
             ssthresh = new_ssthresh;

--- a/src/recovery/hystart.rs
+++ b/src/recovery/hystart.rs
@@ -221,7 +221,7 @@ mod tests {
             init_cwnd,
             init_ssthresh,
             now,
-            crate::MAX_DATAGRAM_SIZE,
+            crate::MAX_SEND_UDP_PAYLOAD_SIZE,
         );
 
         // Expecting Reno slow start.
@@ -265,7 +265,7 @@ mod tests {
                 cwnd,
                 ssthresh,
                 now,
-                crate::MAX_DATAGRAM_SIZE,
+                crate::MAX_SEND_UDP_PAYLOAD_SIZE,
             );
 
             cwnd = new_cwnd;
@@ -296,7 +296,7 @@ mod tests {
                 cwnd,
                 ssthresh,
                 now,
-                crate::MAX_DATAGRAM_SIZE,
+                crate::MAX_SEND_UDP_PAYLOAD_SIZE,
             );
 
             cwnd = new_cwnd;

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -169,7 +169,8 @@ impl Recovery {
 
             in_flight_count: [0; packet::EPOCH_COUNT],
 
-            congestion_window: config.max_send_udp_payload_size * INITIAL_WINDOW_PACKETS,
+            congestion_window: config.max_send_udp_payload_size *
+                INITIAL_WINDOW_PACKETS,
 
             bytes_in_flight: 0,
 
@@ -467,6 +468,10 @@ impl Recovery {
 
     pub fn delivery_rate(&self) -> u64 {
         self.delivery_rate.delivery_rate()
+    }
+
+    pub fn max_datagram_size(&self) -> usize {
+        self.max_datagram_size
     }
 
     fn update_rtt(

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -169,7 +169,7 @@ impl Recovery {
 
             in_flight_count: [0; packet::EPOCH_COUNT],
 
-            congestion_window: config.max_datagram_size * INITIAL_WINDOW_PACKETS,
+            congestion_window: config.max_send_udp_payload_size * INITIAL_WINDOW_PACKETS,
 
             bytes_in_flight: 0,
 
@@ -179,7 +179,7 @@ impl Recovery {
 
             congestion_recovery_start_time: None,
 
-            max_datagram_size: config.max_datagram_size,
+            max_datagram_size: config.max_send_udp_payload_size,
 
             cc_ops: config.cc_algorithm.into(),
 

--- a/tools/apps/src/bin/quiche-client.rs
+++ b/tools/apps/src/bin/quiche-client.rs
@@ -128,6 +128,7 @@ fn main() {
 
     config.set_max_idle_timeout(conn_args.idle_timeout);
     config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
+    config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(conn_args.max_data);
     config.set_initial_max_stream_data_bidi_local(conn_args.max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(conn_args.max_stream_data);

--- a/tools/apps/src/bin/quiche-client.rs
+++ b/tools/apps/src/bin/quiche-client.rs
@@ -127,7 +127,7 @@ fn main() {
     config.set_application_protos(&conn_args.alpns).unwrap();
 
     config.set_max_idle_timeout(conn_args.idle_timeout);
-    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(conn_args.max_data);
     config.set_initial_max_stream_data_bidi_local(conn_args.max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(conn_args.max_stream_data);

--- a/tools/apps/src/bin/quiche-client.rs
+++ b/tools/apps/src/bin/quiche-client.rs
@@ -127,7 +127,7 @@ fn main() {
     config.set_application_protos(&conn_args.alpns).unwrap();
 
     config.set_max_idle_timeout(conn_args.idle_timeout);
-    config.set_max_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(conn_args.max_data);
     config.set_initial_max_stream_data_bidi_local(conn_args.max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(conn_args.max_stream_data);

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -108,7 +108,7 @@ fn main() {
     config.set_application_protos(&conn_args.alpns).unwrap();
 
     config.set_max_idle_timeout(conn_args.idle_timeout);
-    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(conn_args.max_data);
     config.set_initial_max_stream_data_bidi_local(conn_args.max_stream_data);

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -108,7 +108,8 @@ fn main() {
     config.set_application_protos(&conn_args.alpns).unwrap();
 
     config.set_max_idle_timeout(conn_args.idle_timeout);
-    config.set_max_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(conn_args.max_data);
     config.set_initial_max_stream_data_bidi_local(conn_args.max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(conn_args.max_stream_data);

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -91,7 +91,7 @@ pub fn run(
         .unwrap();
 
     config.set_max_idle_timeout(idle_timeout);
-    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(max_stream_data);

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -91,7 +91,7 @@ pub fn run(
         .unwrap();
 
     config.set_max_idle_timeout(idle_timeout);
-    config.set_max_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE as u64);
     config.set_initial_max_data(max_data);
     config.set_initial_max_stream_data_bidi_local(max_stream_data);
     config.set_initial_max_stream_data_bidi_remote(max_stream_data);


### PR DESCRIPTION
In the recovery module we use MAX_DATAGRAM_SIZE constants (1452)
and when the actual payload size (max_udp_payload_size) parameter
and the actual max size of the packet doesn't match, the congestion
control might work inefficiently. For example quiche-server
sets max_udp_payload_size and max udp packet size to 1350, but
since MAX_DATAGRAM_SIZE is 1452, the congestion window grows
too fast then expected, resulting unnecessary packet loss due to
overtransfer.

This PR changes MAX_DATAGRAM_SIZE as a configurable parameter
and adds set_max_datagram_size() API for the application.

When tested, this can reduce errors such as timeout a lot when
running in very high bandwidth/rtt environment.