### PR TITLE
Add quiche_conn_dgram_recv_front_len

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -377,6 +377,9 @@ void quiche_conn_stats(quiche_conn *conn, quiche_stats *out);
 // Returns the maximum DATAGRAM payload that can be sent.
 ssize_t quiche_conn_dgram_max_writable_len(quiche_conn *conn);
 
+// Returns the length of the first stored DATAGRAM.
+ssize_t quiche_conn_dgram_recv_front_len(quiche_conn *conn);
+
 // Reads the first received DATAGRAM.
 ssize_t quiche_conn_dgram_recv(quiche_conn *conn, uint8_t *buf,
                                size_t buf_len);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -790,6 +790,15 @@ pub extern fn quiche_conn_dgram_max_writable_len(conn: &Connection) -> ssize_t {
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_dgram_recv_front_len(conn: &Connection) -> ssize_t {
+    match conn.dgram_recv_front_len() {
+        None => Error::Done.to_c(),
+
+        Some(v) => v as ssize_t,
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_dgram_send(
     conn: &mut Connection, buf: *const u8, buf_len: size_t,
 ) -> ssize_t {


### PR DESCRIPTION
Motivation:

It is useful to know the len of the datagram in the recv queue so we can allocate a buffer with the correct size. This is already possible in rust but wasn't exposed in the c layer.

Modifications:

Add quiche_conn_dgram_recv_front_len which expose this functionality in the c layer.

Result:

Be able to obtain the len of the first datagram in the recv queue.