### PR TITLE
cc: CUBIC - detecting spurious congestion events

### DIFF
--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -755,6 +755,10 @@ impl Recovery {
     fn congestion_event(
         &mut self, time_sent: Instant, epoch: packet::Epoch, now: Instant,
     ) {
+        if !self.in_congestion_recovery(time_sent) {
+            (self.cc_ops.checkpoint)(self);
+        }
+
         (self.cc_ops.congestion_event)(self, time_sent, epoch, now);
     }
 
@@ -839,6 +843,10 @@ pub struct CongestionControlOps {
     ),
 
     pub collapse_cwnd: fn(r: &mut Recovery),
+
+    pub checkpoint: fn(r: &mut Recovery),
+
+    pub rollback: fn(r: &mut Recovery),
 }
 
 impl From<CongestionControlAlgorithm> for &'static CongestionControlOps {

--- a/src/recovery/reno.rs
+++ b/src/recovery/reno.rs
@@ -43,6 +43,8 @@ pub static RENO: CongestionControlOps = CongestionControlOps {
     on_packet_acked,
     congestion_event,
     collapse_cwnd,
+    checkpoint,
+    rollback,
 };
 
 pub fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
@@ -155,6 +157,10 @@ pub fn collapse_cwnd(r: &mut Recovery) {
     r.bytes_acked_sl = 0;
     r.bytes_acked_ca = 0;
 }
+
+fn checkpoint(_r: &mut Recovery) {}
+
+fn rollback(_r: &mut Recovery) {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Implementing detecting spurious congestion events and restore to the previous CC state in CUBIC.

Current algorithm is as follows:
- When the congestion event happen, save the current CUBIC state before cwnd reduction.
- When the current recovery episode ends and the new lost count is smaller than RESTORE_COUNT_THREHOLD (unit of a packet), restore from the saved prior state. It means that this can be a random loss, not a congestion loss which usually come with many multiple losses.