### PR TITLE
tls: update BoringSSL version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1331,6 +1331,8 @@ impl Connection {
 
         conn.handshake.lock().unwrap().init(&conn)?;
 
+        conn.handshake.lock().unwrap().use_legacy_codepoint(true);
+
         conn.encode_transport_params()?;
 
         // Derive initial secrets for the client. We can do this here because
@@ -1612,6 +1614,8 @@ impl Connection {
                 Some(aead_open);
             self.pkt_num_spaces[packet::EPOCH_INITIAL].crypto_seal =
                 Some(aead_seal);
+
+            self.handshake.lock().unwrap().use_legacy_codepoint(true);
 
             // Encode transport parameters again, as the new version might be
             // using a different format.
@@ -3778,13 +3782,6 @@ impl Connection {
             Err(e) => return Err(e),
         };
 
-        if handshake.alpn_protocol().is_empty() {
-            // Send no_application_proto TLS alert when no protocol
-            // can be negotiated.
-            self.error = Some(0x178);
-            return Err(Error::TlsFail);
-        }
-
         self.handshake_completed = handshake.is_completed();
 
         self.alpn = handshake.alpn_protocol().to_vec();
@@ -5209,6 +5206,9 @@ mod tests {
         let mut buf = [0; 65535];
 
         let mut config = Config::new(0xbabababa).unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
         config.verify_peer(false);
 
         let mut pipe = testing::Pipe::with_client_config(&mut config).unwrap();

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -338,6 +338,12 @@ impl Handshake {
         Ok(())
     }
 
+    pub fn use_legacy_codepoint(&self, use_legacy: bool) {
+        unsafe {
+            SSL_set_quic_use_legacy_codepoint(self.as_ptr(), use_legacy as c_int);
+        }
+    }
+
     pub fn set_state(&self, is_server: bool) {
         unsafe {
             if is_server {
@@ -966,6 +972,8 @@ extern {
     fn SSL_set_quic_method(
         ssl: *mut SSL, quic_method: *const SSL_QUIC_METHOD,
     ) -> c_int;
+
+    fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: c_int);
 
     fn SSL_set_quic_early_data_context(
         ssl: *mut SSL, context: *const u8, context_len: usize,


### PR DESCRIPTION
Fixes #837.

---

This extracts the BoringSSL update from https://github.com/cloudflare/quiche/pull/826.