### PR TITLE
h3: use H3_NO_ERROR when shutting down unknown stream

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -1802,7 +1802,11 @@ impl Connection {
 
                 stream::State::Drain => {
                     // Discard incoming data on the stream.
-                    conn.stream_shutdown(stream_id, crate::Shutdown::Read, 0)?;
+                    conn.stream_shutdown(
+                        stream_id,
+                        crate::Shutdown::Read,
+                        0x100,
+                    )?;
 
                     break;
                 },


### PR DESCRIPTION
`0` is not a valid HTTP/3 error code, as No_ERROR corresponds to 0x100.