### PR TITLE
ci: build rust examples

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --features qlog
+          args: --examples --verbose --features qlog
 
       - name: Run cargo package
         uses: actions-rs/cargo@v1

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --features qlog
+          args: --examples --verbose --features qlog
 
       - name: Run cargo package
         uses: actions-rs/cargo@v1

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -37,4 +37,4 @@ $(LIB_DIR)/libquiche.a: $(shell find $(SOURCE_DIR) -type f -name '*.rs')
 	cd .. && cargo build --target-dir $(BUILD_DIR) --features ffi
 
 clean:
-	@$(RM) -rf client server http3-client http3-server build/
+	@$(RM) -rf client server http3-client http3-server build/ *.dSYM

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -37,4 +37,4 @@ $(LIB_DIR)/libquiche.a: $(shell find $(SOURCE_DIR) -type f -name '*.rs')
 	cd .. && cargo build --target-dir $(BUILD_DIR) --features ffi
 
 clean:
-	@$(RM) -rf client server http3-client http3-server build/ *.dSYM
+	@$(RM) -rf client server http3-client http3-server build/ *.dSYM/


### PR DESCRIPTION
It looks like we are not building rust (not C) examples in examples/ directory in CI.