### PR TITLE
qlog: align time units to qlog draft 02 style

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1551,7 +1551,6 @@ impl Connection {
             Some(description.to_string()),
             Some(qlog::Configuration {
                 time_offset: Some("0".to_string()),
-                time_units: Some(qlog::TimeUnits::Ms),
                 original_uris: None,
             }),
             None,

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -711,7 +711,7 @@ impl QlogStreamer {
         } else {
             now.duration_since(self.start_time)
         };
-        let rel_time = dur.as_micros() as f64 / 1000.0;
+        let rel_time = dur.as_secs_f64() * 1000.0;
         let rel_ev_time = EventField::RelativeTime(rel_time.to_string());
         let ev_time = serde_json::to_string(&rel_ev_time).ok();
         let ev_cat =


### PR DESCRIPTION
The qlog crate is primarily based on the qlog draft 01 specification.
This allowed configuration of time units used for logging, either in
milliseconds or microseconds. The qlog crate only supports relative time
logging and defaults to millisecond units in integer form.

The unfortunate side effect of millisecond units is that events occurring
close together get aliased into the same millisecond. Tools like qvis
can then misrepresent things.

In qlog draft 02, the time unit handling changed. It is no longer
configurable, instead it is always milliseconds, represented as floating
point. Previously, an event at relative time 100085 microseconds, would
be logged as "100". With this change it is logged as "100.085".

This change updates the time unit handling to align with draft 02. It
removes time unit configurability and logs event times as floating
point.