### PR TITLE
ci: Fix "this URL is not a hyperlink" warning

### DIFF
--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -27,7 +27,7 @@
 //! CUBIC Congestion Control
 //!
 //! This implementation is based on the following RFC:
-//! https://tools.ietf.org/html/rfc8312
+//! <https://tools.ietf.org/html/rfc8312>
 //!
 //! Note that Slow Start can use HyStart++ when enabled.
 

--- a/src/recovery/delivery_rate.rs
+++ b/src/recovery/delivery_rate.rs
@@ -27,7 +27,7 @@
 //! Delivery rate estimation.
 //!
 //! This implements the algorithm for estimating delivery rate as described in
-//! https://tools.ietf.org/html/draft-cheng-iccrg-delivery-rate-estimation-00
+//! <https://tools.ietf.org/html/draft-cheng-iccrg-delivery-rate-estimation-00>
 
 use std::cmp;
 

--- a/src/recovery/hystart.rs
+++ b/src/recovery/hystart.rs
@@ -28,7 +28,7 @@
 //!
 //! This implementation is based on the following I-D:
 //!
-//! https://tools.ietf.org/html/draft-balasubramanian-tcpm-hystartplusplus-03
+//! <https://tools.ietf.org/html/draft-balasubramanian-tcpm-hystartplusplus-03>
 
 use std::cmp;
 use std::time::Duration;


### PR DESCRIPTION
For nightly build (cargo doc).