### PR TITLE
recovery: fix more PRR calculation issues

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -17,7 +17,7 @@ LIBSSL_DIR = $(dir $(shell find ${BUILD_DIR} -name libssl.a))
 
 LDFLAGS = -L$(LIBCRYPTO_DIR) -L$(LIBSSL_DIR) -L$(LIB_DIR)
 
-LIBS = $(LIB_DIR)/libquiche.a -lev -ldl -pthread
+LIBS = $(LIB_DIR)/libquiche.a -lev -ldl -pthread -lm
 
 all: client server http3-client http3-server
 

--- a/src/recovery/prr.rs
+++ b/src/recovery/prr.rs
@@ -73,8 +73,8 @@ impl PRR {
         self.snd_cnt = if pipe > ssthresh {
             // Proportional Rate Reduction.
             ((self.prr_delivered * ssthresh + self.recoverfs - 1) /
-                self.recoverfs) -
-                self.prr_out
+                self.recoverfs)
+                .saturating_sub(self.prr_out)
         } else {
             // PRR-SSRB.
             let limit = cmp::max(


### PR DESCRIPTION
In addition to #976, fix additional divide by zero case.
Also test cases for all overflow added, including #973.