### PR TITLE
Implement BBR

### DIFF
--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -52,31 +52,33 @@
 // every new min and overwrites 2nd & 3rd choices. The same property
 // holds for 2nd & 3rd best.
 
-use std::time::Duration;
-use std::time::Instant;
+use std::ops::Div;
+use std::ops::Sub;
 
 #[derive(Copy, Clone)]
-struct MinmaxSample<T> {
-    time: Instant,
-    value: T,
+struct MinmaxSample<I, V> {
+    time: I,
+    value: V,
 }
 
-pub struct Minmax<T> {
-    estimate: [MinmaxSample<T>; 3],
+pub struct Minmax<I, V> {
+    estimate: [MinmaxSample<I, V>; 3],
 }
 
-impl<T: PartialOrd + Copy> Minmax<T> {
-    pub fn new(val: T) -> Self {
+impl<D, I, V> Minmax<I, V>
+where
+    D: Copy + PartialEq + PartialOrd + Div<u32, Output = D>,
+    I: Copy + PartialEq + Sub<I, Output = D>,
+    V: Copy + PartialOrd,
+{
+    pub fn new(time: I, val: V) -> Self {
         Minmax {
-            estimate: [MinmaxSample {
-                time: Instant::now(),
-                value: val,
-            }; 3],
+            estimate: [MinmaxSample { time, value: val }; 3],
         }
     }
 
     /// Resets the estimates to the given value.
-    pub fn reset(&mut self, time: Instant, meas: T) -> T {
+    pub fn reset(&mut self, time: I, meas: V) -> V {
         let val = MinmaxSample { time, value: meas };
 
         for i in self.estimate.iter_mut() {
@@ -87,10 +89,10 @@ impl<T: PartialOrd + Copy> Minmax<T> {
     }
 
     /// Updates the min estimate based on the given measurement, and returns it.
-    pub fn running_min(&mut self, win: Duration, time: Instant, meas: T) -> T {
+    pub fn running_min(&mut self, win: D, time: I, meas: V) -> V {
         let val = MinmaxSample { time, value: meas };
 
-        let delta_time = time.duration_since(self.estimate[2].time);
+        let delta_time = time - self.estimate[2].time;
 
         // Reset if there's nothing in the window or a new min value is found.
         if val.value <= self.estimate[0].value || delta_time > win {
@@ -108,10 +110,10 @@ impl<T: PartialOrd + Copy> Minmax<T> {
     }
 
     /// Updates the max estimate based on the given measurement, and returns it.
-    pub fn _running_max(&mut self, win: Duration, time: Instant, meas: T) -> T {
+    pub fn running_max(&mut self, win: D, time: I, meas: V) -> V {
         let val = MinmaxSample { time, value: meas };
 
-        let delta_time = time.duration_since(self.estimate[2].time);
+        let delta_time = time - self.estimate[2].time;
 
         // Reset if there's nothing in the window or a new max value is found.
         if val.value >= self.estimate[0].value || delta_time > win {
@@ -129,10 +131,10 @@ impl<T: PartialOrd + Copy> Minmax<T> {
     }
 
     /// As time advances, update the 1st, 2nd and 3rd estimates.
-    fn subwin_update(&mut self, win: Duration, time: Instant, meas: T) -> T {
+    fn subwin_update(&mut self, win: D, time: I, meas: V) -> V {
         let val = MinmaxSample { time, value: meas };
 
-        let delta_time = time.duration_since(self.estimate[0].time);
+        let delta_time = time - self.estimate[0].time;
 
         if delta_time > win {
             // Passed entire window without a new val so make 2nd estimate the
@@ -143,20 +145,20 @@ impl<T: PartialOrd + Copy> Minmax<T> {
             self.estimate[1] = self.estimate[2];
             self.estimate[2] = val;
 
-            if time.duration_since(self.estimate[0].time) > win {
+            if time - self.estimate[0].time > win {
                 self.estimate[0] = self.estimate[1];
                 self.estimate[1] = self.estimate[2];
                 self.estimate[2] = val;
             }
         } else if self.estimate[1].time == self.estimate[0].time &&
-            delta_time > win.div_f32(4.0)
+            delta_time > win / 4
         {
             // We've passed a quarter of the window without a new val so take a
             // 2nd estimate from the 2nd quarter of the window.
             self.estimate[2] = val;
             self.estimate[1] = val;
         } else if self.estimate[2].time == self.estimate[1].time &&
-            delta_time > win.div_f32(2.0)
+            delta_time > win / 2
         {
             // We've passed half the window without finding a new val so take a
             // 3rd estimate from the last half of the window.
@@ -170,10 +172,12 @@ impl<T: PartialOrd + Copy> Minmax<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+    use std::time::Instant;
 
     #[test]
     fn reset_filter_rtt() {
-        let mut f = Minmax::new(Duration::new(0, 0));
+        let mut f = Minmax::new(Instant::now(), Duration::new(0, 0));
         let now = Instant::now();
         let rtt = Duration::from_millis(50);
 
@@ -192,7 +196,7 @@ mod tests {
 
     #[test]
     fn reset_filter_bandwidth() {
-        let mut f = Minmax::new(0);
+        let mut f = Minmax::new(Instant::now(), 0);
         let now = Instant::now();
         let bw = 2000;
 
@@ -211,7 +215,7 @@ mod tests {
 
     #[test]
     fn get_windowed_min_rtt() {
-        let mut f = Minmax::new(Duration::new(0, 0));
+        let mut f = Minmax::new(Instant::now(), Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let win = Duration::from_millis(500);
@@ -235,7 +239,7 @@ mod tests {
 
     #[test]
     fn get_windowed_min_bandwidth() {
-        let mut f = Minmax::new(0);
+        let mut f = Minmax::new(Instant::now(), 0);
         let bw_200 = 200;
         let bw_500 = 500;
         let win = Duration::from_millis(500);
@@ -259,7 +263,7 @@ mod tests {
 
     #[test]
     fn get_windowed_max_rtt() {
-        let mut f = Minmax::new(Duration::new(0, 0));
+        let mut f = Minmax::new(Instant::now(), Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let win = Duration::from_millis(500);
@@ -269,13 +273,13 @@ mod tests {
         assert_eq!(rtt_max, rtt_24);
 
         time += Duration::from_millis(250);
-        rtt_max = f._running_max(win, time, rtt_25);
+        rtt_max = f.running_max(win, time, rtt_25);
         assert_eq!(rtt_max, rtt_25);
         assert_eq!(f.estimate[1].value, rtt_25);
         assert_eq!(f.estimate[2].value, rtt_25);
 
         time += Duration::from_millis(600);
-        rtt_max = f._running_max(win, time, rtt_24);
+        rtt_max = f.running_max(win, time, rtt_24);
         assert_eq!(rtt_max, rtt_24);
         assert_eq!(f.estimate[1].value, rtt_24);
         assert_eq!(f.estimate[2].value, rtt_24);
@@ -283,7 +287,7 @@ mod tests {
 
     #[test]
     fn get_windowed_max_bandwidth() {
-        let mut f = Minmax::new(0);
+        let mut f = Minmax::new(Instant::now(), 0);
         let bw_200 = 200;
         let bw_500 = 500;
         let win = Duration::from_millis(500);
@@ -293,13 +297,13 @@ mod tests {
         assert_eq!(bw_max, bw_200);
 
         time += Duration::from_millis(5000);
-        bw_max = f._running_max(win, time, bw_500);
+        bw_max = f.running_max(win, time, bw_500);
         assert_eq!(bw_max, bw_500);
         assert_eq!(f.estimate[1].value, bw_500);
         assert_eq!(f.estimate[2].value, bw_500);
 
         time += Duration::from_millis(600);
-        bw_max = f._running_max(win, time, bw_200);
+        bw_max = f.running_max(win, time, bw_200);
         assert_eq!(bw_max, bw_200);
         assert_eq!(f.estimate[1].value, bw_200);
         assert_eq!(f.estimate[2].value, bw_200);
@@ -307,7 +311,7 @@ mod tests {
 
     #[test]
     fn get_windowed_min_estimates_rtt() {
-        let mut f = Minmax::new(Duration::new(0, 0));
+        let mut f = Minmax::new(Instant::now(), Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let rtt_23 = Duration::from_millis(23);
@@ -339,7 +343,7 @@ mod tests {
 
     #[test]
     fn get_windowed_min_estimates_bandwidth() {
-        let mut f = Minmax::new(0);
+        let mut f = Minmax::new(Instant::now(), 0);
         let bw_500 = 500;
         let bw_400 = 400;
         let bw_300 = 300;
@@ -371,7 +375,7 @@ mod tests {
 
     #[test]
     fn get_windowed_max_estimates_rtt() {
-        let mut f = Minmax::new(Duration::new(0, 0));
+        let mut f = Minmax::new(Instant::now(), Duration::new(0, 0));
         let rtt_25 = Duration::from_millis(25);
         let rtt_24 = Duration::from_millis(24);
         let rtt_23 = Duration::from_millis(23);
@@ -383,19 +387,19 @@ mod tests {
         assert_eq!(rtt_max, rtt_25);
 
         time += Duration::from_millis(300);
-        rtt_max = f._running_max(win, time, rtt_24);
+        rtt_max = f.running_max(win, time, rtt_24);
         assert_eq!(rtt_max, rtt_25);
         assert_eq!(f.estimate[1].value, rtt_24);
         assert_eq!(f.estimate[2].value, rtt_24);
 
         time += Duration::from_millis(300);
-        rtt_max = f._running_max(win, time, rtt_23);
+        rtt_max = f.running_max(win, time, rtt_23);
         assert_eq!(rtt_max, rtt_25);
         assert_eq!(f.estimate[1].value, rtt_24);
         assert_eq!(f.estimate[2].value, rtt_23);
 
         time += Duration::from_millis(300);
-        rtt_max = f._running_max(win, time, rtt_26);
+        rtt_max = f.running_max(win, time, rtt_26);
         assert_eq!(rtt_max, rtt_26);
         assert_eq!(f.estimate[1].value, rtt_26);
         assert_eq!(f.estimate[2].value, rtt_26);
@@ -403,7 +407,7 @@ mod tests {
 
     #[test]
     fn get_windowed_max_estimates_bandwidth() {
-        let mut f = Minmax::new(0);
+        let mut f = Minmax::new(Instant::now(), 0);
         let bw_500 = 500;
         let bw_400 = 400;
         let bw_300 = 300;
@@ -415,21 +419,45 @@ mod tests {
         assert_eq!(bw_max, bw_500);
 
         time += Duration::from_millis(300);
-        bw_max = f._running_max(win, time, bw_400);
+        bw_max = f.running_max(win, time, bw_400);
         assert_eq!(bw_max, bw_500);
         assert_eq!(f.estimate[1].value, bw_400);
         assert_eq!(f.estimate[2].value, bw_400);
 
         time += Duration::from_millis(300);
-        bw_max = f._running_max(win, time, bw_300);
+        bw_max = f.running_max(win, time, bw_300);
         assert_eq!(bw_max, bw_500);
         assert_eq!(f.estimate[1].value, bw_400);
         assert_eq!(f.estimate[2].value, bw_300);
 
         time += Duration::from_millis(300);
-        bw_max = f._running_max(win, time, bw_600);
+        bw_max = f.running_max(win, time, bw_600);
         assert_eq!(bw_max, bw_600);
         assert_eq!(f.estimate[1].value, bw_600);
         assert_eq!(f.estimate[2].value, bw_600);
+    }
+
+    #[test]
+    fn get_windowed_min_bandwidth_ints() {
+        let mut f = Minmax::new(0 as u32, 0);
+        let bw_200 = 200;
+        let bw_500 = 500;
+        let win = 2;
+        let mut time = 0;
+
+        let mut bw_min = f.reset(time, bw_500);
+        assert_eq!(bw_min, bw_500);
+
+        time += 1;
+        bw_min = f.running_min(win, time, bw_200);
+        assert_eq!(bw_min, bw_200);
+        assert_eq!(f.estimate[1].value, bw_200);
+        assert_eq!(f.estimate[2].value, bw_200);
+
+        time += 3;
+        bw_min = f.running_min(win, time, bw_500);
+        assert_eq!(bw_min, bw_500);
+        assert_eq!(f.estimate[1].value, bw_500);
+        assert_eq!(f.estimate[2].value, bw_500);
     }
 }

--- a/src/recovery/bbr.rs
+++ b/src/recovery/bbr.rs
@@ -1,0 +1,390 @@
+use crate::minmax::Minmax;
+use crate::packet;
+use crate::rand;
+use crate::recovery::Acked;
+use crate::recovery::CongestionControlOps;
+use crate::recovery::Recovery;
+use std::f64::consts::LN_2;
+use std::time::Duration;
+use std::time::Instant;
+
+const HIGH_GAIN: f64 = 2.0 / LN_2;
+const RTT_WINDOW: Duration = Duration::from_secs(10);
+const PROBE_RTT_TIME: Duration = Duration::from_millis(200);
+const BW_WINDOW: u32 = 10;
+const MIN_PIPE_CWND: usize = 4;
+const PROBE_GAINS: [f64; 8] = [1.25, 0.75, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0];
+
+pub static BBR: CongestionControlOps = CongestionControlOps {
+    on_packet_sent,
+    on_packet_acked,
+    congestion_event,
+    collapse_cwnd,
+    checkpoint,
+    rollback,
+    has_custom_pacing,
+};
+
+pub struct State {
+    mode: Mode,
+
+    // Bottleneck bandwidth
+    bw_filter: Minmax<u32, u64>,
+    bw_max: u64,
+
+    // Round counting
+    next_round_delivered: usize,
+    round_start: bool,
+    round_count: u32,
+
+    // RTT
+    rtt_min: Duration,
+    rtt_stamp: Instant,
+    rtt_expired: bool,
+    probe_rtt_done_stamp: Option<Instant>,
+    probe_rtt_round_done: bool,
+
+    // Pacing
+    pacing_rate: u64,
+    pacing_gain: f64,
+
+    // Filled pipe
+    filled_pipe: bool,
+    full_bw: u64,
+    full_bw_count: u64,
+
+    // Quantum
+    send_quantum: usize,
+
+    // CWND
+    target_cwnd: usize,
+    cwnd_gain: f64,
+
+    // BW Probing
+    probe_gain_idx: usize,
+    cycle_stamp: Instant,
+
+    // Idle restart
+    idle_restart: bool,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State {
+            bw_filter: Minmax::new(0, 0),
+            bw_max: 0,
+            mode: Mode::Startup,
+            next_round_delivered: 0,
+            round_start: false,
+            round_count: 0,
+            rtt_min: crate::recovery::INITIAL_RTT,
+            rtt_stamp: Instant::now(),
+            rtt_expired: false,
+            probe_rtt_done_stamp: None,
+            probe_rtt_round_done: false,
+            pacing_rate: 0,
+            pacing_gain: HIGH_GAIN,
+            filled_pipe: false,
+            full_bw: 0,
+            full_bw_count: 0,
+            send_quantum: 0,
+            target_cwnd: 0,
+            cwnd_gain: HIGH_GAIN,
+            probe_gain_idx: 0,
+            cycle_stamp: Instant::now(),
+            idle_restart: false,
+        }
+    }
+}
+
+#[derive(PartialEq)]
+enum Mode {
+    Startup,
+    Drain,
+    ProbeBw,
+    ProbeRtt,
+}
+
+pub fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
+    handle_restart_from_idle(r);
+    r.bytes_in_flight += sent_bytes;
+}
+
+fn on_packet_acked(
+    r: &mut Recovery, packet: &Acked, _epoch: packet::Epoch, now: Instant,
+) {
+    r.bytes_in_flight = r.bytes_in_flight.saturating_sub(packet.size);
+
+    update_bw(r, packet);
+    check_cycle_phase(r, packet, now);
+    check_full_pipe(r, packet);
+    check_drain(r);
+    update_rtt(r, now);
+    check_probe_rtt(r, now);
+
+    set_pacing_rate(r);
+    set_send_quantum(r);
+    set_cwnd(r, packet);
+}
+
+fn congestion_event(
+    _r: &mut Recovery, _time_sent: Instant, _epoch: packet::Epoch, _now: Instant,
+) {
+    // TODO: Implement loss recovery
+}
+
+pub fn collapse_cwnd(_r: &mut Recovery) {
+    // TODO: Implement loss recovery
+}
+
+fn has_custom_pacing() -> bool {
+    true
+}
+
+fn checkpoint(_r: &mut Recovery) {
+    // TODO: Implement loss recovery
+}
+
+fn rollback(_r: &mut Recovery) {
+    // TODO: Implement loss recovery
+}
+
+fn update_bw(r: &mut Recovery, packet: &Acked) {
+    update_round(r, packet);
+
+    let rate = r.delivery_rate();
+    if rate >= r.bbr_state.bw_max || !packet.is_app_limited {
+        r.bbr_state.bw_max = r.bbr_state.bw_filter.running_max(
+            BW_WINDOW,
+            r.bbr_state.round_count,
+            rate,
+        );
+    }
+}
+
+fn update_round(r: &mut Recovery, packet: &Acked) {
+    if packet.delivered >= r.bbr_state.next_round_delivered {
+        r.bbr_state.next_round_delivered = r.bytes_acked;
+        r.bbr_state.round_count += 1;
+        r.bbr_state.round_start = true;
+    } else {
+        r.bbr_state.round_start = false;
+    }
+}
+
+fn update_rtt(r: &mut Recovery, now: Instant) {
+    r.bbr_state.rtt_expired = now > r.bbr_state.rtt_stamp + RTT_WINDOW;
+
+    if r.latest_rtt <= r.bbr_state.rtt_min || r.bbr_state.rtt_expired {
+        r.bbr_state.rtt_min = r.latest_rtt;
+        r.bbr_state.rtt_stamp = now;
+    }
+}
+
+fn set_pacing_rate(r: &mut Recovery) {
+    set_pacing_rate_gain(r, r.bbr_state.pacing_gain);
+}
+
+fn set_pacing_rate_gain(r: &mut Recovery, gain: f64) {
+    let rate = (gain * r.bbr_state.bw_max as f64) as u64;
+
+    if r.bbr_state.filled_pipe || rate > r.bbr_state.pacing_rate {
+        r.bbr_state.pacing_rate = rate;
+        r.pacing_rate = rate;
+    }
+}
+
+fn set_send_quantum(r: &mut Recovery) {
+    const LOW_THRESH: u64 = 157286; // 1.2 Mbps in MBps
+    const HIGH_THRESH: u64 = 3145728; // 24 Mbps in MBps
+    const HIGH_QUANTUM: usize = 65536; // 64KB
+
+    r.bbr_state.send_quantum = if r.bbr_state.pacing_rate < LOW_THRESH {
+        r.max_datagram_size()
+    } else if r.bbr_state.pacing_rate < HIGH_THRESH {
+        2 * r.max_datagram_size()
+    } else {
+        std::cmp::min((r.bbr_state.pacing_rate / 1000) as usize, HIGH_QUANTUM)
+    };
+}
+
+fn inflight(r: &Recovery, gain: f64) -> usize {
+    let quanta = 3 * r.bbr_state.send_quantum;
+    let estimated_bdp =
+        r.bbr_state.bw_max as f64 * r.bbr_state.rtt_min.as_secs_f64();
+    (gain * estimated_bdp) as usize + quanta
+}
+
+fn update_target_cwnd(r: &mut Recovery) {
+    r.bbr_state.target_cwnd = inflight(r, r.bbr_state.cwnd_gain);
+}
+
+fn modulate_cwnd_for_probe_rtt(r: &mut Recovery) {
+    if r.bbr_state.mode == Mode::ProbeRtt {
+        r.congestion_window = std::cmp::min(
+            r.congestion_window,
+            MIN_PIPE_CWND * r.max_datagram_size(),
+        );
+    }
+}
+
+fn set_cwnd(r: &mut Recovery, packet: &Acked) {
+    update_target_cwnd(r);
+    // TODO: modulate_cwnd_for_recovery();
+
+    // if not packet conservation
+    if r.bbr_state.filled_pipe {
+        r.congestion_window = std::cmp::min(
+            r.congestion_window + packet.size,
+            r.bbr_state.target_cwnd,
+        );
+    } else if r.congestion_window < r.bbr_state.target_cwnd ||
+        r.bytes_acked < MIN_PIPE_CWND * r.max_datagram_size()
+    {
+        r.congestion_window += packet.size;
+    }
+
+    r.congestion_window =
+        std::cmp::max(r.congestion_window, MIN_PIPE_CWND * r.max_datagram_size());
+
+    modulate_cwnd_for_probe_rtt(r);
+}
+
+fn check_full_pipe(r: &mut Recovery, packet: &Acked) {
+    if r.bbr_state.filled_pipe ||
+        !r.bbr_state.round_start ||
+        packet.is_app_limited
+    {
+        return;
+    }
+
+    // Check if BW still growing by more than 25%
+    if r.bbr_state.bw_max >= (r.bbr_state.full_bw * 5) / 4 {
+        r.bbr_state.full_bw = r.bbr_state.bw_max;
+        r.bbr_state.full_bw_count = 0;
+        return;
+    }
+
+    r.bbr_state.full_bw_count += 1;
+
+    if r.bbr_state.full_bw_count >= 3 {
+        r.bbr_state.filled_pipe = true;
+    }
+}
+
+fn enter_startup(r: &mut Recovery) {
+    r.bbr_state.mode = Mode::Startup;
+    r.bbr_state.pacing_gain = HIGH_GAIN;
+    r.bbr_state.cwnd_gain = HIGH_GAIN;
+}
+
+fn enter_drain(r: &mut Recovery) {
+    r.bbr_state.mode = Mode::Drain;
+    r.bbr_state.pacing_gain = 1.0 / HIGH_GAIN;
+    r.bbr_state.cwnd_gain = HIGH_GAIN;
+}
+
+fn check_drain(r: &mut Recovery) {
+    if r.bbr_state.mode == Mode::Startup && r.bbr_state.filled_pipe {
+        enter_drain(r);
+    }
+
+    if r.bbr_state.mode == Mode::Drain && r.bytes_in_flight <= inflight(r, 1.0) {
+        enter_probe_bw(r);
+    }
+}
+
+fn enter_probe_bw(r: &mut Recovery) {
+    r.bbr_state.mode = Mode::ProbeBw;
+    r.bbr_state.pacing_gain = 1.0;
+    r.bbr_state.cwnd_gain = 2.0;
+    r.bbr_state.probe_gain_idx =
+        PROBE_GAINS.len() - 1 - rand::rand_u64_uniform(7) as usize;
+}
+
+fn check_cycle_phase(r: &mut Recovery, packet: &Acked, now: Instant) {
+    if r.bbr_state.mode == Mode::ProbeBw && is_next_cycle_phase(r, packet, now) {
+        advance_cycle_phase(r, now);
+    }
+}
+
+fn is_next_cycle_phase(r: &mut Recovery, packet: &Acked, now: Instant) -> bool {
+    let is_full_length = now - r.bbr_state.cycle_stamp > r.bbr_state.rtt_min;
+    let prior_inflight = r.bytes_in_flight + packet.size;
+
+    if r.bbr_state.pacing_gain == 1.0 {
+        is_full_length
+    } else if r.bbr_state.pacing_gain > 1.0 {
+        // TODO: Account for packets_lost
+        is_full_length && prior_inflight >= inflight(r, r.bbr_state.pacing_gain)
+    } else {
+        is_full_length || prior_inflight <= inflight(r, 1.0)
+    }
+}
+
+fn advance_cycle_phase(r: &mut Recovery, now: Instant) {
+    r.bbr_state.cycle_stamp = now;
+    r.bbr_state.probe_gain_idx =
+        (r.bbr_state.probe_gain_idx + 1) % PROBE_GAINS.len();
+    r.bbr_state.pacing_gain = PROBE_GAINS[r.bbr_state.probe_gain_idx];
+}
+
+fn handle_restart_from_idle(r: &mut Recovery) {
+    if r.bytes_in_flight == 0 && r.app_limited() {
+        r.bbr_state.idle_restart = true;
+        if r.bbr_state.mode == Mode::ProbeBw {
+            set_pacing_rate_gain(r, 1.0);
+        }
+    }
+}
+
+fn check_probe_rtt(r: &mut Recovery, now: Instant) {
+    if r.bbr_state.mode != Mode::ProbeRtt &&
+        r.bbr_state.rtt_expired &&
+        !r.bbr_state.idle_restart
+    {
+        enter_probe_rtt(r);
+        checkpoint(r);
+        r.bbr_state.probe_rtt_done_stamp = None;
+    }
+
+    if r.bbr_state.mode == Mode::ProbeRtt {
+        handle_probe_rtt(r, now);
+    }
+
+    r.bbr_state.idle_restart = false;
+}
+
+fn enter_probe_rtt(r: &mut Recovery) {
+    r.bbr_state.mode = Mode::ProbeRtt;
+    r.bbr_state.pacing_gain = 1.0;
+    r.bbr_state.cwnd_gain = 1.0;
+}
+
+fn handle_probe_rtt(r: &mut Recovery, now: Instant) {
+    if r.bbr_state.probe_rtt_done_stamp.is_none() &&
+        r.bytes_in_flight <= MIN_PIPE_CWND * r.max_datagram_size()
+    {
+        r.bbr_state.probe_rtt_done_stamp = Some(now + PROBE_RTT_TIME);
+        r.bbr_state.probe_rtt_round_done = false;
+        r.bbr_state.next_round_delivered = r.bytes_acked;
+    } else if let Some(probe_rtt_done_stamp) = r.bbr_state.probe_rtt_done_stamp {
+        if r.bbr_state.round_start {
+            r.bbr_state.probe_rtt_round_done = true;
+        }
+
+        if r.bbr_state.probe_rtt_round_done && now > probe_rtt_done_stamp {
+            r.bbr_state.rtt_stamp = now;
+            rollback(r);
+            exit_probe_rtt(r);
+        }
+    }
+}
+
+fn exit_probe_rtt(r: &mut Recovery) {
+    if r.bbr_state.filled_pipe {
+        enter_probe_bw(r);
+    } else {
+        enter_startup(r);
+    }
+}

--- a/src/recovery/bbr.rs
+++ b/src/recovery/bbr.rs
@@ -488,7 +488,9 @@ fn update_round(r: &mut Recovery, packet: &Acked) {
         r.bbr_state.round_start = false;
     }
 
-    if packet.delivered >= r.bbr_state.end_conservation {
+    if packet.delivered >= r.bbr_state.end_conservation &&
+        r.bbr_state.conservation != PacketConservation::Normal
+    {
         // It's been one RTT since the last loss, assume its been repaired
         r.bbr_state.conservation = PacketConservation::Normal;
         restore_cwnd(r);

--- a/src/recovery/bbr.rs
+++ b/src/recovery/bbr.rs
@@ -163,7 +163,7 @@ fn congestion_event(
     if lost_bytes > 0 {
         r.bbr_state.end_conservation = r.bytes_acked;
 
-        if r.bbr_state.conservation == PacketConservation::Normal {
+        if r.bbr_state.conservation == PacketConservation::Normal && r.bbr_state.filled_pipe {
             save_cwnd(r);
             r.bbr_state.conservation = PacketConservation::Conservation;
             r.congestion_window = r.bytes_in_flight + lost_bytes;

--- a/src/recovery/bbr.rs
+++ b/src/recovery/bbr.rs
@@ -58,6 +58,7 @@ pub struct State {
 
     // CWND
     target_cwnd: usize,
+    saved_cwnd: usize,
     cwnd_gain: f64,
 
     // BW Probing
@@ -66,6 +67,15 @@ pub struct State {
 
     // Idle restart
     idle_restart: bool,
+
+    // Loss tracking
+    bytes_lost: usize,
+    bytes_last_lost: usize,
+    bytes_newly_lost: usize,
+
+    // Packet conservation
+    conservation: PacketConservation,
+    end_conservation: usize,
 }
 
 impl Default for State {
@@ -89,10 +99,16 @@ impl Default for State {
             full_bw_count: 0,
             send_quantum: 0,
             target_cwnd: 0,
+            saved_cwnd: 0,
             cwnd_gain: HIGH_GAIN,
             probe_gain_idx: 0,
             cycle_stamp: Instant::now(),
             idle_restart: false,
+            bytes_lost: 0,
+            bytes_last_lost: 0,
+            bytes_newly_lost: 0,
+            conservation: PacketConservation::Normal,
+            end_conservation: 0,
         }
     }
 }
@@ -105,6 +121,13 @@ enum Mode {
     ProbeRtt,
 }
 
+#[derive(PartialEq)]
+enum PacketConservation {
+    Conservation,
+    Growth,
+    Normal,
+}
+
 pub fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
     handle_restart_from_idle(r);
     r.bytes_in_flight += sent_bytes;
@@ -114,6 +137,10 @@ fn on_packet_acked(
     r: &mut Recovery, packet: &Acked, _epoch: packet::Epoch, now: Instant,
 ) {
     r.bytes_in_flight = r.bytes_in_flight.saturating_sub(packet.size);
+
+    r.bbr_state.bytes_newly_lost =
+        r.bbr_state.bytes_lost - r.bbr_state.bytes_last_lost;
+    r.bbr_state.bytes_last_lost = r.bbr_state.bytes_lost;
 
     update_bw(r, packet);
     check_cycle_phase(r, packet, now);
@@ -128,9 +155,21 @@ fn on_packet_acked(
 }
 
 fn congestion_event(
-    _r: &mut Recovery, _time_sent: Instant, _epoch: packet::Epoch, _now: Instant,
+    r: &mut Recovery, lost_bytes: usize, _time_sent: Instant,
+    _epoch: packet::Epoch, _now: Instant,
 ) {
-    // TODO: Implement loss recovery
+    r.bbr_state.bytes_lost += lost_bytes;
+
+    if lost_bytes > 0 {
+        r.bbr_state.end_conservation = r.bytes_acked;
+
+        if r.bbr_state.conservation == PacketConservation::Normal {
+            save_cwnd(r);
+            r.bbr_state.conservation = PacketConservation::Conservation;
+            r.congestion_window = r.bytes_in_flight + lost_bytes;
+            r.bbr_state.next_round_delivered = r.bytes_acked;
+        }
+    }
 }
 
 pub fn collapse_cwnd(_r: &mut Recovery) {
@@ -145,8 +184,24 @@ fn checkpoint(_r: &mut Recovery) {
     // TODO: Implement loss recovery
 }
 
+fn save_cwnd(r: &mut Recovery) {
+    r.bbr_state.saved_cwnd = if r.bbr_state.conservation ==
+        PacketConservation::Normal &&
+        r.bbr_state.mode != Mode::ProbeRtt
+    {
+        r.congestion_window
+    } else {
+        std::cmp::max(r.bbr_state.saved_cwnd, r.congestion_window)
+    }
+}
+
 fn rollback(_r: &mut Recovery) {
     // TODO: Implement loss recovery
+}
+
+fn restore_cwnd(r: &mut Recovery) {
+    r.congestion_window =
+        std::cmp::max(r.congestion_window, r.bbr_state.saved_cwnd);
 }
 
 fn update_bw(r: &mut Recovery, packet: &Acked) {
@@ -167,8 +222,17 @@ fn update_round(r: &mut Recovery, packet: &Acked) {
         r.bbr_state.next_round_delivered = r.bytes_acked;
         r.bbr_state.round_count += 1;
         r.bbr_state.round_start = true;
+
+        if r.bbr_state.conservation == PacketConservation::Conservation {
+            r.bbr_state.conservation = PacketConservation::Growth;
+        }
     } else {
         r.bbr_state.round_start = false;
+    }
+
+    if packet.delivered >= r.bbr_state.end_conservation {
+        r.bbr_state.conservation = PacketConservation::Normal;
+        restore_cwnd(r);
     }
 }
 
@@ -228,24 +292,39 @@ fn modulate_cwnd_for_probe_rtt(r: &mut Recovery) {
     }
 }
 
+fn modulate_cwnd_for_recovery(r: &mut Recovery) {
+    if r.bbr_state.bytes_newly_lost > 0 {
+        r.congestion_window = std::cmp::max(
+            r.congestion_window - r.bbr_state.bytes_newly_lost,
+            MIN_PIPE_CWND * r.max_datagram_size(),
+        );
+    }
+}
+
 fn set_cwnd(r: &mut Recovery, packet: &Acked) {
     update_target_cwnd(r);
-    // TODO: modulate_cwnd_for_recovery();
 
-    // if not packet conservation
-    if r.bbr_state.filled_pipe {
-        r.congestion_window = std::cmp::min(
-            r.congestion_window + packet.size,
-            r.bbr_state.target_cwnd,
-        );
-    } else if r.congestion_window < r.bbr_state.target_cwnd ||
-        r.bytes_acked < MIN_PIPE_CWND * r.max_datagram_size()
-    {
-        r.congestion_window += packet.size;
+    if r.bbr_state.conservation != PacketConservation::Normal {
+        modulate_cwnd_for_recovery(r);
     }
 
-    r.congestion_window =
-        std::cmp::max(r.congestion_window, MIN_PIPE_CWND * r.max_datagram_size());
+    if r.bbr_state.conservation != PacketConservation::Conservation {
+        if r.bbr_state.filled_pipe {
+            r.congestion_window = std::cmp::min(
+                r.congestion_window + packet.size,
+                r.bbr_state.target_cwnd,
+            );
+        } else if r.congestion_window < r.bbr_state.target_cwnd ||
+            r.bytes_acked < MIN_PIPE_CWND * r.max_datagram_size()
+        {
+            r.congestion_window += packet.size;
+        }
+
+        r.congestion_window = std::cmp::max(
+            r.congestion_window,
+            MIN_PIPE_CWND * r.max_datagram_size(),
+        );
+    }
 
     modulate_cwnd_for_probe_rtt(r);
 }
@@ -315,8 +394,9 @@ fn is_next_cycle_phase(r: &mut Recovery, packet: &Acked, now: Instant) -> bool {
     if r.bbr_state.pacing_gain == 1.0 {
         is_full_length
     } else if r.bbr_state.pacing_gain > 1.0 {
-        // TODO: Account for packets_lost
-        is_full_length && prior_inflight >= inflight(r, r.bbr_state.pacing_gain)
+        is_full_length &&
+            (r.bbr_state.bytes_newly_lost > 0 ||
+                prior_inflight >= inflight(r, r.bbr_state.pacing_gain))
     } else {
         is_full_length || prior_inflight <= inflight(r, 1.0)
     }
@@ -344,7 +424,7 @@ fn check_probe_rtt(r: &mut Recovery, now: Instant) {
         !r.bbr_state.idle_restart
     {
         enter_probe_rtt(r);
-        checkpoint(r);
+        save_cwnd(r);
         r.bbr_state.probe_rtt_done_stamp = None;
     }
 
@@ -375,7 +455,7 @@ fn handle_probe_rtt(r: &mut Recovery, now: Instant) {
 
         if r.bbr_state.probe_rtt_round_done && now > probe_rtt_done_stamp {
             r.bbr_state.rtt_stamp = now;
-            rollback(r);
+            restore_cwnd(r);
             exit_probe_rtt(r);
         }
     }

--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -331,7 +331,8 @@ fn on_packet_acked(
 }
 
 fn congestion_event(
-    r: &mut Recovery, time_sent: Instant, epoch: packet::Epoch, now: Instant,
+    r: &mut Recovery, _bytes_lost: usize, time_sent: Instant,
+    epoch: packet::Epoch, now: Instant,
 ) {
     let in_congestion_recovery = r.in_congestion_recovery(time_sent);
 

--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -459,6 +459,8 @@ mod tests {
             pkt_num: p.pkt_num,
             time_sent: p.time_sent,
             size: p.size,
+            delivered: p.delivered,
+            is_app_limited: p.is_app_limited,
         }];
 
         r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
@@ -503,16 +505,22 @@ mod tests {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: p.delivered,
+                is_app_limited: p.is_app_limited,
             },
             Acked {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: p.delivered,
+                is_app_limited: p.is_app_limited,
             },
             Acked {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: p.delivered,
+                is_app_limited: p.is_app_limited,
             },
         ];
 
@@ -531,7 +539,7 @@ mod tests {
         let now = Instant::now();
         let prev_cwnd = r.cwnd();
 
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(32, now, packet::EPOCH_APPLICATION, now);
 
         // In CUBIC, after congestion event, cwnd will be reduced by (1 -
         // CUBIC_BETA)
@@ -553,7 +561,7 @@ mod tests {
         }
 
         // Trigger congestion event to update ssthresh
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(32, now, packet::EPOCH_APPLICATION, now);
 
         // After congestion event, cwnd will be reduced.
         let cur_cwnd = (prev_cwnd as f64 * BETA_CUBIC) as usize;
@@ -577,6 +585,8 @@ mod tests {
                 pkt_num: 0,
                 time_sent: now,
                 size: r.max_datagram_size,
+                delivered: 0,
+                is_app_limited: false,
             }];
 
             r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
@@ -598,7 +608,7 @@ mod tests {
         r.on_packet_sent_cc(30000, now);
 
         // Trigger congestion event to update ssthresh
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(32, now, packet::EPOCH_APPLICATION, now);
 
         // After persistent congestion, cwnd should be the minimum window
         r.collapse_cwnd();
@@ -612,6 +622,8 @@ mod tests {
             // To exit from recovery
             time_sent: now + Duration::from_millis(1),
             size: r.max_datagram_size,
+            delivered: 0,
+            is_app_limited: false,
         }];
 
         r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
@@ -675,6 +687,8 @@ mod tests {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: p.delivered,
+                is_app_limited: p.is_app_limited,
             }];
 
             r.on_packets_acked(acked, epoch, now);
@@ -710,6 +724,8 @@ mod tests {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: p.delivered,
+                is_app_limited: p.is_app_limited,
             }];
 
             r.on_packets_acked(acked, epoch, now);
@@ -732,6 +748,8 @@ mod tests {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: p.delivered,
+                is_app_limited: p.is_app_limited,
             }];
             r.on_packets_acked(acked, epoch, now);
         }
@@ -755,7 +773,7 @@ mod tests {
         }
 
         // Trigger congestion event to update ssthresh
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(32, now, packet::EPOCH_APPLICATION, now);
 
         // After congestion event, cwnd will be reduced.
         let cur_cwnd = (prev_cwnd as f64 * BETA_CUBIC) as usize;
@@ -768,6 +786,8 @@ mod tests {
             // To exit from recovery
             time_sent: now + rtt,
             size: r.max_datagram_size,
+            delivered: 0,
+            is_app_limited: false,
         }];
 
         // Ack more than cwnd bytes with rtt=100ms
@@ -799,7 +819,7 @@ mod tests {
         }
 
         // Trigger congestion event to update ssthresh
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(32, now, packet::EPOCH_APPLICATION, now);
 
         // After 1st congestion event, cwnd will be reduced.
         let cur_cwnd = (prev_cwnd as f64 * BETA_CUBIC) as usize;
@@ -822,6 +842,8 @@ mod tests {
                 pkt_num: 0,
                 time_sent: now,
                 size: r.max_datagram_size,
+                delivered: 0,
+                is_app_limited: false,
             }];
 
             r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
@@ -835,7 +857,7 @@ mod tests {
         // Fast convergence: now there is 2nd congestion event and
         // cwnd is not fully recovered to w_max, w_max will be
         // further reduced.
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(32, now, packet::EPOCH_APPLICATION, now);
 
         // After 2nd congestion event, cwnd will be reduced.
         let cur_cwnd = (prev_cwnd as f64 * BETA_CUBIC) as usize;

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -822,7 +822,7 @@ impl Recovery {
     ) {
         self.bytes_in_flight = self.bytes_in_flight.saturating_sub(lost_bytes);
 
-        self.congestion_event(largest_lost_pkt.time_sent, epoch, now);
+        self.congestion_event(lost_bytes, largest_lost_pkt.time_sent, epoch, now);
 
         if self.in_persistent_congestion(largest_lost_pkt.pkt_num) {
             self.collapse_cwnd();
@@ -830,13 +830,14 @@ impl Recovery {
     }
 
     fn congestion_event(
-        &mut self, time_sent: Instant, epoch: packet::Epoch, now: Instant,
+        &mut self, lost_bytes: usize, time_sent: Instant, epoch: packet::Epoch,
+        now: Instant,
     ) {
         if !self.in_congestion_recovery(time_sent) {
             (self.cc_ops.checkpoint)(self);
         }
 
-        (self.cc_ops.congestion_event)(self, time_sent, epoch, now);
+        (self.cc_ops.congestion_event)(self, lost_bytes, time_sent, epoch, now);
     }
 
     fn collapse_cwnd(&mut self) {
@@ -917,6 +918,7 @@ pub struct CongestionControlOps {
 
     pub congestion_event: fn(
         r: &mut Recovery,
+        lost_bytes: usize,
         time_sent: Instant,
         epoch: packet::Epoch,
         now: Instant,

--- a/src/recovery/reno.rs
+++ b/src/recovery/reno.rs
@@ -225,6 +225,8 @@ mod tests {
             pkt_num: p.pkt_num,
             time_sent: p.time_sent,
             size: p.size,
+            delivered: p.delivered,
+            is_app_limited: p.is_app_limited,
         }];
 
         r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
@@ -270,16 +272,22 @@ mod tests {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: p.delivered,
+                is_app_limited: p.is_app_limited,
             },
             Acked {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: p.delivered,
+                is_app_limited: p.is_app_limited,
             },
             Acked {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: p.delivered,
+                is_app_limited: p.is_app_limited,
             },
         ];
 
@@ -300,7 +308,7 @@ mod tests {
 
         let now = Instant::now();
 
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(32, now, packet::EPOCH_APPLICATION, now);
 
         // In Reno, after congestion event, cwnd will be cut in half.
         assert_eq!(prev_cwnd / 2, r.cwnd());
@@ -319,7 +327,7 @@ mod tests {
         r.on_packet_sent_cc(20000, now);
 
         // Trigger congestion event to update ssthresh
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(32, now, packet::EPOCH_APPLICATION, now);
 
         // After congestion event, cwnd will be reduced.
         let cur_cwnd =
@@ -334,6 +342,8 @@ mod tests {
             time_sent: now + rtt,
             // More than cur_cwnd to increase cwnd
             size: 8000,
+            delivered: 0,
+            is_app_limited: false,
         }];
 
         // Ack more than cwnd bytes with rtt=100ms

--- a/src/recovery/reno.rs
+++ b/src/recovery/reno.rs
@@ -116,7 +116,8 @@ fn on_packet_acked(
 }
 
 fn congestion_event(
-    r: &mut Recovery, time_sent: Instant, epoch: packet::Epoch, now: Instant,
+    r: &mut Recovery, _bytes_lost: usize, time_sent: Instant,
+    epoch: packet::Epoch, now: Instant,
 ) {
     // Start a new congestion event if packet was sent after the
     // start of the previous congestion recovery period.


### PR DESCRIPTION
I've recently been working on a version of BBR for quiche for a research project. It's broadly based on information found in the [draft BBR RFC](https://datatracker.ietf.org/doc/html/draft-cardwell-iccrg-bbr-congestion-control), the [Linux kernel implementation](https://github.com/torvalds/linux/blob/master/net/ipv4/tcp_bbr.c), and [Google's implementation in their (similarly named) QUIC library](https://source.chromium.org/chromium/chromium/src/+/master:net/third_party/quiche/src/quic/core/congestion_control/bbr_sender.cc).

This version of BBR implements the core BBR algorithm, the packet conservation loss handling mechanism, and the long-term sampling functionality which so far has only been implemented in the Linux kernel implementation and isn't detailed in the RFC or the QUIC implementation. I've had to make a number of adaptations to the algorithm to get it to work in quiche and there's still some features missing:

- No ack aggregation handling.
- Packet conservation adapted since we're not using the TCP state machine anymore, adapted from how Google handles this.
- Under constant packet loss (1%) bitrate seems to collapse. May be a delivery rate estimation issue but needs investigating.
- No unit testing

I'm submitting this draft now to see if you'd be receptive to getting BBR merged in and what changes you'd want to see here before starting code review. As part of my research, I've done a bit of evaluation and I've seen typical BBR behaviour where the throughput is higher than what CUBIC usually gets you but it incurs higher packet loss rates.

Closes #514 