### PR TITLE
test: fix a flappy tests::empty_stream_frame

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4602,6 +4602,7 @@ pub mod testing {
             config.set_initial_max_streams_uni(3);
             config.set_max_idle_timeout(180_000);
             config.verify_peer(false);
+            config.set_ack_delay_exponent(5);
 
             Pipe::with_config(&mut config)
         }


### PR DESCRIPTION
This test is sometimes flappy and it's because when ack delay
encoded in the ACK frame is higher than 63 it uses 2 bytes,
instead of 1 bytes the test is expecting.

Tests are running locally so ack delay expected to be very small,
but this is microseconds granularity. For example ack_delay=82
means 656 microseconds (82 << 3, 3 is default ack_delay_exponent)
and it's still small (under 1milliseconds) but can happen when
the test server is slow (e.g. docker container, emulator, etc)

Workaround is to increase ack_delay_exponent parameter. It will
encode ack delay to lower number and makes the possibility to
become higher than 63 very small. I choose 5 here. For example
656 microseconds in the above example now encoded to 20, using
only one 1 varint byte.

Note that there is a still possibility to get higher than 63, but there will
be much less chance of test failure.

Fixes #712 