### PR TITLE
http3_test: add some negative test cases

### DIFF
--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -26,10 +26,12 @@
 
 use ring::rand::*;
 
+use crate::Http3TestError;
+
 pub fn run(
     test: &mut crate::Http3Test, peer_addr: std::net::SocketAddr,
     verify_peer: bool, idle_timeout: u64, max_data: u64,
-) {
+) -> Result<(), Http3TestError> {
     const MAX_DATAGRAM_SIZE: usize = 1350;
 
     let mut buf = [0; 65535];
@@ -114,11 +116,7 @@ pub fn run(
     let url = &test.endpoint();
     let mut conn = quiche::connect(url.domain(), &scid, &mut config).unwrap();
 
-    let write = match conn.send(&mut out) {
-        Ok(v) => v,
-
-        Err(e) => panic!("initial send failed: {:?}", e),
-    };
+    let write = conn.send(&mut out).expect("initial send failed");
 
     while let Err(e) = socket.send(&out[..write]) {
         if e.kind() == std::io::ErrorKind::WouldBlock {
@@ -126,7 +124,7 @@ pub fn run(
             continue;
         }
 
-        panic!("send() failed: {:?}", e);
+        return Err(Http3TestError::Other(format!("send() failed: {:?}", e)));
     }
 
     debug!("written {}", write);
@@ -161,7 +159,10 @@ pub fn run(
                         break 'read;
                     }
 
-                    panic!("recv() failed: {:?}", e);
+                    return Err(Http3TestError::Other(format!(
+                        "recv() failed: {:?}",
+                        e
+                    )));
                 },
             };
 
@@ -188,9 +189,16 @@ pub fn run(
         if conn.is_closed() {
             info!("connection closed, {:?}", conn.stats());
 
+            if !conn.is_established() {
+                error!("connection timed out after {:?}", req_start.elapsed(),);
+
+                return Err(Http3TestError::HandshakeFail);
+            }
+
             if reqs_complete != reqs_count {
-                panic!("Client timed out after {:?} and only completed {}/{} requests",
+                error!("Client timed out after {:?} and only completed {}/{} requests",
                 req_start.elapsed(), reqs_complete, reqs_count);
+                return Err(Http3TestError::HttpFail);
             }
 
             break;
@@ -207,7 +215,18 @@ pub fn run(
 
             reqs_count = test.requests_count();
 
-            test.send_requests(&mut conn, &mut h3_conn).unwrap();
+            match test.send_requests(&mut conn, &mut h3_conn) {
+                Ok(_) => (),
+
+                Err(quiche::h3::Error::Done) => (),
+
+                Err(e) => {
+                    return Err(Http3TestError::Other(format!(
+                        "error sending: {:?}",
+                        e
+                    )));
+                },
+            };
 
             http3_conn = Some(h3_conn);
         }
@@ -258,7 +277,12 @@ pub fn run(
                                 // Already closed.
                                 Ok(_) | Err(quiche::Error::Done) => (),
 
-                                Err(e) => panic!("error closing conn: {:?}", e),
+                                Err(e) => {
+                                    return Err(Http3TestError::Other(format!(
+                                        "error closing conn: {:?}",
+                                        e
+                                    )));
+                                },
                             }
 
                             test.assert();
@@ -269,7 +293,12 @@ pub fn run(
                         match test.send_requests(&mut conn, http3_conn) {
                             Ok(_) => (),
                             Err(quiche::h3::Error::Done) => (),
-                            Err(e) => panic!("error sending request {:?}", e),
+                            Err(e) => {
+                                return Err(Http3TestError::Other(format!(
+                                    "error sending request: {:?}",
+                                    e
+                                )));
+                            },
                         }
                     },
 
@@ -314,7 +343,10 @@ pub fn run(
                     break;
                 }
 
-                panic!("send() failed: {:?}", e);
+                return Err(Http3TestError::Other(format!(
+                    "send() failed: {:?}",
+                    e
+                )));
             }
 
             debug!("written {}", write);
@@ -324,11 +356,14 @@ pub fn run(
             info!("connection closed, {:?}", conn.stats());
 
             if reqs_complete != reqs_count {
-                panic!("Client timed out after {:?} and only completed {}/{} requests",
+                error!("Client timed out after {:?} and only completed {}/{} requests",
                 req_start.elapsed(), reqs_complete, reqs_count);
+                return Err(Http3TestError::HttpFail);
             }
 
             break;
         }
     }
+
+    Ok(())
 }


### PR DESCRIPTION
Previously, http3_test was focused on successful tests where the server
under test was expected to handle requests and provide complete
responses. If an error occurred the test runner would panic and throw
up to the invoker to deal with.

With this change, instead of panicking, the Result is returned directly
to the invoker. This allows for checking success or failure
explicitly.

Several new test cases have been added that ensure the server can handle
clients that violate rules set out in the HTTP/3 spec.