### PR TITLE
h3: add event yielding to poll()

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -480,6 +480,12 @@ void quiche_h3_config_set_qpack_max_table_capacity(quiche_h3_config *config, uin
 // Sets the `SETTINGS_QPACK_BLOCKED_STREAMS` setting.
 void quiche_h3_config_set_qpack_blocked_streams(quiche_h3_config *config, uint64_t v);
 
+// Sets the `quiche_h3_conn_poll()` repetition threshold for DATAGRAM events.
+void quiche_h3_config_set_dgram_poll_threshold(quiche_h3_config *config, uint64_t v);
+
+// Sets the `quiche_h3_conn_poll()` repetition threshold for stream events.
+void quiche_h3_config_set_dgram_poll_threshold(quiche_h3_config *config, uint64_t v);
+
 // Frees the HTTP/3 config object.
 void quiche_h3_config_free(quiche_h3_config *config);
 

--- a/src/h3/ffi.rs
+++ b/src/h3/ffi.rs
@@ -70,6 +70,20 @@ pub extern fn quiche_h3_config_set_qpack_blocked_streams(
 }
 
 #[no_mangle]
+pub extern fn quiche_h3_config_set_dgram_poll_threshold(
+    config: &mut h3::Config, v: u64,
+) {
+    config.set_dgram_poll_threshold(v);
+}
+
+#[no_mangle]
+pub extern fn quiche_h3_config_set_stream_poll_threshold(
+    config: &mut h3::Config, v: u64,
+) {
+    config.set_stream_poll_threshold(v);
+}
+
+#[no_mangle]
 pub extern fn quiche_h3_config_free(config: *mut h3::Config) {
     unsafe { Box::from_raw(config) };
 }


### PR DESCRIPTION
When DATAGRAM support was added, poll() was updated to return
Event::Datagram. We made the decision to prefer returning such
events ahead of stream events (Event::Headers, Event::Data).

There can be cases when an application wants to handle streams
ahead of DATAGRAMS. However, just reordering things inside poll()
wouldn't work for applications that prefer to read DATAGRAMs.

This change introduces a basic yield mechanism into poll().
Poll() starts by processing DATAGRAMs. Once a threshold
count is hit, it moves to processing request
streams. Once that threshold is hit, it moves back to DATAGRAMs.

The thresholds are configured using quiche::h3::Config. By
default there are no thresholds applied, this maintains prior
behavior.

Since this changes poll(), I've added several unit tests for both
simple DATAGRAM sending/receiving, and DATAGRAM poll yielding.