### PR TITLE
stream: use VecDeque to store SendBuf data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2773,7 +2773,7 @@ impl Connection {
 
         let was_flushable = stream.is_flushable();
 
-        let sent = stream.send.push_slice(buf, fin)?;
+        let sent = stream.send.write(buf, fin)?;
 
         let urgency = stream.urgency;
         let incremental = stream.incremental;

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -676,7 +676,7 @@ extern fn add_handshake_data(
             &mut conn.pkt_num_spaces[packet::EPOCH_APPLICATION],
     };
 
-    if space.crypto_stream.send.push_slice(buf, false).is_err() {
+    if space.crypto_stream.send.write(buf, false).is_err() {
         return 0;
     }
 


### PR DESCRIPTION
This changes the internal storage of SendBuf to a VecDeque, but it
doesn't change the underlying logic. In the future this will allow us to
change how SendBuf data is emitted to avoid the allocation and
additional copy we currently perform.

In most cases insertions to the SendBuf happen at the end of the buffer,
however, due to the fact that buffers need to be stored in order, in
case of retransmissions they might happen at any index in the vector.

While at it, the SendBuf::push_slice() method is also renamed to
SendBuf::write() to be consistent with RecvBuf.