### PR TITLE
avoid cloning connection IDs when sending packets

### DIFF
--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -180,7 +180,7 @@ fn main() {
 
             // Lookup a connection based on the packet's connection ID. If there
             // is no connection matching, create a new one.
-            let (_, client) = if !clients.contains_key(&hdr.dcid) &&
+            let (_, client) = if !clients.contains_key(hdr.dcid.as_ref()) &&
                 !clients.contains_key(conn_id)
             {
                 if hdr.ty != quiche::Type::Initial {
@@ -279,7 +279,7 @@ fn main() {
 
                 clients.get_mut(&scid[..]).unwrap()
             } else {
-                match clients.get_mut(&hdr.dcid) {
+                match clients.get_mut(hdr.dcid.as_ref()) {
                     Some(v) => v,
 
                     None => clients.get_mut(conn_id).unwrap(),

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -172,7 +172,7 @@ fn main() {
 
             // Lookup a connection based on the packet's connection ID. If there
             // is no connection matching, create a new one.
-            let (_, client) = if !clients.contains_key(&hdr.dcid) &&
+            let (_, client) = if !clients.contains_key(hdr.dcid.as_ref()) &&
                 !clients.contains_key(conn_id)
             {
                 if hdr.ty != quiche::Type::Initial {
@@ -270,7 +270,7 @@ fn main() {
 
                 clients.get_mut(&scid[..]).unwrap()
             } else {
-                match clients.get_mut(&hdr.dcid) {
+                match clients.get_mut(hdr.dcid.as_ref()) {
                     Some(v) => v,
 
                     None => clients.get_mut(conn_id).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1476,11 +1476,11 @@ impl Connection {
                 return Err(Error::Done);
             }
 
-            if hdr.dcid != self.scid {
+            if hdr.dcid.as_ref() != self.scid {
                 return Err(Error::Done);
             }
 
-            if hdr.scid != self.dcid {
+            if hdr.scid.as_ref() != self.dcid {
                 return Err(Error::Done);
             }
 
@@ -2044,16 +2044,11 @@ impl Connection {
 
         let hdr = Header {
             ty: pkt_type,
-            version: self.version,
-            dcid: self.dcid.clone(),
 
-            // Don't needlessly clone the source connection ID for 1-RTT packets
-            // as it is not used.
-            scid: if pkt_type != packet::Type::Short {
-                self.scid.clone()
-            } else {
-                Vec::new()
-            },
+            version: self.version,
+
+            dcid: ConnectionId::from_ref(&self.dcid),
+            scid: ConnectionId::from_ref(&self.scid),
 
             pkt_num: 0,
             pkt_num_len: pn_len,
@@ -4672,8 +4667,8 @@ pub mod testing {
         let hdr = Header {
             ty: pkt_type,
             version: conn.version,
-            dcid: conn.dcid.clone(),
-            scid: conn.scid.clone(),
+            dcid: ConnectionId::from_ref(&conn.dcid),
+            scid: ConnectionId::from_ref(&conn.scid),
             pkt_num: 0,
             pkt_num_len: pn_len,
             token: conn.token.clone(),
@@ -6113,8 +6108,8 @@ mod tests {
         let hdr = Header {
             ty: packet::Type::Initial,
             version: pipe.client.version,
-            dcid: pipe.client.dcid.clone(),
-            scid: pipe.client.scid.clone(),
+            dcid: ConnectionId::from_ref(&pipe.client.dcid),
+            scid: ConnectionId::from_ref(&pipe.client.scid),
             pkt_num: 0,
             pkt_num_len: pn_len,
             token: pipe.client.token.clone(),
@@ -7748,9 +7743,12 @@ mod tests {
     }
 }
 
+pub use crate::packet::ConnectionId;
 pub use crate::packet::Header;
 pub use crate::packet::Type;
+
 pub use crate::recovery::CongestionControlAlgorithm;
+
 pub use crate::stream::StreamIter;
 
 mod crypto;

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -232,7 +232,7 @@ fn main() {
 
             // Lookup a connection based on the packet's connection ID. If there
             // is no connection matching, create a new one.
-            let (_, client) = if !clients.contains_key(&hdr.dcid) &&
+            let (_, client) = if !clients.contains_key(hdr.dcid.as_ref()) &&
                 !clients.contains_key(conn_id)
             {
                 if hdr.ty != quiche::Type::Initial {
@@ -361,7 +361,7 @@ fn main() {
 
                 clients.get_mut(&scid[..]).unwrap()
             } else {
-                match clients.get_mut(&hdr.dcid) {
+                match clients.get_mut(hdr.dcid.as_ref()) {
                     Some(v) => v,
 
                     None => clients.get_mut(conn_id).unwrap(),


### PR DESCRIPTION
This introduces a new "ConnectionId" type that represents a QUIC
connection ID as either a Vec<u8> (as we do right now) or a &[u8].

The latter form allows us to avoid cloning the connection IDs when
generating outgoing packets. When parsing incming packets we still
need to use a Vec though.

Note that this is a backwards-incompatible API change as it modifies
the public Header type.