### PR TITLE
stream_send(...) should return Err(Error::Done) if no bytes are send

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3448,6 +3448,9 @@ impl Connection {
         // Truncate the input buffer based on the connection's send capacity if
         // necessary.
         let cap = self.tx_cap;
+        if cap == 0 {
+            return Err(Error::Done)
+        }
 
         let (buf, fin) = if cap < buf.len() {
             (&buf[..cap], false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8080,7 +8080,7 @@ mod tests {
             Ok(15)
         );
         assert_eq!(pipe.advance(), Ok(()));
-        assert_eq!(pipe.client.stream_send(8, b"a", false), Ok(0));
+        assert_eq!(pipe.client.stream_send(8, b"a", false), Err(Error::Done));
         assert_eq!(pipe.advance(), Ok(()));
 
         let mut r = pipe.server.readable();
@@ -10450,7 +10450,7 @@ mod tests {
         assert_eq!(pipe.server.stream_send(8, &buf[..5000], false), Ok(2000));
 
         // No more connection send capacity.
-        assert_eq!(pipe.server.stream_send(12, &buf[..5000], false), Ok(0));
+        assert_eq!(pipe.server.stream_send(12, &buf[..5000], false), Err(Error::Done));
         assert_eq!(pipe.server.tx_cap, 0);
 
         assert_eq!(pipe.advance(), Ok(()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3449,7 +3449,7 @@ impl Connection {
         // necessary.
         let cap = self.tx_cap;
         if cap == 0 && !fin {
-            return Err(Error::Done)
+            return Err(Error::Done);
         }
 
         let (buf, fin) = if cap < buf.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3390,9 +3390,9 @@ impl Connection {
     /// On success the number of bytes written is returned, or [`Done`] if no
     /// data was written (e.g. because the stream has no capacity).
     ///
-    /// This methods also allows to send 0-length FIN `STREAM_FRAME` frames,
-    /// which means it is possible to use it with 0-length bytes while the
-    /// FIN flag is set. In this case it will return [`Ok(0)`].
+    /// Applications can provide a 0-length buffer with the fin flag set to 
+    /// true. This will lead to a 0-length FIN STREAM frame being sent at the 
+    /// latest offset. This is the only case where [`Ok(0)`] is returned.
     ///
     /// In addition, if the peer has signalled that it doesn't want to receive
     /// any more data from this stream by sending the `STOP_SENDING` frame, the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10450,7 +10450,10 @@ mod tests {
         assert_eq!(pipe.server.stream_send(8, &buf[..5000], false), Ok(2000));
 
         // No more connection send capacity.
-        assert_eq!(pipe.server.stream_send(12, &buf[..5000], false), Err(Error::Done));
+        assert_eq!(
+            pipe.server.stream_send(12, &buf[..5000], false),
+            Err(Error::Done)
+        );
         assert_eq!(pipe.server.tx_cap, 0);
 
         assert_eq!(pipe.advance(), Ok(()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3448,7 +3448,7 @@ impl Connection {
         // Truncate the input buffer based on the connection's send capacity if
         // necessary.
         let cap = self.tx_cap;
-        if cap == 0 {
+        if cap == 0 && !fin {
             return Err(Error::Done)
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3390,6 +3390,10 @@ impl Connection {
     /// On success the number of bytes written is returned, or [`Done`] if no
     /// data was written (e.g. because the stream has no capacity).
     ///
+    /// This methods also allows to send 0-length FIN `STREAM_FRAME` frames, which means
+    /// it is possible to use it with 0-length bytes while the FIN flag is set.
+    /// In this case it will return [`Ok(0)`].
+    ///
     /// In addition, if the peer has signalled that it doesn't want to receive
     /// any more data from this stream by sending the `STOP_SENDING` frame, the
     /// [`StreamStopped`] error will be returned instead of any data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3390,8 +3390,8 @@ impl Connection {
     /// On success the number of bytes written is returned, or [`Done`] if no
     /// data was written (e.g. because the stream has no capacity).
     ///
-    /// Applications can provide a 0-length buffer with the fin flag set to 
-    /// true. This will lead to a 0-length FIN STREAM frame being sent at the 
+    /// Applications can provide a 0-length buffer with the fin flag set to
+    /// true. This will lead to a 0-length FIN STREAM frame being sent at the
     /// latest offset. This is the only case where [`Ok(0)`] is returned.
     ///
     /// In addition, if the peer has signalled that it doesn't want to receive

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3390,9 +3390,9 @@ impl Connection {
     /// On success the number of bytes written is returned, or [`Done`] if no
     /// data was written (e.g. because the stream has no capacity).
     ///
-    /// This methods also allows to send 0-length FIN `STREAM_FRAME` frames, which means
-    /// it is possible to use it with 0-length bytes while the FIN flag is set.
-    /// In this case it will return [`Ok(0)`].
+    /// This methods also allows to send 0-length FIN `STREAM_FRAME` frames,
+    /// which means it is possible to use it with 0-length bytes while the
+    /// FIN flag is set. In this case it will return [`Ok(0)`].
     ///
     /// In addition, if the peer has signalled that it doesn't want to receive
     /// any more data from this stream by sending the `STOP_SENDING` frame, the


### PR DESCRIPTION
Motivation:

The documention of stream_send(...) states that Err(Error::Done) is returned if no bytes were send. This is not always the case and Ok(0) might be returned.

Modifications:

Return Err(Error::Done) if tx_cap is 0.

Result:

Return value matches the documentation.