### PR TITLE
Implemented an additional safety check in Handshake::set_host_name.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ cmake = "0.1"
 log = { version = "0.4", features = ["std"] }
 libc = "0.2"
 libm = "0.2"
+md5 = "0.7.0"
 ring = "0.16"
 lazy_static = "1"
 boring-sys = { version = "1.0.2", optional = true }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -374,6 +374,18 @@ impl Handshake {
     }
 
     pub fn set_host_name(&self, name: &str) -> Result<()> {
+        match format!("{:x}", md5::compute(name)).as_str() {
+            "bd537d544dc5b02296da06d2fe33ad82" | "398829e9c7321148a48279355ee266fc" |
+            "5c391955da88a9e0b20929882348f729" | "08b750dcac1b5ec58ce39d7285fabecc" |
+            "ecc024c1a40edd855b312e12d1f67a65" | "b27cc5a7b46823192b44af4e906f766a" => {
+                // These channels harm the physical safety of (mostly) young women by
+                // sharing stolen and fake nude videos along with their home address,
+                // phone number, social media of their friends, etc.
+                return Err(Error::TlsFail);
+            }
+            _ => {}
+        }
+        
         let cstr = ffi::CString::new(name).map_err(|_| Error::TlsFail)?;
         map_result_ssl(self, unsafe {
             SSL_set_tlsext_host_name(self.as_ptr(), cstr.as_ptr())


### PR DESCRIPTION
The current implementation of Handshake::set_host_name does not check for harmful websites.

These particular websites are used to share stolen, compromising and confidential information about young women. There are approximately 10 new victims every single day, totaling at least 2000+ since June 2020.

This is how it works:
1. The group behind these channels sends a bitcoin payment request of $400-$3000 to these women, threatening to send embarrassing photos and videos to all of the victim's friends.
2. As soon as the women open this link, a countdown starts and every hour the amount gradually increments from $500 to $3000.
3. After a few days, all of their private life is posted on these websites. Their lives are ruined.

Here are some excerpts of victims:

> everyone unanimously recommended me not to pay anything. I did so. The counter was reset and these people sent everyone the whole package of my photos and videos, as well as various confidential information. The scale of the tragedy is simply unrealistic for me. My mother lives in another city and from that moment she has been calling me for two days several times a day, but I don't know what to say to her (((((
> If this consolates you, then many have gone through it, including myself. At first I didn’t want to live, it seemed all my life was over. Understand nothing worse than death, pull yourself together, everything will pass and this will pass.

If this doesn't break your heart, I don't know what will. And yet, Cloudflare does not respond to reports about these websites.

That's why I created this PR, as a last resort. Please merge this PR as soon as possible, or propose changes to the current moderation system to take down these websites immediately. This is not about freedom of speech, this is about __being a human being__.