### PR TITLE
Draft: Implement BBR

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -61,8 +61,11 @@ static void debug_log(const char *line, void *argp) {
 static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
     static uint8_t out[MAX_DATAGRAM_SIZE];
 
+    quiche_send_info send_info;
+
     while (1) {
-        ssize_t written = quiche_conn_send(conn_io->conn, out, sizeof(out));
+        ssize_t written = quiche_conn_send(conn_io->conn, out, sizeof(out),
+                                           &send_info);
 
         if (written == QUICHE_ERR_DONE) {
             fprintf(stderr, "done writing\n");
@@ -74,7 +77,10 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
             return;
         }
 
-        ssize_t sent = send(conn_io->sock, out, written, 0);
+        ssize_t sent = sendto(conn_io->sock, out, written, 0,
+                              (struct sockaddr *) &send_info.to,
+                              send_info.to_len);
+
         if (sent != written) {
             perror("failed to send");
             return;
@@ -96,7 +102,13 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
     static uint8_t buf[65535];
 
     while (1) {
-        ssize_t read = recv(conn_io->sock, buf, sizeof(buf), 0);
+        struct sockaddr_storage peer_addr;
+        socklen_t peer_addr_len = sizeof(peer_addr);
+        memset(&peer_addr, 0, peer_addr_len);
+
+        ssize_t read = recvfrom(conn_io->sock, buf, sizeof(buf), 0,
+                                (struct sockaddr *) &peer_addr,
+                                &peer_addr_len);
 
         if (read < 0) {
             if ((errno == EWOULDBLOCK) || (errno == EAGAIN)) {
@@ -108,7 +120,13 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
             return;
         }
 
-        ssize_t done = quiche_conn_recv(conn_io->conn, buf, read);
+        quiche_recv_info recv_info = {
+            (struct sockaddr *) &peer_addr,
+
+            peer_addr_len,
+        };
+
+        ssize_t done = quiche_conn_recv(conn_io->conn, buf, read, &recv_info);
 
         if (done < 0) {
             fprintf(stderr, "failed to process packet\n");
@@ -269,8 +287,9 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    quiche_conn *conn = quiche_connect(host, (const uint8_t *) scid,
-                                       sizeof(scid), config);
+    quiche_conn *conn = quiche_connect(host, (const uint8_t*) scid, sizeof(scid),
+                                       peer->ai_addr, peer->ai_addrlen, config);
+
     if (conn == NULL) {
         fprintf(stderr, "failed to create connection\n");
         return -1;

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -109,7 +109,8 @@ fn main() {
     let scid = quiche::ConnectionId::from_ref(&scid);
 
     // Create a QUIC connection and initiate handshake.
-    let mut conn = quiche::connect(url.domain(), &scid, &mut config).unwrap();
+    let mut conn =
+        quiche::connect(url.domain(), &scid, peer_addr, &mut config).unwrap();
 
     info!(
         "connecting to {:} from {:} with scid {}",
@@ -118,9 +119,9 @@ fn main() {
         hex_dump(&scid)
     );
 
-    let write = conn.send(&mut out).expect("initial send failed");
+    let (write, send_info) = conn.send(&mut out).expect("initial send failed");
 
-    while let Err(e) = socket.send(&out[..write]) {
+    while let Err(e) = socket.send_to(&out[..write], &send_info.to) {
         if e.kind() == std::io::ErrorKind::WouldBlock {
             debug!("send() would block");
             continue;
@@ -151,7 +152,7 @@ fn main() {
                 break 'read;
             }
 
-            let len = match socket.recv(&mut buf) {
+            let (len, from) = match socket.recv_from(&mut buf) {
                 Ok(v) => v,
 
                 Err(e) => {
@@ -168,8 +169,10 @@ fn main() {
 
             debug!("got {} bytes", len);
 
+            let recv_info = quiche::RecvInfo { from };
+
             // Process potentially coalesced packets.
-            let read = match conn.recv(&mut buf[..len]) {
+            let read = match conn.recv(&mut buf[..len], recv_info) {
                 Ok(v) => v,
 
                 Err(e) => {
@@ -233,7 +236,7 @@ fn main() {
         // Generate outgoing QUIC packets and send them on the UDP socket, until
         // quiche reports that there are no more packets to be sent.
         loop {
-            let write = match conn.send(&mut out) {
+            let (write, send_info) = match conn.send(&mut out) {
                 Ok(v) => v,
 
                 Err(quiche::Error::Done) => {
@@ -249,7 +252,7 @@ fn main() {
                 },
             };
 
-            if let Err(e) = socket.send(&out[..write]) {
+            if let Err(e) = socket.send_to(&out[..write], &send_info.to) {
                 if e.kind() == std::io::ErrorKind::WouldBlock {
                     debug!("send() would block");
                     break;

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -108,7 +108,8 @@ fn main() {
     let scid = quiche::ConnectionId::from_ref(&scid);
 
     // Create a QUIC connection and initiate handshake.
-    let mut conn = quiche::connect(url.domain(), &scid, &mut config).unwrap();
+    let mut conn =
+        quiche::connect(url.domain(), &scid, peer_addr, &mut config).unwrap();
 
     info!(
         "connecting to {:} from {:} with scid {}",
@@ -117,9 +118,9 @@ fn main() {
         hex_dump(&scid)
     );
 
-    let write = conn.send(&mut out).expect("initial send failed");
+    let (write, send_info) = conn.send(&mut out).expect("initial send failed");
 
-    while let Err(e) = socket.send(&out[..write]) {
+    while let Err(e) = socket.send_to(&out[..write], &send_info.to) {
         if e.kind() == std::io::ErrorKind::WouldBlock {
             debug!("send() would block");
             continue;
@@ -169,7 +170,7 @@ fn main() {
                 break 'read;
             }
 
-            let len = match socket.recv(&mut buf) {
+            let (len, from) = match socket.recv_from(&mut buf) {
                 Ok(v) => v,
 
                 Err(e) => {
@@ -186,8 +187,10 @@ fn main() {
 
             debug!("got {} bytes", len);
 
+            let recv_info = quiche::RecvInfo { from };
+
             // Process potentially coalesced packets.
-            let read = match conn.recv(&mut buf[..len]) {
+            let read = match conn.recv(&mut buf[..len], recv_info) {
                 Ok(v) => v,
 
                 Err(e) => {
@@ -283,7 +286,7 @@ fn main() {
         // Generate outgoing QUIC packets and send them on the UDP socket, until
         // quiche reports that there are no more packets to be sent.
         loop {
-            let write = match conn.send(&mut out) {
+            let (write, send_info) = match conn.send(&mut out) {
                 Ok(v) => v,
 
                 Err(quiche::Error::Done) => {
@@ -299,7 +302,7 @@ fn main() {
                 },
             };
 
-            if let Err(e) = socket.send(&out[..write]) {
+            if let Err(e) = socket.send_to(&out[..write], &send_info.to) {
                 if e.kind() == std::io::ErrorKind::WouldBlock {
                     debug!("send() would block");
                     break;

--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -89,8 +89,11 @@ static void debug_log(const char *line, void *argp) {
 static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
     static uint8_t out[MAX_DATAGRAM_SIZE];
 
+    quiche_send_info send_info;
+
     while (1) {
-        ssize_t written = quiche_conn_send(conn_io->conn, out, sizeof(out));
+        ssize_t written = quiche_conn_send(conn_io->conn, out, sizeof(out),
+                                           &send_info);
 
         if (written == QUICHE_ERR_DONE) {
             fprintf(stderr, "done writing\n");
@@ -173,7 +176,9 @@ static uint8_t *gen_cid(uint8_t *cid, size_t cid_len) {
 }
 
 static struct conn_io *create_conn(uint8_t *scid, size_t scid_len,
-                                   uint8_t *odcid, size_t odcid_len) {
+                                   uint8_t *odcid, size_t odcid_len,
+                                   struct sockaddr_storage *peer_addr,
+                                   socklen_t peer_addr_len) {
     struct conn_io *conn_io = calloc(1, sizeof(*conn_io));
     if (conn_io == NULL) {
         fprintf(stderr, "failed to allocate connection IO\n");
@@ -187,7 +192,11 @@ static struct conn_io *create_conn(uint8_t *scid, size_t scid_len,
     memcpy(conn_io->cid, scid, LOCAL_CONN_ID_LEN);
 
     quiche_conn *conn = quiche_accept(conn_io->cid, LOCAL_CONN_ID_LEN,
-                                      odcid, odcid_len, config);
+                                      odcid, odcid_len,
+                                      (struct sockaddr *) peer_addr,
+                                      peer_addr_len,
+                                      config);
+
     if (conn == NULL) {
         fprintf(stderr, "failed to create connection\n");
         return NULL;
@@ -195,6 +204,9 @@ static struct conn_io *create_conn(uint8_t *scid, size_t scid_len,
 
     conn_io->sock = conns->sock;
     conn_io->conn = conn;
+
+    memcpy(&conn_io->peer_addr, &peer_addr, peer_addr_len);
+    conn_io->peer_addr_len = peer_addr_len;
 
     ev_init(&conn_io->timer, timeout_cb);
     conn_io->timer.data = conn_io;
@@ -334,16 +346,21 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                 continue;
             }
 
-            conn_io = create_conn(dcid, dcid_len, odcid, odcid_len);
+            conn_io = create_conn(dcid, dcid_len, odcid, odcid_len,
+                                  &peer_addr, peer_addr_len);
+
             if (conn_io == NULL) {
                 continue;
             }
-
-            memcpy(&conn_io->peer_addr, &peer_addr, peer_addr_len);
-            conn_io->peer_addr_len = peer_addr_len;
         }
 
-        ssize_t done = quiche_conn_recv(conn_io->conn, buf, read);
+        quiche_recv_info recv_info = {
+            (struct sockaddr *) &peer_addr,
+
+            peer_addr_len,
+        };
+
+        ssize_t done = quiche_conn_recv(conn_io->conn, buf, read, &recv_info);
 
         if (done < 0) {
             fprintf(stderr, "failed to process packet: %zd\n", done);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -47,8 +47,7 @@ struct Client {
     partial_responses: HashMap<u64, PartialResponse>,
 }
 
-type ClientMap =
-    HashMap<quiche::ConnectionId<'static>, (net::SocketAddr, Client)>;
+type ClientMap = HashMap<quiche::ConnectionId<'static>, Client>;
 
 fn main() {
     let mut buf = [0; 65535];
@@ -118,8 +117,7 @@ fn main() {
         // Find the shorter timeout from all the active connections.
         //
         // TODO: use event loop that properly supports timers
-        let timeout =
-            clients.values().filter_map(|(_, c)| c.conn.timeout()).min();
+        let timeout = clients.values().filter_map(|c| c.conn.timeout()).min();
 
         poll.poll(&mut events, timeout).unwrap();
 
@@ -132,12 +130,12 @@ fn main() {
             if events.is_empty() {
                 debug!("timed out");
 
-                clients.values_mut().for_each(|(_, c)| c.conn.on_timeout());
+                clients.values_mut().for_each(|c| c.conn.on_timeout());
 
                 break 'read;
             }
 
-            let (len, src) = match socket.recv_from(&mut buf) {
+            let (len, from) = match socket.recv_from(&mut buf) {
                 Ok(v) => v,
 
                 Err(e) => {
@@ -177,7 +175,7 @@ fn main() {
 
             // Lookup a connection based on the packet's connection ID. If there
             // is no connection matching, create a new one.
-            let (_, client) = if !clients.contains_key(&hdr.dcid) &&
+            let client = if !clients.contains_key(&hdr.dcid) &&
                 !clients.contains_key(&conn_id)
             {
                 if hdr.ty != quiche::Type::Initial {
@@ -194,7 +192,7 @@ fn main() {
 
                     let out = &out[..len];
 
-                    if let Err(e) = socket.send_to(out, &src) {
+                    if let Err(e) = socket.send_to(out, &from) {
                         if e.kind() == std::io::ErrorKind::WouldBlock {
                             debug!("send() would block");
                             break;
@@ -217,7 +215,7 @@ fn main() {
                 if token.is_empty() {
                     warn!("Doing stateless retry");
 
-                    let new_token = mint_token(&hdr, &src);
+                    let new_token = mint_token(&hdr, &from);
 
                     let len = quiche::retry(
                         &hdr.scid,
@@ -231,7 +229,7 @@ fn main() {
 
                     let out = &out[..len];
 
-                    if let Err(e) = socket.send_to(out, &src) {
+                    if let Err(e) = socket.send_to(out, &from) {
                         if e.kind() == std::io::ErrorKind::WouldBlock {
                             debug!("send() would block");
                             break;
@@ -242,7 +240,7 @@ fn main() {
                     continue 'read;
                 }
 
-                let odcid = validate_token(&src, token);
+                let odcid = validate_token(&from, token);
 
                 // The token was not valid, meaning the retry failed, so
                 // drop the packet.
@@ -263,14 +261,15 @@ fn main() {
                 debug!("New connection: dcid={:?} scid={:?}", hdr.dcid, scid);
 
                 let conn =
-                    quiche::accept(&scid, odcid.as_ref(), &mut config).unwrap();
+                    quiche::accept(&scid, odcid.as_ref(), from, &mut config)
+                        .unwrap();
 
                 let client = Client {
                     conn,
                     partial_responses: HashMap::new(),
                 };
 
-                clients.insert(scid.clone(), (src, client));
+                clients.insert(scid.clone(), client);
 
                 clients.get_mut(&scid).unwrap()
             } else {
@@ -281,8 +280,10 @@ fn main() {
                 }
             };
 
+            let recv_info = quiche::RecvInfo { from };
+
             // Process potentially coalesced packets.
-            let read = match client.conn.recv(pkt_buf) {
+            let read = match client.conn.recv(pkt_buf, recv_info) {
                 Ok(v) => v,
 
                 Err(e) => {
@@ -329,9 +330,9 @@ fn main() {
         // Generate outgoing QUIC packets for all active connections and send
         // them on the UDP socket, until quiche reports that there are no more
         // packets to be sent.
-        for (peer, client) in clients.values_mut() {
+        for client in clients.values_mut() {
             loop {
-                let write = match client.conn.send(&mut out) {
+                let (write, send_info) = match client.conn.send(&mut out) {
                     Ok(v) => v,
 
                     Err(quiche::Error::Done) => {
@@ -347,8 +348,7 @@ fn main() {
                     },
                 };
 
-                // TODO: coalesce packets.
-                if let Err(e) = socket.send_to(&out[..write], &peer) {
+                if let Err(e) = socket.send_to(&out[..write], &send_info.to) {
                     if e.kind() == std::io::ErrorKind::WouldBlock {
                         debug!("send() would block");
                         break;
@@ -362,7 +362,7 @@ fn main() {
         }
 
         // Garbage collect closed connections.
-        clients.retain(|_, (_, ref mut c)| {
+        clients.retain(|_, ref mut c| {
             debug!("Collecting garbage");
 
             if c.conn.is_closed() {

--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -1,4 +1,4 @@
-From 8159b9f5ea2f6f0fbb31f78b629009d615c428d3 Mon Sep 17 00:00:00 2001
+From 3f07343d97a8efacc90880d9d42d79c522e4ba34 Mon Sep 17 00:00:00 2001
 From: Alessandro Ghedini <alessandro@cloudflare.com>
 Date: Thu, 22 Oct 2020 12:28:02 +0100
 Subject: [PATCH] Initial QUIC and HTTP/3 implementation using quiche
@@ -14,7 +14,7 @@ Subject: [PATCH] Initial QUIC and HTTP/3 implementation using quiche
  auto/options                            |    9 +
  src/core/ngx_connection.h               |    7 +
  src/core/ngx_core.h                     |    3 +
- src/event/ngx_event_quic.c              |  604 +++++++
+ src/event/ngx_event_quic.c              |  618 +++++++
  src/event/ngx_event_quic.h              |   49 +
  src/event/ngx_event_udp.c               |    8 +
  src/http/modules/ngx_http_ssl_module.c  |   13 +-
@@ -32,7 +32,7 @@ Subject: [PATCH] Initial QUIC and HTTP/3 implementation using quiche
  src/http/v3/ngx_http_v3_module.c        |  286 +++
  src/http/v3/ngx_http_v3_module.h        |   34 +
  src/os/unix/ngx_udp_sendmsg_chain.c     |    1 +
- 28 files changed, 3690 insertions(+), 11 deletions(-)
+ 28 files changed, 3704 insertions(+), 11 deletions(-)
  create mode 100644 auto/lib/quiche/conf
  create mode 100644 auto/lib/quiche/make
  create mode 100644 src/event/ngx_event_quic.c
@@ -340,10 +340,10 @@ index 93ca9174d..d0441f034 100644
  #include <ngx_module.h>
 diff --git a/src/event/ngx_event_quic.c b/src/event/ngx_event_quic.c
 new file mode 100644
-index 000000000..aa7e8e697
+index 000000000..6172e5be3
 --- /dev/null
 +++ b/src/event/ngx_event_quic.c
-@@ -0,0 +1,604 @@
+@@ -0,0 +1,618 @@
 +
 +/*
 + * Copyright (C) Cloudflare, Inc.
@@ -518,7 +518,8 @@ index 000000000..aa7e8e697
 +    }
 +#endif
 +
-+    conn = quiche_conn_new_with_tls(scid, sizeof(scid), NULL, 0, quic->config,
++    conn = quiche_conn_new_with_tls(scid, sizeof(scid), NULL, 0,
++                                    c->sockaddr, c->socklen, quic->config,
 +                                    c->ssl->connection, true);
 +    if (conn == NULL) {
 +        ngx_log_error(NGX_LOG_ERR, c->log, 0, "failed to create quic connection");
@@ -548,12 +549,17 @@ index 000000000..aa7e8e697
 +    size_t    buf_len;
 +    ssize_t   done;
 +
++    quiche_recv_info recv_info = {
++        c->sockaddr,
++        c->socklen,
++    };
++
 +    /* Process the client's Initial packet, which was saved into c->buffer by
 +     * ngx_event_recvmsg(). */
 +    buf = c->buffer->pos;
 +    buf_len = ngx_buf_size(c->buffer);
 +
-+    done = quiche_conn_recv(c->quic->conn, buf, buf_len);
++    done = quiche_conn_recv(c->quic->conn, buf, buf_len, &recv_info);
 +
 +    if ((done < 0) && (done != QUICHE_ERR_DONE)) {
 +        ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
@@ -605,7 +611,12 @@ index 000000000..aa7e8e697
 +            return;
 +        }
 +
-+        ssize_t done = quiche_conn_recv(c->quic->conn, buf, n);
++        quiche_recv_info recv_info = {
++            c->sockaddr,
++            c->socklen,
++        };
++
++        ssize_t done = quiche_conn_recv(c->quic->conn, buf, n, &recv_info);
 +
 +        if (done == QUICHE_ERR_DONE) {
 +            break;
@@ -644,6 +655,7 @@ index 000000000..aa7e8e697
 +ngx_quic_write_handler(ngx_event_t *wev)
 +{
 +    ngx_connection_t   *c;
++    quiche_send_info    send_info;
 +    static uint8_t      out[MAX_DATAGRAM_SIZE];
 +
 +    c = wev->data;
@@ -667,7 +679,8 @@ index 000000000..aa7e8e697
 +    }
 +
 +    for (;;) {
-+        ssize_t written = quiche_conn_send(c->quic->conn, out, sizeof(out));
++        ssize_t written = quiche_conn_send(c->quic->conn, out, sizeof(out),
++                                           &send_info);
 +
 +        if (written == QUICHE_ERR_DONE) {
 +            ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0, "quic done writing");
@@ -787,8 +800,9 @@ index 000000000..aa7e8e697
 +ngx_int_t
 +ngx_quic_shutdown(ngx_connection_t *c)
 +{
-+    ssize_t         written;
-+    static uint8_t  out[MAX_DATAGRAM_SIZE];
++    ssize_t           written;
++    quiche_send_info  send_info;
++    static uint8_t    out[MAX_DATAGRAM_SIZE];
 +
 +    /* Connection is closed, free memory. */
 +    if (quiche_conn_is_closed(c->quic->conn)) {
@@ -813,7 +827,7 @@ index 000000000..aa7e8e697
 +    /* Try sending a packet in order to flush pending frames (CONNECTION_CLOSE
 +     * for example), but ignore errors as we are already closing the connection
 +     * anyway. */
-+    written = quiche_conn_send(c->quic->conn, out, sizeof(out));
++    written = quiche_conn_send(c->quic->conn, out, sizeof(out), &send_info);
 +
 +    if (written > 0) {
 +        ngx_quic_send_udp_packet(c, out, written);
@@ -4293,5 +4307,5 @@ index 5399c7916..9b03ca536 100644
                             "sendmsg() not ready");
              return NGX_AGAIN;
 -- 
-2.30.2
+2.31.1
 

--- a/fuzz/src/packet_recv_server.rs
+++ b/fuzz/src/packet_recv_server.rs
@@ -6,6 +6,8 @@ extern crate libfuzzer_sys;
 #[macro_use]
 extern crate lazy_static;
 
+use std::net::SocketAddr;
+
 use std::sync::Mutex;
 
 lazy_static! {
@@ -36,9 +38,14 @@ static SCID: quiche::ConnectionId<'static> =
     quiche::ConnectionId::from_ref(&[0; quiche::MAX_CONN_ID_LEN]);
 
 fuzz_target!(|data: &[u8]| {
-    let mut buf = data.to_vec();
-    let mut conn =
-        quiche::accept(&SCID, None, &mut CONFIG.lock().unwrap()).unwrap();
+    let from: SocketAddr = "127.0.0.1:1234".parse().unwrap();
 
-    conn.recv(&mut buf).ok();
+    let mut buf = data.to_vec();
+
+    let mut conn =
+        quiche::accept(&SCID, None, from, &mut CONFIG.lock().unwrap()).unwrap();
+
+    let info = quiche::RecvInfo { from };
+
+    conn.recv(&mut buf, info).ok();
 });

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -272,8 +272,12 @@ ssize_t quiche_conn_recv(quiche_conn *conn, uint8_t *buf, size_t buf_len,
                          quiche_recv_info *info);
 
 typedef struct {
+    // The address the packet should be sent to.
     struct sockaddr_storage to;
     socklen_t to_len;
+
+    // The time to send the packet out.
+    struct timespec time;
 } quiche_send_info;
 
 // Writes a single QUIC packet to be sent to the peer.

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -216,11 +216,13 @@ typedef struct Connection quiche_conn;
 // Creates a new server-side connection.
 quiche_conn *quiche_accept(const uint8_t *scid, size_t scid_len,
                            const uint8_t *odcid, size_t odcid_len,
+                           struct sockaddr *from, size_t from_len,
                            quiche_config *config);
 
 // Creates a new client-side connection.
 quiche_conn *quiche_connect(const char *server_name, const uint8_t *scid,
-                            size_t scid_len, quiche_config *config);
+                            size_t scid_len, struct sockaddr *to, size_t to_len,
+                            quiche_config *config);
 
 // Writes a version negotiation packet.
 ssize_t quiche_negotiate_version(const uint8_t *scid, size_t scid_len,
@@ -239,6 +241,7 @@ bool quiche_version_is_supported(uint32_t version);
 
 quiche_conn *quiche_conn_new_with_tls(const uint8_t *scid, size_t scid_len,
                                       const uint8_t *odcid, size_t odcid_len,
+                                      struct sockaddr *peer, size_t peer_len,
                                       quiche_config *config, void *ssl,
                                       bool is_server);
 
@@ -259,11 +262,23 @@ void quiche_conn_set_qlog_fd(quiche_conn *conn, int fd, const char *log_title,
 // Configures the given session for resumption.
 int quiche_conn_set_session(quiche_conn *conn, const uint8_t *buf, size_t buf_len);
 
+typedef struct {
+    struct sockaddr *from;
+    socklen_t from_len;
+} quiche_recv_info;
+
 // Processes QUIC packets received from the peer.
-ssize_t quiche_conn_recv(quiche_conn *conn, uint8_t *buf, size_t buf_len);
+ssize_t quiche_conn_recv(quiche_conn *conn, uint8_t *buf, size_t buf_len,
+                         quiche_recv_info *info);
+
+typedef struct {
+    struct sockaddr_storage to;
+    socklen_t to_len;
+} quiche_send_info;
 
 // Writes a single QUIC packet to be sent to the peer.
-ssize_t quiche_conn_send(quiche_conn *conn, uint8_t *out, size_t out_len);
+ssize_t quiche_conn_send(quiche_conn *conn, uint8_t *out, size_t out_len,
+                         quiche_send_info *out_info);
 
 // Reads contiguous data from a stream.
 ssize_t quiche_conn_stream_recv(quiche_conn *conn, uint64_t stream_id,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -29,6 +29,8 @@ use std::ptr;
 use std::slice;
 use std::sync::atomic;
 
+use std::net::SocketAddr;
+
 #[cfg(unix)]
 use std::os::unix::io::FromRawFd;
 
@@ -36,6 +38,11 @@ use libc::c_char;
 use libc::c_int;
 use libc::c_void;
 use libc::size_t;
+use libc::sockaddr;
+use libc::sockaddr_in;
+use libc::sockaddr_in6;
+use libc::sockaddr_storage;
+use libc::socklen_t;
 use libc::ssize_t;
 
 use crate::*;
@@ -342,7 +349,7 @@ pub extern fn quiche_header_info(
 #[no_mangle]
 pub extern fn quiche_accept(
     scid: *const u8, scid_len: size_t, odcid: *const u8, odcid_len: size_t,
-    config: &mut Config,
+    from: &sockaddr, from_len: socklen_t, config: &mut Config,
 ) -> *mut Connection {
     let scid = unsafe { slice::from_raw_parts(scid, scid_len) };
     let scid = ConnectionId::from_ref(scid);
@@ -355,7 +362,9 @@ pub extern fn quiche_accept(
         None
     };
 
-    match accept(&scid, odcid.as_ref(), config) {
+    let from = std_addr_from_c(from, from_len);
+
+    match accept(&scid, odcid.as_ref(), from, config) {
         Ok(c) => Box::into_raw(Pin::into_inner(c)),
 
         Err(_) => ptr::null_mut(),
@@ -364,8 +373,8 @@ pub extern fn quiche_accept(
 
 #[no_mangle]
 pub extern fn quiche_connect(
-    server_name: *const c_char, scid: *const u8, scid_len: size_t,
-    config: &mut Config,
+    server_name: *const c_char, scid: *const u8, scid_len: size_t, to: &sockaddr,
+    to_len: socklen_t, config: &mut Config,
 ) -> *mut Connection {
     let server_name = if server_name.is_null() {
         None
@@ -376,7 +385,9 @@ pub extern fn quiche_connect(
     let scid = unsafe { slice::from_raw_parts(scid, scid_len) };
     let scid = ConnectionId::from_ref(scid);
 
-    match connect(server_name, &scid, config) {
+    let to = std_addr_from_c(to, to_len);
+
+    match connect(server_name, &scid, to, config) {
         Ok(c) => Box::into_raw(Pin::into_inner(c)),
 
         Err(_) => ptr::null_mut(),
@@ -436,7 +447,8 @@ pub extern fn quiche_retry(
 #[no_mangle]
 pub extern fn quiche_conn_new_with_tls(
     scid: *const u8, scid_len: size_t, odcid: *const u8, odcid_len: size_t,
-    config: &mut Config, ssl: *mut c_void, is_server: bool,
+    peer: &sockaddr, peer_len: socklen_t, config: &mut Config, ssl: *mut c_void,
+    is_server: bool,
 ) -> *mut Connection {
     let scid = unsafe { slice::from_raw_parts(scid, scid_len) };
     let scid = ConnectionId::from_ref(scid);
@@ -449,9 +461,18 @@ pub extern fn quiche_conn_new_with_tls(
         None
     };
 
+    let peer = std_addr_from_c(peer, peer_len);
+
     let tls = unsafe { tls::Handshake::from_ptr(ssl) };
 
-    match Connection::with_tls(&scid, odcid.as_ref(), config, tls, is_server) {
+    match Connection::with_tls(
+        &scid,
+        odcid.as_ref(),
+        peer,
+        config,
+        tls,
+        is_server,
+    ) {
         Ok(c) => Box::into_raw(Pin::into_inner(c)),
 
         Err(_) => ptr::null_mut(),
@@ -552,9 +573,23 @@ pub extern fn quiche_conn_set_session(
     }
 }
 
+#[repr(C)]
+pub struct RecvInfo<'a> {
+    from: &'a sockaddr,
+    from_len: socklen_t,
+}
+
+impl<'a> From<&RecvInfo<'a>> for crate::RecvInfo {
+    fn from(info: &RecvInfo) -> crate::RecvInfo {
+        crate::RecvInfo {
+            from: std_addr_from_c(info.from, info.from_len),
+        }
+    }
+}
+
 #[no_mangle]
 pub extern fn quiche_conn_recv(
-    conn: &mut Connection, buf: *mut u8, buf_len: size_t,
+    conn: &mut Connection, buf: *mut u8, buf_len: size_t, info: &RecvInfo,
 ) -> ssize_t {
     if buf_len > <ssize_t>::max_value() as usize {
         panic!("The provided buffer is too large");
@@ -562,16 +597,30 @@ pub extern fn quiche_conn_recv(
 
     let buf = unsafe { slice::from_raw_parts_mut(buf, buf_len) };
 
-    match conn.recv(buf) {
+    match conn.recv(buf, info.into()) {
         Ok(v) => v as ssize_t,
 
         Err(e) => e.to_c(),
     }
 }
 
+#[repr(C)]
+pub struct SendInfo {
+    to: sockaddr_storage,
+    to_len: socklen_t,
+}
+
+impl From<crate::SendInfo> for SendInfo {
+    fn from(info: crate::SendInfo) -> SendInfo {
+        let (to, to_len) = std_addr_to_c(&info.to);
+
+        SendInfo { to, to_len }
+    }
+}
+
 #[no_mangle]
 pub extern fn quiche_conn_send(
-    conn: &mut Connection, out: *mut u8, out_len: size_t,
+    conn: &mut Connection, out: *mut u8, out_len: size_t, out_info: &mut SendInfo,
 ) -> ssize_t {
     if out_len > <ssize_t>::max_value() as usize {
         panic!("The provided buffer is too large");
@@ -580,7 +629,11 @@ pub extern fn quiche_conn_send(
     let out = unsafe { slice::from_raw_parts_mut(out, out_len) };
 
     match conn.send(out) {
-        Ok(v) => v as ssize_t,
+        Ok((v, info)) => {
+            *out_info = info.into();
+
+            v as ssize_t
+        },
 
         Err(e) => e.to_c(),
     }
@@ -869,12 +922,12 @@ pub extern fn quiche_stream_iter_free(iter: *mut StreamIter) {
 
 #[repr(C)]
 pub struct Stats {
-    pub recv: usize,
-    pub sent: usize,
-    pub lost: usize,
-    pub rtt: u64,
-    pub cwnd: usize,
-    pub delivery_rate: u64,
+    recv: usize,
+    sent: usize,
+    lost: usize,
+    rtt: u64,
+    cwnd: usize,
+    delivery_rate: u64,
 }
 
 #[no_mangle]
@@ -968,4 +1021,58 @@ pub extern fn quiche_conn_peer_streams_left_bidi(conn: &mut Connection) -> u64 {
 #[no_mangle]
 pub extern fn quiche_conn_peer_streams_left_uni(conn: &mut Connection) -> u64 {
     conn.peer_streams_left_uni()
+}
+
+fn std_addr_from_c(addr: &sockaddr, addr_len: socklen_t) -> SocketAddr {
+    unsafe {
+        match addr.sa_family as i32 {
+            libc::AF_INET => {
+                assert!(addr_len as usize == std::mem::size_of::<sockaddr_in>());
+
+                SocketAddr::V4(
+                    *(addr as *const _ as *const sockaddr_in as *const _),
+                )
+            },
+
+            libc::AF_INET6 => {
+                assert!(addr_len as usize == std::mem::size_of::<sockaddr_in6>());
+
+                SocketAddr::V6(
+                    *(addr as *const _ as *const sockaddr_in6 as *const _),
+                )
+            },
+
+            _ => unimplemented!("unsupported address type"),
+        }
+    }
+}
+
+fn std_addr_to_c(addr: &SocketAddr) -> (sockaddr_storage, socklen_t) {
+    unsafe {
+        match addr {
+            SocketAddr::V4(addr) => {
+                let mut sa = std::mem::zeroed();
+                let sa_len = std::mem::size_of::<sockaddr_in>();
+
+                let src = addr as *const _ as *const u8;
+                let dst = &mut sa as *mut _ as *mut u8;
+
+                std::ptr::copy_nonoverlapping(src, dst, sa_len);
+
+                (sa, sa_len as socklen_t)
+            },
+
+            SocketAddr::V6(addr) => {
+                let mut sa = std::mem::zeroed();
+                let sa_len = std::mem::size_of::<sockaddr_in6>();
+
+                let src = addr as *const _ as *const u8;
+                let dst = &mut sa as *mut _ as *mut u8;
+
+                std::ptr::copy_nonoverlapping(src, dst, sa_len);
+
+                (sa, sa_len as socklen_t)
+            },
+        }
+    }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -44,6 +44,7 @@ use libc::sockaddr_in6;
 use libc::sockaddr_storage;
 use libc::socklen_t;
 use libc::ssize_t;
+use libc::timespec;
 
 use crate::*;
 
@@ -608,6 +609,8 @@ pub extern fn quiche_conn_recv(
 pub struct SendInfo {
     to: sockaddr_storage,
     to_len: socklen_t,
+
+    time: timespec,
 }
 
 #[no_mangle]
@@ -623,6 +626,8 @@ pub extern fn quiche_conn_send(
     match conn.send(out) {
         Ok((v, info)) => {
             out_info.to_len = std_addr_to_c(&info.to, &mut out_info.to);
+
+            std_time_to_c(&info.time, &mut out_info.time);
 
             v as ssize_t
         },
@@ -1064,5 +1069,11 @@ fn std_addr_to_c(addr: &SocketAddr, out: &mut sockaddr_storage) -> socklen_t {
                 sa_len as socklen_t
             },
         }
+    }
+}
+
+fn std_time_to_c(time: &std::time::Instant, out: &mut timespec) {
+    unsafe {
+        ptr::copy_nonoverlapping(time as *const _ as *const timespec, out, 1)
     }
 }

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -60,7 +60,8 @@
 //! ```no_run
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
 //! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
-//! # let mut conn = quiche::connect(None, &scid, &mut config).unwrap();
+//! # let from = "127.0.0.1:1234".parse().unwrap();
+//! # let mut conn = quiche::accept(&scid, None, from, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! let h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
 //! # Ok::<(), quiche::h3::Error>(())
@@ -75,7 +76,8 @@
 //! ```no_run
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
 //! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
-//! # let mut conn = quiche::connect(None, &scid, &mut config).unwrap();
+//! # let to = "127.0.0.1:1234".parse().unwrap();
+//! # let mut conn = quiche::connect(None, &scid, to, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
 //! let req = vec![
@@ -96,7 +98,8 @@
 //! ```no_run
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
 //! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
-//! # let mut conn = quiche::connect(None, &scid, &mut config).unwrap();
+//! # let to = "127.0.0.1:1234".parse().unwrap();
+//! # let mut conn = quiche::connect(None, &scid, to, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
 //! let req = vec![
@@ -126,7 +129,8 @@
 //!
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
 //! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
-//! # let mut conn = quiche::accept(&scid, None, &mut config).unwrap();
+//! # let from = "127.0.0.1:1234".parse().unwrap();
+//! # let mut conn = quiche::accept(&scid, None, from, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
 //! loop {
@@ -187,7 +191,8 @@
 //!
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
 //! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
-//! # let mut conn = quiche::connect(None, &scid, &mut config).unwrap();
+//! # let to = "127.0.0.1:1234".parse().unwrap();
+//! # let mut conn = quiche::connect(None, &scid, to, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
 //! loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,6 +490,9 @@ pub struct RecvInfo {
 pub struct SendInfo {
     /// The address the packet should be sent to.
     pub to: SocketAddr,
+
+    /// The time to send the packet out.
+    pub time: time::Instant,
 }
 
 /// Represents information carried by `CONNECTION_CLOSE` frames.
@@ -2390,7 +2393,14 @@ impl Connection {
             done += pad_len;
         }
 
-        let info = SendInfo { to: self.peer_addr };
+        let info = SendInfo {
+            to: self.peer_addr,
+
+            time: self
+                .recovery
+                .get_packet_send_time()
+                .unwrap_or_else(time::Instant::now),
+        };
 
         Ok((done, info))
     }

--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -52,31 +52,33 @@
 // every new min and overwrites 2nd & 3rd choices. The same property
 // holds for 2nd & 3rd best.
 
-use std::time::Duration;
-use std::time::Instant;
+use std::ops::Div;
+use std::ops::Sub;
 
 #[derive(Copy, Clone)]
-struct MinmaxSample<T> {
-    time: Instant,
-    value: T,
+struct MinmaxSample<I, V> {
+    time: I,
+    value: V,
 }
 
-pub struct Minmax<T> {
-    estimate: [MinmaxSample<T>; 3],
+pub struct Minmax<I, V> {
+    estimate: [MinmaxSample<I, V>; 3],
 }
 
-impl<T: PartialOrd + Copy> Minmax<T> {
-    pub fn new(val: T) -> Self {
+impl<D, I, V> Minmax<I, V>
+where
+    D: Copy + PartialEq + PartialOrd + Div<u32, Output = D>,
+    I: Copy + PartialEq + Sub<I, Output = D>,
+    V: Copy + PartialOrd,
+{
+    pub fn new(time: I, val: V) -> Self {
         Minmax {
-            estimate: [MinmaxSample {
-                time: Instant::now(),
-                value: val,
-            }; 3],
+            estimate: [MinmaxSample { time, value: val }; 3],
         }
     }
 
     /// Resets the estimates to the given value.
-    pub fn reset(&mut self, time: Instant, meas: T) -> T {
+    pub fn reset(&mut self, time: I, meas: V) -> V {
         let val = MinmaxSample { time, value: meas };
 
         for i in self.estimate.iter_mut() {
@@ -87,10 +89,10 @@ impl<T: PartialOrd + Copy> Minmax<T> {
     }
 
     /// Updates the min estimate based on the given measurement, and returns it.
-    pub fn running_min(&mut self, win: Duration, time: Instant, meas: T) -> T {
+    pub fn running_min(&mut self, win: D, time: I, meas: V) -> V {
         let val = MinmaxSample { time, value: meas };
 
-        let delta_time = time.duration_since(self.estimate[2].time);
+        let delta_time = time - self.estimate[2].time;
 
         // Reset if there's nothing in the window or a new min value is found.
         if val.value <= self.estimate[0].value || delta_time > win {
@@ -108,10 +110,10 @@ impl<T: PartialOrd + Copy> Minmax<T> {
     }
 
     /// Updates the max estimate based on the given measurement, and returns it.
-    pub fn _running_max(&mut self, win: Duration, time: Instant, meas: T) -> T {
+    pub fn running_max(&mut self, win: D, time: I, meas: V) -> V {
         let val = MinmaxSample { time, value: meas };
 
-        let delta_time = time.duration_since(self.estimate[2].time);
+        let delta_time = time - self.estimate[2].time;
 
         // Reset if there's nothing in the window or a new max value is found.
         if val.value >= self.estimate[0].value || delta_time > win {
@@ -129,10 +131,10 @@ impl<T: PartialOrd + Copy> Minmax<T> {
     }
 
     /// As time advances, update the 1st, 2nd and 3rd estimates.
-    fn subwin_update(&mut self, win: Duration, time: Instant, meas: T) -> T {
+    fn subwin_update(&mut self, win: D, time: I, meas: V) -> V {
         let val = MinmaxSample { time, value: meas };
 
-        let delta_time = time.duration_since(self.estimate[0].time);
+        let delta_time = time - self.estimate[0].time;
 
         if delta_time > win {
             // Passed entire window without a new val so make 2nd estimate the
@@ -143,20 +145,20 @@ impl<T: PartialOrd + Copy> Minmax<T> {
             self.estimate[1] = self.estimate[2];
             self.estimate[2] = val;
 
-            if time.duration_since(self.estimate[0].time) > win {
+            if time - self.estimate[0].time > win {
                 self.estimate[0] = self.estimate[1];
                 self.estimate[1] = self.estimate[2];
                 self.estimate[2] = val;
             }
         } else if self.estimate[1].time == self.estimate[0].time &&
-            delta_time > win.div_f32(4.0)
+            delta_time > win / 4
         {
             // We've passed a quarter of the window without a new val so take a
             // 2nd estimate from the 2nd quarter of the window.
             self.estimate[2] = val;
             self.estimate[1] = val;
         } else if self.estimate[2].time == self.estimate[1].time &&
-            delta_time > win.div_f32(2.0)
+            delta_time > win / 2
         {
             // We've passed half the window without finding a new val so take a
             // 3rd estimate from the last half of the window.
@@ -170,10 +172,12 @@ impl<T: PartialOrd + Copy> Minmax<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+    use std::time::Instant;
 
     #[test]
     fn reset_filter_rtt() {
-        let mut f = Minmax::new(Duration::new(0, 0));
+        let mut f = Minmax::new(Instant::now(), Duration::new(0, 0));
         let now = Instant::now();
         let rtt = Duration::from_millis(50);
 
@@ -192,7 +196,7 @@ mod tests {
 
     #[test]
     fn reset_filter_bandwidth() {
-        let mut f = Minmax::new(0);
+        let mut f = Minmax::new(Instant::now(), 0);
         let now = Instant::now();
         let bw = 2000;
 
@@ -211,7 +215,7 @@ mod tests {
 
     #[test]
     fn get_windowed_min_rtt() {
-        let mut f = Minmax::new(Duration::new(0, 0));
+        let mut f = Minmax::new(Instant::now(), Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let win = Duration::from_millis(500);
@@ -235,7 +239,7 @@ mod tests {
 
     #[test]
     fn get_windowed_min_bandwidth() {
-        let mut f = Minmax::new(0);
+        let mut f = Minmax::new(Instant::now(), 0);
         let bw_200 = 200;
         let bw_500 = 500;
         let win = Duration::from_millis(500);
@@ -259,7 +263,7 @@ mod tests {
 
     #[test]
     fn get_windowed_max_rtt() {
-        let mut f = Minmax::new(Duration::new(0, 0));
+        let mut f = Minmax::new(Instant::now(), Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let win = Duration::from_millis(500);
@@ -269,13 +273,13 @@ mod tests {
         assert_eq!(rtt_max, rtt_24);
 
         time += Duration::from_millis(250);
-        rtt_max = f._running_max(win, time, rtt_25);
+        rtt_max = f.running_max(win, time, rtt_25);
         assert_eq!(rtt_max, rtt_25);
         assert_eq!(f.estimate[1].value, rtt_25);
         assert_eq!(f.estimate[2].value, rtt_25);
 
         time += Duration::from_millis(600);
-        rtt_max = f._running_max(win, time, rtt_24);
+        rtt_max = f.running_max(win, time, rtt_24);
         assert_eq!(rtt_max, rtt_24);
         assert_eq!(f.estimate[1].value, rtt_24);
         assert_eq!(f.estimate[2].value, rtt_24);
@@ -283,7 +287,7 @@ mod tests {
 
     #[test]
     fn get_windowed_max_bandwidth() {
-        let mut f = Minmax::new(0);
+        let mut f = Minmax::new(Instant::now(), 0);
         let bw_200 = 200;
         let bw_500 = 500;
         let win = Duration::from_millis(500);
@@ -293,13 +297,13 @@ mod tests {
         assert_eq!(bw_max, bw_200);
 
         time += Duration::from_millis(5000);
-        bw_max = f._running_max(win, time, bw_500);
+        bw_max = f.running_max(win, time, bw_500);
         assert_eq!(bw_max, bw_500);
         assert_eq!(f.estimate[1].value, bw_500);
         assert_eq!(f.estimate[2].value, bw_500);
 
         time += Duration::from_millis(600);
-        bw_max = f._running_max(win, time, bw_200);
+        bw_max = f.running_max(win, time, bw_200);
         assert_eq!(bw_max, bw_200);
         assert_eq!(f.estimate[1].value, bw_200);
         assert_eq!(f.estimate[2].value, bw_200);
@@ -307,7 +311,7 @@ mod tests {
 
     #[test]
     fn get_windowed_min_estimates_rtt() {
-        let mut f = Minmax::new(Duration::new(0, 0));
+        let mut f = Minmax::new(Instant::now(), Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let rtt_23 = Duration::from_millis(23);
@@ -339,7 +343,7 @@ mod tests {
 
     #[test]
     fn get_windowed_min_estimates_bandwidth() {
-        let mut f = Minmax::new(0);
+        let mut f = Minmax::new(Instant::now(), 0);
         let bw_500 = 500;
         let bw_400 = 400;
         let bw_300 = 300;
@@ -371,7 +375,7 @@ mod tests {
 
     #[test]
     fn get_windowed_max_estimates_rtt() {
-        let mut f = Minmax::new(Duration::new(0, 0));
+        let mut f = Minmax::new(Instant::now(), Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let rtt_23 = Duration::from_millis(23);
@@ -383,19 +387,19 @@ mod tests {
         assert_eq!(rtt_max, rtt_25);
 
         time += Duration::from_millis(300);
-        rtt_max = f._running_max(win, time, rtt_24);
+        rtt_max = f.running_max(win, time, rtt_24);
         assert_eq!(rtt_max, rtt_25);
         assert_eq!(f.estimate[1].value, rtt_24);
         assert_eq!(f.estimate[2].value, rtt_24);
 
         time += Duration::from_millis(300);
-        rtt_max = f._running_max(win, time, rtt_23);
+        rtt_max = f.running_max(win, time, rtt_23);
         assert_eq!(rtt_max, rtt_25);
         assert_eq!(f.estimate[1].value, rtt_24);
         assert_eq!(f.estimate[2].value, rtt_23);
 
         time += Duration::from_millis(300);
-        rtt_max = f._running_max(win, time, rtt_26);
+        rtt_max = f.running_max(win, time, rtt_26);
         assert_eq!(rtt_max, rtt_26);
         assert_eq!(f.estimate[1].value, rtt_26);
         assert_eq!(f.estimate[2].value, rtt_26);
@@ -403,7 +407,7 @@ mod tests {
 
     #[test]
     fn get_windowed_max_estimates_bandwidth() {
-        let mut f = Minmax::new(0);
+        let mut f = Minmax::new(Instant::now(), 0);
         let bw_500 = 500;
         let bw_400 = 400;
         let bw_300 = 300;
@@ -415,21 +419,45 @@ mod tests {
         assert_eq!(bw_max, bw_500);
 
         time += Duration::from_millis(300);
-        bw_max = f._running_max(win, time, bw_400);
+        bw_max = f.running_max(win, time, bw_400);
         assert_eq!(bw_max, bw_500);
         assert_eq!(f.estimate[1].value, bw_400);
         assert_eq!(f.estimate[2].value, bw_400);
 
         time += Duration::from_millis(300);
-        bw_max = f._running_max(win, time, bw_300);
+        bw_max = f.running_max(win, time, bw_300);
         assert_eq!(bw_max, bw_500);
         assert_eq!(f.estimate[1].value, bw_400);
         assert_eq!(f.estimate[2].value, bw_300);
 
         time += Duration::from_millis(300);
-        bw_max = f._running_max(win, time, bw_600);
+        bw_max = f.running_max(win, time, bw_600);
         assert_eq!(bw_max, bw_600);
         assert_eq!(f.estimate[1].value, bw_600);
         assert_eq!(f.estimate[2].value, bw_600);
+    }
+
+    #[test]
+    fn get_windowed_min_bandwidth_ints() {
+        let mut f = Minmax::new(0 as u32, 0);
+        let bw_200 = 200;
+        let bw_500 = 500;
+        let win = 2;
+        let mut time = 0;
+
+        let mut bw_min = f.reset(time, bw_500);
+        assert_eq!(bw_min, bw_500);
+
+        time += 1;
+        bw_min = f.running_min(win, time, bw_200);
+        assert_eq!(bw_min, bw_200);
+        assert_eq!(f.estimate[1].value, bw_200);
+        assert_eq!(f.estimate[2].value, bw_200);
+
+        time += 3;
+        bw_min = f.running_min(win, time, bw_500);
+        assert_eq!(bw_min, bw_500);
+        assert_eq!(f.estimate[1].value, bw_500);
+        assert_eq!(f.estimate[2].value, bw_500);
     }
 }

--- a/src/recovery/bbr.rs
+++ b/src/recovery/bbr.rs
@@ -1,0 +1,390 @@
+use crate::minmax::Minmax;
+use crate::packet;
+use crate::rand;
+use crate::recovery::Acked;
+use crate::recovery::CongestionControlOps;
+use crate::recovery::Recovery;
+use std::f64::consts::LN_2;
+use std::time::Duration;
+use std::time::Instant;
+
+const HIGH_GAIN: f64 = 2.0 / LN_2;
+const RTT_WINDOW: Duration = Duration::from_secs(10);
+const PROBE_RTT_TIME: Duration = Duration::from_millis(200);
+const BW_WINDOW: u32 = 10;
+const MIN_PIPE_CWND: usize = 4;
+const PROBE_GAINS: [f64; 8] = [1.25, 0.75, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0];
+
+pub static BBR: CongestionControlOps = CongestionControlOps {
+    on_packet_sent,
+    on_packet_acked,
+    congestion_event,
+    collapse_cwnd,
+    checkpoint,
+    rollback,
+    has_custom_pacing,
+};
+
+pub struct State {
+    mode: Mode,
+
+    // Bottleneck bandwidth
+    bw_filter: Minmax<u32, u64>,
+    bw_max: u64,
+
+    // Round counting
+    next_round_delivered: usize,
+    round_start: bool,
+    round_count: u32,
+
+    // RTT
+    rtt_min: Duration,
+    rtt_stamp: Instant,
+    rtt_expired: bool,
+    probe_rtt_done_stamp: Option<Instant>,
+    probe_rtt_round_done: bool,
+
+    // Pacing
+    pacing_rate: u64,
+    pacing_gain: f64,
+
+    // Filled pipe
+    filled_pipe: bool,
+    full_bw: u64,
+    full_bw_count: u64,
+
+    // Quantum
+    send_quantum: usize,
+
+    // CWND
+    target_cwnd: usize,
+    cwnd_gain: f64,
+
+    // BW Probing
+    probe_gain_idx: usize,
+    cycle_stamp: Instant,
+
+    // Idle restart
+    idle_restart: bool,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State {
+            bw_filter: Minmax::new(0, 0),
+            bw_max: 0,
+            mode: Mode::Startup,
+            next_round_delivered: 0,
+            round_start: false,
+            round_count: 0,
+            rtt_min: crate::recovery::INITIAL_RTT,
+            rtt_stamp: Instant::now(),
+            rtt_expired: false,
+            probe_rtt_done_stamp: None,
+            probe_rtt_round_done: false,
+            pacing_rate: 0,
+            pacing_gain: HIGH_GAIN,
+            filled_pipe: false,
+            full_bw: 0,
+            full_bw_count: 0,
+            send_quantum: 0,
+            target_cwnd: 0,
+            cwnd_gain: HIGH_GAIN,
+            probe_gain_idx: 0,
+            cycle_stamp: Instant::now(),
+            idle_restart: false,
+        }
+    }
+}
+
+#[derive(PartialEq)]
+enum Mode {
+    Startup,
+    Drain,
+    ProbeBw,
+    ProbeRtt,
+}
+
+pub fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
+    handle_restart_from_idle(r);
+    r.bytes_in_flight += sent_bytes;
+}
+
+fn on_packet_acked(
+    r: &mut Recovery, packet: &Acked, _epoch: packet::Epoch, now: Instant,
+) {
+    r.bytes_in_flight = r.bytes_in_flight.saturating_sub(packet.size);
+
+    update_bw(r, packet);
+    check_cycle_phase(r, packet, now);
+    check_full_pipe(r, packet);
+    check_drain(r);
+    update_rtt(r, now);
+    check_probe_rtt(r, now);
+
+    set_pacing_rate(r);
+    set_send_quantum(r);
+    set_cwnd(r, packet);
+}
+
+fn congestion_event(
+    _r: &mut Recovery, _time_sent: Instant, _epoch: packet::Epoch, _now: Instant,
+) {
+    // TODO: Implement loss recovery
+}
+
+pub fn collapse_cwnd(_r: &mut Recovery) {
+    // TODO: Implement loss recovery
+}
+
+fn has_custom_pacing() -> bool {
+    true
+}
+
+fn checkpoint(_r: &mut Recovery) {
+    // TODO: Implement loss recovery
+}
+
+fn rollback(_r: &mut Recovery) {
+    // TODO: Implement loss recovery
+}
+
+fn update_bw(r: &mut Recovery, packet: &Acked) {
+    update_round(r, packet);
+
+    let rate = r.delivery_rate();
+    if rate >= r.bbr_state.bw_max || !packet.is_app_limited {
+        r.bbr_state.bw_max = r.bbr_state.bw_filter.running_max(
+            BW_WINDOW,
+            r.bbr_state.round_count,
+            rate,
+        );
+    }
+}
+
+fn update_round(r: &mut Recovery, packet: &Acked) {
+    if packet.delivered >= r.bbr_state.next_round_delivered {
+        r.bbr_state.next_round_delivered = r.delivery_rate.delivered();
+        r.bbr_state.round_count += 1;
+        r.bbr_state.round_start = true;
+    } else {
+        r.bbr_state.round_start = false;
+    }
+}
+
+fn update_rtt(r: &mut Recovery, now: Instant) {
+    r.bbr_state.rtt_expired = now > r.bbr_state.rtt_stamp + RTT_WINDOW;
+
+    if r.latest_rtt <= r.bbr_state.rtt_min || r.bbr_state.rtt_expired {
+        r.bbr_state.rtt_min = r.latest_rtt;
+        r.bbr_state.rtt_stamp = now;
+    }
+}
+
+fn set_pacing_rate(r: &mut Recovery) {
+    set_pacing_rate_gain(r, r.bbr_state.pacing_gain);
+}
+
+fn set_pacing_rate_gain(r: &mut Recovery, gain: f64) {
+    let rate = (gain * r.bbr_state.bw_max as f64) as u64;
+
+    if r.bbr_state.filled_pipe || rate > r.bbr_state.pacing_rate {
+        r.bbr_state.pacing_rate = rate;
+        r.pacing_rate = rate;
+    }
+}
+
+fn set_send_quantum(r: &mut Recovery) {
+    const LOW_THRESH: u64 = 157286; // 1.2 Mbps in MBps
+    const HIGH_THRESH: u64 = 3145728; // 24 Mbps in MBps
+    const HIGH_QUANTUM: usize = 65536; // 64KB
+
+    r.bbr_state.send_quantum = if r.bbr_state.pacing_rate < LOW_THRESH {
+        r.max_datagram_size()
+    } else if r.bbr_state.pacing_rate < HIGH_THRESH {
+        2 * r.max_datagram_size()
+    } else {
+        std::cmp::min((r.bbr_state.pacing_rate / 1000) as usize, HIGH_QUANTUM)
+    };
+}
+
+fn inflight(r: &Recovery, gain: f64) -> usize {
+    let quanta = 3 * r.bbr_state.send_quantum;
+    let estimated_bdp =
+        r.bbr_state.bw_max as f64 * r.bbr_state.rtt_min.as_secs_f64();
+    (gain * estimated_bdp) as usize + quanta
+}
+
+fn update_target_cwnd(r: &mut Recovery) {
+    r.bbr_state.target_cwnd = inflight(r, r.bbr_state.cwnd_gain);
+}
+
+fn modulate_cwnd_for_probe_rtt(r: &mut Recovery) {
+    if r.bbr_state.mode == Mode::ProbeRtt {
+        r.congestion_window = std::cmp::min(
+            r.congestion_window,
+            MIN_PIPE_CWND * r.max_datagram_size(),
+        );
+    }
+}
+
+fn set_cwnd(r: &mut Recovery, packet: &Acked) {
+    update_target_cwnd(r);
+    // TODO: modulate_cwnd_for_recovery();
+
+    // if not packet conservation
+    if r.bbr_state.filled_pipe {
+        r.congestion_window = std::cmp::min(
+            r.congestion_window + packet.size,
+            r.bbr_state.target_cwnd,
+        );
+    } else if r.congestion_window < r.bbr_state.target_cwnd ||
+        r.delivery_rate.delivered() < MIN_PIPE_CWND * r.max_datagram_size()
+    {
+        r.congestion_window += packet.size;
+    }
+
+    r.congestion_window =
+        std::cmp::max(r.congestion_window, MIN_PIPE_CWND * r.max_datagram_size());
+
+    modulate_cwnd_for_probe_rtt(r);
+}
+
+fn check_full_pipe(r: &mut Recovery, packet: &Acked) {
+    if r.bbr_state.filled_pipe ||
+        !r.bbr_state.round_start ||
+        packet.is_app_limited
+    {
+        return;
+    }
+
+    // Check if BW still growing by more than 25%
+    if r.bbr_state.bw_max >= (r.bbr_state.full_bw * 5) / 4 {
+        r.bbr_state.full_bw = r.bbr_state.bw_max;
+        r.bbr_state.full_bw_count = 0;
+        return;
+    }
+
+    r.bbr_state.full_bw_count += 1;
+
+    if r.bbr_state.full_bw_count >= 3 {
+        r.bbr_state.filled_pipe = true;
+    }
+}
+
+fn enter_startup(r: &mut Recovery) {
+    r.bbr_state.mode = Mode::Startup;
+    r.bbr_state.pacing_gain = HIGH_GAIN;
+    r.bbr_state.cwnd_gain = HIGH_GAIN;
+}
+
+fn enter_drain(r: &mut Recovery) {
+    r.bbr_state.mode = Mode::Drain;
+    r.bbr_state.pacing_gain = 1.0 / HIGH_GAIN;
+    r.bbr_state.cwnd_gain = HIGH_GAIN;
+}
+
+fn check_drain(r: &mut Recovery) {
+    if r.bbr_state.mode == Mode::Startup && r.bbr_state.filled_pipe {
+        enter_drain(r);
+    }
+
+    if r.bbr_state.mode == Mode::Drain && r.bytes_in_flight <= inflight(r, 1.0) {
+        enter_probe_bw(r);
+    }
+}
+
+fn enter_probe_bw(r: &mut Recovery) {
+    r.bbr_state.mode = Mode::ProbeBw;
+    r.bbr_state.pacing_gain = 1.0;
+    r.bbr_state.cwnd_gain = 2.0;
+    r.bbr_state.probe_gain_idx =
+        PROBE_GAINS.len() - 1 - rand::rand_u64_uniform(7) as usize;
+}
+
+fn check_cycle_phase(r: &mut Recovery, packet: &Acked, now: Instant) {
+    if r.bbr_state.mode == Mode::ProbeBw && is_next_cycle_phase(r, packet, now) {
+        advance_cycle_phase(r, now);
+    }
+}
+
+fn is_next_cycle_phase(r: &mut Recovery, packet: &Acked, now: Instant) -> bool {
+    let is_full_length = now - r.bbr_state.cycle_stamp > r.bbr_state.rtt_min;
+    let prior_inflight = r.bytes_in_flight + packet.size;
+
+    if r.bbr_state.pacing_gain == 1.0 {
+        is_full_length
+    } else if r.bbr_state.pacing_gain > 1.0 {
+        // TODO: Account for packets_lost
+        is_full_length && prior_inflight >= inflight(r, r.bbr_state.pacing_gain)
+    } else {
+        is_full_length || prior_inflight <= inflight(r, 1.0)
+    }
+}
+
+fn advance_cycle_phase(r: &mut Recovery, now: Instant) {
+    r.bbr_state.cycle_stamp = now;
+    r.bbr_state.probe_gain_idx =
+        (r.bbr_state.probe_gain_idx + 1) % PROBE_GAINS.len();
+    r.bbr_state.pacing_gain = PROBE_GAINS[r.bbr_state.probe_gain_idx];
+}
+
+fn handle_restart_from_idle(r: &mut Recovery) {
+    if r.bytes_in_flight == 0 && r.app_limited() {
+        r.bbr_state.idle_restart = true;
+        if r.bbr_state.mode == Mode::ProbeBw {
+            set_pacing_rate_gain(r, 1.0);
+        }
+    }
+}
+
+fn check_probe_rtt(r: &mut Recovery, now: Instant) {
+    if r.bbr_state.mode != Mode::ProbeRtt &&
+        r.bbr_state.rtt_expired &&
+        !r.bbr_state.idle_restart
+    {
+        enter_probe_rtt(r);
+        checkpoint(r);
+        r.bbr_state.probe_rtt_done_stamp = None;
+    }
+
+    if r.bbr_state.mode == Mode::ProbeRtt {
+        handle_probe_rtt(r, now);
+    }
+
+    r.bbr_state.idle_restart = false;
+}
+
+fn enter_probe_rtt(r: &mut Recovery) {
+    r.bbr_state.mode = Mode::ProbeRtt;
+    r.bbr_state.pacing_gain = 1.0;
+    r.bbr_state.cwnd_gain = 1.0;
+}
+
+fn handle_probe_rtt(r: &mut Recovery, now: Instant) {
+    if r.bbr_state.probe_rtt_done_stamp.is_none() &&
+        r.bytes_in_flight <= MIN_PIPE_CWND * r.max_datagram_size()
+    {
+        r.bbr_state.probe_rtt_done_stamp = Some(now + PROBE_RTT_TIME);
+        r.bbr_state.probe_rtt_round_done = false;
+        r.bbr_state.next_round_delivered = r.delivery_rate.delivered();
+    } else if let Some(probe_rtt_done_stamp) = r.bbr_state.probe_rtt_done_stamp {
+        if r.bbr_state.round_start {
+            r.bbr_state.probe_rtt_round_done = true;
+        }
+
+        if r.bbr_state.probe_rtt_round_done && now > probe_rtt_done_stamp {
+            r.bbr_state.rtt_stamp = now;
+            rollback(r);
+            exit_probe_rtt(r);
+        }
+    }
+}
+
+fn exit_probe_rtt(r: &mut Recovery) {
+    if r.bbr_state.filled_pipe {
+        enter_probe_bw(r);
+    } else {
+        enter_startup(r);
+    }
+}

--- a/src/recovery/bbr.rs
+++ b/src/recovery/bbr.rs
@@ -163,7 +163,7 @@ fn congestion_event(
     if lost_bytes > 0 {
         r.bbr_state.end_conservation = r.delivery_rate.delivered();
 
-        if r.bbr_state.conservation == PacketConservation::Normal {
+        if r.bbr_state.conservation == PacketConservation::Normal && r.bbr_state.filled_pipe {
             save_cwnd(r);
             r.bbr_state.conservation = PacketConservation::Conservation;
             r.congestion_window = r.bytes_in_flight + lost_bytes;

--- a/src/recovery/bbr.rs
+++ b/src/recovery/bbr.rs
@@ -14,6 +14,11 @@ const PROBE_RTT_TIME: Duration = Duration::from_millis(200);
 const BW_WINDOW: u32 = 10;
 const MIN_PIPE_CWND: usize = 4;
 const PROBE_GAINS: [f64; 8] = [1.25, 0.75, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0];
+const LT_MAX_RTTS: u64 = 48;
+const LT_MIN_RTTS: u64 = 4;
+const LT_LOSS_THRESH: usize = 5;
+const LT_BW_RATIO: u64 = 8;
+const LT_BW_DIFF: u64 = 500;
 
 pub static BBR: CongestionControlOps = CongestionControlOps {
     on_packet_sent,
@@ -76,10 +81,21 @@ pub struct State {
     // Packet conservation
     conservation: PacketConservation,
     end_conservation: usize,
+
+    // Long-term sampling
+    lt_sampling: bool,
+    lt_last_stamp: Instant,
+    lt_last_delivered: usize,
+    lt_last_lost: usize,
+    lt_rtt_cnt: u64,
+    lt_use_bw: bool,
+    lt_bw: u64,
 }
 
 impl Default for State {
     fn default() -> Self {
+        let now = Instant::now();
+
         State {
             bw_filter: Minmax::new(0, 0),
             bw_max: 0,
@@ -88,7 +104,7 @@ impl Default for State {
             round_start: false,
             round_count: 0,
             rtt_min: crate::recovery::INITIAL_RTT,
-            rtt_stamp: Instant::now(),
+            rtt_stamp: now,
             rtt_expired: false,
             probe_rtt_done_stamp: None,
             probe_rtt_round_done: false,
@@ -102,13 +118,20 @@ impl Default for State {
             saved_cwnd: 0,
             cwnd_gain: HIGH_GAIN,
             probe_gain_idx: 0,
-            cycle_stamp: Instant::now(),
+            cycle_stamp: now,
             idle_restart: false,
             bytes_lost: 0,
             bytes_last_lost: 0,
             bytes_newly_lost: 0,
             conservation: PacketConservation::Normal,
             end_conservation: 0,
+            lt_sampling: false,
+            lt_last_stamp: now,
+            lt_last_delivered: 0,
+            lt_last_lost: 0,
+            lt_rtt_cnt: 0,
+            lt_use_bw: false,
+            lt_bw: 0,
         }
     }
 }
@@ -142,7 +165,7 @@ fn on_packet_acked(
         r.bbr_state.bytes_lost - r.bbr_state.bytes_last_lost;
     r.bbr_state.bytes_last_lost = r.bbr_state.bytes_lost;
 
-    update_bw(r, packet);
+    update_bw(r, packet, now);
     check_cycle_phase(r, packet, now);
     check_full_pipe(r, packet);
     check_drain(r);
@@ -204,8 +227,9 @@ fn restore_cwnd(r: &mut Recovery) {
         std::cmp::max(r.congestion_window, r.bbr_state.saved_cwnd);
 }
 
-fn update_bw(r: &mut Recovery, packet: &Acked) {
+fn update_bw(r: &mut Recovery, packet: &Acked, now: Instant) {
     update_round(r, packet);
+    lt_bw_sampling(r, packet, now);
 
     let rate = r.delivery_rate();
     if rate >= r.bbr_state.bw_max || !packet.is_app_limited {
@@ -215,6 +239,89 @@ fn update_bw(r: &mut Recovery, packet: &Acked) {
             rate,
         );
     }
+}
+
+fn lt_bw_sampling(r: &mut Recovery, packet: &Acked, now: Instant) {
+    if r.bbr_state.lt_use_bw {
+        if r.bbr_state.mode == Mode::ProbeBw && r.bbr_state.round_start {
+            r.bbr_state.lt_rtt_cnt += 1;
+            if r.bbr_state.lt_rtt_cnt >= LT_MAX_RTTS {
+                lt_reset(r, now);
+                enter_probe_bw(r);
+            }
+        }
+
+        return;
+    }
+
+    if !r.bbr_state.lt_sampling {
+        if r.bbr_state.bytes_newly_lost == 0 {
+            return;
+        }
+
+        lt_reset_interval(r, now);
+        r.bbr_state.lt_sampling = true;
+    }
+
+    if packet.is_app_limited {
+        lt_reset(r, now);
+        return;
+    }
+
+    if r.bbr_state.round_start {
+        r.bbr_state.lt_rtt_cnt += 1;
+    }
+
+    if r.bbr_state.lt_rtt_cnt < LT_MIN_RTTS {
+        return;
+    }
+
+    if r.bbr_state.lt_rtt_cnt > 4 * LT_MIN_RTTS {
+        lt_reset(r, now);
+        return;
+    }
+
+    if r.bbr_state.bytes_newly_lost == 0 {
+        return;
+    }
+
+    let lost = r.bbr_state.bytes_lost - r.bbr_state.lt_last_lost;
+    let delivered = r.delivery_rate.delivered() - r.bbr_state.lt_last_delivered;
+
+    if delivered == 0 || lost * LT_LOSS_THRESH < delivered {
+        return;
+    }
+
+    let interval = now - r.bbr_state.lt_last_stamp;
+    let rate = (delivered as f64 / interval.as_secs_f64()) as u64;
+
+    if r.bbr_state.lt_bw != 0 {
+        let diff = (rate as i64 - r.bbr_state.lt_bw as i64).abs() as u64;
+        if diff * LT_BW_RATIO <= r.bbr_state.lt_bw || diff <= LT_BW_DIFF {
+            r.bbr_state.lt_bw = (rate + r.bbr_state.lt_bw) / 2;
+            r.bbr_state.lt_use_bw = true;
+            r.bbr_state.pacing_gain = 1.0;
+            r.bbr_state.lt_rtt_cnt = 0;
+            return;
+        }
+    }
+
+    r.bbr_state.lt_bw = rate;
+    lt_reset_interval(r, now);
+}
+
+fn lt_reset_interval(r: &mut Recovery, now: Instant) {
+    r.bbr_state.lt_last_stamp = now;
+    r.bbr_state.lt_last_delivered = r.delivery_rate.delivered();
+    r.bbr_state.lt_last_lost = r.bbr_state.bytes_lost;
+    r.bbr_state.lt_rtt_cnt = 0;
+}
+
+fn lt_reset(r: &mut Recovery, now: Instant) {
+    r.bbr_state.lt_use_bw = false;
+    r.bbr_state.lt_bw = 0;
+    r.bbr_state.lt_sampling = false;
+    lt_reset_interval(r, now);
 }
 
 fn update_round(r: &mut Recovery, packet: &Acked) {
@@ -250,7 +357,7 @@ fn set_pacing_rate(r: &mut Recovery) {
 }
 
 fn set_pacing_rate_gain(r: &mut Recovery, gain: f64) {
-    let rate = (gain * r.bbr_state.bw_max as f64) as u64;
+    let rate = (gain * bw(r) as f64) as u64;
 
     if r.bbr_state.filled_pipe || rate > r.bbr_state.pacing_rate {
         r.bbr_state.pacing_rate = rate;
@@ -406,7 +513,11 @@ fn advance_cycle_phase(r: &mut Recovery, now: Instant) {
     r.bbr_state.cycle_stamp = now;
     r.bbr_state.probe_gain_idx =
         (r.bbr_state.probe_gain_idx + 1) % PROBE_GAINS.len();
-    r.bbr_state.pacing_gain = PROBE_GAINS[r.bbr_state.probe_gain_idx];
+    if r.bbr_state.lt_use_bw {
+        r.bbr_state.pacing_gain = 1.0;
+    } else {
+        r.bbr_state.pacing_gain = PROBE_GAINS[r.bbr_state.probe_gain_idx];
+    }
 }
 
 fn handle_restart_from_idle(r: &mut Recovery) {
@@ -466,5 +577,13 @@ fn exit_probe_rtt(r: &mut Recovery) {
         enter_probe_bw(r);
     } else {
         enter_startup(r);
+    }
+}
+
+fn bw(r: &mut Recovery) -> u64 {
+    if r.bbr_state.lt_use_bw {
+        r.bbr_state.lt_bw
+    } else {
+        r.bbr_state.bw_max
     }
 }

--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -51,6 +51,7 @@ pub static CUBIC: CongestionControlOps = CongestionControlOps {
     collapse_cwnd,
     checkpoint,
     rollback,
+    has_custom_pacing,
 };
 
 /// CUBIC Constants.
@@ -402,6 +403,10 @@ fn rollback(r: &mut Recovery) {
     r.cubic_state.w_max = r.cubic_state.prior.w_max;
     r.cubic_state.k = r.cubic_state.prior.k;
     r.congestion_recovery_start_time = r.cubic_state.prior.epoch_start;
+}
+
+fn has_custom_pacing() -> bool {
+    false
 }
 
 #[cfg(test)]

--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -345,7 +345,8 @@ fn on_packet_acked(
 }
 
 fn congestion_event(
-    r: &mut Recovery, time_sent: Instant, epoch: packet::Epoch, now: Instant,
+    r: &mut Recovery, _bytes_lost: usize, time_sent: Instant,
+    epoch: packet::Epoch, now: Instant,
 ) {
     let in_congestion_recovery = r.in_congestion_recovery(time_sent);
 

--- a/src/recovery/delivery_rate.rs
+++ b/src/recovery/delivery_rate.rs
@@ -124,6 +124,10 @@ impl Rate {
     pub fn delivery_rate(&self) -> u64 {
         self.rate_sample.delivery_rate
     }
+
+    pub fn delivered(&self) -> usize {
+        self.delivered
+    }
 }
 
 impl std::fmt::Debug for Rate {

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -821,7 +821,7 @@ impl Recovery {
     ) {
         self.bytes_in_flight = self.bytes_in_flight.saturating_sub(lost_bytes);
 
-        self.congestion_event(largest_lost_pkt.time_sent, epoch, now);
+        self.congestion_event(lost_bytes, largest_lost_pkt.time_sent, epoch, now);
 
         if self.in_persistent_congestion(largest_lost_pkt.pkt_num) {
             self.collapse_cwnd();
@@ -829,13 +829,14 @@ impl Recovery {
     }
 
     fn congestion_event(
-        &mut self, time_sent: Instant, epoch: packet::Epoch, now: Instant,
+        &mut self, lost_bytes: usize, time_sent: Instant, epoch: packet::Epoch,
+        now: Instant,
     ) {
         if !self.in_congestion_recovery(time_sent) {
             (self.cc_ops.checkpoint)(self);
         }
 
-        (self.cc_ops.congestion_event)(self, time_sent, epoch, now);
+        (self.cc_ops.congestion_event)(self, lost_bytes, time_sent, epoch, now);
     }
 
     fn collapse_cwnd(&mut self) {
@@ -916,6 +917,7 @@ pub struct CongestionControlOps {
 
     pub congestion_event: fn(
         r: &mut Recovery,
+        lost_bytes: usize,
         time_sent: Instant,
         epoch: packet::Epoch,
         now: Instant,

--- a/src/recovery/reno.rs
+++ b/src/recovery/reno.rs
@@ -45,6 +45,7 @@ pub static RENO: CongestionControlOps = CongestionControlOps {
     collapse_cwnd,
     checkpoint,
     rollback,
+    has_custom_pacing,
 };
 
 pub fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
@@ -161,6 +162,10 @@ pub fn collapse_cwnd(r: &mut Recovery) {
 fn checkpoint(_r: &mut Recovery) {}
 
 fn rollback(_r: &mut Recovery) {}
+
+fn has_custom_pacing() -> bool {
+    false
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/recovery/reno.rs
+++ b/src/recovery/reno.rs
@@ -126,7 +126,8 @@ fn on_packet_acked(
 }
 
 fn congestion_event(
-    r: &mut Recovery, time_sent: Instant, epoch: packet::Epoch, now: Instant,
+    r: &mut Recovery, _bytes_lost: usize, time_sent: Instant,
+    epoch: packet::Epoch, now: Instant,
 ) {
     // Start a new congestion event if packet was sent after the
     // start of the previous congestion recovery period.

--- a/tools/apps/src/client.rs
+++ b/tools/apps/src/client.rs
@@ -157,7 +157,8 @@ pub fn connect(
 
     // Create a QUIC connection and initiate handshake.
     let mut conn =
-        quiche::connect(connect_url.domain(), &scid, &mut config).unwrap();
+        quiche::connect(connect_url.domain(), &scid, peer_addr, &mut config)
+            .unwrap();
 
     if let Some(keylog) = &mut keylog {
         if let Ok(keylog) = keylog.try_clone() {
@@ -193,9 +194,9 @@ pub fn connect(
         scid,
     );
 
-    let write = conn.send(&mut out).expect("initial send failed");
+    let (write, send_info) = conn.send(&mut out).expect("initial send failed");
 
-    while let Err(e) = socket.send(&out[..write]) {
+    while let Err(e) = socket.send_to(&out[..write], &send_info.to) {
         if e.kind() == std::io::ErrorKind::WouldBlock {
             trace!("send() would block");
             continue;
@@ -229,7 +230,7 @@ pub fn connect(
                 break 'read;
             }
 
-            let len = match socket.recv(&mut buf) {
+            let (len, from) = match socket.recv_from(&mut buf) {
                 Ok(v) => v,
 
                 Err(e) => {
@@ -260,8 +261,10 @@ pub fn connect(
 
             pkt_count += 1;
 
+            let recv_info = quiche::RecvInfo { from };
+
             // Process potentially coalesced packets.
-            let read = match conn.recv(&mut buf[..len]) {
+            let read = match conn.recv(&mut buf[..len], recv_info) {
                 Ok(v) => v,
 
                 Err(e) => {
@@ -381,7 +384,7 @@ pub fn connect(
         // Generate outgoing QUIC packets and send them on the UDP socket, until
         // quiche reports that there are no more packets to be sent.
         loop {
-            let write = match conn.send(&mut out) {
+            let (write, send_info) = match conn.send(&mut out) {
                 Ok(v) => v,
 
                 Err(quiche::Error::Done) => {
@@ -397,7 +400,7 @@ pub fn connect(
                 },
             };
 
-            if let Err(e) = socket.send(&out[..write]) {
+            if let Err(e) = socket.send_to(&out[..write], &send_info.to) {
                 if e.kind() == std::io::ErrorKind::WouldBlock {
                     trace!("send() would block");
                     break;

--- a/tools/apps/src/common.rs
+++ b/tools/apps/src/common.rs
@@ -39,7 +39,6 @@ use std::rc::Rc;
 
 use std::cell::RefCell;
 
-use std::net;
 use std::path;
 
 use quiche::ConnectionId;
@@ -97,7 +96,7 @@ pub struct Client {
     pub partial_responses: std::collections::HashMap<u64, PartialResponse>,
 }
 
-pub type ClientMap = HashMap<ConnectionId<'static>, (net::SocketAddr, Client)>;
+pub type ClientMap = HashMap<ConnectionId<'static>, Client>;
 
 /// Makes a buffered writer for a resource with a target URL.
 ///


### PR DESCRIPTION
I've recently been working on a version of BBR for quiche for a research project. It's broadly based on information found in the [draft BBR RFC](https://datatracker.ietf.org/doc/html/draft-cardwell-iccrg-bbr-congestion-control), the [Linux kernel implementation](https://github.com/torvalds/linux/blob/master/net/ipv4/tcp_bbr.c), and [Google's implementation in their (similarly named) QUIC library](https://source.chromium.org/chromium/chromium/src/+/master:net/third_party/quiche/src/quic/core/congestion_control/bbr_sender.cc).

This version of BBR implements the core BBR algorithm, the packet conservation loss handling mechanism, and the long-term sampling functionality which so far has only been implemented in the Linux kernel implementation and isn't detailed in the RFC or the QUIC implementation. I've had to make a number of adaptations to the algorithm to get it to work in quiche and there's still some features missing:

- No ack aggregation handling.
- Packet conservation adapted since we're not using the TCP state machine anymore, adapted from how Google handles this.
- Under constant packet loss (1%) bitrate seems to collapse. May be a delivery rate estimation issue but needs investigating.

Also more general caveats, there's no unit testing and comments are sparse. I'm submitting this draft now to see if you'd be receptive to getting BBR merged in and what changes you'd want to see here before starting code review. As part of my research, I've done a bit of evaluation and I've seen typical BBR behaviour where the throughput is higher than what CUBIC usually gets you but it incurs higher packet loss rates.

Depends on #770 
Closes #514 