### PR TITLE
introduce a possibility for manual stream flow control by an application

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -195,6 +195,9 @@ void quiche_config_enable_dgram(quiche_config *config, bool enabled,
                                 size_t recv_queue_len,
                                 size_t send_queue_len);
 
+// Configures whether to enable automatic flow control limits update on streams.
+void quiche_config_enable_stream_flow_control_auto_update(quiche_config *config, bool enabled);
+
 // Frees the config object.
 void quiche_config_free(quiche_config *config);
 
@@ -261,6 +264,9 @@ ssize_t quiche_conn_send(quiche_conn *conn, uint8_t *out, size_t out_len);
 // Reads contiguous data from a stream.
 ssize_t quiche_conn_stream_recv(quiche_conn *conn, uint64_t stream_id,
                                 uint8_t *out, size_t buf_len, bool *fin);
+
+// Slides stream window offset.
+void quiche_conn_stream_consume(quiche_conn *conn, uint64_t stream_id, size_t n);
 
 // Writes data to a stream.
 ssize_t quiche_conn_stream_send(quiche_conn *conn, uint64_t stream_id,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -250,6 +250,13 @@ pub extern fn quiche_config_enable_dgram(
 }
 
 #[no_mangle]
+pub extern fn quiche_config_enable_stream_flow_control_auto_update(
+    config: &mut Config, enabled: bool,
+) {
+    config.enable_stream_flow_control_auto_update(enabled);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_set_max_send_udp_payload_size(
     config: &mut Config, v: size_t,
 ) {
@@ -580,6 +587,11 @@ pub extern fn quiche_conn_stream_recv(
     *fin = out_fin;
 
     out_len as ssize_t
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_stream_consume(conn: &mut Connection, stream_id: u64, n: size_t) {
+    let _ = conn.stream_consume(stream_id, n);
 }
 
 #[no_mangle]

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -829,13 +829,14 @@ impl PktNumSpace {
                 std::u64::MAX,
                 true,
                 true,
+                false,
             ),
         }
     }
 
     pub fn clear(&mut self) {
         self.crypto_stream =
-            stream::Stream::new(std::u64::MAX, std::u64::MAX, true, true);
+            stream::Stream::new(std::u64::MAX, std::u64::MAX, true, true, false);
 
         self.ack_elicited = false;
     }


### PR DESCRIPTION
This feature allows an application to slow down the reception of packets from the peer.
Without this, the application needs to buffer packets. And since it cannot stop the library
from sending MAX_DATA frames, the buffer can grow to quite large sizes in case the processing
speed is much lower than the packet reception speed.