### PR TITLE
Modify windowed minmax module to be generic over timing values

### DIFF
--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -84,7 +84,7 @@ pub struct Recovery {
 
     rttvar: Duration,
 
-    minmax_filter: minmax::Minmax<Duration>,
+    minmax_filter: minmax::Minmax<Instant, Duration>,
 
     min_rtt: Duration,
 
@@ -152,7 +152,7 @@ impl Recovery {
             // handled by the `rtt()` method instead.
             smoothed_rtt: None,
 
-            minmax_filter: minmax::Minmax::new(Duration::new(0, 0)),
+            minmax_filter: minmax::Minmax::new(Instant::now(), Duration::new(0, 0)),
 
             min_rtt: Duration::new(0, 0),
 


### PR DESCRIPTION
**Motivation**: Currently, the minmax module is generic over the values it stores but uses `Duration` and `Instant` to fix what time values were generated at and for determining when values have fallen outside of the window. This works well for many cases, but there are some instances where windowed minimums/maximums are used but the windows don't strictly correlate to wallclock time. One such case is BBR's bottleneck bandwidth control signal, which uses a virtual timer based on RTT to for managing the windowed maximum (see [BBR RFC 4.1.1.3](https://tools.ietf.org/html/draft-cardwell-iccrg-bbr-congestion-control-00#section-4.1.1.3)).

**Solution**: I added a couple extra type parameters and bounds on `Minmax`: one for representing a moment in time (`I`)  and another for representing the time elapsed between two moments (`D`). Those two generic types have a number of trait bounds placed on them to ensure that the programmer has selected appropriate types to be used for moments and durations. All of the trait bounds selected allow for `Instant` and `Duration` like before this PR, but also allows for the use of `u32` to represent both a moment in time and the elapsed amount of time. 

**Downsides**: A couple drawbacks to this PR is that it lengthens the type signature of `Minmax` and it may not be obvious to users that they have type parameters defining both the type of the value and the type used to represent a moment of time, but this could be resolved with documentation.

**Alternatives**: Instead of making the current implementation generic, two separate implementations could be written: one which uses `Duration` and `Instant` for use cases where wallclock time is used and another which uses `u32` or some similar integer type for arbitrary timing. Another alternative would be to use the generic implementation, limit its visibility, and instead expose those same two APIs as previously mentioned. This would keep the type signatures shorter and more readable, possibly make it easier for developers to understand how to use the Minmax filters at a glance, but limit flexibility beyond those two use cases (although I'm struggling to think of a situation where anything other than wallclock values/arbitrary integers would need to be used though).

I apologise for not filing an issue in advance. I had written this diff as part of some ongoing research and figured it may be useful for quiche generally since a similar change would be necessary for implementing BBR. I'll happily take any comments about the design or the level of testing necessary, and thanks for looking this over!