### PR TITLE
build: support building quiche against boring-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ libc = "0.2"
 libm = "0.2"
 ring = "0.16"
 lazy_static = "1"
+boring-sys = { version = "1.0.2", optional = true }
 qlog = { version = "0.3", path = "tools/qlog", optional = true }
 
 [target."cfg(windows)".dependencies]

--- a/src/build.rs
+++ b/src/build.rs
@@ -249,6 +249,11 @@ fn main() {
         println!("cargo:rustc-link-lib=static=ssl");
     }
 
+    if cfg!(feature = "boring-sys") {
+        println!("cargo:rustc-link-lib=static=crypto");
+        println!("cargo:rustc-link-lib=static=ssl");
+    }
+
     // MacOS: Allow cdylib to link with undefined symbols
     if cfg!(target_os = "macos") {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-undefined,dynamic_lookup");


### PR DESCRIPTION
This adds an optional dependency on boring-sys, to allow building quiche
as part of projects that use that crate.