### PR TITLE
remove spurious link mark-up in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3395,7 +3395,7 @@ impl Connection {
     ///
     /// Applications can provide a 0-length buffer with the fin flag set to
     /// true. This will lead to a 0-length FIN STREAM frame being sent at the
-    /// latest offset. This is the only case where [`Ok(0)`] is returned.
+    /// latest offset. This is the only case where `Ok(0)` is returned.
     ///
     /// In addition, if the peer has signalled that it doesn't want to receive
     /// any more data from this stream by sending the `STOP_SENDING` frame, the


### PR DESCRIPTION
This ends up being rendered as "[Ok(0)]".