### PR TITLE
stream: undo consistent RabgeBuf allocation on send

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -382,7 +382,7 @@ impl Frame {
             Frame::Crypto { data } => {
                 encode_crypto_header(data.off() as u64, data.len() as u64, b)?;
 
-                data.with(|s| b.put_bytes(s))?;
+                b.put_bytes(&data)?;
             },
 
             Frame::CryptoHeader { .. } => (),
@@ -403,7 +403,7 @@ impl Frame {
                     b,
                 )?;
 
-                data.with(|s| b.put_bytes(s))?;
+                b.put_bytes(&data)?;
             },
 
             Frame::StreamHeader { .. } => (),


### PR DESCRIPTION
Currently, when writing stream data, `RangeBuf` objects are allocated
with a fixed capacity, and if the buffer is not immediately filled, the
next stream write will re-use it.

This was originally implemented to try to reduce memory fragmentation of
stream data, and, in order to be able to maintain the `Send` and `Sync`
traits implementation, the `RangeBuf` data buffer was wrapped in an
`RWlock`, in order to implement thread-safe interior mutability.

However due to the fact that the locking falls within 2 hot code paths
(stream data writing, and STREAM frame creation) it heavuily affects
throughput.

In retrospect, the benefit of reduced memory fragmentation does not seem
to justify the performance penalty, so this undoes the consistent
allocation change to remove the need for the lock.

This partially reverts commit 0976433e68ea1926aa9cf581e1a5846aba6da672.