### PR TITLE
h3: only emit Finished events for request/push streams

### DIFF
--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -174,6 +174,10 @@ impl Stream {
         }
     }
 
+    pub fn ty(&self) -> Option<Type> {
+        self.ty
+    }
+
     pub fn state(&self) -> State {
         self.state
     }


### PR DESCRIPTION
After 5d39b5b1, we started collecting GREASE and other unknown type
streams correctly. However the way these were handled meant that we were
issuing Finished events regardless of the stream's type.

This makes FInished events be emitted only for request and push streams.