### PR TITLE
qlog: Always serialize frames field last

### DIFF
--- a/tools/qlog/Cargo.toml
+++ b/tools/qlog/Cargo.toml
@@ -12,6 +12,6 @@ license = "BSD-2-Clause"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_derive = "1.0"
 serde_with = "1.3.1"


### PR DESCRIPTION
In order to preserve the behavior where multiple frames can be appended on a stream event, the frames field must serialized last. If that is not the case, it is not possible to keep the frames array "open" for appending.

This commit fixes Issue #785, specifically. It uses the preserve_order feature of the serde json library. This feature tells the library to serialize all structure fields in the order that they are inserted.