### PR TITLE
recovery: add machinery for saving and rolling back congestion control state

### DIFF
--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -49,6 +49,8 @@ pub static CUBIC: CongestionControlOps = CongestionControlOps {
     on_packet_acked,
     congestion_event,
     collapse_cwnd,
+    checkpoint,
+    rollback,
 };
 
 /// CUBIC Constants.
@@ -75,6 +77,29 @@ pub struct State {
 
     // Store cwnd increment during congestion avoidance.
     cwnd_inc: usize,
+
+    // CUBIC state checkpoint preceding the last congestion event.
+    prior: PriorState,
+}
+
+/// Stores the CUBIC state from before the last congestion event.
+///
+/// <https://tools.ietf.org/id/draft-ietf-tcpm-rfc8312bis-00.html#section-4.9>
+#[derive(Debug, Default)]
+struct PriorState {
+    congestion_window: usize,
+
+    ssthresh: usize,
+
+    w_max: f64,
+
+    w_last_max: f64,
+
+    k: f64,
+
+    epoch_start: Option<Instant>,
+
+    lost_count: usize,
 }
 
 /// CUBIC Functions.
@@ -645,4 +670,23 @@ mod tests {
         // During LSS cwnd will be increased less than usual slow start.
         assert_eq!(r.cwnd(), cwnd_prev + r.max_datagram_size);
     }
+}
+
+fn checkpoint(r: &mut Recovery) {
+    r.cubic_state.prior.congestion_window = r.congestion_window;
+    r.cubic_state.prior.ssthresh = r.ssthresh;
+    r.cubic_state.prior.w_max = r.cubic_state.w_max;
+    r.cubic_state.prior.w_last_max = r.cubic_state.w_last_max;
+    r.cubic_state.prior.k = r.cubic_state.k;
+    r.cubic_state.prior.epoch_start = r.congestion_recovery_start_time;
+    r.cubic_state.prior.lost_count = r.lost_count;
+}
+
+fn rollback(r: &mut Recovery) {
+    r.congestion_window = r.cubic_state.prior.congestion_window;
+    r.ssthresh = r.cubic_state.prior.ssthresh;
+    r.cubic_state.w_max = r.cubic_state.prior.w_max;
+    r.cubic_state.w_last_max = r.cubic_state.prior.w_last_max;
+    r.cubic_state.k = r.cubic_state.prior.k;
+    r.congestion_recovery_start_time = r.cubic_state.prior.epoch_start;
 }

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -755,6 +755,10 @@ impl Recovery {
     fn congestion_event(
         &mut self, time_sent: Instant, epoch: packet::Epoch, now: Instant,
     ) {
+        if !self.in_congestion_recovery(time_sent) {
+            (self.cc_ops.checkpoint)(self);
+        }
+
         (self.cc_ops.congestion_event)(self, time_sent, epoch, now);
     }
 
@@ -839,6 +843,10 @@ pub struct CongestionControlOps {
     ),
 
     pub collapse_cwnd: fn(r: &mut Recovery),
+
+    pub checkpoint: fn(r: &mut Recovery),
+
+    pub rollback: fn(r: &mut Recovery),
 }
 
 impl From<CongestionControlAlgorithm> for &'static CongestionControlOps {

--- a/src/recovery/reno.rs
+++ b/src/recovery/reno.rs
@@ -43,6 +43,8 @@ pub static RENO: CongestionControlOps = CongestionControlOps {
     on_packet_acked,
     congestion_event,
     collapse_cwnd,
+    checkpoint,
+    rollback,
 };
 
 pub fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
@@ -342,3 +344,7 @@ mod tests {
         assert_eq!(r.cwnd(), cur_cwnd + r.max_datagram_size);
     }
 }
+
+fn checkpoint(_r: &mut Recovery) {}
+
+fn rollback(_r: &mut Recovery) {}


### PR DESCRIPTION
This simply splits out the changes to save and restore CC state from https://github.com/cloudflare/quiche/pull/890 so e.g. it could also be used for https://github.com/cloudflare/quiche/pull/470.