### PR TITLE
support for certificate compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,13 @@ include = [
 ]
 
 [features]
-default = ["boringssl-vendored"]
+default = ["boringssl-vendored", "certificate-compression"]
 
 # Build vendored BoringSSL library.
 boringssl-vendored = []
+
+# Enable certificate compression.
+certificate-compression = ["pkg-config"]
 
 # Generate pkg-config metadata file for libquiche.
 pkg-config-meta = []
@@ -51,6 +54,7 @@ no-default-features = true
 
 [build-dependencies]
 cmake = "0.1"
+pkg-config = { version = "0.3", optional = true }
 
 [dependencies]
 log = { version = "0.4", features = ["std"] }

--- a/src/build.rs
+++ b/src/build.rs
@@ -254,6 +254,19 @@ fn main() {
         println!("cargo:rustc-link-lib=static=ssl");
     }
 
+    #[cfg(feature = "certificate-compression")]
+    {
+        let pkgcfg = pkg_config::Config::new();
+
+        if pkgcfg.probe("libbrotlienc").is_ok() {
+            println!("cargo:rustc-cfg=feature=\"brotlienc\"");
+        }
+
+        if pkgcfg.probe("libbrotlidec").is_ok() {
+            println!("cargo:rustc-cfg=feature=\"brotlidec\"");
+        }
+    }
+
     // MacOS: Allow cdylib to link with undefined symbols
     if cfg!(target_os = "macos") {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-undefined,dynamic_lookup");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,6 +661,16 @@ impl Config {
             .load_verify_locations_from_directory(dir)
     }
 
+    /// Enables support for certificate compression (RFC8879).
+    ///
+    /// Note that if support wasn't enabled at build time, this does nothing.
+    pub fn compress_certificates(&mut self) -> Result<()> {
+        self.tls_ctx
+            .lock()
+            .unwrap()
+            .enable_certificate_compression()
+    }
+
     /// Configures whether to verify the peer's certificate.
     ///
     /// The default value is `true` for client connections, and `false` for
@@ -5422,6 +5432,7 @@ pub mod testing {
             config.set_max_idle_timeout(180_000);
             config.verify_peer(false);
             config.set_ack_delay_exponent(5);
+            config.compress_certificates().unwrap();
 
             Pipe::with_config(&mut config)
         }

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -82,6 +82,8 @@ fn main() {
     config.load_cert_chain_from_pem_file(&args.cert).unwrap();
     config.load_priv_key_from_pem_file(&args.key).unwrap();
 
+    config.compress_certificates().unwrap();
+
     config.set_application_protos(&conn_args.alpns).unwrap();
 
     config.set_max_idle_timeout(conn_args.idle_timeout);

--- a/tools/apps/src/client.rs
+++ b/tools/apps/src/client.rs
@@ -94,6 +94,8 @@ pub fn connect(
     // Create the configuration for the QUIC connection.
     let mut config = quiche::Config::new(args.version).unwrap();
 
+    config.compress_certificates().unwrap();
+
     config.verify_peer(!args.no_verify);
 
     config.set_application_protos(&conn_args.alpns).unwrap();


### PR DESCRIPTION
This adds native support for certificate compression (RFC 8879), using
brotli. Before, an application could only support this by providing its
own BoringSSL SSL object, and only through the FFI API.

Due to the additional dependencies, this is an optional feature, but it
is enabled by default at build time. An application still needs to
enable it at runtime though.