### PR TITLE
Add peer_max_streams_bidi() and peer_max_streams_uni()

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -330,11 +330,11 @@ bool quiche_conn_is_draining(quiche_conn *conn);
 
 // Returns the amount of bidirectional streams that can be created
 // before the stream count limit is reached.
-uint64_t quiche_conn_peer_streams_remaining_allowed_bidi(quiche_conn *conn);
+uint64_t quiche_conn_peer_streams_left_bidi(quiche_conn *conn);
 
 // Returns the amount of unidirectional streams that can be created
 // before the stream count limit is reached.
-uint64_t quiche_conn_peer_streams_remaining_allowed_uni(quiche_conn *conn);
+uint64_t quiche_conn_peer_streams_left_uni(quiche_conn *conn);
 
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -328,6 +328,12 @@ bool quiche_conn_is_readable(quiche_conn *conn);
 // Returns true if the connection is draining.
 bool quiche_conn_is_draining(quiche_conn *conn);
 
+// Returns the peer's maximum bidirectional stream count limit.
+uint64_t quiche_conn_peer_max_streams_bidi(quiche_conn *conn);
+
+// Returns the peer's maximum unidirectional stream count limit.
+uint64_t quiche_conn_peer_max_streams_uni(quiche_conn *conn);
+
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);
 

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -328,12 +328,12 @@ bool quiche_conn_is_readable(quiche_conn *conn);
 // Returns true if the connection is draining.
 bool quiche_conn_is_draining(quiche_conn *conn);
 
-// Returns the amount of bidirectional streams that can be created
-// before the stream count limit is reached.
+// Returns the number of bidirectional streams that can be created
+// before the peer's stream count limit is reached.
 uint64_t quiche_conn_peer_streams_left_bidi(quiche_conn *conn);
 
-// Returns the amount of unidirectional streams that can be created
-// before the stream count limit is reached.
+// Returns the number of unidirectional streams that can be created
+// before the peer's stream count limit is reached.
 uint64_t quiche_conn_peer_streams_left_uni(quiche_conn *conn);
 
 // Returns true if the connection is closed.

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -328,12 +328,12 @@ bool quiche_conn_is_readable(quiche_conn *conn);
 // Returns true if the connection is draining.
 bool quiche_conn_is_draining(quiche_conn *conn);
 
-// Returns the amount of bidirectional streams that can be created in respect to the limit
-// set by the peer before the stream count limit is hit.
+// Returns the amount of bidirectional streams that can be created
+// before the stream count limit is reached.
 uint64_t quiche_conn_peer_streams_remaining_allowed_bidi(quiche_conn *conn);
 
-// Returns the amount of unidirectional streams that can be created in respect to the limit
-// set by the peer before the stream count limit is hit.
+// Returns the amount of unidirectional streams that can be created
+// before the stream count limit is reached.
 uint64_t quiche_conn_peer_streams_remaining_allowed_uni(quiche_conn *conn);
 
 // Returns true if the connection is closed.

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -328,11 +328,13 @@ bool quiche_conn_is_readable(quiche_conn *conn);
 // Returns true if the connection is draining.
 bool quiche_conn_is_draining(quiche_conn *conn);
 
-// Returns the peer's maximum bidirectional stream count limit.
-uint64_t quiche_conn_peer_max_streams_bidi(quiche_conn *conn);
+// Returns the amount of bidirectional streams that can be created in respect to the limit
+// set by the peer before the stream count limit is hit.
+uint64_t quiche_conn_peer_streams_remaining_allowed_bidi(quiche_conn *conn);
 
-// Returns the peer's maximum unidirectional stream count limit.
-uint64_t quiche_conn_peer_max_streams_uni(quiche_conn *conn);
+// Returns the amount of unidirectional streams that can be created in respect to the limit
+// set by the peer before the stream count limit is hit.
+uint64_t quiche_conn_peer_streams_remaining_allowed_uni(quiche_conn *conn);
 
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -869,11 +869,15 @@ pub extern fn quiche_conn_free(conn: *mut Connection) {
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_peer_streams_remaining_allowed_bidi(conn: &mut Connection) -> u64 {
+pub extern fn quiche_conn_peer_streams_remaining_allowed_bidi(
+    conn: &mut Connection
+) -> u64 {
     conn.peer_streams_remaining_allowed_bidi()
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_peer_streams_remaining_allowed_uni(conn: &mut Connection) -> u64 {
+pub extern fn quiche_conn_peer_streams_remaining_allowed_uni(
+    conn: &mut Connection
+) -> u64 {
     conn.peer_streams_remaining_allowed_uni()
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -870,14 +870,14 @@ pub extern fn quiche_conn_free(conn: *mut Connection) {
 
 #[no_mangle]
 pub extern fn quiche_conn_peer_streams_remaining_allowed_bidi(
-    conn: &mut Connection
+    conn: &mut Connection,
 ) -> u64 {
     conn.peer_streams_remaining_allowed_bidi()
 }
 
 #[no_mangle]
 pub extern fn quiche_conn_peer_streams_remaining_allowed_uni(
-    conn: &mut Connection
+    conn: &mut Connection,
 ) -> u64 {
     conn.peer_streams_remaining_allowed_uni()
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -869,15 +869,11 @@ pub extern fn quiche_conn_free(conn: *mut Connection) {
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_peer_streams_left_bidi(
-    conn: &mut Connection,
-) -> u64 {
+pub extern fn quiche_conn_peer_streams_left_bidi(conn: &mut Connection) -> u64 {
     conn.peer_streams_left_bidi()
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_peer_streams_left_uni(
-    conn: &mut Connection,
-) -> u64 {
+pub extern fn quiche_conn_peer_streams_left_uni(conn: &mut Connection) -> u64 {
     conn.peer_streams_left_uni()
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -867,3 +867,13 @@ pub extern fn quiche_conn_dgram_purge_outgoing(
 pub extern fn quiche_conn_free(conn: *mut Connection) {
     unsafe { Box::from_raw(conn) };
 }
+
+#[no_mangle]
+pub extern fn quiche_conn_peer_max_streams_bidi(conn: &mut Connection) -> u64 {
+    conn.peer_max_streams_bidi()
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_peer_max_streams_uni(conn: &mut Connection) -> u64 {
+    conn.peer_max_streams_uni()
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -869,11 +869,11 @@ pub extern fn quiche_conn_free(conn: *mut Connection) {
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_peer_max_streams_bidi(conn: &mut Connection) -> u64 {
-    conn.peer_max_streams_bidi()
+pub extern fn quiche_conn_peer_streams_remaining_allowed_bidi(conn: &mut Connection) -> u64 {
+    conn.peer_streams_remaining_allowed_bidi()
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_peer_max_streams_uni(conn: &mut Connection) -> u64 {
-    conn.peer_max_streams_uni()
+pub extern fn quiche_conn_peer_streams_remaining_allowed_uni(conn: &mut Connection) -> u64 {
+    conn.peer_streams_remaining_allowed_uni()
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -869,15 +869,15 @@ pub extern fn quiche_conn_free(conn: *mut Connection) {
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_peer_streams_remaining_allowed_bidi(
+pub extern fn quiche_conn_peer_streams_left_bidi(
     conn: &mut Connection,
 ) -> u64 {
-    conn.peer_streams_remaining_allowed_bidi()
+    conn.peer_streams_left_bidi()
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_peer_streams_remaining_allowed_uni(
+pub extern fn quiche_conn_peer_streams_left_uni(
     conn: &mut Connection,
 ) -> u64 {
-    conn.peer_streams_remaining_allowed_uni()
+    conn.peer_streams_left_uni()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3190,22 +3190,24 @@ impl Connection {
         stream.recv.is_fin()
     }
 
-    /// Returns the peer's maximum bidirectional stream count limit.
+    /// Returns the amount of bidirectional streams that can be created in respect to the limit
+    /// set by the peer before the stream count limit is hit.
     ///
     /// This can be useful to know if its possible to create a bidirectional
     /// stream or not without trying it first.
     #[inline]
-    pub fn peer_max_streams_bidi(&self) -> u64 {
-        self.streams.peer_max_streams_bidi()
+    pub fn peer_streams_remaining_allowed_bidi(&self) -> u64 {
+        self.streams.peer_streams_remaining_allowed_bidi()
     }
 
-    /// Returns the peer's maximum unidirectional stream count limit.
+    /// Returns the amount of unidirectional streams that can be created in respect to the limit
+    /// set by the peer before the stream count limit is hit.
     ///
     /// This can be useful to know if its possible to create a unidirectional
     /// stream or not without trying it first.
     #[inline]
-    pub fn peer_max_streams_uni(&self) -> u64 {
-        self.streams.peer_max_streams_uni()
+    pub fn peer_streams_remaining_allowed_uni(&self) -> u64 {
+        self.streams.peer_streams_remaining_allowed_uni()
     }
 
     /// Initializes the stream's application data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3190,6 +3190,24 @@ impl Connection {
         stream.recv.is_fin()
     }
 
+    /// Returns the peer's maximum bidirectional stream count limit.
+    ///
+    /// This can be useful to know if its possible to create a bidirectional
+    /// stream or not without trying it first.
+    #[inline]
+    pub fn peer_max_streams_bidi(&self) -> u64 {
+        self.streams.peer_max_streams_bidi()
+    }
+
+    /// Returns the peer's maximum unidirectional stream count limit.
+    ///
+    /// This can be useful to know if its possible to create a unidirectional
+    /// stream or not without trying it first.
+    #[inline]
+    pub fn peer_max_streams_uni(&self) -> u64 {
+        self.streams.peer_max_streams_uni()
+    }
+
     /// Initializes the stream's application data.
     ///
     /// This can be used by applications to store per-stream information without

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3190,8 +3190,8 @@ impl Connection {
         stream.recv.is_fin()
     }
 
-    /// Returns the amount of bidirectional streams that can be created in respect to the limit
-    /// set by the peer before the stream count limit is hit.
+    /// Returns the amount of bidirectional streams that can be created
+    /// before the stream count limit is reached.
     ///
     /// This can be useful to know if its possible to create a bidirectional
     /// stream or not without trying it first.
@@ -3200,8 +3200,8 @@ impl Connection {
         self.streams.peer_streams_remaining_allowed_bidi()
     }
 
-    /// Returns the amount of unidirectional streams that can be created in respect to the limit
-    /// set by the peer before the stream count limit is hit.
+    /// Returns the amount of unidirectional streams that can be created
+    /// before the stream count limit is reached.
     ///
     /// This can be useful to know if its possible to create a unidirectional
     /// stream or not without trying it first.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3190,21 +3190,21 @@ impl Connection {
         stream.recv.is_fin()
     }
 
-    /// Returns the amount of bidirectional streams that can be created
-    /// before the stream count limit is reached.
+    /// Returns the number of bidirectional streams that can be created
+    /// before the peer's stream count limit is reached.
     ///
-    /// This can be useful to know if its possible to create a bidirectional
-    /// stream or not without trying it first.
+    /// This can be useful to know if it's possible to create a bidirectional
+    /// stream without trying it first.
     #[inline]
     pub fn peer_streams_left_bidi(&self) -> u64 {
         self.streams.peer_streams_left_bidi()
     }
 
-    /// Returns the amount of unidirectional streams that can be created
-    /// before the stream count limit is reached.
+    /// Returns the number of unidirectional streams that can be created
+    /// before the peer's stream count limit is reached.
     ///
-    /// This can be useful to know if its possible to create a unidirectional
-    /// stream or not without trying it first.
+    /// This can be useful to know if it's possible to create a unidirectional
+    /// stream without trying it first.
     #[inline]
     pub fn peer_streams_left_uni(&self) -> u64 {
         self.streams.peer_streams_left_uni()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3196,8 +3196,8 @@ impl Connection {
     /// This can be useful to know if its possible to create a bidirectional
     /// stream or not without trying it first.
     #[inline]
-    pub fn peer_streams_remaining_allowed_bidi(&self) -> u64 {
-        self.streams.peer_streams_remaining_allowed_bidi()
+    pub fn peer_streams_left_bidi(&self) -> u64 {
+        self.streams.peer_streams_left_bidi()
     }
 
     /// Returns the amount of unidirectional streams that can be created
@@ -3206,8 +3206,8 @@ impl Connection {
     /// This can be useful to know if its possible to create a unidirectional
     /// stream or not without trying it first.
     #[inline]
-    pub fn peer_streams_remaining_allowed_uni(&self) -> u64 {
-        self.streams.peer_streams_remaining_allowed_uni()
+    pub fn peer_streams_left_uni(&self) -> u64 {
+        self.streams.peer_streams_left_uni()
     }
 
     /// Initializes the stream's application data.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -414,6 +414,16 @@ impl StreamMap {
         self.local_max_streams_uni_next
     }
 
+    /// Returns the peer's maximum bidirectional stream count limit.
+    pub fn peer_max_streams_bidi(&self) -> u64 {
+        self.peer_max_streams_bidi
+    }
+
+    /// Returns the peer's maximum unidirectional stream count limit.
+    pub fn peer_max_streams_uni(&self) -> u64 {
+        self.peer_max_streams_uni
+    }
+
     /// Drops completed stream.
     ///
     /// This should only be called when Stream::is_complete() returns true for

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -414,14 +414,14 @@ impl StreamMap {
         self.local_max_streams_uni_next
     }
 
-    /// Returns the amount of bidirectional streams that can be created
-    /// before the stream count limit is reached.
+    /// Returns the number of bidirectional streams that can be created
+    /// before the peer's stream count limit is reached.
     pub fn peer_streams_left_bidi(&self) -> u64 {
         self.peer_max_streams_bidi - self.local_opened_streams_bidi
     }
 
-    /// Returns the amount of unidirectional streams that can be created
-    /// before the stream count limit is reached.
+    /// Returns the number of unidirectional streams that can be created
+    /// before the peer's stream count limit is reached.
     pub fn peer_streams_left_uni(&self) -> u64 {
         self.peer_max_streams_uni - self.local_opened_streams_uni
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -414,14 +414,14 @@ impl StreamMap {
         self.local_max_streams_uni_next
     }
 
-    /// Returns the amount of bidirectional streams that can be created in respect to the limit
-    /// set by the peer.
+    /// Returns the amount of bidirectional streams that can be created
+    /// before the stream count limit is reached.
     pub fn peer_streams_remaining_allowed_bidi(&self) -> u64 {
         self.peer_max_streams_bidi - self.local_opened_streams_bidi
     }
 
-    /// Returns the amount of unidirectional streams that can be created in respect to the limit
-    /// set by the peer.
+    /// Returns the amount of unidirectional streams that can be created
+    /// before the stream count limit is reached.
     pub fn peer_streams_remaining_allowed_uni(&self) -> u64 {
         self.peer_max_streams_uni - self.local_opened_streams_uni
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -414,14 +414,16 @@ impl StreamMap {
         self.local_max_streams_uni_next
     }
 
-    /// Returns the peer's maximum bidirectional stream count limit.
-    pub fn peer_max_streams_bidi(&self) -> u64 {
-        self.peer_max_streams_bidi
+    /// Returns the amount of bidirectional streams that can be created in respect to the limit
+    /// set by the peer.
+    pub fn peer_streams_remaining_allowed_bidi(&self) -> u64 {
+        self.peer_max_streams_bidi - self.local_opened_streams_bidi
     }
 
-    /// Returns the peer's maximum unidirectional stream count limit.
-    pub fn peer_max_streams_uni(&self) -> u64 {
-        self.peer_max_streams_uni
+    /// Returns the amount of unidirectional streams that can be created in respect to the limit
+    /// set by the peer.
+    pub fn peer_streams_remaining_allowed_uni(&self) -> u64 {
+        self.peer_max_streams_uni - self.local_opened_streams_uni
     }
 
     /// Drops completed stream.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -416,13 +416,13 @@ impl StreamMap {
 
     /// Returns the amount of bidirectional streams that can be created
     /// before the stream count limit is reached.
-    pub fn peer_streams_remaining_allowed_bidi(&self) -> u64 {
+    pub fn peer_streams_left_bidi(&self) -> u64 {
         self.peer_max_streams_bidi - self.local_opened_streams_bidi
     }
 
     /// Returns the amount of unidirectional streams that can be created
     /// before the stream count limit is reached.
-    pub fn peer_streams_remaining_allowed_uni(&self) -> u64 {
+    pub fn peer_streams_left_uni(&self) -> u64 {
         self.peer_max_streams_uni - self.local_opened_streams_uni
     }
 


### PR DESCRIPTION
Motivation:

Sometimes its useful to know if a stream creation would be allowed before actual trying to create the stream.

Modifications:

Add peer_max_streams_bidi() and peer_max_streams_uni() that can be used to check for the maximum allowed stream id by the remote peer.

Result:

Fixes https://github.com/cloudflare/quiche/issues/734