### PR TITLE
ci: add libm to nightly C example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -17,7 +17,7 @@ LIBSSL_DIR = $(dir $(shell find ${BUILD_DIR} -name libssl.a))
 
 LDFLAGS = -L$(LIBCRYPTO_DIR) -L$(LIBSSL_DIR) -L$(LIB_DIR)
 
-LIBS = $(LIB_DIR)/libquiche.a -lev -ldl -pthread
+LIBS = $(LIB_DIR)/libquiche.a -lev -ldl -pthread -lm
 
 all: client server http3-client http3-server
 


### PR DESCRIPTION
CI is failing when building C examples on nightly:

```
/usr/bin/ld: /home/runner/work/quiche/quiche/examples/build/debug/libquiche.a(std-363511a59ca6fedb.std.2k3kczsj-cgu.0.rcgu.o): undefined reference to symbol 'fmaf@@GLIBC_2.2.5'
```

stable is ok without it, so I think it's nightly issue.