### PR TITLE
Remove delivery rate in the connection level stats logs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4413,13 +4413,8 @@ impl std::fmt::Debug for Stats {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "recv={} sent={} lost={} rtt={:?} cwnd={} delivery_rate={}",
-            self.recv,
-            self.sent,
-            self.lost,
-            self.rtt,
-            self.cwnd,
-            self.delivery_rate
+            "recv={} sent={} lost={} rtt={:?} cwnd={}",
+            self.recv, self.sent, self.lost, self.rtt, self.cwnd,
         )
     }
 }


### PR DESCRIPTION
Delivery rate is instanteous and is calculated at the end of every ack received. Logging it with entire connection level stats is misleading.