### PR TITLE
h3: ensure urgency is always shifted

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -737,7 +737,7 @@ impl Connection {
             return Err(Error::FrameUnexpected);
         }
 
-        let mut urgency = 3;
+        let mut urgency = 3u8.saturating_add(PRIORITY_URGENCY_OFFSET);
         let mut incremental = false;
 
         for param in priority.split(',') {


### PR DESCRIPTION
This wouldn't cause any problem if the client consistently sent, or consistently did not send, prioritiy parameters. However, if a client mixed things up and omitted sometimes (which the spec recommends it does for defaults) then scheduling results might not meet expectations.