### PR TITLE
h3: avoid marking a stream as finished multiple times

### DIFF
--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -73,6 +73,9 @@ pub enum State {
 
     /// Reading and discarding data.
     Drain,
+
+    /// All data has been read.
+    Finished,
 }
 
 impl Type {
@@ -485,6 +488,11 @@ impl Stream {
         }
 
         Ok((len, fin))
+    }
+
+    /// Marks the stream as finished.
+    pub fn finished(&mut self) {
+        let _ = self.state_transition(State::Finished, 0, false);
     }
 
     /// Tries to read DATA payload from the given cursor.


### PR DESCRIPTION
If an application keeps calling `recv_body()` on a stream that is
already finished, we end up adding it to the finished streams queue
multiple times.

The application shouldn't really do this, but do the sane thing if it
does happen.