### PR TITLE
stream: allocate send RangeBuf with consistent sizes

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -382,7 +382,7 @@ impl Frame {
             Frame::Crypto { data } => {
                 encode_crypto_header(data.off() as u64, data.len() as u64, b)?;
 
-                b.put_bytes(&data)?;
+                data.with(|s| b.put_bytes(s))?;
             },
 
             Frame::CryptoHeader { .. } => (),
@@ -403,7 +403,7 @@ impl Frame {
                     b,
                 )?;
 
-                b.put_bytes(data.as_ref())?;
+                data.with(|s| b.put_bytes(s))?;
             },
 
             Frame::StreamHeader { .. } => (),


### PR DESCRIPTION
This changes how RangeBuf objects are allocated when sending data.

Currently a new RangeBuf is allocated for each application write (of the
size of the write itself).

This change makes it possible to allocate RangeBufs of a pre-defined
capacity, whether the application data can fill it or not:

 * If the application data is bigger than the RangeBuf capacity, new
   RangeBuf objects are allocated (with the same fixed capacity) until
   all the application data has been stored.

 * If the application data is smaller than the RangeBuf capacity, the
   RangeBuf is stored with the unused capacity at the back of the
   SendBuf. Following writes will then try to fill the trailing RangeBuf
   if it has any spare capacity.

The use of Arc<RwLock<>> for the RangeBuf's internal buffer makes
accessing the data somewhat more complicated as we can't slice the
Vec<u8> directly anymore, which is why the `with()` method was added.

However this added complexity is necessary to make sure Connection can
implement the Send trait, and due to the fact that Arc requires its
inner type to be both Sync and Send, we need to use RwLock (instead of,
say, RefCell) to satisfy the type constraints.

---

The `RwLock` thing is kind of annoying, need to do some benchmarks to see if it has any impact on performance. Also, in the future we probably want to do something similar for `RecvBuf` as well, but that will need some refactoring as well.