### PR TITLE
make Config and Connection Send + Sync

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -640,6 +640,7 @@ pub extern fn quiche_conn_is_readable(conn: &Connection) -> bool {
 
 struct AppData(*mut c_void);
 unsafe impl Send for AppData {}
+unsafe impl Sync for AppData {}
 
 #[no_mangle]
 pub extern fn quiche_conn_stream_init_application_data(

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -496,7 +496,7 @@ pub struct Stream {
     pub local: bool,
 
     /// Application data.
-    pub data: Option<Box<dyn Send + std::any::Any>>,
+    pub data: Option<Box<dyn std::any::Any + Send + Sync>>,
 
     /// The stream's urgency (lower is better). Default is `DEFAULT_URGENCY`.
     pub urgency: u8,


### PR DESCRIPTION
This makes both Config and Connection Sync-able (in addition to
Send-able which they were already).

The biggest hurdle is the fact that the BoringSSL SSL_CTX and SSL
structures are not thread-safe, so they need to be wrapped in Mutex.

In the case of Config this probably has no real downside, since an
application is not supposed to keep changing it once the initial
configuration is applied.

For Connection, this might affect performance slightly, but mostly just
during the handshake. However some of Connection's methods (like
`is_established()`) could be called repeatedly by the application even
after the handshake, so we "cache" the return value (since they won't
change after the handshake is complete) so we won't need to go through
the mutex anymore.