### PR TITLE
Read stream shutdown fixes

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -910,6 +910,8 @@ impl RecvBuf {
 
         self.data.clear();
 
+        self.off = self.max_off();
+
         Ok(())
     }
 


### PR DESCRIPTION
A couple of fixes related to `stream_shutdown(Read)`.