### PR TITLE
properly handle incoming STOP_SENDING frames

### DIFF
--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -534,6 +534,8 @@ fn handle_request(
     let written = match http3_conn.send_body(conn, stream_id, &body, true) {
         Ok(v) => v,
 
+        Err(quiche::h3::Error::Done) => 0,
+
         Err(e) => {
             error!("{} stream send failed {:?}", conn.trace_id(), e);
             return;
@@ -636,7 +638,11 @@ fn handle_writable(client: &mut Client, stream_id: u64) {
     let written = match http3_conn.send_body(conn, stream_id, body, true) {
         Ok(v) => v,
 
+        Err(quiche::h3::Error::Done) => 0,
+
         Err(e) => {
+            client.partial_responses.remove(&stream_id);
+
             error!("{} stream send failed {:?}", conn.trace_id(), e);
             return;
         },

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -502,6 +502,8 @@ fn handle_writable(client: &mut Client, stream_id: u64) {
         Err(quiche::Error::Done) => 0,
 
         Err(e) => {
+            client.partial_responses.remove(&stream_id);
+
             error!("{} stream send failed {:?}", conn.trace_id(), e);
             return;
         },

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -94,6 +94,9 @@ enum quiche_error {
     // The peer violated the local stream limits.
     QUICHE_ERR_STREAM_LIMIT = -12,
 
+    // The specified stream was stopped by the peer.
+    QUICHE_ERR_STREAM_STOPPED = -15,
+
     // The received data exceeds the stream's final size.
     QUICHE_ERR_FINAL_SIZE = -13,
 

--- a/tools/apps/src/common.rs
+++ b/tools/apps/src/common.rs
@@ -726,6 +726,8 @@ impl HttpConn for Http09Conn {
             Err(quiche::Error::Done) => 0,
 
             Err(e) => {
+                partial_responses.remove(&stream_id);
+
                 error!("{} stream send failed {:?}", conn.trace_id(), e);
                 return;
             },
@@ -1420,11 +1422,11 @@ impl HttpConn for Http3Conn {
         let written = match self.h3_conn.send_body(conn, stream_id, body, true) {
             Ok(v) => v,
 
-            Err(quiche::h3::Error::Done) => {
-                return;
-            },
+            Err(quiche::h3::Error::Done) => 0,
 
             Err(e) => {
+                partial_responses.remove(&stream_id);
+
                 error!("{} stream send failed {:?}", conn.trace_id(), e);
                 return;
             },


### PR DESCRIPTION
This implements resetting a stream's send-side, as well as sending a
RESET_STREAM frame, upon receipt of STOP_SENDING from the peer.

By resetting a stream, all of its already buffered data is dropped, and
no more writes are permitted.

In order to signal to the application that a stream was "stopped" and
reset, the stream is marked as writable upon receipt of the STOP_SENDING
frame, but when calling `stream_send()` as well as `stream_capacity()` a
new error, `StreamStopped` will be returned.

Returning the error from the `stream_capacity()` is required to make
sure the application is notified in cases where the method is called to
check whether any capacity is available before calling `stream_send()`
(like we do in the HTTP/3 code), and the target stream is blocked (so
`stream_send()` isn't called at all).

The `StreamStopped` error carries the raw error code sent as part of the
STOP_SENDING frame, so that an application can treat the error case
differently depending on the meaning of the code.

Currently the error is turned into a `TransportError` at the HTTP/3
layer. In the future we can better translate this into an appropriate
HTTP/3 error.

---

This depends on https://github.com/cloudflare/quiche/pull/769 due to the new error.