### PR TITLE
Fix duplicate declaration in quiche.h

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -487,7 +487,7 @@ void quiche_h3_config_set_qpack_blocked_streams(quiche_h3_config *config, uint64
 void quiche_h3_config_set_dgram_poll_threshold(quiche_h3_config *config, uint64_t v);
 
 // Sets the `quiche_h3_conn_poll()` repetition threshold for stream events.
-void quiche_h3_config_set_dgram_poll_threshold(quiche_h3_config *config, uint64_t v);
+void quiche_h3_config_set_stream_poll_threshold(quiche_h3_config *config, uint64_t v);
 
 // Frees the HTTP/3 config object.
 void quiche_h3_config_free(quiche_h3_config *config);


### PR DESCRIPTION
When compiling a C program which includes `quiche.h`, the compiler noticed that `quiche_h3_config_set_dgram_poll_threshold` is defined twice.
It seems like changing `dgram` to `stream` was overlooked when this declaration was copied.