### PR TITLE
qlog: add means to provide external event time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2024,14 +2024,17 @@ impl Connection {
                 Some(&hdr.dcid),
             );
 
-            q.add_event(qlog::event::Event::packet_received(
-                hdr.ty.to_qlog(),
-                qlog_pkt_hdr,
-                Some(Vec::new()),
-                None,
-                None,
-                None,
-            ))
+            q.add_event_with_instant(
+                qlog::event::Event::packet_received(
+                    hdr.ty.to_qlog(),
+                    qlog_pkt_hdr,
+                    Some(Vec::new()),
+                    None,
+                    None,
+                    None,
+                ),
+                now,
+            )
             .ok();
         });
 
@@ -2119,7 +2122,7 @@ impl Connection {
 
         qlog_with!(self.qlog_streamer, q, {
             let ev = self.recovery.to_qlog();
-            q.add_event(ev).ok();
+            q.add_event_with_instant(ev, now).ok();
         });
 
         // Only log the remote transport parameters once the connection is
@@ -2137,7 +2140,7 @@ impl Connection {
                         handshake.cipher(),
                     );
 
-                    q.add_event(ev).ok();
+                    q.add_event_with_instant(ev, now).ok();
 
                     self.qlogged_peer_params = true;
                 }
@@ -3158,7 +3161,7 @@ impl Connection {
                 Some(Vec::new()),
             );
 
-            q.add_event(packet_sent_ev).ok();
+            q.add_event_with_instant(packet_sent_ev, now).ok();
         });
 
         for frame in &mut frames {
@@ -3218,7 +3221,7 @@ impl Connection {
 
         qlog_with!(self.qlog_streamer, q, {
             let ev = self.recovery.to_qlog();
-            q.add_event(ev).ok();
+            q.add_event_with_instant(ev, now).ok();
         });
 
         self.pkt_num_spaces[epoch].next_pkt_num += 1;
@@ -4092,7 +4095,7 @@ impl Connection {
 
                 qlog_with!(self.qlog_streamer, q, {
                     let ev = self.recovery.to_qlog();
-                    q.add_event(ev).ok();
+                    q.add_event_with_instant(ev, now).ok();
                 });
 
                 return;


### PR DESCRIPTION
Previously, the `add_event()` method populated the qlog event_time
field by calling `std::time::Instant::elapsed()`, which causes an in
direct call for `std::time::Instand::now()`. This incurs additional
system calls that are wasteful, especially if events are logged in
rapid succession or the time is available elsewhere.

This change introduces the `add_event_with_instant()` method that
allows callers to provide their own Instant that they wish to use
when logging an event.