### PR TITLE
Pacing: Pacing of egress QUIC packets

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -273,8 +273,12 @@ ssize_t quiche_conn_recv(quiche_conn *conn, uint8_t *buf, size_t buf_len,
                          const quiche_recv_info *info);
 
 typedef struct {
+    // The address the packet should be sent to.
     struct sockaddr_storage to;
     socklen_t to_len;
+
+    // The time to send the packet out.
+    struct timespec at;
 } quiche_send_info;
 
 // Writes a single QUIC packet to be sent to the peer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,6 +490,9 @@ pub struct RecvInfo {
 pub struct SendInfo {
     /// The address the packet should be sent to.
     pub to: SocketAddr,
+
+    /// The time to send the packet out.
+    pub at: time::Instant,
 }
 
 /// Represents information carried by `CONNECTION_CLOSE` frames.
@@ -2390,7 +2393,14 @@ impl Connection {
             done += pad_len;
         }
 
-        let info = SendInfo { to: self.peer_addr };
+        let info = SendInfo {
+            to: self.peer_addr,
+
+            at: self
+                .recovery
+                .get_packet_send_time()
+                .unwrap_or_else(time::Instant::now),
+        };
 
         Ok((done, info))
     }

--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -51,6 +51,7 @@ pub static CUBIC: CongestionControlOps = CongestionControlOps {
     collapse_cwnd,
     checkpoint,
     rollback,
+    has_custom_pacing,
 };
 
 /// CUBIC Constants.
@@ -402,6 +403,10 @@ fn rollback(r: &mut Recovery) {
     r.cubic_state.w_max = r.cubic_state.prior.w_max;
     r.cubic_state.k = r.cubic_state.prior.k;
     r.congestion_recovery_start_time = r.cubic_state.prior.epoch_start;
+}
+
+fn has_custom_pacing() -> bool {
+    false
 }
 
 #[cfg(test)]

--- a/src/recovery/reno.rs
+++ b/src/recovery/reno.rs
@@ -45,6 +45,7 @@ pub static RENO: CongestionControlOps = CongestionControlOps {
     collapse_cwnd,
     checkpoint,
     rollback,
+    has_custom_pacing,
 };
 
 pub fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
@@ -161,6 +162,10 @@ pub fn collapse_cwnd(r: &mut Recovery) {
 fn checkpoint(_r: &mut Recovery) {}
 
 fn rollback(_r: &mut Recovery) {}
+
+fn has_custom_pacing() -> bool {
+    false
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Currently pacing is enabled for Cubic and Reno, since BBR is under development.