### PR TITLE
CI: Add Android build to Github Action

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -281,3 +281,100 @@ jobs:
 
       - name: Build Docker images
         run: make docker-build
+
+  android_ndk_old:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ndk_version: ["r13b"]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install stable toolchain aarch64-linux-android
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          target: aarch64-linux-android
+          override: true
+
+      - name: Install stable toolchain arm-linux-androideabi
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          target: arm-linux-androideabi
+          override: true
+
+      - name: Install stable toolchain armv7-linux-androideabi
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          target: armv7-linux-androideabi
+          override: true
+
+      - name: Install stable toolchain i686-linux-android
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          target: i686-linux-android
+          override: true
+
+      - name: Download NDK
+        run: curl -O https://dl.google.com/android/repository/android-ndk-${{ matrix.ndk_version }}-linux-x86_64.zip
+
+      - name: Extract NDK
+        run: unzip -q android-ndk-${{ matrix.ndk_version }}-linux-x86_64.zip
+
+      - name: Run build
+        run: |
+          mkdir -p $TOOLCHAIN_DIR &&
+          tools/android/setup_android.sh &&
+          tools/android/build_android.sh --verbose --features ndk-old-gcc
+        env:
+          ANDROID_NDK_HOME: ${{ github.workspace }}/android-ndk-${{ matrix.ndk_version }}
+          TOOLCHAIN_DIR: ${{ github.workspace }}/toolchain
+
+  android_ndk_lts:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ndk_version: ["21"]
+        target: ["aarch64-linux-android", "arm-linux-androideabi", "armv7-linux-androideabi", "i686-linux-android"]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install stable toolchain for the target
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.TOOLCHAIN }}
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: Install cargo-ndk
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-ndk
+
+      - name: Download NDK
+        run: curl -O https://dl.google.com/android/repository/android-ndk-r${{ matrix.ndk_version }}-linux-x86_64.zip
+
+      - name: Extract NDK
+        run: unzip -q android-ndk-r${{ matrix.ndk_version }}-linux-x86_64.zip
+
+      - name: Run cargo ndk
+        uses: actions-rs/cargo@v1
+        with:
+          command: ndk
+          args: --target ${{ matrix.target }} --android-platform ${{ matrix.ndk_version }} -- build --verbose
+        env:
+          ANDROID_NDK_HOME: ${{ github.workspace }}/android-ndk-r${{ matrix.ndk_version }}


### PR DESCRIPTION
Basically porting what we have in Travis CI to Github Action.
In case of NDK LTS build, I split into each target platform for
parallel build.

- android_ndk_old (r13b)
- android_ndk_lts (21) - 4 targets