### PR TITLE
make FFI API optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ fuzzing = []
 # For building with Android NDK < 18 and GCC.
 ndk-old-gcc = []
 
+# Expose the FFI API.
+ffi = []
+
 [package.metadata.docs.rs]
 no-default-features = true
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -34,7 +34,7 @@ http3-server: http3-server.c $(INCLUDE_DIR)/quiche.h $(LIB_DIR)/libquiche.a
 	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@ $(INCS) $(LIBS)
 
 $(LIB_DIR)/libquiche.a: $(shell find $(SOURCE_DIR) -type f -name '*.rs')
-	cd .. && cargo build --target-dir $(BUILD_DIR)
+	cd .. && cargo build --target-dir $(BUILD_DIR) --features ffi
 
 clean:
 	@$(RM) -rf client server http3-client http3-server build/

--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -135,11 +135,11 @@ index 000000000..1e8f8a9c0
 +
 +
 +# Default is release build
-+QUICHE_BUILD_FLAGS="--release --no-default-features"
++QUICHE_BUILD_FLAGS="--release --no-default-features --features ffi"
 +QUICHE_BUILD_TARGET="release"
 +
 +if [ $NGX_DEBUG = YES ]; then
-+    QUICHE_BUILD_FLAGS="--no-default-features"
++    QUICHE_BUILD_FLAGS="--no-default-features --features ffi"
 +    QUICHE_BUILD_TARGET="debug"
 +fi
 +

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -385,6 +385,7 @@ impl Error {
         }
     }
 
+    #[cfg(feature = "ffi")]
     fn to_c(self) -> libc::ssize_t {
         match self {
             Error::Done => -1,
@@ -4059,6 +4060,7 @@ mod tests {
     }
 }
 
+#[cfg(feature = "ffi")]
 mod ffi;
 mod frame;
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,6 +398,7 @@ impl Error {
         }
     }
 
+    #[cfg(feature = "ffi")]
     fn to_c(self) -> libc::ssize_t {
         match self {
             Error::Done => -1,
@@ -8575,6 +8576,7 @@ pub use crate::stream::StreamIter;
 
 mod crypto;
 mod dgram;
+#[cfg(feature = "ffi")]
 mod ffi;
 mod frame;
 pub mod h3;

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -300,6 +300,7 @@ impl Drop for Context {
 pub struct Handshake(*mut SSL);
 
 impl Handshake {
+    #[cfg(feature = "ffi")]
     pub unsafe fn from_ptr(ssl: *mut c_void) -> Handshake {
         let ssl = ssl as *mut SSL;
         Handshake(ssl)


### PR DESCRIPTION
Currently the FFI API is always built, whether quiche is used as part of
a Rust project or not. This can be problematic when multiple versions of
quiche are built as part of the same project, as the FFI API would then
conflict. It also doesn't make sense to expose FFI functions if they are
not going to be used.

This adds a new feature (disabled by default) to enable the FFI API.