### PR TITLE
support for sending 0-RTT packets on the client

### DIFF
--- a/tools/apps/src/args.rs
+++ b/tools/apps/src/args.rs
@@ -38,6 +38,7 @@ pub struct CommonArgs {
     pub max_streams_bidi: u64,
     pub max_streams_uni: u64,
     pub idle_timeout: u64,
+    pub early_data: bool,
     pub dump_packet_path: Option<String>,
     pub no_grease: bool,
     pub cc_algorithm: String,
@@ -118,6 +119,8 @@ impl Args for CommonArgs {
         let idle_timeout = args.get_str("--idle-timeout");
         let idle_timeout = u64::from_str_radix(idle_timeout, 10).unwrap();
 
+        let early_data = args.get_bool("--early-data");
+
         let dump_packet_path = if args.get_str("--dump-packets") != "" {
             Some(args.get_str("--dump-packets").to_string())
         } else {
@@ -137,6 +140,7 @@ impl Args for CommonArgs {
             max_streams_bidi,
             max_streams_uni,
             idle_timeout,
+            early_data,
             dump_packet_path,
             no_grease,
             cc_algorithm: cc_algorithm.to_string(),
@@ -157,6 +161,7 @@ impl Default for CommonArgs {
             max_streams_bidi: 100,
             max_streams_uni: 100,
             idle_timeout: 30000,
+            early_data: false,
             dump_packet_path: None,
             no_grease: false,
             cc_algorithm: "cubic".to_string(),
@@ -182,6 +187,7 @@ Options:
   --idle-timeout TIMEOUT   Idle timeout in milliseconds [default: 30000].
   --wire-version VERSION   The version number to send to the server [default: babababa].
   --http-version VERSION   HTTP version to use [default: all].
+  --early-data             Enable sending early data.
   --dgram-proto PROTO      DATAGRAM application protocol to use [default: none].
   --dgram-count COUNT      Number of DATAGRAMs to send [default: 0].
   --dgram-data DATA        Data to send for certain types of DATAGRAM application protocol [default: quack].
@@ -327,7 +333,7 @@ Options:
   --max-streams-uni STREAMS   Number of allowed concurrent streams [default: 100].
   --idle-timeout TIMEOUT   Idle timeout in milliseconds [default: 30000].
   --dump-packets PATH         Dump the incoming packets as files in the given directory.
-  --early-data                Enables receiving early data.
+  --early-data                Enable receiving early data.
   --no-retry                  Disable stateless retry.
   --no-grease                 Don't send GREASE.
   --http-version VERSION      HTTP version to use [default: all].
@@ -347,7 +353,6 @@ pub struct ServerArgs {
     pub index: String,
     pub cert: String,
     pub key: String,
-    pub early_data: bool,
 }
 
 impl Args for ServerArgs {
@@ -356,7 +361,6 @@ impl Args for ServerArgs {
 
         let listen = args.get_str("--listen").to_string();
         let no_retry = args.get_bool("--no-retry");
-        let early_data = args.get_bool("--early-data");
         let root = args.get_str("--root").to_string();
         let index = args.get_str("--index").to_string();
         let cert = args.get_str("--cert").to_string();
@@ -369,7 +373,6 @@ impl Args for ServerArgs {
             index,
             cert,
             key,
-            early_data,
         }
     }
 }

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -109,7 +109,7 @@ fn main() {
         config.log_keys();
     }
 
-    if args.early_data {
+    if conn_args.early_data {
         config.enable_early_data();
     }
 

--- a/tools/qns/run_endpoint.sh
+++ b/tools/qns/run_endpoint.sh
@@ -47,9 +47,8 @@ check_testcase () {
 
         zerortt )
             if [ "$ROLE" == "client" ]; then
-                # We don't support session resumption on the client-side yet.
-                echo "unsupported"
-                exit 127
+                echo "supported"
+                QUICHE_CLIENT_OPT="$QUICHE_CLIENT_OPT --session-file=session.bin --early-data"
             elif [ "$ROLE" == "server" ]; then
                 echo "supported"
                 QUICHE_SERVER_OPT="$QUICHE_SERVER_OPT --early-data"
@@ -75,7 +74,7 @@ run_quiche_client_tests () {
     sleep 3
 
     case $1 in
-        multiconnect | resumption )
+        multiconnect | resumption | zerortt )
             for req in $REQUESTS
             do
                 $QUICHE_DIR/$QUICHE_CLIENT $QUICHE_CLIENT_OPT \


### PR DESCRIPTION
This adds support for clients to generate 0-RTT packets. Currently only
STREAM and DATAGRAM frames are allowed, though this is somewhat stricter
than what is allowed in theory.

This requies exporting the peer's transport parameters as part of the
TLS session, so that they can be restored on resumption.

This also changes how epoch/packet type is picked when creating a new
packet. Packet types offer more granularity (e.g. Short vs. ZeroRTT), so
it's better to pick the type first and then derive the epoch, rather
than the other way around.

Closes #683.

---

It seems to work reasonably fine so far, but probably needs more interop testing.