### PR TITLE
Add Connection::is_draining FFI

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -321,6 +321,9 @@ bool quiche_conn_is_in_early_data(quiche_conn *conn);
 // Returns whether there is stream or DATAGRAM data available to read.
 bool quiche_conn_is_readable(quiche_conn *conn);
 
+// Returns true if the connection is draining.
+bool quiche_conn_is_draining(quiche_conn *conn);
+
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -732,6 +732,11 @@ pub extern fn quiche_conn_is_in_early_data(conn: &mut Connection) -> bool {
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_is_draining(conn: &mut Connection) -> bool {
+    conn.is_draining()
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_is_closed(conn: &mut Connection) -> bool {
     conn.is_closed()
 }


### PR DESCRIPTION
`Connection::is_draining` was introduced [here](https://github.com/cloudflare/quiche/commit/a533bcf622ebe25256c5a3c9704ce95bc9eff469) but was not exposed for FFI