### PR TITLE
fix deadlock in handshake completion trace log

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3629,7 +3629,7 @@ impl Connection {
                handshake.cipher(),
                handshake.curve(),
                handshake.sigalg(),
-               self.is_resumed(),
+               handshake.is_resumed(),
                self.peer_transport_params);
 
         Ok(())


### PR DESCRIPTION
Follow-up to b1316fcf53f5065477d2c86e8707a82928260217. When logging the
"connection established" trace log, the handshake lock is already held
when `self.is_resumed()` is called, which also attempts to access the
handshake object through the mutex.

This only happens if the logging is enabled at the trace level.