### PR TITLE
initial GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+on:
+  push:
+    branches:
+      - master
+
+name: Deploy
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake
+
+      - name: Run cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps
+
+      - name: Deploy to GitHub Pages
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: target/doc
+          fqdn: docs.quic.tech
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Push Docker images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Build Docker images
+        run: make docker-build
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Publish Docker images
+        run: make docker-publish

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,173 @@
+on: [push, pull_request]
+
+name: Nightly
+
+env:
+  RUSTFLAGS: "-D warnings"
+  TOOLCHAIN: "nightly-2020-10-25"
+
+jobs:
+  quiche:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          components: rustfmt
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake libev-dev uthash-dev
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose
+
+      - name: Run cargo package
+        uses: actions-rs/cargo@v1
+        with:
+          command: package
+          args: --verbose --allow-dirty
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+      - name: Run cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps
+
+      - name: Build C examples
+        run: make -C examples
+
+  quiche_x86:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          components: rustfmt
+          target: i686-unknown-linux-gnu
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake gcc-multilib g++-multilib
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --target=i686-unknown-linux-gnu
+
+  apps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          components: rustfmt
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --manifest-path=tools/apps/Cargo.toml
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path=tools/apps/Cargo.toml -- --check
+
+  qlog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          components: rustfmt
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --manifest-path=tools/qlog/Cargo.toml
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path=tools/qlog/Cargo.toml -- --check
+
+  http3_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          components: rustfmt
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-run --verbose --manifest-path=tools/http3_test/Cargo.toml
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path=tools/http3_test/Cargo.toml -- --check

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,0 +1,215 @@
+on: [push, pull_request]
+
+name: Stable
+
+env:
+  RUSTFLAGS: "-D warnings"
+  TOOLCHAIN: "stable"
+
+jobs:
+  quiche:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          components: clippy
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake libev-dev uthash-dev
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose
+
+      - name: Run cargo package
+        uses: actions-rs/cargo@v1
+        with:
+          command: package
+          args: --verbose --allow-dirty
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --examples -- -D warnings
+
+      - name: Run cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps
+
+      - name: Build C examples
+        run: make -C examples
+
+  quiche_x86:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          target: i686-unknown-linux-gnu
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake gcc-multilib g++-multilib
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --target=i686-unknown-linux-gnu
+
+  apps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --manifest-path=tools/apps/Cargo.toml
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=tools/apps/Cargo.toml -- -D warnings
+
+  qlog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --manifest-path=tools/qlog/Cargo.toml
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=tools/qlog/Cargo.toml -- -D warnings
+
+  http3_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-run --verbose --manifest-path=tools/http3_test/Cargo.toml
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=tools/http3_test/Cargo.toml -- -D warnings
+
+  nginx:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ "1.16.1" ]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get install cmake libpcre3-dev zlib1g-dev
+
+      - name: Download NGINX sources
+        run: curl -O https://nginx.org/download/nginx-${{ matrix.version }}.tar.gz
+
+      - name: Extract NGINX sources
+        run: tar xzf nginx-${{ matrix.version }}.tar.gz
+
+      - name: Build NGINX
+        run: |
+          cd nginx-${{ matrix.version }} &&
+          patch -p01 < ../extras/nginx/nginx-1.16.patch &&
+          ./configure --with-http_ssl_module --with-http_v2_module --with-http_v3_module --with-openssl="../deps/boringssl" --with-quiche=".." --with-debug &&
+          make -j`nproc` &&
+          objs/nginx -V
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Build Docker images
+        run: make docker-build


### PR DESCRIPTION
This adds some GitHub Actions workflows. It's not quite as complete as the Travis CI configuration yet (e.g. missing Windows, macOS, Android builds), and I couldn't test the deploy workflow yet (only one way to find out if it works...). Also, we first need to create the secret for the Docker Hub credentials (though we could also just publish the image on the GitHub registry instead which might be easier).

One advantage of Actions vs Travis CI is that we seem to have a bigger number of concurrent jobs available, so the build overall should take less time than on Travis. Not quite sure yet whether we'll end up hitting the monthly limits yet though.