### PR TITLE
properly handle incoming RESET_STREAM frames

### DIFF
--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -278,6 +278,14 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                     }
                     break;
 
+                case QUICHE_H3_EVENT_RESET:
+                    fprintf(stderr, "request was reset\n");
+
+                    if (quiche_conn_close(conn_io->conn, true, 0, NULL, 0) < 0) {
+                        fprintf(stderr, "failed to close connection\n");
+                    }
+                    break;
+
                 case QUICHE_H3_EVENT_DATAGRAM:
                     break;
 

--- a/examples/http3-client.rs
+++ b/examples/http3-client.rs
@@ -266,6 +266,15 @@ fn main() {
                         conn.close(true, 0x00, b"kthxbye").unwrap();
                     },
 
+                    Ok((_stream_id, quiche::h3::Event::Reset(e))) => {
+                        error!(
+                            "request was reset by peer with {}, closing...",
+                            e
+                        );
+
+                        conn.close(true, 0x00, b"kthxbye").unwrap();
+                    },
+
                     Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
 
                     Ok((goaway_id, quiche::h3::Event::GoAway)) => {

--- a/examples/http3-server.c
+++ b/examples/http3-server.c
@@ -442,6 +442,9 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                     case QUICHE_H3_EVENT_FINISHED:
                         break;
 
+                    case QUICHE_H3_EVENT_RESET:
+                        break;
+
                     case QUICHE_H3_EVENT_DATAGRAM:
                         break;
 

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -360,6 +360,8 @@ fn main() {
 
                         Ok((_stream_id, quiche::h3::Event::Finished)) => (),
 
+                        Ok((_stream_id, quiche::h3::Event::Reset { .. })) => (),
+
                         Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
 
                         Ok((_goaway_id, quiche::h3::Event::GoAway)) => (),

--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -1,4 +1,4 @@
-From 3f07343d97a8efacc90880d9d42d79c522e4ba34 Mon Sep 17 00:00:00 2001
+From ddf9ebdb4460bb059b50ef6d7147e7553853f944 Mon Sep 17 00:00:00 2001
 From: Alessandro Ghedini <alessandro@cloudflare.com>
 Date: Thu, 22 Oct 2020 12:28:02 +0100
 Subject: [PATCH] Initial QUIC and HTTP/3 implementation using quiche
@@ -26,13 +26,13 @@ Subject: [PATCH] Initial QUIC and HTTP/3 implementation using quiche
  src/http/ngx_http_request.h             |    3 +
  src/http/ngx_http_request_body.c        |   33 +
  src/http/ngx_http_upstream.c            |   13 +
- src/http/v3/ngx_http_v3.c               | 2191 +++++++++++++++++++++++
+ src/http/v3/ngx_http_v3.c               | 2221 +++++++++++++++++++++++
  src/http/v3/ngx_http_v3.h               |   79 +
  src/http/v3/ngx_http_v3_filter_module.c |   68 +
  src/http/v3/ngx_http_v3_module.c        |  286 +++
  src/http/v3/ngx_http_v3_module.h        |   34 +
  src/os/unix/ngx_udp_sendmsg_chain.c     |    1 +
- 28 files changed, 3704 insertions(+), 11 deletions(-)
+ 28 files changed, 3734 insertions(+), 11 deletions(-)
  create mode 100644 auto/lib/quiche/conf
  create mode 100644 auto/lib/quiche/make
  create mode 100644 src/event/ngx_event_quic.c
@@ -1608,10 +1608,10 @@ index a7391d09a..398af2797 100644
      if (ngx_event_flags & NGX_USE_KQUEUE_EVENT) {
 diff --git a/src/http/v3/ngx_http_v3.c b/src/http/v3/ngx_http_v3.c
 new file mode 100644
-index 000000000..2e536f3ff
+index 000000000..fd0bcfb9c
 --- /dev/null
 +++ b/src/http/v3/ngx_http_v3.c
-@@ -0,0 +1,2191 @@
+@@ -0,0 +1,2221 @@
 +
 +/*
 + * Copyright (C) Cloudflare, Inc.
@@ -1968,6 +1968,8 @@ index 000000000..2e536f3ff
 +ngx_http_v3_handler(ngx_connection_t *c)
 +{
 +    ngx_chain_t                out;
++    ngx_connection_t          *fc;
++    ngx_http_request_t        *r;
 +    ngx_http_v3_connection_t  *h3c;
 +    ngx_http_v3_stream_t      *stream;
 +
@@ -2048,6 +2050,29 @@ index 000000000..2e536f3ff
 +
 +                    stream->in_closed = 1;
 +                }
++
++                break;
++            }
++
++            case QUICHE_H3_EVENT_RESET: {
++                /* Lookup stream. If there isn't one, it means it has already
++                 * been closed, so ignore the event. */
++                stream = ngx_http_v3_stream_lookup(h3c, stream_id);
++
++                if (stream != NULL && !stream->in_closed) {
++                    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
++                                   "http3 reset");
++
++                    r = stream->request;
++                    fc = r->connection;
++
++                    fc->error = 1;
++
++                    ngx_post_event(stream->request->connection->read,
++                                   &ngx_posted_events);
++                }
++
++                stream->in_closed = 1;
 +
 +                break;
 +            }
@@ -3490,12 +3515,20 @@ index 000000000..2e536f3ff
 +    r = c->data;
 +    h3c = r->qstream->connection;
 +
++    if (c->error) {
++        rev->ready = 0;
++
++        return NGX_ERROR;
++    }
++
 +    n = quiche_h3_recv_body(h3c->h3, c->quic->conn, r->qstream->id, buf, size);
 +
 +    ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0,
 +                   "http3 body recv: %z of %uz", n, size);
 +
 +    if (quiche_conn_stream_finished(c->quic->conn, r->qstream->id)) {
++        rev->ready = 0;
++
 +        /* Re-schedule connection read event to poll for Finished event. */
 +        ngx_post_event(h3c->connection->read, &ngx_posted_events);
 +    }
@@ -3522,15 +3555,12 @@ index 000000000..2e536f3ff
 +        n = NGX_AGAIN;
 +
 +    } else {
-+        /* n = ngx_connection_error(c, err, "recv() failed"); */
++        rev->error = 1;
++
 +        n = NGX_ERROR;
 +    }
 +
 +    rev->ready = 0;
-+
-+    if (n == NGX_ERROR) {
-+        rev->error = 1;
-+    }
 +
 +    return n;
 +}
@@ -4307,5 +4337,5 @@ index 5399c7916..9b03ca536 100644
                             "sendmsg() not ready");
              return NGX_AGAIN;
 -- 
-2.31.1
+2.32.0.rc2
 

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -97,6 +97,9 @@ enum quiche_error {
     // The specified stream was stopped by the peer.
     QUICHE_ERR_STREAM_STOPPED = -15,
 
+    // The specified stream was reset by the peer.
+    QUICHE_ERR_STREAM_RESET = -16,
+
     // The received data exceeds the stream's final size.
     QUICHE_ERR_FINAL_SIZE = -13,
 
@@ -573,6 +576,7 @@ enum quiche_h3_event_type {
     QUICHE_H3_EVENT_FINISHED,
     QUICHE_H3_EVENT_DATAGRAM,
     QUICHE_H3_EVENT_GOAWAY,
+    QUICHE_H3_EVENT_RESET,
 };
 
 typedef struct Http3Event quiche_h3_event;

--- a/src/h3/ffi.rs
+++ b/src/h3/ffi.rs
@@ -114,6 +114,8 @@ pub extern fn quiche_h3_event_type(ev: &h3::Event) -> u32 {
         h3::Event::Datagram { .. } => 3,
 
         h3::Event::GoAway { .. } => 4,
+
+        h3::Event::Reset { .. } => 5,
     }
 }
 

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -584,7 +584,7 @@ pub enum Event {
 
     /// Stream was reset.
     ///
-    /// The associated data represents the error code received by the peer.
+    /// The associated data represents the error code sent by the peer.
     Reset(u64),
 
     /// DATAGRAM was received.
@@ -4551,7 +4551,7 @@ mod tests {
         assert_eq!(s.poll_server(), Ok((stream, Event::Reset(42))));
         assert_eq!(s.poll_server(), Err(Error::Done));
 
-        // Sending RESET_STREAM again shouldn't trigger another Finished event.
+        // Sending RESET_STREAM again shouldn't trigger another Reset event.
         assert_eq!(
             s.pipe.send_pkt_to_server(pkt_type, &frames, &mut buf),
             Ok(39)

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -164,6 +164,10 @@
 //!             // Peer terminated stream, handle it.
 //!         },
 //!
+//!         Ok((stream_id, quiche::h3::Event::Reset(err))) => {
+//!             // Peer reset the stream, handle it.
+//!         },
+//!
 //!         Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
 //!
 //!         Ok((goaway_id, quiche::h3::Event::GoAway)) => {
@@ -218,6 +222,10 @@
 //!
 //!         Ok((stream_id, quiche::h3::Event::Finished)) => {
 //!             // Peer terminated stream, handle it.
+//!         },
+//!
+//!         Ok((stream_id, quiche::h3::Event::Reset(err))) => {
+//!             // Peer reset the stream, handle it.
 //!         },
 //!
 //!         Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
@@ -573,6 +581,11 @@ pub enum Event {
 
     /// Stream was closed,
     Finished,
+
+    /// Stream was reset.
+    ///
+    /// The associated data represents the error code received by the peer.
+    Reset(u64),
 
     /// DATAGRAM was received.
     ///
@@ -1311,6 +1324,11 @@ impl Connection {
                 Ok(v) => Some(v),
 
                 Err(Error::Done) => None,
+
+                // Return early if the stream was reset, to avoid returning
+                // a Finished event later as well.
+                Err(Error::TransportError(crate::Error::StreamReset(e))) =>
+                    return Ok((s, Event::Reset(e))),
 
                 Err(e) => return Err(e),
             };
@@ -4484,6 +4502,183 @@ mod tests {
 
         assert_eq!(s.recv_body_server(stream, &mut recv_buf), Ok(body.len()));
         assert_eq!(s.poll_server(), Ok((stream, Event::Finished)));
+    }
+
+    #[test]
+    fn reset_stream() {
+        let mut buf = [0; 65535];
+
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        // Client sends request.
+        let (stream, req) = s.send_request(false).unwrap();
+
+        let ev_headers = Event::Headers {
+            list: req,
+            has_body: true,
+        };
+
+        // Server sends response and closes stream.
+        assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        let resp = s.send_response(stream, true).unwrap();
+
+        let ev_headers = Event::Headers {
+            list: resp,
+            has_body: false,
+        };
+
+        assert_eq!(s.poll_client(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_client(), Ok((stream, Event::Finished)));
+        assert_eq!(s.poll_client(), Err(Error::Done));
+
+        // Client sends RESET_STREAM, closing stream.
+        let frames = [crate::frame::Frame::ResetStream {
+            stream_id: stream,
+            error_code: 42,
+            final_size: 68,
+        }];
+
+        let pkt_type = crate::packet::Type::Short;
+        assert_eq!(
+            s.pipe.send_pkt_to_server(pkt_type, &frames, &mut buf),
+            Ok(39)
+        );
+
+        // Server issues Reset event for the stream.
+        assert_eq!(s.poll_server(), Ok((stream, Event::Reset(42))));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        // Sending RESET_STREAM again shouldn't trigger another Finished event.
+        assert_eq!(
+            s.pipe.send_pkt_to_server(pkt_type, &frames, &mut buf),
+            Ok(39)
+        );
+
+        assert_eq!(s.poll_server(), Err(Error::Done));
+    }
+
+    #[test]
+    fn reset_finished_at_server() {
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        // Client sends HEADERS and doesn't fin
+        let (stream, _req) = s.send_request(false).unwrap();
+
+        // ..then Client sends RESET_STREAM
+        assert_eq!(
+            s.pipe.client.stream_shutdown(0, crate::Shutdown::Write, 0),
+            Ok(())
+        );
+
+        assert_eq!(s.pipe.advance(), Ok(()));
+
+        // Server receives just a reset
+        assert_eq!(s.poll_server(), Ok((stream, Event::Reset(0))));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        // Client sends HEADERS and fin
+        let (stream, req) = s.send_request(true).unwrap();
+
+        // ..then Client sends RESET_STREAM
+        assert_eq!(
+            s.pipe.client.stream_shutdown(4, crate::Shutdown::Write, 0),
+            Ok(())
+        );
+
+        let ev_headers = Event::Headers {
+            list: req,
+            has_body: false,
+        };
+
+        // Server receives headers and fin.
+        assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_server(), Ok((stream, Event::Finished)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+    }
+
+    #[test]
+    fn reset_finished_at_client() {
+        let mut buf = [0; 65535];
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        // Client sends HEADERS and doesn't fin
+        let (stream, req) = s.send_request(false).unwrap();
+
+        let ev_headers = Event::Headers {
+            list: req,
+            has_body: true,
+        };
+
+        // Server receives headers.
+        assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        // Server sends response and doesn't fin
+        s.send_response(stream, false).unwrap();
+
+        assert_eq!(s.pipe.advance(), Ok(()));
+
+        // .. then Server sends RESET_STREAM
+        assert_eq!(
+            s.pipe
+                .server
+                .stream_shutdown(stream, crate::Shutdown::Write, 0),
+            Ok(())
+        );
+
+        assert_eq!(s.pipe.advance(), Ok(()));
+
+        // Client receives Reset only
+        assert_eq!(s.poll_client(), Ok((stream, Event::Reset(0))));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        // Client sends headers and fin.
+        let (stream, req) = s.send_request(true).unwrap();
+
+        let ev_headers = Event::Headers {
+            list: req,
+            has_body: false,
+        };
+
+        // Server receives headers and fin.
+        assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_server(), Ok((stream, Event::Finished)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        // Server sends response and fin
+        let resp = s.send_response(stream, true).unwrap();
+
+        assert_eq!(s.pipe.advance(), Ok(()));
+
+        // ..then Server sends RESET_STREAM
+        let frames = [crate::frame::Frame::ResetStream {
+            stream_id: stream,
+            error_code: 42,
+            final_size: 68,
+        }];
+
+        let pkt_type = crate::packet::Type::Short;
+        assert_eq!(
+            s.pipe.send_pkt_to_server(pkt_type, &frames, &mut buf),
+            Ok(39)
+        );
+
+        assert_eq!(s.pipe.advance(), Ok(()));
+
+        let ev_headers = Event::Headers {
+            list: resp,
+            has_body: false,
+        };
+
+        // Client receives headers and fin.
+        assert_eq!(s.poll_client(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_client(), Ok((stream, Event::Finished)));
+        assert_eq!(s.poll_client(), Err(Error::Done));
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -702,6 +702,9 @@ pub struct RecvBuf {
     /// The final stream offset received from the peer, if any.
     fin_off: Option<u64>,
 
+    /// The error code received via RESET_STREAM.
+    error: Option<u64>,
+
     /// Whether incoming data is validated but not buffered.
     drain: bool,
 }
@@ -835,6 +838,11 @@ impl RecvBuf {
             return Err(Error::Done);
         }
 
+        // The stream was reset, so return the error code instead.
+        if let Some(e) = self.error {
+            return Err(Error::StreamReset(e));
+        }
+
         while cap > 0 && self.ready() {
             let mut buf = match self.data.peek_mut() {
                 Some(v) => v,
@@ -867,7 +875,7 @@ impl RecvBuf {
     }
 
     /// Resets the stream at the given offset.
-    pub fn reset(&mut self, final_size: u64) -> Result<usize> {
+    pub fn reset(&mut self, error_code: u64, final_size: u64) -> Result<usize> {
         // Stream's size is already known, forbid changing it.
         if let Some(fin_off) = self.fin_off {
             if fin_off != final_size {
@@ -880,11 +888,27 @@ impl RecvBuf {
             return Err(Error::FinalSize);
         }
 
-        self.fin_off = Some(final_size);
-
-        // Return how many bytes need to be removed from the connection flow
+        // Calculate how many bytes need to be removed from the connection flow
         // control.
-        Ok((final_size - self.len) as usize)
+        let max_data_delta = final_size - self.len;
+
+        if self.error.is_some() {
+            return Ok(max_data_delta as usize);
+        }
+
+        self.error = Some(error_code);
+
+        // Clear all data already buffered.
+        self.off = final_size;
+
+        self.data.clear();
+
+        // In order to ensure the application is notified when the stream is
+        // reset, enqueue a zero-length buffer at the final size offset.
+        let buf = RangeBuf::from(b"", final_size, true);
+        self.write(buf)?;
+
+        Ok(max_data_delta as usize)
     }
 
     /// Commits the new max_data limit.
@@ -2368,7 +2392,7 @@ mod tests {
         let first = RangeBuf::from(b"hello", 0, true);
 
         assert_eq!(stream.recv.write(first), Ok(()));
-        assert_eq!(stream.recv.reset(10), Err(Error::FinalSize));
+        assert_eq!(stream.recv.reset(0, 10), Err(Error::FinalSize));
     }
 
     #[test]
@@ -2379,8 +2403,8 @@ mod tests {
         let first = RangeBuf::from(b"hello", 0, false);
 
         assert_eq!(stream.recv.write(first), Ok(()));
-        assert_eq!(stream.recv.reset(5), Ok(0));
-        assert_eq!(stream.recv.reset(5), Ok(0));
+        assert_eq!(stream.recv.reset(0, 5), Ok(0));
+        assert_eq!(stream.recv.reset(0, 5), Ok(0));
     }
 
     #[test]
@@ -2391,8 +2415,8 @@ mod tests {
         let first = RangeBuf::from(b"hello", 0, false);
 
         assert_eq!(stream.recv.write(first), Ok(()));
-        assert_eq!(stream.recv.reset(5), Ok(0));
-        assert_eq!(stream.recv.reset(10), Err(Error::FinalSize));
+        assert_eq!(stream.recv.reset(0, 5), Ok(0));
+        assert_eq!(stream.recv.reset(0, 10), Err(Error::FinalSize));
     }
 
     #[test]
@@ -2403,7 +2427,7 @@ mod tests {
         let first = RangeBuf::from(b"hello", 0, false);
 
         assert_eq!(stream.recv.write(first), Ok(()));
-        assert_eq!(stream.recv.reset(4), Err(Error::FinalSize));
+        assert_eq!(stream.recv.reset(0, 4), Err(Error::FinalSize));
     }
 
     #[test]

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -329,6 +329,12 @@ pub fn run(
                         }
                     },
 
+                    Ok((_stream_id, quiche::h3::Event::Reset(e))) => {
+                        error!("request was reset by peer with {}", e);
+
+                        break;
+                    },
+
                     Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
 
                     Ok((_goaway_id, quiche::h3::Event::GoAway)) => (),


### PR DESCRIPTION
When a RESET_STREAM frame is received, unless the stream was already
readable for other reason, the application wouldn't know about it.

For example, if one peer sent STREAM frames without setting the fin
flag, then sent a RESET_STREAM frame completing the stream (even without
an error), the other peer would correctly close the receive-side of the
stream, but not notify the application.

This would prevent, for example, issuing HTTP/3 events to the application.

This change causes the stream to be marked as readable when a
RESET_STREAM frame is received, as if a STREAM frame with fin=true was
received. In addition, a `StreamReset` error will be returned by the
`stream_recv()` method when called by the application.

This also changes the behaviour in case a RESET_STREAM frame is
received, but either the application hasn't read the data yet, or the
data hasn't been received at all (i.e. there is a gap between the
current known stream offset, and the final size reported in the
RESET_STREAM frame).

In this case we now drop any already buffered data (so it won't be
returned to the application), and any missing data will also be dropped
on receipt. The application will still be notified by making the stream
readable.

For HTTP/3, a new "Reset" event is added, which propagates the error
code from the RESET_STREAM frame up to the application, without causing
the whole connection to be closed when `poll()` is called.