### PR TITLE
Add SSL_ERROR_WANT_CERTIFICATE_VERIFY and SSL_ERROR_PENDING_SESSION h…

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -848,6 +848,9 @@ fn map_result_ssl(ssl: &Handshake, bssl_result: c_int) -> Result<()> {
                 // SSL_ERROR_SYSCALL
                 5 => Err(Error::TlsFail),
 
+                // SSL_ERROR_PENDING_SESSION
+                11 => Err(Error::Done),
+
                 // SSL_ERROR_PENDING_CERTIFICATE
                 12 => Err(Error::Done),
 
@@ -856,6 +859,9 @@ fn map_result_ssl(ssl: &Handshake, bssl_result: c_int) -> Result<()> {
 
                 // SSL_ERROR_PENDING_TICKET
                 14 => Err(Error::Done),
+
+                //  SSL_ERROR_WANT_CERTIFICATE_VERIFY
+                16 => Err(Error::Done),
 
                 _ => Err(Error::TlsFail),
             }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -860,7 +860,7 @@ fn map_result_ssl(ssl: &Handshake, bssl_result: c_int) -> Result<()> {
                 // SSL_ERROR_PENDING_TICKET
                 14 => Err(Error::Done),
 
-                //  SSL_ERROR_WANT_CERTIFICATE_VERIFY
+                // SSL_ERROR_WANT_CERTIFICATE_VERIFY
                 16 => Err(Error::Done),
 
                 _ => Err(Error::TlsFail),


### PR DESCRIPTION
…andling

Motivation:

For more advanced use-cases the certificate verification or session lookup may be executed asynchronously.  In this case SSL_ERROR_WANT_CERTIFICATE_VERIFY / SSL_ERROR_PENDING_SESSION will be returned

Modifications:

Add mapping for SSL_ERROR_WANT_CERTIFICATE_VERIFY / SSL_ERROR_PENDING_SESSIO

Result:

Be able to to use asynchronous certificate verification and session lookup