### PR TITLE
tls: try to sanitize use of raw pointers for Context and Handshake

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,8 +303,6 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::str::FromStr;
 
-use std::sync::Mutex;
-
 use std::collections::VecDeque;
 
 /// The current QUIC wire version.
@@ -537,11 +535,7 @@ pub struct Config {
 
     version: u32,
 
-    // BoringSSL's SSL_CTX structure is technically safe to share across threads
-    // but once shared, functions that modify it can't be used any more. We can't
-    // encode that in Rust, so just make it Send+Sync with a mutex to fulfill
-    // the Sync constraint.
-    tls_ctx: Mutex<tls::Context>,
+    tls_ctx: tls::Context,
 
     application_protos: Vec<Vec<u8>>,
 
@@ -576,7 +570,7 @@ impl Config {
             return Err(Error::UnknownVersion);
         }
 
-        let tls_ctx = Mutex::new(tls::Context::new()?);
+        let tls_ctx = tls::Context::new()?;
 
         Ok(Config {
             local_transport_params: TransportParams::default(),
@@ -607,10 +601,7 @@ impl Config {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn load_cert_chain_from_pem_file(&mut self, file: &str) -> Result<()> {
-        self.tls_ctx
-            .lock()
-            .unwrap()
-            .use_certificate_chain_file(file)
+        self.tls_ctx.use_certificate_chain_file(file)
     }
 
     /// Configures the given private key.
@@ -625,7 +616,7 @@ impl Config {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn load_priv_key_from_pem_file(&mut self, file: &str) -> Result<()> {
-        self.tls_ctx.lock().unwrap().use_privkey_file(file)
+        self.tls_ctx.use_privkey_file(file)
     }
 
     /// Specifies a file where trusted CA certificates are stored for the
@@ -641,10 +632,7 @@ impl Config {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn load_verify_locations_from_file(&mut self, file: &str) -> Result<()> {
-        self.tls_ctx
-            .lock()
-            .unwrap()
-            .load_verify_locations_from_file(file)
+        self.tls_ctx.load_verify_locations_from_file(file)
     }
 
     /// Specifies a directory where trusted CA certificates are stored for the
@@ -662,10 +650,7 @@ impl Config {
     pub fn load_verify_locations_from_directory(
         &mut self, dir: &str,
     ) -> Result<()> {
-        self.tls_ctx
-            .lock()
-            .unwrap()
-            .load_verify_locations_from_directory(dir)
+        self.tls_ctx.load_verify_locations_from_directory(dir)
     }
 
     /// Configures whether to verify the peer's certificate.
@@ -673,7 +658,7 @@ impl Config {
     /// The default value is `true` for client connections, and `false` for
     /// server ones.
     pub fn verify_peer(&mut self, verify: bool) {
-        self.tls_ctx.lock().unwrap().set_verify(verify);
+        self.tls_ctx.set_verify(verify);
     }
 
     /// Configures whether to send GREASE values.
@@ -692,7 +677,7 @@ impl Config {
     /// [`set_keylog()`]: struct.Connection.html#method.set_keylog
     /// [keylog]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format
     pub fn log_keys(&mut self) {
-        self.tls_ctx.lock().unwrap().enable_keylog();
+        self.tls_ctx.enable_keylog();
     }
 
     /// Configures the session ticket key material.
@@ -706,12 +691,12 @@ impl Config {
     /// servers), in which case the application is also responsible for
     /// rotating the key to provide forward secrecy.
     pub fn set_ticket_key(&mut self, key: &[u8]) -> Result<()> {
-        self.tls_ctx.lock().unwrap().set_ticket_key(key)
+        self.tls_ctx.set_ticket_key(key)
     }
 
     /// Enables sending or receiving early data.
     pub fn enable_early_data(&mut self) {
-        self.tls_ctx.lock().unwrap().set_early_data_enabled(true);
+        self.tls_ctx.set_early_data_enabled(true);
     }
 
     /// Configures the list of supported application protocols.
@@ -745,10 +730,7 @@ impl Config {
 
         self.application_protos = protos_list;
 
-        self.tls_ctx
-            .lock()
-            .unwrap()
-            .set_alpn(&self.application_protos)
+        self.tls_ctx.set_alpn(&self.application_protos)
     }
 
     /// Sets the `max_idle_timeout` transport parameter, in milliseconds.
@@ -954,11 +936,7 @@ pub struct Connection {
     local_transport_params: TransportParams,
 
     /// TLS handshake state.
-    ///
-    /// Due to the requirement for `Connection` to be Send+Sync, and the fact
-    /// that BoringSSL's SSL structure is not thread safe, we need to wrap the
-    /// handshake object in a mutex.
-    handshake: Mutex<tls::Handshake>,
+    handshake: tls::Handshake,
 
     /// Serialized TLS session buffer.
     ///
@@ -1171,10 +1149,10 @@ pub fn connect(
     server_name: Option<&str>, scid: &ConnectionId, to: SocketAddr,
     config: &mut Config,
 ) -> Result<Pin<Box<Connection>>> {
-    let conn = Connection::new(scid, None, to, config, false)?;
+    let mut conn = Connection::new(scid, None, to, config, false)?;
 
     if let Some(server_name) = server_name {
-        conn.handshake.lock().unwrap().set_host_name(server_name)?;
+        conn.handshake.set_host_name(server_name)?;
     }
 
     Ok(conn)
@@ -1329,7 +1307,7 @@ impl Connection {
         scid: &ConnectionId, odcid: Option<&ConnectionId>, peer: SocketAddr,
         config: &mut Config, is_server: bool,
     ) -> Result<Pin<Box<Connection>>> {
-        let tls = config.tls_ctx.lock().unwrap().new_handshake()?;
+        let tls = config.tls_ctx.new_handshake()?;
         Connection::with_tls(scid, odcid, peer, config, tls, is_server)
     }
 
@@ -1360,7 +1338,7 @@ impl Connection {
 
             local_transport_params: config.local_transport_params.clone(),
 
-            handshake: Mutex::new(tls),
+            handshake: tls,
 
             session: None,
 
@@ -1479,11 +1457,10 @@ impl Connection {
         conn.local_transport_params.initial_source_connection_id =
             Some(scid.to_vec().into());
 
-        conn.handshake.lock().unwrap().init(&conn)?;
+        let conn_ptr = &conn as &Connection as *const Connection;
+        conn.handshake.init(conn_ptr, is_server)?;
 
         conn.handshake
-            .lock()
-            .unwrap()
             .use_legacy_codepoint(config.version != PROTOCOL_VERSION_V1);
 
         conn.encode_transport_params()?;
@@ -1569,13 +1546,11 @@ impl Connection {
 
         streamer.start_log().ok();
 
-        let handshake = self.handshake.lock().unwrap();
-
         let ev = self.local_transport_params.to_qlog(
             qlog::TransportOwner::Local,
             self.version,
-            handshake.alpn_protocol(),
-            handshake.cipher(),
+            self.handshake.alpn_protocol(),
+            self.handshake.cipher(),
         );
 
         streamer.add_event(ev).ok();
@@ -1599,10 +1574,7 @@ impl Connection {
         let session_len = b.get_u64()? as usize;
         let session_bytes = b.get_bytes(session_len)?;
 
-        self.handshake
-            .lock()
-            .unwrap()
-            .set_session(session_bytes.as_ref())?;
+        self.handshake.set_session(session_bytes.as_ref())?;
 
         let raw_params_len = b.get_u64()? as usize;
         let raw_params_bytes = b.get_bytes(raw_params_len)?;
@@ -1828,7 +1800,7 @@ impl Connection {
             // Reset connection state to force sending another Initial packet.
             self.drop_epoch_state(packet::EPOCH_INITIAL, now);
             self.got_peer_conn_id = false;
-            self.handshake.lock().unwrap().clear()?;
+            self.handshake.clear()?;
 
             self.pkt_num_spaces[packet::EPOCH_INITIAL].crypto_open =
                 Some(aead_open);
@@ -1836,8 +1808,6 @@ impl Connection {
                 Some(aead_seal);
 
             self.handshake
-                .lock()
-                .unwrap()
                 .use_legacy_codepoint(self.version != PROTOCOL_VERSION_V1);
 
             // Encode transport parameters again, as the new version might be
@@ -1887,7 +1857,7 @@ impl Connection {
             // Reset connection state to force sending another Initial packet.
             self.drop_epoch_state(packet::EPOCH_INITIAL, now);
             self.got_peer_conn_id = false;
-            self.handshake.lock().unwrap().clear()?;
+            self.handshake.clear()?;
 
             self.pkt_num_spaces[packet::EPOCH_INITIAL].crypto_open =
                 Some(aead_open);
@@ -1906,8 +1876,6 @@ impl Connection {
             self.did_version_negotiation = true;
 
             self.handshake
-                .lock()
-                .unwrap()
                 .use_legacy_codepoint(self.version != PROTOCOL_VERSION_V1);
 
             // Encode transport parameters again, as the new version might be
@@ -2149,13 +2117,11 @@ impl Connection {
         if self.is_established() {
             qlog_with!(self.qlog_streamer, q, {
                 if !self.qlogged_peer_params {
-                    let handshake = self.handshake.lock().unwrap();
-
                     let ev = self.peer_transport_params.to_qlog(
                         qlog::TransportOwner::Remote,
                         self.version,
-                        handshake.alpn_protocol(),
-                        handshake.cipher(),
+                        self.handshake.alpn_protocol(),
+                        self.handshake.cipher(),
                     );
 
                     q.add_event_with_instant(ev, now).ok();
@@ -4202,7 +4168,7 @@ impl Connection {
     /// Returns the peer's leaf certificate (if any) as a DER-encoded buffer.
     #[inline]
     pub fn peer_cert(&self) -> Option<Vec<u8>> {
-        self.handshake.lock().unwrap().peer_cert()
+        self.handshake.peer_cert()
     }
 
     /// Returns the serialized cryptographic session for the connection.
@@ -4243,14 +4209,14 @@ impl Connection {
     /// Returns true if the connection is resumed.
     #[inline]
     pub fn is_resumed(&self) -> bool {
-        self.handshake.lock().unwrap().is_resumed()
+        self.handshake.is_resumed()
     }
 
     /// Returns true if the connection has a pending handshake that has
     /// progressed enough to send or receive early data.
     #[inline]
     pub fn is_in_early_data(&self) -> bool {
-        self.handshake.lock().unwrap().is_in_early_data()
+        self.handshake.is_in_early_data()
     }
 
     /// Returns whether there is stream or DATAGRAM data available to read.
@@ -4361,10 +4327,7 @@ impl Connection {
             &mut raw_params,
         )?;
 
-        self.handshake
-            .lock()
-            .unwrap()
-            .set_quic_transport_params(raw_params)?;
+        self.handshake.set_quic_transport_params(raw_params)?;
 
         Ok(())
     }
@@ -4461,14 +4424,12 @@ impl Connection {
     ///
     /// If the connection is already established, it does nothing.
     fn do_handshake(&mut self) -> Result<()> {
-        let handshake = self.handshake.lock().unwrap();
-
-        // Handshake is already complete, nothing more to do.
-        if handshake.is_completed() {
+        if self.handshake_completed {
+            // Handshake is already complete, nothing more to do.
             return Ok(());
         }
 
-        match handshake.do_handshake() {
+        match self.handshake.do_handshake() {
             Ok(_) => (),
 
             Err(Error::Done) => {
@@ -4478,14 +4439,11 @@ impl Connection {
                 // This is potentially dangerous as the handshake hasn't been
                 // completed yet, though it's required to be able to send data
                 // in 0.5 RTT.
-                let raw_params = handshake.quic_transport_params();
+                let raw_params = self.handshake.quic_transport_params();
 
                 if !self.parsed_peer_transport_params && !raw_params.is_empty() {
                     let peer_params =
                         TransportParams::decode(&raw_params, self.is_server)?;
-
-                    // Unlock handshake object.
-                    drop(handshake);
 
                     self.parse_peer_transport_params(peer_params)?;
                 }
@@ -4496,23 +4454,15 @@ impl Connection {
             Err(e) => return Err(e),
         };
 
-        self.handshake_completed = handshake.is_completed();
+        self.handshake_completed = self.handshake.is_completed();
 
-        self.alpn = handshake.alpn_protocol().to_vec();
+        self.alpn = self.handshake.alpn_protocol().to_vec();
 
-        let cipher = handshake.cipher();
-        let curve = handshake.curve();
-        let sigalg = handshake.sigalg();
-        let is_resumed = handshake.is_resumed();
-
-        let raw_params = handshake.quic_transport_params();
+        let raw_params = self.handshake.quic_transport_params();
 
         if !self.parsed_peer_transport_params && !raw_params.is_empty() {
             let peer_params =
                 TransportParams::decode(&raw_params, self.is_server)?;
-
-            // Unlock handshake object.
-            drop(handshake);
 
             self.parse_peer_transport_params(peer_params)?;
         }
@@ -4524,8 +4474,13 @@ impl Connection {
         }
 
         trace!("{} connection established: proto={:?} cipher={:?} curve={:?} sigalg={:?} resumed={} {:?}",
-               &self.trace_id, std::str::from_utf8(self.application_proto()),
-               cipher, curve, sigalg, is_resumed, self.peer_transport_params);
+               &self.trace_id,
+               std::str::from_utf8(self.application_proto()),
+               self.handshake.cipher(),
+               self.handshake.curve(),
+               self.handshake.sigalg(),
+               self.handshake.is_resumed(),
+               self.peer_transport_params);
 
         Ok(())
     }
@@ -4539,7 +4494,7 @@ impl Connection {
             .as_ref()
             .map_or(false, |conn_err| !conn_err.is_app)
         {
-            let epoch = match self.handshake.lock().unwrap().write_level() {
+            let epoch = match self.handshake.write_level() {
                 crypto::Level::Initial => packet::EPOCH_INITIAL,
                 crypto::Level::ZeroRTT => unreachable!(),
                 crypto::Level::Handshake => packet::EPOCH_HANDSHAKE,
@@ -4768,14 +4723,11 @@ impl Connection {
 
                 while let Ok((read, _)) = stream.recv.emit(&mut crypto_buf) {
                     let recv_buf = &crypto_buf[..read];
-                    self.handshake
-                        .lock()
-                        .unwrap()
-                        .provide_data(level, &recv_buf)?;
+                    self.handshake.provide_data(level, &recv_buf)?;
                 }
 
                 if self.is_established() {
-                    self.handshake.lock().unwrap().process_post_handshake()?;
+                    self.handshake.process_post_handshake()?;
                 } else {
                     self.do_handshake()?;
                 }
@@ -6166,11 +6118,7 @@ mod tests {
 
         // Disable session tickets on the server (SSL_OP_NO_TICKET) to avoid
         // triggering 1-RTT packet send with a CRYPTO frame.
-        pipe.server
-            .handshake
-            .lock()
-            .unwrap()
-            .set_options(0x0000_4000);
+        pipe.server.handshake.set_options(0x0000_4000);
 
         assert_eq!(pipe.handshake(), Ok(()));
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -156,7 +156,7 @@ impl Context {
 
     pub fn new_handshake(&mut self) -> Result<Handshake> {
         unsafe {
-            let ssl = SSL_new(self.as_ptr());
+            let ssl = SSL_new(self.as_mut_ptr());
             Ok(Handshake(ssl))
         }
     }
@@ -165,7 +165,7 @@ impl Context {
         let file = ffi::CString::new(file).map_err(|_| Error::TlsFail)?;
         map_result(unsafe {
             SSL_CTX_load_verify_locations(
-                self.as_ptr(),
+                self.as_mut_ptr(),
                 file.as_ptr(),
                 std::ptr::null(),
             )
@@ -178,7 +178,7 @@ impl Context {
         let path = ffi::CString::new(path).map_err(|_| Error::TlsFail)?;
         map_result(unsafe {
             SSL_CTX_load_verify_locations(
-                self.as_ptr(),
+                self.as_mut_ptr(),
                 std::ptr::null(),
                 path.as_ptr(),
             )
@@ -188,20 +188,20 @@ impl Context {
     pub fn use_certificate_chain_file(&mut self, file: &str) -> Result<()> {
         let cstr = ffi::CString::new(file).map_err(|_| Error::TlsFail)?;
         map_result(unsafe {
-            SSL_CTX_use_certificate_chain_file(self.as_ptr(), cstr.as_ptr())
+            SSL_CTX_use_certificate_chain_file(self.as_mut_ptr(), cstr.as_ptr())
         })
     }
 
     pub fn use_privkey_file(&mut self, file: &str) -> Result<()> {
         let cstr = ffi::CString::new(file).map_err(|_| Error::TlsFail)?;
         map_result(unsafe {
-            SSL_CTX_use_PrivateKey_file(self.as_ptr(), cstr.as_ptr(), 1)
+            SSL_CTX_use_PrivateKey_file(self.as_mut_ptr(), cstr.as_ptr(), 1)
         })
     }
 
     #[cfg(not(windows))]
     fn load_ca_certs(&mut self) -> Result<()> {
-        unsafe { map_result(SSL_CTX_set_default_verify_paths(self.as_ptr())) }
+        unsafe { map_result(SSL_CTX_set_default_verify_paths(self.as_mut_ptr())) }
     }
 
     #[cfg(windows)]
@@ -216,7 +216,7 @@ impl Context {
                 return Err(Error::TlsFail);
             }
 
-            let ctx_store = SSL_CTX_get_cert_store(self.as_ptr());
+            let ctx_store = SSL_CTX_get_cert_store(self.as_mut_ptr());
             if ctx_store.is_null() {
                 return Err(Error::TlsFail);
             }
@@ -258,11 +258,11 @@ impl Context {
             // This is needed to enable the session callback on the client. On
             // the server it doesn't do anything.
             SSL_CTX_set_session_cache_mode(
-                self.as_ptr(),
+                self.as_mut_ptr(),
                 0x0001, // SSL_SESS_CACHE_CLIENT
             );
 
-            SSL_CTX_sess_set_new_cb(self.as_ptr(), new_session);
+            SSL_CTX_sess_set_new_cb(self.as_mut_ptr(), new_session);
         };
     }
 
@@ -274,13 +274,13 @@ impl Context {
         };
 
         unsafe {
-            SSL_CTX_set_verify(self.as_ptr(), mode, ptr::null());
+            SSL_CTX_set_verify(self.as_mut_ptr(), mode, ptr::null());
         }
     }
 
     pub fn enable_keylog(&mut self) {
         unsafe {
-            SSL_CTX_set_keylog_callback(self.as_ptr(), keylog);
+            SSL_CTX_set_keylog_callback(self.as_mut_ptr(), keylog);
         }
     }
 
@@ -295,7 +295,7 @@ impl Context {
         // Configure ALPN for servers.
         unsafe {
             SSL_CTX_set_alpn_select_cb(
-                self.as_ptr(),
+                self.as_mut_ptr(),
                 select_alpn,
                 ptr::null_mut(),
             );
@@ -303,13 +303,21 @@ impl Context {
 
         // Configure ALPN for clients.
         map_result_zero_is_success(unsafe {
-            SSL_CTX_set_alpn_protos(self.as_ptr(), protos.as_ptr(), protos.len())
+            SSL_CTX_set_alpn_protos(
+                self.as_mut_ptr(),
+                protos.as_ptr(),
+                protos.len(),
+            )
         })
     }
 
     pub fn set_ticket_key(&mut self, key: &[u8]) -> Result<()> {
         map_result(unsafe {
-            SSL_CTX_set_tlsext_ticket_keys(self.as_ptr(), key.as_ptr(), key.len())
+            SSL_CTX_set_tlsext_ticket_keys(
+                self.as_mut_ptr(),
+                key.as_ptr(),
+                key.len(),
+            )
         })
     }
 
@@ -317,20 +325,26 @@ impl Context {
         let enabled = if enabled { 1 } else { 0 };
 
         unsafe {
-            SSL_CTX_set_early_data_enabled(self.as_ptr(), enabled);
+            SSL_CTX_set_early_data_enabled(self.as_mut_ptr(), enabled);
         }
     }
 
-    fn as_ptr(&self) -> *mut SSL_CTX {
+    fn as_mut_ptr(&mut self) -> *mut SSL_CTX {
         self.0
     }
 }
 
+// NOTE: These traits are not automatically implemented for Context due to the
+// raw pointer it wraps. However, the underlying data is not aliased (as Context
+// should be its only owner), and there is no interior mutability, as the
+// pointer is not accessed directly outside of this module, and the Context
+// object API should preserve Rust's borrowing guarantees.
 unsafe impl std::marker::Send for Context {}
+unsafe impl std::marker::Sync for Context {}
 
 impl Drop for Context {
     fn drop(&mut self) {
-        unsafe { SSL_CTX_free(self.as_ptr()) }
+        unsafe { SSL_CTX_free(self.as_mut_ptr()) }
     }
 }
 
@@ -347,8 +361,10 @@ impl Handshake {
         unsafe { SSL_get_error(self.as_ptr(), ret_code) }
     }
 
-    pub fn init(&self, conn: &Connection) -> Result<()> {
-        self.set_state(conn.is_server);
+    pub fn init(
+        &mut self, conn: *const Connection, is_server: bool,
+    ) -> Result<()> {
+        self.set_state(is_server);
 
         self.set_ex_data(*QUICHE_EX_DATA_INDEX, conn)?;
 
@@ -366,80 +382,90 @@ impl Handshake {
         Ok(())
     }
 
-    pub fn use_legacy_codepoint(&self, use_legacy: bool) {
+    pub fn use_legacy_codepoint(&mut self, use_legacy: bool) {
         unsafe {
-            SSL_set_quic_use_legacy_codepoint(self.as_ptr(), use_legacy as c_int);
+            SSL_set_quic_use_legacy_codepoint(
+                self.as_mut_ptr(),
+                use_legacy as c_int,
+            );
         }
     }
 
-    pub fn set_state(&self, is_server: bool) {
+    pub fn set_state(&mut self, is_server: bool) {
         unsafe {
             if is_server {
-                SSL_set_accept_state(self.as_ptr());
+                SSL_set_accept_state(self.as_mut_ptr());
             } else {
-                SSL_set_connect_state(self.as_ptr());
+                SSL_set_connect_state(self.as_mut_ptr());
             }
         }
     }
 
-    pub fn set_ex_data<T>(&self, idx: c_int, data: &T) -> Result<()> {
+    pub fn set_ex_data<T>(&mut self, idx: c_int, data: *const T) -> Result<()> {
         map_result(unsafe {
-            let ptr = data as *const T as *const c_void;
-            SSL_set_ex_data(self.as_ptr(), idx, ptr)
+            let ptr = data as *const c_void;
+            SSL_set_ex_data(self.as_mut_ptr(), idx, ptr)
         })
     }
 
-    pub fn set_quic_method(&self) -> Result<()> {
+    pub fn set_quic_method(&mut self) -> Result<()> {
         map_result(unsafe {
-            SSL_set_quic_method(self.as_ptr(), &QUICHE_STREAM_METHOD)
+            SSL_set_quic_method(self.as_mut_ptr(), &QUICHE_STREAM_METHOD)
         })
     }
 
-    pub fn set_quic_early_data_context(&self, context: &[u8]) -> Result<()> {
+    pub fn set_quic_early_data_context(&mut self, context: &[u8]) -> Result<()> {
         map_result(unsafe {
             SSL_set_quic_early_data_context(
-                self.as_ptr(),
+                self.as_mut_ptr(),
                 context.as_ptr(),
                 context.len(),
             )
         })
     }
 
-    pub fn set_min_proto_version(&self, version: u16) {
-        unsafe { SSL_set_min_proto_version(self.as_ptr(), version) }
+    pub fn set_min_proto_version(&mut self, version: u16) {
+        unsafe { SSL_set_min_proto_version(self.as_mut_ptr(), version) }
     }
 
-    pub fn set_max_proto_version(&self, version: u16) {
-        unsafe { SSL_set_max_proto_version(self.as_ptr(), version) }
+    pub fn set_max_proto_version(&mut self, version: u16) {
+        unsafe { SSL_set_max_proto_version(self.as_mut_ptr(), version) }
     }
 
-    pub fn set_quiet_shutdown(&self, mode: bool) {
-        unsafe { SSL_set_quiet_shutdown(self.as_ptr(), if mode { 1 } else { 0 }) }
+    pub fn set_quiet_shutdown(&mut self, mode: bool) {
+        unsafe {
+            SSL_set_quiet_shutdown(self.as_mut_ptr(), if mode { 1 } else { 0 })
+        }
     }
 
-    pub fn set_host_name(&self, name: &str) -> Result<()> {
+    pub fn set_host_name(&mut self, name: &str) -> Result<()> {
         let cstr = ffi::CString::new(name).map_err(|_| Error::TlsFail)?;
-        map_result_ssl(self, unsafe {
-            SSL_set_tlsext_host_name(self.as_ptr(), cstr.as_ptr())
-        })?;
+        let rc =
+            unsafe { SSL_set_tlsext_host_name(self.as_mut_ptr(), cstr.as_ptr()) };
+        map_result_ssl(self, rc)?;
 
-        let param = unsafe { SSL_get0_param(self.as_ptr()) };
+        let param = unsafe { SSL_get0_param(self.as_mut_ptr()) };
 
         map_result(unsafe {
             X509_VERIFY_PARAM_set1_host(param, cstr.as_ptr(), name.len())
         })
     }
 
-    pub fn set_quic_transport_params(&self, buf: &[u8]) -> Result<()> {
-        map_result_ssl(self, unsafe {
-            SSL_set_quic_transport_params(self.as_ptr(), buf.as_ptr(), buf.len())
-        })
+    pub fn set_quic_transport_params(&mut self, buf: &[u8]) -> Result<()> {
+        let rc = unsafe {
+            SSL_set_quic_transport_params(
+                self.as_mut_ptr(),
+                buf.as_ptr(),
+                buf.len(),
+            )
+        };
+        map_result_ssl(self, rc)
     }
 
     #[cfg(test)]
     pub fn set_options(&mut self, opts: u32) {
         unsafe {
-            SSL_set_options(self.as_ptr(), opts);
+            SSL_set_options(self.as_mut_ptr(), opts);
         }
     }
 
@@ -473,7 +499,7 @@ impl Handshake {
         unsafe { slice::from_raw_parts(ptr, len as usize) }
     }
 
-    pub fn set_session(&self, session: &[u8]) -> Result<()> {
+    pub fn set_session(&mut self, session: &[u8]) -> Result<()> {
         unsafe {
             let ctx = SSL_get_SSL_CTX(self.as_ptr());
 
@@ -488,31 +514,39 @@ impl Handshake {
                 return Err(Error::TlsFail);
             }
 
-            let rc = SSL_set_session(self.as_ptr(), session);
+            let rc = SSL_set_session(self.as_mut_ptr(), session);
             SSL_SESSION_free(session);
 
             map_result(rc)
         }
     }
 
-    pub fn provide_data(&self, level: crypto::Level, buf: &[u8]) -> Result<()> {
-        map_result_ssl(self, unsafe {
-            SSL_provide_quic_data(self.as_ptr(), level, buf.as_ptr(), buf.len())
-        })
+    pub fn provide_data(
+        &mut self, level: crypto::Level, buf: &[u8],
+    ) -> Result<()> {
+        let rc = unsafe {
+            SSL_provide_quic_data(
+                self.as_mut_ptr(),
+                level,
+                buf.as_ptr(),
+                buf.len(),
+            )
+        };
+        map_result_ssl(self, rc)
     }
 
-    pub fn do_handshake(&self) -> Result<()> {
-        map_result_ssl(self, unsafe { SSL_do_handshake(self.as_ptr()) })
+    pub fn do_handshake(&mut self) -> Result<()> {
+        let rc = unsafe { SSL_do_handshake(self.as_mut_ptr()) };
+        map_result_ssl(self, rc)
     }
 
-    pub fn process_post_handshake(&self) -> Result<()> {
-        map_result_ssl(self, unsafe {
-            SSL_process_quic_post_handshake(self.as_ptr())
-        })
+    pub fn process_post_handshake(&mut self) -> Result<()> {
+        let rc = unsafe { SSL_process_quic_post_handshake(self.as_mut_ptr()) };
+        map_result_ssl(self, rc)
     }
 
-    pub fn reset_early_data_reject(&self) {
-        unsafe { SSL_reset_early_data_reject(self.as_ptr()) };
+    pub fn reset_early_data_reject(&mut self) {
+        unsafe { SSL_reset_early_data_reject(self.as_mut_ptr()) };
     }
 
     pub fn write_level(&self) -> crypto::Level {
@@ -599,19 +633,30 @@ impl Handshake {
     }
 
     pub fn clear(&mut self) -> Result<()> {
-        map_result_ssl(self, unsafe { SSL_clear(self.as_ptr()) })
+        let rc = unsafe { SSL_clear(self.as_mut_ptr()) };
+        map_result_ssl(self, rc)
     }
 
-    fn as_ptr(&self) -> *mut SSL {
+    fn as_ptr(&self) -> *const SSL {
+        self.0
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut SSL {
         self.0
     }
 }
 
+// NOTE: These traits are not automatically implemented for Handshake due to the
+// raw pointer it wraps. However, the underlying data is not aliased (as
+// Handshake should be its only owner), and there is no interior mutability, as
+// the pointer is not accessed directly outside of this module, and the
+// Handshake object API should preserve Rust's borrowing guarantees.
 unsafe impl std::marker::Send for Handshake {}
+unsafe impl std::marker::Sync for Handshake {}
 
 impl Drop for Handshake {
     fn drop(&mut self) {
-        unsafe { SSL_free(self.as_ptr()) }
+        unsafe { SSL_free(self.as_mut_ptr()) }
     }
 }
 
@@ -948,7 +993,7 @@ fn map_result_ptr<'a, T>(bssl_result: *const T) -> Result<&'a T> {
     }
 }
 
-fn map_result_ssl(ssl: &Handshake, bssl_result: c_int) -> Result<()> {
+fn map_result_ssl(ssl: &mut Handshake, bssl_result: c_int) -> Result<()> {
     match bssl_result {
         1 => Ok(()),
 
@@ -1082,7 +1127,7 @@ extern {
 
     fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 
-    fn SSL_get_error(ssl: *mut SSL, ret_code: c_int) -> c_int;
+    fn SSL_get_error(ssl: *const SSL, ret_code: c_int) -> c_int;
 
     fn SSL_set_accept_state(ssl: *mut SSL);
     fn SSL_set_connect_state(ssl: *mut SSL);
@@ -1092,21 +1137,21 @@ extern {
     fn SSL_set_ex_data(ssl: *mut SSL, idx: c_int, ptr: *const c_void) -> c_int;
     fn SSL_get_ex_data(ssl: *mut SSL, idx: c_int) -> *mut c_void;
 
-    fn SSL_get_current_cipher(ssl: *mut SSL) -> *const SSL_CIPHER;
+    fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 
-    fn SSL_get_curve_id(ssl: *mut SSL) -> u16;
+    fn SSL_get_curve_id(ssl: *const SSL) -> u16;
     fn SSL_get_curve_name(curve: u16) -> *const c_char;
 
-    fn SSL_get_peer_signature_algorithm(ssl: *mut SSL) -> u16;
+    fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
     fn SSL_get_signature_algorithm_name(
         sigalg: u16, include_curve: i32,
     ) -> *const c_char;
 
     fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int;
 
-    fn SSL_get_SSL_CTX(ssl: *mut SSL) -> *mut SSL_CTX;
+    fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 
-    fn SSL_get0_peer_certificates(ssl: *mut SSL) -> *const STACK_OF;
+    fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const STACK_OF;
 
     fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16);
     fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16);
@@ -1133,11 +1178,11 @@ extern {
     ) -> c_int;
 
     fn SSL_get_peer_quic_transport_params(
-        ssl: *mut SSL, out_params: *mut *const u8, out_params_len: *mut usize,
+        ssl: *const SSL, out_params: *mut *const u8, out_params_len: *mut usize,
     );
 
     fn SSL_get0_alpn_selected(
-        ssl: *mut SSL, out: *mut *const u8, out_len: *mut u32,
+        ssl: *const SSL, out: *mut *const u8, out_len: *mut u32,
     );
 
     fn SSL_provide_quic_data(
@@ -1150,13 +1195,13 @@ extern {
 
     fn SSL_do_handshake(ssl: *mut SSL) -> c_int;
 
-    fn SSL_quic_write_level(ssl: *mut SSL) -> crypto::Level;
+    fn SSL_quic_write_level(ssl: *const SSL) -> crypto::Level;
 
-    fn SSL_session_reused(ssl: *mut SSL) -> c_int;
+    fn SSL_session_reused(ssl: *const SSL) -> c_int;
 
-    fn SSL_in_init(ssl: *mut SSL) -> c_int;
+    fn SSL_in_init(ssl: *const SSL) -> c_int;
 
-    fn SSL_in_early_data(ssl: *mut SSL) -> c_int;
+    fn SSL_in_early_data(ssl: *const SSL) -> c_int;
 
     fn SSL_clear(ssl: *mut SSL) -> c_int;
 


### PR DESCRIPTION
The requirements for the Sync trait are somewhat confusing [0], but it
appears that the reason why it is not automatically implemented for
pointers is aliasing (that is, the data referenced by the pointer may be
aliased). In addition, non-thread-safe "interior mutable" types
(including pointers) also shouldn't be Sync (see e.g. Rc vs. Arc).

[0] https://doc.rust-lang.org/std/marker/trait.Sync.html

In the case of tls::Context and tls::Handshake, there is no aliasing,
but they do have "accidental interior mutability", where a non-mutable
reference is used to get a mutable pointer in a number of methods.

This means that explicitly implementing both Send and Sync for
tls::Context and tls::Handshake _should_ be safe, after the "accidental
interior mutability" problem mentioned above is fixed. This is done by
making a number of tls::Context and tls::Handshake methods take a
mutable reference.

A side-effect of all this is that we don't need to wrap tls::Context /
tls::Handshake in Mutex anymore, which was somewhat smelly to begin
with, so it's good to remove that as well.