### PR TITLE
coalesce outgoing packets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.47 as build
+FROM rust:1.50 as build
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ is disabled by default), by passing ``--features ffi`` to ``cargo``.
 Building
 --------
 
-quiche requires Rust 1.47 or later to build. The latest stable Rust release can
+quiche requires Rust 1.50 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched


### PR DESCRIPTION
Instead of writing one QUIC packet at a time, `send()` will now try to
coalesce multiple packets onto the same UDP datagram.

In order to support that, padding of Initial packets needs to be moved
outside the QUIC packet itself, so instead of using PADDING frames, we
simply leave some free space at the end of the datagram.

One notable change, is that Initial packets from the server are now also
padded as needed to reach the minimum 1200 length. This is to ensure
that the network path actually supports the minimum size in both
directions.

Though in practice this doesn't change much, since in most cases the
packet is pretty full already so the padding done from the server is
minimal

---

This fixes a `MUST` violation (padding of server Initial packets) in the later draft versions, which prevents interop with some implementations, and supersedes https://github.com/cloudflare/quiche/pull/802.

Also, this requires https://github.com/cloudflare/quiche/pull/852 to avoid breaking tests.