### PR TITLE
use ConnectionId in public functions

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -101,10 +101,10 @@ fn main() {
     config.set_disable_active_migration(true);
 
     // Generate a random source connection ID for the connection.
-    let mut scid = vec![0; quiche::MAX_CONN_ID_LEN];
+    let mut scid = [0; quiche::MAX_CONN_ID_LEN];
     SystemRandom::new().fill(&mut scid[..]).unwrap();
 
-    let scid = quiche::ConnectionId::from_vec(scid);
+    let scid = quiche::ConnectionId::from_ref(&scid);
 
     // Create a QUIC connection and initiate handshake.
     let mut conn = quiche::connect(url.domain(), &scid, &mut config).unwrap();

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -102,10 +102,10 @@ fn main() {
     let mut http3_conn = None;
 
     // Generate a random source connection ID for the connection.
-    let mut scid = vec![0; quiche::MAX_CONN_ID_LEN];
+    let mut scid = [0; quiche::MAX_CONN_ID_LEN];
     SystemRandom::new().fill(&mut scid[..]).unwrap();
 
-    let scid = quiche::ConnectionId::from_vec(scid);
+    let scid = quiche::ConnectionId::from_ref(&scid);
 
     // Create a QUIC connection and initiate handshake.
     let mut conn = quiche::connect(url.domain(), &scid, &mut config).unwrap();

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -206,6 +206,8 @@ fn main() {
                 let mut scid = [0; quiche::MAX_CONN_ID_LEN];
                 scid.copy_from_slice(&conn_id);
 
+                let scid = quiche::ConnectionId::from_ref(&scid);
+
                 // Token is always present in Initial packets.
                 let token = hdr.token.as_ref().unwrap();
 
@@ -242,7 +244,7 @@ fn main() {
 
                 // The token was not valid, meaning the retry failed, so
                 // drop the packet.
-                if odcid == None {
+                if odcid.is_none() {
                     error!("Invalid address validation token");
                     continue 'read;
                 }
@@ -258,7 +260,8 @@ fn main() {
 
                 debug!("New connection: dcid={:?} scid={:?}", hdr.dcid, scid);
 
-                let conn = quiche::accept(&scid, odcid, &mut config).unwrap();
+                let conn =
+                    quiche::accept(&scid, odcid.as_ref(), &mut config).unwrap();
 
                 let client = Client {
                     conn,
@@ -406,7 +409,7 @@ fn mint_token(hdr: &quiche::Header, src: &net::SocketAddr) -> Vec<u8> {
 /// authenticate of the token. *It should not be used in production system*.
 fn validate_token<'a>(
     src: &net::SocketAddr, token: &'a [u8],
-) -> Option<&'a [u8]> {
+) -> Option<quiche::ConnectionId<'a>> {
     if token.len() < 6 {
         return None;
     }
@@ -428,7 +431,7 @@ fn validate_token<'a>(
 
     let token = &token[addr.len()..];
 
-    Some(&token[..])
+    Some(quiche::ConnectionId::from_ref(&token[..]))
 }
 
 /// Handles incoming HTTP/0.9 requests.

--- a/fuzz/src/packet_recv_client.rs
+++ b/fuzz/src/packet_recv_client.rs
@@ -26,7 +26,8 @@ lazy_static! {
     };
 }
 
-static SCID: [u8; quiche::MAX_CONN_ID_LEN] = [0; quiche::MAX_CONN_ID_LEN];
+static SCID: quiche::ConnectionId<'static> =
+    quiche::ConnectionId::from_ref(&[0; quiche::MAX_CONN_ID_LEN]);
 
 fuzz_target!(|data: &[u8]| {
     let mut buf = data.to_vec();

--- a/fuzz/src/packet_recv_server.rs
+++ b/fuzz/src/packet_recv_server.rs
@@ -32,7 +32,8 @@ lazy_static! {
     };
 }
 
-static SCID: [u8; quiche::MAX_CONN_ID_LEN] = [0; quiche::MAX_CONN_ID_LEN];
+static SCID: quiche::ConnectionId<'static> =
+    quiche::ConnectionId::from_ref(&[0; quiche::MAX_CONN_ID_LEN]);
 
 fuzz_target!(|data: &[u8]| {
     let mut buf = data.to_vec();

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -59,7 +59,7 @@
 //!
 //! ```no_run
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
-//! # let scid = [0xba; 16];
+//! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
 //! # let mut conn = quiche::connect(None, &scid, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! let h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
@@ -74,7 +74,7 @@
 //!
 //! ```no_run
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
-//! # let scid = [0xba; 16];
+//! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
 //! # let mut conn = quiche::connect(None, &scid, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
@@ -95,7 +95,7 @@
 //!
 //! ```no_run
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
-//! # let scid = [0xba; 16];
+//! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
 //! # let mut conn = quiche::connect(None, &scid, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
@@ -125,7 +125,7 @@
 //! use quiche::h3::NameValue;
 //!
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
-//! # let scid = [0xba; 16];
+//! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
 //! # let mut conn = quiche::accept(&scid, None, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
@@ -186,7 +186,7 @@
 //! use quiche::h3::NameValue;
 //!
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
-//! # let scid = [0xba; 16];
+//! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
 //! # let mut conn = quiche::connect(None, &scid, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -140,13 +140,13 @@ enum ConnectionIdInner<'a> {
 impl<'a> ConnectionId<'a> {
     /// Creates a new connection ID from the given vector.
     #[inline]
-    pub fn from_vec(cid: Vec<u8>) -> Self {
+    pub const fn from_vec(cid: Vec<u8>) -> Self {
         Self(ConnectionIdInner::Vec(cid))
     }
 
     /// Creates a new connection ID from the given slice.
     #[inline]
-    pub fn from_ref(cid: &'a [u8]) -> Self {
+    pub const fn from_ref(cid: &'a [u8]) -> Self {
         Self(ConnectionIdInner::Ref(cid))
     }
 }

--- a/tools/apps/src/client.rs
+++ b/tools/apps/src/client.rs
@@ -146,10 +146,10 @@ pub fn connect(
     let mut app_proto_selected = false;
 
     // Generate a random source connection ID for the connection.
-    let mut scid = vec![0; quiche::MAX_CONN_ID_LEN];
+    let mut scid = [0; quiche::MAX_CONN_ID_LEN];
     SystemRandom::new().fill(&mut scid[..]).unwrap();
 
-    let scid = quiche::ConnectionId::from_vec(scid);
+    let scid = quiche::ConnectionId::from_ref(&scid);
 
     // Create a QUIC connection and initiate handshake.
     let mut conn =

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -110,8 +110,11 @@ pub fn run(
     let mut scid = [0; quiche::MAX_CONN_ID_LEN];
     SystemRandom::new().fill(&mut scid[..]).unwrap();
 
+    let scid = quiche::ConnectionId::from_ref(&scid);
+
     // Create a QUIC connection and initiate handshake.
     let url = &test.endpoint();
+
     let mut conn = quiche::connect(url.domain(), &scid, &mut config).unwrap();
 
     let write = match conn.send(&mut out) {


### PR DESCRIPTION
This changes the remaining public APIs to use the ConnectionId type for
connection ID values, instead of slices.

The FFI API is left as-is, as there isn't much point to introduce a new
type there.