### PR TITLE
Expose CONNECTION_CLOSE's Error Code and Reason Phrase via received_close_info()

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -338,6 +338,13 @@ uint64_t quiche_conn_peer_streams_left_uni(quiche_conn *conn);
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);
 
+// Returns 0 if Some, 1 if None, -1 if Some but reason_len is too small
+int quiche_conn_received_close_info(quiche_conn *conn,
+                                    bool *is_app,
+                                    uint64_t *error_code,
+                                    uint8_t *reason,
+                                    size_t *reason_len);
+
 // Initializes the stream's application data.
 //
 // Stream data can only be initialized once. Additional calls to this method

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -338,7 +338,7 @@ uint64_t quiche_conn_peer_streams_left_uni(quiche_conn *conn);
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);
 
-// Returns 0 if Some, 1 if None, -1 if Some but reason_len is too small
+// Returns 0 if Some, 1 if None, -1 if Some but reason_len is too small.
 int quiche_conn_received_close_info(quiche_conn *conn,
                                     bool *is_app,
                                     uint64_t *error_code,

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -339,6 +339,9 @@ uint64_t quiche_conn_peer_streams_left_uni(quiche_conn *conn);
 bool quiche_conn_is_closed(quiche_conn *conn);
 
 // Returns 0 if Some, 1 if None, -1 if Some but reason_len is too small.
+//
+// Always sets reason_len to the length of reason, so an exact length
+// buffer can be malloc'd and filled with a second call.
 int quiche_conn_received_close_info(quiche_conn *conn,
                                     bool *is_app,
                                     uint64_t *error_code,

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -338,14 +338,11 @@ uint64_t quiche_conn_peer_streams_left_uni(quiche_conn *conn);
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);
 
-// Returns 0 if Some, 1 if None, -1 if Some but reason_len is too small.
-//
-// Always sets reason_len to the length of reason, so an exact length
-// buffer can be malloc'd and filled with a second call.
-int quiche_conn_received_close_info(quiche_conn *conn,
+// Returns true if Some, false if None
+bool quiche_conn_peer_error(quiche_conn *conn,
                                     bool *is_app,
                                     uint64_t *error_code,
-                                    uint8_t *reason,
+                                    const uint8_t **reason,
                                     size_t *reason_len);
 
 // Initializes the stream's application data.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -776,6 +776,7 @@ pub extern fn quiche_conn_received_close_info(
             *error_code = conn_err.error_code;
 
             if *reason_len < conn_err.reason_phrase.len() {
+                *reason_len = conn_err.reason_phrase.len(); // Always provide the length of reason
                 return -1; // Some, but can't fit reason into provided buf
             }
             let reason = slice::from_raw_parts_mut(reason, *reason_len);

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -1223,7 +1223,7 @@ impl Connection {
         // When connection close is initiated by the local application (e.g. due
         // to a protocol error), the connection itself might be in a broken
         // state, so return early.
-        if conn.error.is_some() || conn.app_error.is_some() {
+        if conn.is_closing() {
             return Err(Error::Done);
         }
 
@@ -3374,8 +3374,8 @@ mod tests {
         assert_eq!(s.poll_server(), Err(Error::ExcessiveLoad));
 
         assert_eq!(
-            s.pipe.server.app_error,
-            Some(Error::to_wire(Error::ExcessiveLoad))
+            s.pipe.server.local_error.as_ref().unwrap().error_code,
+            Error::to_wire(Error::ExcessiveLoad)
         );
     }
 

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -1223,7 +1223,7 @@ impl Connection {
         // When connection close is initiated by the local application (e.g. due
         // to a protocol error), the connection itself might be in a broken
         // state, so return early.
-        if conn.is_closing() {
+        if conn.local_error.is_some() {
             return Err(Error::Done);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3845,13 +3845,13 @@ impl Connection {
     }
 
     /// Returns the error code and reason phrase from a connection close or
-    /// application close event received from the peer, if any
+    /// application close event received from the peer, if any.
     ///
     /// The values contained in the tuple are symmetric with the [`close()`]
-    /// method
+    /// method.
     ///
     /// Note that a `Some` return value does not necessarily imply
-    /// [`is_closed()`] or any other connection state
+    /// [`is_closed()`] or any other connection state.
     ///
     /// [`close()`]: struct.Connection.html#method.close
     /// [`is_closed()`]: struct.Connection.html#method.is_closed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4389,21 +4389,26 @@ impl Connection {
             frame::Frame::PathResponse { .. } => (),
 
             frame::Frame::ConnectionClose {
-                error_code, reason, ..
+                error_code,
+                reason: reason_phrase,
+                ..
             } => {
                 self.peer_error = Some(ConnectionError {
                     is_app: false,
                     error_code,
-                    reason_phrase: reason,
+                    reason_phrase,
                 });
                 self.draining_timer = Some(now + (self.recovery.pto() * 3));
             },
 
-            frame::Frame::ApplicationClose { error_code, reason } => {
+            frame::Frame::ApplicationClose {
+                error_code,
+                reason: reason_phrase,
+            } => {
                 self.peer_error = Some(ConnectionError {
                     is_app: true,
                     error_code,
-                    reason_phrase: reason,
+                    reason_phrase,
                 });
                 self.draining_timer = Some(now + (self.recovery.pto() * 3));
             },

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -38,6 +38,7 @@ use crate::Error;
 use crate::Result;
 
 use crate::Connection;
+use crate::ConnectionError;
 
 use crate::crypto;
 use crate::octets;
@@ -728,7 +729,11 @@ extern fn send_alert(ssl: *mut SSL, level: crypto::Level, alert: u8) -> c_int {
     );
 
     let error: u64 = TLS_ALERT_ERROR + u64::from(alert);
-    conn.error = Some(error);
+    conn.local_error = Some(ConnectionError {
+        is_app: false,
+        error_code: error,
+        reason_phrase: Vec::new(),
+    });
 
     1
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -732,7 +732,7 @@ extern fn send_alert(ssl: *mut SSL, level: crypto::Level, alert: u8) -> c_int {
     conn.local_error = Some(ConnectionError {
         is_app: false,
         error_code: error,
-        reason_phrase: Vec::new(),
+        reason: Vec::new(),
     });
 
     1


### PR DESCRIPTION
Addresses #766

Renames existing `error`, `app_error`, `app_reason` fields to have a `local_` prefix.
Adds fields for `peer_error`, etc.
Adds a `received_close_info` method to `Connection`, as well as the FFI.
Includes tests.

I am especially unfamiliar with conventions for the FFI. Are there tests for it?