### PR TITLE
Expose connection source / destination id via c API

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -320,6 +320,12 @@ int quiche_conn_close(quiche_conn *conn, bool app, uint64_t err,
 // Returns a string uniquely representing the connection.
 void quiche_conn_trace_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
+// Returns the source connection id.
+void quiche_conn_source_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
+
+// Returns the destination connection id.
+void quiche_conn_destination_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
+
 // Returns the negotiated ALPN protocol.
 void quiche_conn_application_proto(quiche_conn *conn, const uint8_t **out,
                                    size_t *out_len);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -323,7 +323,7 @@ void quiche_conn_trace_id(quiche_conn *conn, const uint8_t **out, size_t *out_le
 // Returns the source connection ID.
 void quiche_conn_source_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
-// Returns the destination connection id.
+// Returns the destination connection ID.
 void quiche_conn_destination_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
 // Returns the negotiated ALPN protocol.

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -320,7 +320,7 @@ int quiche_conn_close(quiche_conn *conn, bool app, uint64_t err,
 // Returns a string uniquely representing the connection.
 void quiche_conn_trace_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
-// Returns the source connection id.
+// Returns the source connection ID.
 void quiche_conn_source_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
 // Returns the destination connection id.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -767,6 +767,26 @@ pub extern fn quiche_conn_trace_id(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_source_id(
+    conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
+) {
+    let id = conn.source_id().to_vec();
+
+    *out = id.as_ptr();
+    *out_len = id.len();
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_destination_id(
+    conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
+) {
+    let id = conn.destination_id().to_vec();
+
+    *out = id.as_ptr();
+    *out_len = id.len();
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_application_proto(
     conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
 ) {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -770,7 +770,7 @@ pub extern fn quiche_conn_trace_id(
 pub extern fn quiche_conn_source_id(
     conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
 ) {
-    let id = conn.source_id().to_vec();
+    let id = conn.source_id().as_ref();
 
     *out = id.as_ptr();
     *out_len = id.len();
@@ -780,7 +780,7 @@ pub extern fn quiche_conn_source_id(
 pub extern fn quiche_conn_destination_id(
     conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
 ) {
-    let id = conn.destination_id().to_vec();
+    let id = conn.destination_id().as_ref();
 
     *out = id.as_ptr();
     *out_len = id.len();

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -770,8 +770,8 @@ pub extern fn quiche_conn_trace_id(
 pub extern fn quiche_conn_source_id(
     conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
 ) {
-    let id = conn.source_id().as_ref();
-
+    let conn_id = conn.source_id();
+    let id = conn_id.as_ref();
     *out = id.as_ptr();
     *out_len = id.len();
 }
@@ -780,7 +780,8 @@ pub extern fn quiche_conn_source_id(
 pub extern fn quiche_conn_destination_id(
     conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
 ) {
-    let id = conn.destination_id().as_ref();
+    let conn_id = conn.destination_id();
+    let id = conn_id.as_ref();
 
     *out = id.as_ptr();
     *out_len = id.len();


### PR DESCRIPTION
Motivation:

We should expose functions to access the source and destination ids via the c API as well

Modifications:

Expose functions in the C API

Result:

Be able to access the ids of a connection