### PR TITLE
stream: process incoming data when draining

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -778,10 +778,6 @@ impl RecvBuf {
             }
         }
 
-        if self.drain {
-            return Ok(());
-        }
-
         let mut tmp_buf = Some(buf);
 
         while let Some(mut buf) = tmp_buf {
@@ -815,7 +811,9 @@ impl RecvBuf {
 
             self.len = cmp::max(self.len, buf.max_off());
 
-            self.data.push(buf);
+            if !self.drain {
+                self.data.push(buf);
+            }
         }
 
         Ok(())


### PR DESCRIPTION
When a stream enters the draining state, besides not storing the
received data, it also stops updating its internal state, like the
stream's maximum offset, which affects the flow control calculation.

For example, if the stream is reset by the peer, this could trigger a
spurious flow control violation error, causing the connection to be
terminated.