### PR TITLE
qlog: add basic DATAGRAM frame logging

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -905,7 +905,8 @@ impl Frame {
 
             Frame::HandshakeDone => qlog::QuicFrame::handshake_done(),
 
-            Frame::Datagram { .. } => qlog::QuicFrame::unknown(0x30),
+            Frame::Datagram { data } =>
+                qlog::QuicFrame::datagram(data.len().to_string(), None),
         }
     }
 }

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -1652,6 +1652,7 @@ pub enum QuicFrameTypeName {
     ConnectionClose,
     ApplicationClose,
     HandshakeDone,
+    Datagram,
     Unknown,
 }
 
@@ -1966,6 +1967,13 @@ pub enum QuicFrame {
         frame_type: QuicFrameTypeName,
     },
 
+    Datagram {
+        frame_type: QuicFrameTypeName,
+        length: String,
+
+        raw: Option<String>,
+    },
+
     Unknown {
         frame_type: QuicFrameTypeName,
         raw_frame_type: u64,
@@ -2146,6 +2154,14 @@ impl QuicFrame {
     pub fn handshake_done() -> Self {
         QuicFrame::HandshakeDone {
             frame_type: QuicFrameTypeName::HandshakeDone,
+        }
+    }
+
+    pub fn datagram(length: String, raw: Option<String>) -> Self {
+        QuicFrame::Datagram {
+            frame_type: QuicFrameTypeName::Datagram,
+            length,
+            raw,
         }
     }
 


### PR DESCRIPTION
Previously, we logged DATAGRAM frames as a generic "unknown" frame
event with a hard-coded frame type of 0x30. This change adds a
proper frame definition that results in such frames getting logged
as "datagram" along with the length of the frame payload.