### PR TITLE
h3: emit GOAWAY from client

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -1318,9 +1318,13 @@ impl Connection {
     pub fn send_goaway(
         &mut self, conn: &mut super::Connection, id: u64,
     ) -> Result<()> {
+        let mut id = id;
+
+        // TODO: server push
+        //
+        // In the meantime always send 0 from client.
         if !self.is_server {
-            // TODO: server push
-            return Ok(());
+            id = 0;
         }
 
         if self.is_server && id % 4 != 0 {
@@ -2996,12 +3000,12 @@ mod tests {
         let mut s = Session::default().unwrap();
         s.handshake().unwrap();
 
-        s.client.send_goaway(&mut s.pipe.client, 1).unwrap();
+        s.client.send_goaway(&mut s.pipe.client, 100).unwrap();
 
         s.advance().ok();
 
         // TODO: server push
-        assert_eq!(s.poll_server(), Err(Error::Done));
+        assert_eq!(s.poll_server(), Ok((0, Event::GoAway)));
     }
 
     #[test]


### PR DESCRIPTION
Previously, if `send_goaway()` was called on a client connection, it
would return without emitting a frame. This was justified by the lack
of server push support in quiche. However, it also prevented client
GOAWAY when the endpoints didn't use push, which is unfortunate.

This change simply always populates the emitted GOAWAY frame with an
ID of 0, which is valid and consistent with our server push support
status.