### PR TITLE
cubic: fix cwnd growth during congestion avoidance

### DIFF
--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -323,12 +323,9 @@ fn on_packet_acked(
         // Update the increment and increase cwnd by MSS.
         r.cubic_state.cwnd_inc += cubic_cwnd - r.congestion_window;
 
-        // cwnd_inc can be more than 1 MSS in the late stage of max probing.
-        // however QUIC recovery draft 7.4 (Congestion Avoidance) limits
-        // the increase of cwnd to 1 max_datagram_size per cwnd acknowledged.
         if r.cubic_state.cwnd_inc >= r.max_datagram_size {
             r.congestion_window += r.max_datagram_size;
-            r.cubic_state.cwnd_inc = 0;
+            r.cubic_state.cwnd_inc -= r.max_datagram_size;
         }
     }
 }


### PR DESCRIPTION
cwnd_inc is used for storing cwnd increments during congestion
avoidance. When cwnd_inc >= MSS we increase cwnd by 1 MSS.
Currently we clear cwnd_inc when cwnd is updated but this will
lead to slightly slower growth because the residual part is gone.