### PR TITLE
h3: close GREASE stream

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -1480,7 +1480,7 @@ impl Connection {
             Ok(stream_id) => {
                 trace!("{} open GREASE stream {}", conn.trace_id(), stream_id);
 
-                conn.stream_send(stream_id, b"GREASE is the word", false)?;
+                conn.stream_send(stream_id, b"GREASE is the word", true)?;
             },
 
             Err(Error::IdError) => {


### PR DESCRIPTION
There's no need to keep this open forever, so close it once we sent all
the GREASE data.