### PR TITLE
Expose C API that is needed for session resumption and 0-RTT

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -314,6 +314,13 @@ void quiche_conn_on_timeout(quiche_conn *conn);
 int quiche_conn_close(quiche_conn *conn, bool app, uint64_t err,
                       const uint8_t *reason, size_t reason_len);
 
+// Configures the given session for resumption.
+int quiche_conn_set_session(quiche_conn *conn, const uint8_t *buf, size_t buf_len);
+
+// Returns the serialized cryptographic session for the connection..
+void quiche_conn_get_session(quiche_conn *conn, const uint8_t **out,
+                                   size_t *out_len);
+
 // Returns a string uniquely representing the connection.
 void quiche_conn_trace_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -744,6 +744,32 @@ pub extern fn quiche_conn_on_timeout(conn: &mut Connection) {
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_get_session(
+    conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
+) {
+    match conn.session() {
+        None => *out_len = 0,
+        Some(session) => {
+            *out = session.as_ptr();
+            *out_len = session.len();
+        },
+    }
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_set_session(
+    conn: &mut Connection, buf: *const u8, buf_len: size_t,
+) -> c_int {
+    let buf = unsafe { slice::from_raw_parts(buf, buf_len) };
+
+    match conn.set_session(buf) {
+        Ok(_) => 0,
+
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_trace_id(
     conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
 ) {


### PR DESCRIPTION
Motivation:

Quiche added support for session resumption and 0-RTT lately but the API was not exposed via the C api.

This was done in https://github.com/cloudflare/quiche/pull/911 and https://github.com/cloudflare/quiche/pull/914.

Modifications:

Add C API to also be able to make use of the functionality via C.

Result:

Be able to use session resumption and 0-RTT via the C api