### PR TITLE
quiche-client: connectionless udp socket

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -246,11 +246,6 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    if (connect(sock, peer->ai_addr, peer->ai_addrlen) < 0) {
-        perror("failed to connect socket");
-        return -1;
-    }
-
     quiche_config *config = quiche_config_new(0xbabababa);
     if (config == NULL) {
         fprintf(stderr, "failed to create config\n");

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -69,7 +69,6 @@ fn main() {
     // Create the UDP socket backing the QUIC connection, and register it with
     // the event loop.
     let socket = std::net::UdpSocket::bind(bind_addr).unwrap();
-    socket.connect(peer_addr).unwrap();
 
     let socket = mio::net::UdpSocket::from_socket(socket).unwrap();
     poll.register(

--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -344,11 +344,6 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    if (connect(sock, peer->ai_addr, peer->ai_addrlen) < 0) {
-        perror("failed to connect socket");
-        return -1;
-    }
-
     quiche_config *config = quiche_config_new(0xbabababa);
     if (config == NULL) {
         fprintf(stderr, "failed to create config\n");

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -67,7 +67,6 @@ fn main() {
     // Create the UDP socket backing the QUIC connection, and register it with
     // the event loop.
     let socket = std::net::UdpSocket::bind(bind_addr).unwrap();
-    socket.connect(peer_addr).unwrap();
 
     let socket = mio::net::UdpSocket::from_socket(socket).unwrap();
     poll.register(

--- a/tools/apps/src/client.rs
+++ b/tools/apps/src/client.rs
@@ -81,7 +81,6 @@ pub fn connect(
     // Create the UDP socket backing the QUIC connection, and register it with
     // the event loop.
     let socket = std::net::UdpSocket::bind(bind_addr).unwrap();
-    socket.connect(peer_addr).unwrap();
 
     let socket = mio::net::UdpSocket::from_socket(socket).unwrap();
     poll.register(

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -73,7 +73,6 @@ pub fn run(
     // Create the UDP socket backing the QUIC connection, and register it with
     // the event loop.
     let socket = std::net::UdpSocket::bind(bind_addr).unwrap();
-    socket.connect(peer_addr).unwrap();
 
     let socket = mio::net::UdpSocket::from_socket(socket).unwrap();
     poll.register(


### PR DESCRIPTION
Since #898 the client uses sendto() and recvfrom(), the socket need to be
connectionless.

Before:
```
[2021-05-26T21:58:46.109658000Z INFO  quiche_apps::client] connecting to 172.16.127.145:8443 from 172.16.127.1:52740 with scid 5e6d2dac34510af3a071466617d450357c844777
thread 'main' panicked at 'send() failed: Os { code: 56, kind: Other, message: "Socket is already connected" }', src/bin/quiche-client.rs:48:39
```

After:
```
[2021-05-26T22:04:21.549094000Z INFO  quiche_apps::client] connecting to 172.16.127.145:8443 from 0.0.0.0:64418 with scid a3ff695193c37da3945c83c8645e585edf7eca89
[2021-05-26T22:04:24.537648000Z INFO  quiche_apps::common] 1/1 response(s) received in 2.986774919s, closing...
[2021-05-26T22:04:24.576217000Z INFO  quiche_apps::client] connection closed, recv=80512 sent=775 lost=0 rtt=1.969746ms cwnd=57531
```