### PR TITLE
cc: RFC3465 ABC Slow Start

### DIFF
--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -170,15 +170,26 @@ fn on_packet_acked(
 
     if r.congestion_window < r.ssthresh {
         // Slow start.
+        let new_cwnd;
+
         if r.hystart.enabled() && epoch == packet::EPOCH_APPLICATION {
             let (cwnd, ssthresh) = r.hystart_on_packet_acked(packet, now);
 
-            r.congestion_window = cwnd;
+            new_cwnd = cwnd;
             r.ssthresh = ssthresh;
         } else {
             // Reno Slow Start.
-            r.congestion_window += packet.size;
+            new_cwnd = r.congestion_window + packet.size;
         }
+
+        let cwnd_inc = cmp::min(
+            new_cwnd - r.congestion_window,
+            r.max_datagram_size * recovery::ABC_L -
+                cmp::min(r.bytes_acked, r.max_datagram_size * recovery::ABC_L),
+        );
+
+        r.bytes_acked += packet.size;
+        r.congestion_window += cwnd_inc;
     } else {
         // Congestion avoidance.
         let ca_start_time;
@@ -334,7 +345,7 @@ mod tests {
             time_sent: now,
             time_acked: None,
             time_lost: None,
-            size: 5000,
+            size: r.max_datagram_size,
             ack_eliciting: true,
             in_flight: true,
             delivered: 0,
@@ -344,12 +355,10 @@ mod tests {
             has_data: false,
         };
 
-        // Send 5k x 4 = 20k, higher than default cwnd(~15k)
-        // to become no longer app limited
-        r.on_packet_sent_cc(p.size, now);
-        r.on_packet_sent_cc(p.size, now);
-        r.on_packet_sent_cc(p.size, now);
-        r.on_packet_sent_cc(p.size, now);
+        // Send initcwnd full MSS packets to become no longer app limited
+        for _ in 0..recovery::INITIAL_WINDOW_PACKETS {
+            r.on_packet_sent_cc(p.size, now);
+        }
 
         let cwnd_prev = r.cwnd();
 
@@ -363,6 +372,61 @@ mod tests {
 
         // Check if cwnd increased by packet size (slow start)
         assert_eq!(r.cwnd(), cwnd_prev + p.size);
+    }
+
+    #[test]
+    fn cubic_slow_start_abc_l() {
+        let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        cfg.set_cc_algorithm(recovery::CongestionControlAlgorithm::CUBIC);
+
+        let mut r = Recovery::new(&cfg);
+        let now = Instant::now();
+
+        let p = recovery::Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: r.max_datagram_size,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            recent_delivered_packet_sent_time: now,
+            is_app_limited: false,
+            has_data: false,
+        };
+
+        // Send initcwnd full MSS packets to become no longer app limited
+        for _ in 0..recovery::INITIAL_WINDOW_PACKETS {
+            r.on_packet_sent_cc(p.size, now);
+        }
+
+        let cwnd_prev = r.cwnd();
+
+        let acked = vec![
+            Acked {
+                pkt_num: p.pkt_num,
+                time_sent: p.time_sent,
+                size: p.size * 3,
+            },
+            Acked {
+                pkt_num: p.pkt_num,
+                time_sent: p.time_sent,
+                size: p.size * 3,
+            },
+            Acked {
+                pkt_num: p.pkt_num,
+                time_sent: p.time_sent,
+                size: p.size * 3,
+            },
+        ];
+
+        r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
+
+        // Acked 3 packets, but cwnd will increase 2 x mss.
+        assert_eq!(r.cwnd(), cwnd_prev + p.size * recovery::ABC_L);
     }
 
     #[test]
@@ -390,8 +454,10 @@ mod tests {
         let now = Instant::now();
         let prev_cwnd = r.cwnd();
 
-        // Fill up bytes_in_flight to avoid app_limited=true
-        r.on_packet_sent_cc(20000, now);
+        // Send initcwnd full MSS packets to become no longer app limited
+        for _ in 0..recovery::INITIAL_WINDOW_PACKETS {
+            r.on_packet_sent_cc(r.max_datagram_size, now);
+        }
 
         // Trigger congestion event to update ssthresh
         r.congestion_event(now, packet::EPOCH_APPLICATION, now);
@@ -406,7 +472,7 @@ mod tests {
             pkt_num: 0,
             // To exit from recovery
             time_sent: now + rtt,
-            size: 8000,
+            size: r.max_datagram_size,
         }];
 
         // Ack more than cwnd bytes with rtt=100ms
@@ -442,23 +508,15 @@ mod tests {
             pkt_num: 0,
             // To exit from recovery
             time_sent: now + Duration::from_millis(1),
-            size: 10000,
+            size: r.max_datagram_size,
         }];
 
-        // rtt = 100ms
-        let rtt = Duration::from_millis(100);
-        std::thread::sleep(rtt);
-
-        // Ack 10000 x 2 to exit from slow start
-        r.on_packets_acked(acked.clone(), packet::EPOCH_APPLICATION, now);
-        std::thread::sleep(rtt);
-
-        // This will make CC into congestion avoidance mode
         r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
 
+        // Slow start again - cwnd will be increased by 1 MSS
         assert_eq!(
             r.cwnd(),
-            r.max_datagram_size * recovery::MINIMUM_WINDOW_PACKETS + 10000
+            r.max_datagram_size * (recovery::MINIMUM_WINDOW_PACKETS + 1)
         );
     }
 

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -64,6 +64,9 @@ const MINIMUM_WINDOW_PACKETS: usize = 2;
 
 const LOSS_REDUCTION_FACTOR: f64 = 0.5;
 
+// RFC3465 Slow Start burst limit constant
+const ABC_L: usize = 2;
+
 pub struct Recovery {
     loss_detection_timer: Option<Instant>,
 
@@ -713,6 +716,10 @@ impl Recovery {
     ) {
         for pkt in acked {
             (self.cc_ops.on_packet_acked)(self, &pkt, epoch, now);
+        }
+
+        if self.congestion_window < self.ssthresh {
+            self.bytes_acked = 0;
         }
     }
 


### PR DESCRIPTION
Implements https://tools.ietf.org/html/rfc3465#section-2.2

During slow start, when there is an ACK frame ack'ing
too many packet at once, cwnd will go too high. For example
there is an single ACK ack'ing 5 packets, cwnd will be increased
by 5 x MSS. This can lead to unexpected burst of cwnd, such as
ACK for multiple received STREAM frames, or recovering from a loss.

To prevent from such burst, during slow start an single ACK
will not increase cwnd more than MSS x ABC_L constant. ABC_L is
defined as 2 in RFC3465, and QUIC transport draft also recommends
ACK'ing every two packets (transport-32 section 13.2.2), so this looks
a good number to start.