### PR TITLE
use ConnectionId more widely

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -47,7 +47,8 @@ struct Client {
     partial_responses: HashMap<u64, PartialResponse>,
 }
 
-type ClientMap = HashMap<Vec<u8>, (net::SocketAddr, Client)>;
+type ClientMap =
+    HashMap<quiche::ConnectionId<'static>, (net::SocketAddr, Client)>;
 
 fn main() {
     let mut buf = [0; 65535];
@@ -170,11 +171,12 @@ fn main() {
 
             let conn_id = ring::hmac::sign(&conn_id_seed, &hdr.dcid);
             let conn_id = &conn_id.as_ref()[..quiche::MAX_CONN_ID_LEN];
+            let conn_id = conn_id.to_vec().into();
 
             // Lookup a connection based on the packet's connection ID. If there
             // is no connection matching, create a new one.
-            let (_, client) = if !clients.contains_key(hdr.dcid.as_ref()) &&
-                !clients.contains_key(conn_id)
+            let (_, client) = if !clients.contains_key(&hdr.dcid) &&
+                !clients.contains_key(&conn_id)
             {
                 if hdr.ty != quiche::Type::Initial {
                     error!("Packet is not Initial");
@@ -250,15 +252,11 @@ fn main() {
                     continue 'read;
                 }
 
-                // Reuse the source connection ID we sent in the Retry
-                // packet, instead of changing it again.
-                scid.copy_from_slice(&hdr.dcid);
+                // Reuse the source connection ID we sent in the Retry packet,
+                // instead of changing it again.
+                let scid = hdr.dcid.clone();
 
-                debug!(
-                    "New connection: dcid={} scid={}",
-                    hex_dump(&hdr.dcid),
-                    hex_dump(&scid)
-                );
+                debug!("New connection: dcid={:?} scid={:?}", hdr.dcid, scid);
 
                 let conn = quiche::accept(&scid, odcid, &mut config).unwrap();
 
@@ -267,14 +265,14 @@ fn main() {
                     partial_responses: HashMap::new(),
                 };
 
-                clients.insert(scid.to_vec(), (src, client));
+                clients.insert(scid.clone(), (src, client));
 
-                clients.get_mut(&scid[..]).unwrap()
+                clients.get_mut(&scid).unwrap()
             } else {
-                match clients.get_mut(hdr.dcid.as_ref()) {
+                match clients.get_mut(&hdr.dcid) {
                     Some(v) => v,
 
-                    None => clients.get_mut(conn_id).unwrap(),
+                    None => clients.get_mut(&conn_id).unwrap(),
                 }
             };
 
@@ -514,10 +512,4 @@ fn handle_writable(client: &mut Client, stream_id: u64) {
     if resp.written == resp.body.len() {
         client.partial_responses.remove(&stream_id);
     }
-}
-
-fn hex_dump(buf: &[u8]) -> String {
-    let vec: Vec<String> = buf.iter().map(|b| format!("{:02x}", b)).collect();
-
-    vec.join("")
 }

--- a/tools/apps/src/client.rs
+++ b/tools/apps/src/client.rs
@@ -256,7 +256,7 @@ pub fn connect(
     #[cfg(feature = "qlog")]
     {
         if let Some(dir) = std::env::var_os("QLOGDIR") {
-            let id = hex_dump(&scid);
+            let id = format!("{:?}", scid);
             let writer = make_qlog_writer(&dir, "client", &id);
 
             conn.set_qlog(
@@ -268,10 +268,10 @@ pub fn connect(
     }
 
     info!(
-        "connecting to {:} from {:} with scid {}",
+        "connecting to {:} from {:} with scid {:?}",
         peer_addr,
         socket.local_addr().unwrap(),
-        hex_dump(&scid)
+        scid,
     );
 
     let write = conn.send(&mut out).expect("initial send failed");

--- a/tools/apps/src/common.rs
+++ b/tools/apps/src/common.rs
@@ -42,16 +42,11 @@ use std::cell::RefCell;
 use std::net;
 use std::path;
 
+use quiche::ConnectionId;
+
 use quiche::h3::NameValue;
 
 const MAX_JSON_DUMP_PAYLOAD: usize = 10000;
-
-/// Returns a String containing a pretty printed version of the `buf` slice.
-pub fn hex_dump(buf: &[u8]) -> String {
-    let vec: Vec<String> = buf.iter().map(|b| format!("{:02x}", b)).collect();
-
-    vec.join("")
-}
 
 pub fn stdout_sink(out: String) {
     print!("{}", out);
@@ -245,7 +240,7 @@ pub struct Client {
     pub partial_responses: std::collections::HashMap<u64, PartialResponse>,
 }
 
-pub type ClientMap = HashMap<Vec<u8>, (net::SocketAddr, Client)>;
+pub type ClientMap = HashMap<ConnectionId<'static>, (net::SocketAddr, Client)>;
 
 /// Makes a buffered writer for a resource with a target URL.
 ///


### PR DESCRIPTION
Basically this replaces instances of Vec<u8> used to represent
connection IDs, with ConnectionId.

This also implements a few additional traits for ConnectionId to make
its use a bit easier.

---

This doesn't yet change the public API (well, no more than e0394a87cd75f30caa4ce1863bed3017ef0f7e94 does), but I think we should update `accept()`, `connect()`, `retry()`, etc... at some point to use `ConnectionId` instead of `&[u8]`.

Also, in the server examples/app,  there are a couple more clones of IDs than there were before, because of some lifetime issues I ran into. Will probably need more sleep to figure out a better way around that though :)