### PR TITLE
avoid sending STREAM frames for stopped streams

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1335,6 +1335,11 @@ impl SendBuf {
         false
     }
 
+    /// Returns true if the stream was stopped before completion.
+    pub fn is_stopped(&self) -> bool {
+        self.error.is_some()
+    }
+
     /// Returns true if there is data to be written.
     fn ready(&self) -> bool {
         !self.data.is_empty() && self.off_front() < self.off


### PR DESCRIPTION
When a STOP_SENDING frame is received, if the corresponding stream is
already flushable we end up sending a 0-length STREAM frame with
fin=true immediately after the RESET_STREAM frame.

This is because while the buffered data is dropped when receiving the
STOP_SENDING, the stream is still in the flushable queue, and since no
data is buffered anymore, and the final size is known, the 0-length
STREAM frame is generated.

It's not currently easy to remove a specific stream from the flushable
queue due to the priority mechanism, so instead check if the stream is
stopped before trying to generate a STREAM frame.