### PR TITLE
ci: add x86_64-unknown-freebsd

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -146,6 +146,11 @@ jobs:
     strategy:
       matrix:
         target: ["aarch64-unknown-linux-gnu","armv7-unknown-linux-gnueabihf","i686-unknown-linux-gnu"]
+        cmd: ["test"]
+        include:
+          # cross doesn't support test in FreeBSD yet.
+          - target: "x86_64-unknown-freebsd"
+            cmd: "build"
     # Only run on "pull_request" event for external PRs. This is to avoid
     # duplicate builds for PRs created from internal branches.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
@@ -155,18 +160,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}
-          target: ${{ matrix.target }}
-          override: true
-
-      - name: Run cargo test
+      - name: Run cargo build/test
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: ${{ matrix.cmd }}
           args: --target=${{ matrix.target }} --verbose
           use-cross: true
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-freebsd]
+image = "rustembedded/cross:x86_64-unknown-freebsd"


### PR DESCRIPTION
- FreeBSD is experimental support in `cross` release,
so try to specify a docker image in Cross.toml.
- `cargo test` is failing (https://github.com/rust-embedded/cross/issues/220), so only `build` is enabled.