### PR TITLE
http3_test: add 0-rtt connection resumption

### DIFF
--- a/tools/http3_test/README.md
+++ b/tools/http3_test/README.md
@@ -48,6 +48,14 @@ A set of environment variables allow tuning of test beheviour:
 * EXPECT_REQ_HEADERS - expected request header/value pairs in JSON format.
                        Currently used by `headers` test only.
 
+* EARLY_DATA       - boolean value ("true" or "false") that controls if
+                     the test client attempts to 0-rtt connection.
+                     Default value is false.
+
+* SESSION_FILE     - the file name used for storing QUIC session ticket.
+                     With EARLY_DATA, it can be used for the test client
+                     to attempt 0-rtt connection resumption.
+
 For example, to test a non-default server, use the HTTPBIN_ENDPOINT environment
 variable
 

--- a/tools/http3_test/tests/httpbin_tests.rs
+++ b/tools/http3_test/tests/httpbin_tests.rs
@@ -127,6 +127,32 @@ mod httpbin_tests {
         }
     }
 
+    fn early_data() -> bool {
+        match std::env::var_os("EARLY_DATA") {
+            Some(val) => match val.to_str().unwrap() {
+                "true" => {
+                    return true;
+                },
+
+                _ => {
+                    return false;
+                },
+            },
+
+            None => {
+                return false;
+            },
+        };
+    }
+
+    fn session_file() -> Option<String> {
+        if let Some(val) = std::env::var_os("SESSION_FILE") {
+            Some(val.into_string().unwrap())
+        } else {
+            None
+        }
+    }
+
     // A rudimentary structure to hold httpbin response data
     #[derive(Debug, serde::Deserialize)]
     struct HttpBinResponseBody {
@@ -159,7 +185,15 @@ mod httpbin_tests {
         });
 
         let mut test = Http3Test::new(endpoint(None), reqs, assert, concurrent);
-        runner::run(&mut test, host(), verify_peer(), idle_timeout(), max_data())
+        runner::run(
+            &mut test,
+            host(),
+            verify_peer(),
+            idle_timeout(),
+            max_data(),
+            early_data(),
+            session_file(),
+        )
     }
 
     fn do_test_with_stream_data(
@@ -179,7 +213,15 @@ mod httpbin_tests {
             assert,
             concurrent,
         );
-        runner::run(&mut test, host(), verify_peer(), idle_timeout(), max_data())
+        runner::run(
+            &mut test,
+            host(),
+            verify_peer(),
+            idle_timeout(),
+            max_data(),
+            early_data(),
+            session_file(),
+        )
     }
 
     // Build a single request and expected response with status code


### PR DESCRIPTION
Add EARLY_DATA and SESSION_FILE for testing 0-rtt connection
resumption on http3_test.

Based on #914 