### PR TITLE
recovery: remove ABC_L constant and its logic

### DIFF
--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -64,9 +64,6 @@ const MINIMUM_WINDOW_PACKETS: usize = 2;
 
 const LOSS_REDUCTION_FACTOR: f64 = 0.5;
 
-// RFC3465 Slow Start burst limit constant
-const ABC_L: usize = 2;
-
 pub struct Recovery {
     loss_detection_timer: Option<Instant>,
 
@@ -783,8 +780,6 @@ impl Recovery {
         for pkt in acked {
             (self.cc_ops.on_packet_acked)(self, &pkt, epoch, now);
         }
-
-        self.bytes_acked_sl = 0;
     }
 
     fn in_congestion_recovery(&self, sent_time: Instant) -> bool {


### PR DESCRIPTION
RFC3465 ABC_L constant (2) is to prevent an ACK from
growing cwnd too fast for TCP ACK. However in QUIC
recovery we process each ack'ed packet one by one in
on_packet_acked(), there is no case where 2 or more
packets are acked in on_packet_acked() hook.

Also current logic limits growing cwnd more than 2 MSS
for ACK packet containing more than 2 ACK packets,
cwnd can grow too conservative in case that an ACK range
contains many packets. For example the receiver may
ack multiple packets in a single ACK frame when it processed
multiple packets at once.

This PR partially reverts #737.