### PR TITLE
Expose Connection:trace_id in C API

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -300,6 +300,9 @@ void quiche_conn_on_timeout(quiche_conn *conn);
 int quiche_conn_close(quiche_conn *conn, bool app, uint64_t err,
                       const uint8_t *reason, size_t reason_len);
 
+// Returns a string uniquely representing the connection.
+void quiche_conn_trace_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
+
 // Returns the negotiated ALPN protocol.
 void quiche_conn_application_proto(quiche_conn *conn, const uint8_t **out,
                                    size_t *out_len);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -690,6 +690,16 @@ pub extern fn quiche_conn_on_timeout(conn: &mut Connection) {
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_trace_id(
+    conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
+) {
+    let trace_id = conn.trace_id();
+
+    *out = trace_id.as_ptr();
+    *out_len = trace_id.len();
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_application_proto(
     conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
 ) {


### PR DESCRIPTION
Added `quiche_conn_trace_id` to FFI. Covers #713.