### PR TITLE
examples/apps: fix client SCID formatting

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -101,8 +101,10 @@ fn main() {
     config.set_disable_active_migration(true);
 
     // Generate a random source connection ID for the connection.
-    let mut scid = [0; quiche::MAX_CONN_ID_LEN];
+    let mut scid = vec![0; quiche::MAX_CONN_ID_LEN];
     SystemRandom::new().fill(&mut scid[..]).unwrap();
+
+    let scid = quiche::ConnectionId::from_vec(scid);
 
     // Create a QUIC connection and initiate handshake.
     let mut conn = quiche::connect(url.domain(), &scid, &mut config).unwrap();

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -102,8 +102,10 @@ fn main() {
     let mut http3_conn = None;
 
     // Generate a random source connection ID for the connection.
-    let mut scid = [0; quiche::MAX_CONN_ID_LEN];
+    let mut scid = vec![0; quiche::MAX_CONN_ID_LEN];
     SystemRandom::new().fill(&mut scid[..]).unwrap();
+
+    let scid = quiche::ConnectionId::from_vec(scid);
 
     // Create a QUIC connection and initiate handshake.
     let mut conn = quiche::connect(url.domain(), &scid, &mut config).unwrap();

--- a/tools/apps/src/client.rs
+++ b/tools/apps/src/client.rs
@@ -239,8 +239,10 @@ pub fn connect(
     let mut app_proto_selected = false;
 
     // Generate a random source connection ID for the connection.
-    let mut scid = [0; quiche::MAX_CONN_ID_LEN];
+    let mut scid = vec![0; quiche::MAX_CONN_ID_LEN];
     SystemRandom::new().fill(&mut scid[..]).unwrap();
+
+    let scid = quiche::ConnectionId::from_vec(scid);
 
     // Create a QUIC connection and initiate handshake.
     let mut conn =


### PR DESCRIPTION
Due to the fact that ConnectionId wasn't used for the initial SCID
generated by the client, it would get formatted as a vector, rather
than being pretty printed in hex form.

e.g. see qlog files generated in interop runner in the last few days:
https://interop.seemann.io/logs/2020-11-28T08:09/xquic_quiche/handshake/client/qlog/