### PR TITLE
support exporting and importing TLS sessions

### DIFF
--- a/tools/apps/src/args.rs
+++ b/tools/apps/src/args.rs
@@ -196,6 +196,7 @@ Options:
   --disable-hystart        Disable HyStart++.
   -H --header HEADER ...   Add a request header.
   -n --requests REQUESTS   Send the given number of identical requests [default: 1].
+  --session-file PATH      File used to cache a TLS session for resumption.
   -h --help                Show this screen.
 ";
 
@@ -211,6 +212,7 @@ pub struct ClientArgs {
     pub body: Option<Vec<u8>>,
     pub method: String,
     pub connect_to: Option<String>,
+    pub session_file: Option<String>,
 }
 
 impl Args for ClientArgs {
@@ -268,6 +270,12 @@ impl Args for ClientArgs {
             None
         };
 
+        let session_file = if args.get_bool("--session-file") {
+            Some(args.get_str("--session-file").to_string())
+        } else {
+            None
+        };
+
         ClientArgs {
             version,
             dump_response_path,
@@ -279,6 +287,7 @@ impl Args for ClientArgs {
             body,
             method,
             connect_to,
+            session_file,
         }
     }
 }
@@ -296,6 +305,7 @@ impl Default for ClientArgs {
             body: None,
             method: "GET".to_string(),
             connect_to: None,
+            session_file: None,
         }
     }
 }

--- a/tools/apps/src/client.rs
+++ b/tools/apps/src/client.rs
@@ -176,6 +176,12 @@ pub fn connect(
         }
     }
 
+    if let Some(session_file) = &args.session_file {
+        if let Ok(session) = std::fs::read(session_file) {
+            conn.set_session(&session).ok();
+        }
+    }
+
     info!(
         "connecting to {:} from {:} with scid {:?}",
         peer_addr,
@@ -273,6 +279,12 @@ pub fn connect(
                 );
 
                 return Err(ClientError::HandshakeFail);
+            }
+
+            if let Some(session_file) = &args.session_file {
+                if let Some(session) = conn.session() {
+                    std::fs::write(session_file, &session).ok();
+                }
             }
 
             if let Some(h_conn) = http_conn {
@@ -402,6 +414,12 @@ pub fn connect(
                 );
 
                 return Err(ClientError::HandshakeFail);
+            }
+
+            if let Some(session_file) = &args.session_file {
+                if let Some(session) = conn.session() {
+                    std::fs::write(session_file, &session).ok();
+                }
             }
 
             if let Some(h_conn) = http_conn {

--- a/tools/qns/run_endpoint.sh
+++ b/tools/qns/run_endpoint.sh
@@ -39,7 +39,11 @@ check_testcase () {
             echo "supported"
         fi
         ;;
-    resumption | zerortt )
+    resumption )
+        echo "supported"
+        QUICHE_CLIENT_OPT="$QUICHE_CLIENT_OPT --session-file=session.bin"
+        ;;
+    zerortt )
         if [ "$ROLE" == "client" ]; then
             # We don't support session resumption on the client-side yet.
             echo "unsupported"


### PR DESCRIPTION
This makes it possible to support session resumption on a client and is
a pre-requisite for supporting sending 0-RTT data.