### PR TITLE
apps: implementing limiting send burst

### DIFF
--- a/tools/apps/src/common.rs
+++ b/tools/apps/src/common.rs
@@ -94,6 +94,8 @@ pub struct Client {
     pub partial_requests: std::collections::HashMap<u64, PartialRequest>,
 
     pub partial_responses: std::collections::HashMap<u64, PartialResponse>,
+
+    pub bytes_sent: usize,
 }
 
 pub type ClientMap = HashMap<ConnectionId<'static>, Client>;


### PR DESCRIPTION
Similar to #684, but this is only for quiche-server in apps.
Should be able to help stable rtt and cwnd for high speed transfer.