### PR TITLE
ci: use cargo ndk 2

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: ["aarch64-unknown-linux-gnu", "armv7-unknown-linux-gnueabihf","i686-unknown-linux-gnu"]
+        target: ["aarch64-unknown-linux-gnu","armv7-unknown-linux-gnueabihf","i686-unknown-linux-gnu"]
     # Only run on "pull_request" event for external PRs. This is to avoid
     # duplicate builds for PRs created from internal branches.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
@@ -375,10 +375,20 @@ jobs:
 
   android_ndk_lts:
     runs-on: ubuntu-latest
+    env:
+      NDK_LTS_VER: "21"
     strategy:
       matrix:
-        ndk_version: ["21"]
-        target: ["aarch64-linux-android", "arm-linux-androideabi", "armv7-linux-androideabi", "i686-linux-android"]
+        target: ["aarch64-linux-android","armv7-linux-androideabi","x86_64-linux-android","i686-linux-android"]
+        include:
+          - target: "aarch64-linux-android"
+            arch: "arm64-v8a"
+          - target: "armv7-linux-androideabi"
+            arch: "armeabi-v7a"
+          - target: "x86_64-linux-android"
+            arch: "x86_64"
+          - target: "i686-linux-android"
+            arch: "x86"
     # Only run on "pull_request" event for external PRs. This is to avoid
     # duplicate builds for PRs created from internal branches.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
@@ -400,18 +410,17 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-ndk
-          version: 1.0.0
 
       - name: Download NDK
-        run: curl -O https://dl.google.com/android/repository/android-ndk-r${{ matrix.ndk_version }}-linux-x86_64.zip
+        run: curl -O https://dl.google.com/android/repository/android-ndk-r${{ env.NDK_LTS_VER }}-linux-x86_64.zip
 
       - name: Extract NDK
-        run: unzip -q android-ndk-r${{ matrix.ndk_version }}-linux-x86_64.zip
+        run: unzip -q android-ndk-r${{ env.NDK_LTS_VER }}-linux-x86_64.zip
 
       - name: Run cargo ndk
         uses: actions-rs/cargo@v1
         with:
           command: ndk
-          args: --target ${{ matrix.target }} --android-platform ${{ matrix.ndk_version }} -- build --verbose
+          args: -t ${{ matrix.arch }} -p ${{ env.NDK_LTS_VER }} -- build --verbose
         env:
-          ANDROID_NDK_HOME: ${{ github.workspace }}/android-ndk-r${{ matrix.ndk_version }}
+          ANDROID_NDK_HOME: ${{ github.workspace }}/android-ndk-r${{ env.NDK_LTS_VER  }}


### PR DESCRIPTION
- `cargo ndk` command line option are changed in v2.
- Since triple target doesn't work, a list of (triple, target) is added in the build matrix.
- arm-linux-androideabi is replaced with x86_64-linux-android