### PR TITLE
lib: fix DATAGRAM fram size calculation in  dgram_max_writable_len()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3480,7 +3480,8 @@ impl Connection {
                 // ...clamp to what peer can support...
                 max_len = cmp::min(peer_frame_len as usize, max_len);
                 // ...subtract frame overhead, checked for underflow.
-                max_len.checked_sub(frame::MAX_DGRAM_OVERHEAD)
+                // (1 byte of frame type + len of length )
+                max_len.checked_sub(1 + frame::MAX_DGRAM_OVERHEAD)
             },
         }
     }
@@ -8343,6 +8344,10 @@ mod tests {
         assert_eq!(pipe.handshake(&mut buf), Ok(()));
 
         let max_dgram_size = pipe.client.dgram_max_writable_len().unwrap();
+
+        // Tests use a 16-byte connection ID, so the max datagram frame payload
+        // size is (1200 byte-long packet - 40 bytes overhead)
+        assert_eq!(max_dgram_size, 1160);
 
         let dgram_packet: Vec<u8> = vec![42; max_dgram_size];
 


### PR DESCRIPTION
It seems we forgot to account for the 1-byte of frame type in dgram_max_writable_len(). Since this went undetected, I've added an explicit assertion of the return value in an existing test. The actual packet overhead varies due to variable DCID length, but the maximum overhead is 44 bytes with this change.