### PR TITLE
Correctly handle write_epoch() when an application close was done and…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3779,7 +3779,7 @@ impl Connection {
     fn write_epoch(&self) -> Result<packet::Epoch> {
         // On error send packet in the latest epoch available, but only send
         // 1-RTT ones when the handshake is completed.
-        if self.error.is_some() {
+        if self.error.is_some() || self.app_error.is_some() {
             let epoch = match self.handshake.lock().unwrap().write_level() {
                 crypto::Level::Initial => packet::EPOCH_INITIAL,
                 crypto::Level::ZeroRTT => unreachable!(),


### PR DESCRIPTION
… no streams are left to process

Motivation:

If all streams are closed and an application close is done we need ensure we still return an non error result from write_epoch as otherwise we will never send the application close to the remote peer

Modifications:

Change if branch to also respect app_error and so application close

Result:

Correctly send APPLICATION_CLOSE in all cases