### PR TITLE
write frames into output packet upon creation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2107,7 +2107,7 @@ impl Connection {
         let header_offset = b.off();
 
         // Reserve space for payload length in advance. Since we don't yet know
-        // what the final length will be, we reserver 2 bytes in all cases.
+        // what the final length will be, we reserve 2 bytes in all cases.
         //
         // Only long header packets have an explicit length field.
         if pkt_type != packet::Type::Short {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,6 +313,9 @@ const DEFAULT_MAX_DGRAM_QUEUE_LEN: usize = 0;
 // frames size. We enforce the recommendation for forward compatibility.
 const MAX_DGRAM_FRAME_SIZE: u64 = 65536;
 
+// The length of the payload length field.
+const PAYLOAD_LENGTH_LEN: usize = 2;
+
 /// A specialized [`Result`] type for quiche operations.
 ///
 /// This type is used throughout quiche's public API for any operation that
@@ -1086,10 +1089,11 @@ pub fn version_is_supported(version: u32) -> bool {
 /// there is no room to add the frame in the packet. You may retry to add the
 /// frame later.
 macro_rules! push_frame_to_pkt {
-    ($frames:expr, $frame:expr, $payload_len: expr, $left:expr) => {{
+    ($out:expr, $frames:expr, $frame:expr, $left:expr) => {{
         if $frame.wire_len() <= $left {
-            $payload_len += $frame.wire_len();
             $left -= $frame.wire_len();
+
+            $frame.to_bytes(&mut $out)?;
 
             $frames.push($frame);
 
@@ -2100,7 +2104,19 @@ impl Connection {
         let mut in_flight = false;
         let mut has_data = false;
 
-        let mut payload_len = 0;
+        let header_offset = b.off();
+
+        // Reserve space for payload length in advance. Since we don't yet know
+        // what the final length will be, we reserver 2 bytes in all cases.
+        //
+        // Only long header packets have an explicit length field.
+        if pkt_type != packet::Type::Short {
+            b.skip(PAYLOAD_LENGTH_LEN)?;
+        }
+
+        packet::encode_pkt_num(pn, &mut b)?;
+
+        let payload_offset = b.off();
 
         // Create ACK frame.
         if self.pkt_num_spaces[epoch].recv_pkt_need_ack.len() > 0 &&
@@ -2120,7 +2136,7 @@ impl Connection {
                 ranges: self.pkt_num_spaces[epoch].recv_pkt_need_ack.clone(),
             };
 
-            if push_frame_to_pkt!(frames, frame, payload_len, left) {
+            if push_frame_to_pkt!(b, frames, frame, left) {
                 self.pkt_num_spaces[epoch].ack_elicited = false;
             }
         }
@@ -2133,7 +2149,7 @@ impl Connection {
             {
                 let frame = frame::Frame::HandshakeDone;
 
-                if push_frame_to_pkt!(frames, frame, payload_len, left) {
+                if push_frame_to_pkt!(b, frames, frame, left) {
                     self.handshake_done_sent = true;
 
                     ack_eliciting = true;
@@ -2147,7 +2163,7 @@ impl Connection {
                     max: self.streams.max_streams_bidi_next(),
                 };
 
-                if push_frame_to_pkt!(frames, frame, payload_len, left) {
+                if push_frame_to_pkt!(b, frames, frame, left) {
                     self.streams.update_max_streams_bidi();
 
                     ack_eliciting = true;
@@ -2161,7 +2177,7 @@ impl Connection {
                     max: self.streams.max_streams_uni_next(),
                 };
 
-                if push_frame_to_pkt!(frames, frame, payload_len, left) {
+                if push_frame_to_pkt!(b, frames, frame, left) {
                     self.streams.update_max_streams_uni();
 
                     ack_eliciting = true;
@@ -2175,7 +2191,7 @@ impl Connection {
                     max: self.max_rx_data_next,
                 };
 
-                if push_frame_to_pkt!(frames, frame, payload_len, left) {
+                if push_frame_to_pkt!(b, frames, frame, left) {
                     self.almost_full = false;
 
                     // Commits the new max_rx_data limit.
@@ -2190,7 +2206,7 @@ impl Connection {
             if let Some(limit) = self.blocked_limit {
                 let frame = frame::Frame::DataBlocked { limit };
 
-                if push_frame_to_pkt!(frames, frame, payload_len, left) {
+                if push_frame_to_pkt!(b, frames, frame, left) {
                     self.blocked_limit = None;
 
                     ack_eliciting = true;
@@ -2216,7 +2232,7 @@ impl Connection {
                     max: stream.recv.max_data_next(),
                 };
 
-                if push_frame_to_pkt!(frames, frame, payload_len, left) {
+                if push_frame_to_pkt!(b, frames, frame, left) {
                     stream.recv.update_max_data();
 
                     self.streams.mark_almost_full(stream_id, false);
@@ -2235,7 +2251,7 @@ impl Connection {
             {
                 let frame = frame::Frame::StreamDataBlocked { stream_id, limit };
 
-                if push_frame_to_pkt!(frames, frame, payload_len, left) {
+                if push_frame_to_pkt!(b, frames, frame, left) {
                     self.streams.mark_blocked(stream_id, false, 0);
 
                     ack_eliciting = true;
@@ -2252,7 +2268,7 @@ impl Connection {
                 reason: Vec::new(),
             };
 
-            if push_frame_to_pkt!(frames, frame, payload_len, left) {
+            if push_frame_to_pkt!(b, frames, frame, left) {
                 self.draining_timer = Some(now + (self.recovery.pto() * 3));
 
                 ack_eliciting = true;
@@ -2268,7 +2284,7 @@ impl Connection {
                     reason: self.app_reason.clone(),
                 };
 
-                if push_frame_to_pkt!(frames, frame, payload_len, left) {
+                if push_frame_to_pkt!(b, frames, frame, left) {
                     self.draining_timer = Some(now + (self.recovery.pto() * 3));
 
                     ack_eliciting = true;
@@ -2283,7 +2299,7 @@ impl Connection {
                 data: challenge.clone(),
             };
 
-            if push_frame_to_pkt!(frames, frame, payload_len, left) {
+            if push_frame_to_pkt!(b, frames, frame, left) {
                 self.challenge = None;
 
                 ack_eliciting = true;
@@ -2304,7 +2320,7 @@ impl Connection {
 
             let frame = frame::Frame::Crypto { data: crypto_buf };
 
-            if push_frame_to_pkt!(frames, frame, payload_len, left) {
+            if push_frame_to_pkt!(b, frames, frame, left) {
                 ack_eliciting = true;
                 in_flight = true;
                 has_data = true;
@@ -2324,12 +2340,7 @@ impl Connection {
                             Some(data) => {
                                 let frame = frame::Frame::Datagram { data };
 
-                                if push_frame_to_pkt!(
-                                    frames,
-                                    frame,
-                                    payload_len,
-                                    left
-                                ) {
+                                if push_frame_to_pkt!(b, frames, frame, left) {
                                     ack_eliciting = true;
                                     in_flight = true;
                                 }
@@ -2386,7 +2397,7 @@ impl Connection {
                     data: stream_buf,
                 };
 
-                if push_frame_to_pkt!(frames, frame, payload_len, left) {
+                if push_frame_to_pkt!(b, frames, frame, left) {
                     ack_eliciting = true;
                     in_flight = true;
                     has_data = true;
@@ -2419,7 +2430,7 @@ impl Connection {
         {
             let frame = frame::Frame::Ping;
 
-            if push_frame_to_pkt!(frames, frame, payload_len, left) {
+            if push_frame_to_pkt!(b, frames, frame, left) {
                 ack_eliciting = true;
                 in_flight = true;
             }
@@ -2439,43 +2450,43 @@ impl Connection {
 
         // Pad the client's initial packet.
         if !self.is_server && pkt_type == packet::Type::Initial {
+            let payload_len = b.off() - payload_offset;
             let pkt_len = pn_len + payload_len + crypto_overhead;
 
             let frame = frame::Frame::Padding {
                 len: cmp::min(MIN_CLIENT_INITIAL_LEN - pkt_len, left),
             };
 
-            payload_len += frame.wire_len();
-
-            frames.push(frame);
-
-            in_flight = true;
+            if push_frame_to_pkt!(b, frames, frame, left) {
+                in_flight = true;
+            }
         }
 
         // Pad payload so that it's always at least 4 bytes.
-        if payload_len < PAYLOAD_MIN_LEN {
+        if b.off() - payload_offset < PAYLOAD_MIN_LEN {
+            let payload_len = b.off() - payload_offset;
+
             let frame = frame::Frame::Padding {
                 len: PAYLOAD_MIN_LEN - payload_len,
             };
 
-            payload_len += frame.wire_len();
-
-            frames.push(frame);
-
-            in_flight = true;
+            #[allow(unused_assignments)]
+            if push_frame_to_pkt!(b, frames, frame, left) {
+                in_flight = true;
+            }
         }
 
-        payload_len += crypto_overhead;
+        let payload_len = b.off() - payload_offset;
+        let payload_len = payload_len + crypto_overhead;
 
-        // Only long header packets have an explicit length field.
+        // Fill in payload length.
         if pkt_type != packet::Type::Short {
             let len = pn_len + payload_len;
-            b.put_varint(len as u64)?;
+
+            let (_, mut payload_with_len) = b.split_at(header_offset)?;
+            payload_with_len
+                .put_varint_with_len(len as u64, PAYLOAD_LENGTH_LEN)?;
         }
-
-        packet::encode_pkt_num(pn, &mut b)?;
-
-        let payload_offset = b.off();
 
         trace!(
             "{} tx pkt {:?} len={} pn={}",
@@ -2505,11 +2516,8 @@ impl Connection {
             q.add_event(packet_sent_ev).ok();
         });
 
-        // Encode frames into the output packet.
         for frame in &mut frames {
             trace!("{} tx frm {:?}", self.trace_id, frame);
-
-            frame.to_bytes(&mut b)?;
 
             qlog_with!(self.qlog_streamer, q, {
                 q.add_frame(frame.to_qlog(), false).ok();

--- a/src/octets.rs
+++ b/src/octets.rs
@@ -287,6 +287,17 @@ impl<'a> Octets<'a> {
         Ok(&self.buf[cap - len..])
     }
 
+    /// Advances the buffer's offset.
+    pub fn skip(&mut self, skip: usize) -> Result<()> {
+        if skip > self.cap() {
+            return Err(BufferTooShortError);
+        }
+
+        self.off += skip;
+
+        Ok(())
+    }
+
     /// Returns the remaining capacity in the buffer.
     pub fn cap(&self) -> usize {
         self.buf.len() - self.off
@@ -625,6 +636,17 @@ impl<'a> OctetsMut<'a> {
 
         let cap = self.cap();
         Ok(&mut self.buf[cap - len..])
+    }
+
+    /// Advances the buffer's offset.
+    pub fn skip(&mut self, skip: usize) -> Result<()> {
+        if skip > self.cap() {
+            return Err(BufferTooShortError);
+        }
+
+        self.off += skip;
+
+        Ok(())
     }
 
     /// Returns the remaining capacity in the buffer.


### PR DESCRIPTION
Instead of waiting to write frames into the packet to after all frames
are generated, write frames immediately after creation.

For now this doesn't really make much of a difference, but in the future
this will allow writing stream data directly into the packet without
having to copy it into an intermediate buffer first, which should also
decrease the number of allocations.

This requires changing how the payload length is encoded into the packet
as well. Since we don't know the length in advance, we simply reserve a
fixed number of bytes, and later fill this space once all frames have
been encoded.

For the time being we still maintain a vector of all frames. This is
mostly only for logging purposes to avoid logging frames before packet
headers, as the latter are logged alongside the payload length.