### PR TITLE
ci: run fmt early

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,12 @@ jobs:
           components: rustfmt
           override: true
 
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
       - name: Install dependencies
         run: sudo apt-get install libev-dev uthash-dev
 
@@ -40,12 +46,6 @@ jobs:
         with:
           command: package
           args: --verbose --allow-dirty
-
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Run `cargo fmt` right after toolchain installation.
It should help to catch fmt errors early before trying the actual build.