### PR TITLE
RFC: h3: poll with closure API

### DIFF
--- a/src/dgram.rs
+++ b/src/dgram.rs
@@ -85,6 +85,10 @@ impl DatagramQueue {
         None
     }
 
+    pub fn iter_internal(&self) -> std::collections::vec_deque::Iter<Vec<u8>> {
+        self.queue.iter()
+    }
+
     pub fn has_pending(&self) -> bool {
         !self.queue.is_empty()
     }


### PR DESCRIPTION
This adds a `poll_with()` method that, instead of returning single
events like `poll()` does, passes each event to an application-provided
closure. Notably this means that all available events are passed to the
application, rather than just the first one like `poll()`.

This allows applications to potentially skip particular events while
still processing others, or stop processing before all events are
issued, rather than always getting the same event over and over until it
is processed.

The poll() method is also re-implemented using poll_with(). The stream
and DATAGRAM thresholds only apply to the poll() method, as an
application can more easily decide to skip particular events when using
poll_with(), so additional options to do that are not required.

For DATAGRAMs, due to the fact that each Datagram event needs to be
associated with a flow ID, we can't simply use the `dgram_recv_peek()`
method provided by the transport connection anymore, so the internal
dgram recv queue is accessed directly to ensure all required events are
issued (instead of just issuing the same event for the first DATAGRAM
over and over).

---

A somewhat more idiomatic alternative to using a closure would be to
instead have an event iterator type returned by a `poll_iter()` method
or something like that. A typical use-case would be something like this:

```rust
for ev in http3_conn.poll_iter(&mut conn) {
    match ev {
        (stream_id, quiche::h3::Event::Data) => {
            http3_conn.recv_body(stream_id, &mut buf)?;
        },

        ...
    }
}
```

However, due to the fact that polling for events requires mutable references to
both the transport and HTTP/3 connection objects, the above would require the
application to `collect()` the iterator, which could be expensive if many events
are generated. In any case, this could also be implementated on top of the poll
closure API.

It's not quite clear to me if there is a way to implement the above safely and without
requiring `collect()`. Will need to think about this some more, but if anyone has a
better idea, do tell.

Also, thinking about the whole DATAGRAM situation again, it's not quite clear
how useful it is to provide the flow ID to applications, as they will need to
read DATAGRAMs in order regardless of the flow ID, unlike stream events where
the application can read data for specific streams.

So an alternative could be to simply issue a single Datagram event if there is
at least one DATAGRAM queued, and use some kind of fake ID (e.g. could just
hardcode to "0" or something like that), which would simplify the logic to a
certain extent, as the actual DATAGRAM would not need to be touched at all.

The alternative to make the flow ID somewhat more useful I think would be to
make `recv_dgram()` only return DATAGRAMs that match a specifc ID provided by
the application. This could be used to e.g. avoid processing flows that the
application deems to be blocked, while still processing others, though it's
unclear in what cases this would be useful, so it might end up being a waste of
time.