### PR TITLE
ci: use HTTP/1.1 to download Android NDK

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -359,7 +359,7 @@ jobs:
           override: true
 
       - name: Download NDK
-        run: curl -O https://dl.google.com/android/repository/android-ndk-${{ matrix.ndk_version }}-linux-x86_64.zip
+        run: curl --http1.1 -O https://dl.google.com/android/repository/android-ndk-${{ matrix.ndk_version }}-linux-x86_64.zip
 
       - name: Extract NDK
         run: unzip -q android-ndk-${{ matrix.ndk_version }}-linux-x86_64.zip
@@ -412,7 +412,7 @@ jobs:
           crate: cargo-ndk
 
       - name: Download NDK
-        run: curl -O https://dl.google.com/android/repository/android-ndk-r${{ env.NDK_LTS_VER }}-linux-x86_64.zip
+        run: curl --http1.1 -O https://dl.google.com/android/repository/android-ndk-r${{ env.NDK_LTS_VER }}-linux-x86_64.zip
 
       - name: Extract NDK
         run: unzip -q android-ndk-r${{ env.NDK_LTS_VER }}-linux-x86_64.zip


### PR DESCRIPTION
Android builds keep failing randomly when downloading the Android NDK
from Google's servers with error "Error in the HTTP2 framing layer", so
disable HTTP/2 when downloading.