### PR TITLE
Expose Connection::stream_priority in C API

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -270,6 +270,10 @@ enum quiche_shutdown {
     QUICHE_SHUTDOWN_WRITE = 1,
 };
 
+// Set the priority for a stream.
+int quiche_conn_stream_priority(quiche_conn *conn, uint64_t stream_id,
+		                uint8_t urgency, bool incremental);
+
 // Shuts down reading or writing from/to the specified stream.
 int quiche_conn_stream_shutdown(quiche_conn *conn, uint64_t stream_id,
                                 enum quiche_shutdown direction, uint64_t err);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -272,7 +272,7 @@ enum quiche_shutdown {
 
 // Set the priority for a stream.
 int quiche_conn_stream_priority(quiche_conn *conn, uint64_t stream_id,
-		                uint8_t urgency, bool incremental);
+                                uint8_t urgency, bool incremental);
 
 // Shuts down reading or writing from/to the specified stream.
 int quiche_conn_stream_shutdown(quiche_conn *conn, uint64_t stream_id,

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -270,7 +270,7 @@ enum quiche_shutdown {
     QUICHE_SHUTDOWN_WRITE = 1,
 };
 
-// Set the priority for a stream.
+// Sets the priority for a stream.
 int quiche_conn_stream_priority(quiche_conn *conn, uint64_t stream_id,
                                 uint8_t urgency, bool incremental);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -584,6 +584,17 @@ pub extern fn quiche_conn_stream_send(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_stream_priority(
+    conn: &mut Connection, stream_id: u64, urgency: u8, incremental: bool,
+) -> c_int {
+    match conn.stream_priority(stream_id, urgency, incremental) {
+        Ok(_) => 0,
+
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_stream_shutdown(
     conn: &mut Connection, stream_id: u64, direction: Shutdown, err: u64,
 ) -> c_int {


### PR DESCRIPTION
Added `quiche_conn_stream_priority` to FFI. Covers #721.