### PR TITLE
Changes control flow credits increases to a fixed amount of half init…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1377,7 +1377,7 @@ impl Connection {
 
             rx_data: 0,
             max_rx_data,
-            max_rx_data_incr: max_rx_data /2,
+            max_rx_data_incr: max_rx_data / 2,
             almost_full: false,
 
             tx_cap: 0,
@@ -4999,9 +4999,10 @@ impl Connection {
 
     /// Returns true if the connection-level flow control needs to be updated.
     ///
-    /// This happens when the current offset for the connection is more than half of the
-    /// previously allocated control flow credit since last MAX_DATA frame.
-    /// max_rx_data - max_rx_data_incr < rx_data < max_rx_data < max_rx_data + max_rx_data_incr
+    /// This happens when the current offset for the connection is more than
+    /// half of the previously allocated control flow credit since last
+    /// MAX_DATA frame. max_rx_data - max_rx_data_incr < rx_data <
+    /// max_rx_data < max_rx_data + max_rx_data_incr
     fn should_update_max_data(&self) -> bool {
         self.rx_data > self.max_rx_data - self.max_rx_data_incr
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -715,7 +715,7 @@ impl RecvBuf {
         RecvBuf {
             max_data,
             // MAX_DATA increments are set at half the initial max_data
-            max_data_incr: max_data/2,
+            max_data_incr: max_data / 2,
             ..RecvBuf::default()
         }
     }
@@ -943,10 +943,9 @@ impl RecvBuf {
 
     /// Returns true if we need to update the local flow control limit.
     pub fn almost_full(&self) -> bool {
-        // Send MAX_STREAM_DATA when at least half of the allowed data since last MAX_STREAM_DATA
-        // has been consumed.
-        self.fin_off.is_none() && 
-        self.len > self.max_data - self.max_data_incr
+        // Send MAX_STREAM_DATA when at least half of the allowed data since last
+        // MAX_STREAM_DATA has been consumed.
+        self.fin_off.is_none() && self.len > self.max_data - self.max_data_incr
     }
 
     /// Returns the largest offset ever received.
@@ -2299,7 +2298,6 @@ mod tests {
         stream.recv.update_max_data();
         assert_eq!(stream.recv.max_data_next(), 32);
         assert!(!stream.recv.almost_full());
-
 
         let (len, fin) = stream.recv.emit(&mut buf).unwrap();
         assert_eq!(&buf[..len], b"helloworld");

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -916,7 +916,7 @@ impl RecvBuf {
     }
 
     /// Return the new max_data limit.
-    pub fn max_data_next(&mut self) -> u64 {
+    pub fn max_data_next(&self) -> u64 {
         self.max_data + self.max_data_incr
     }
 
@@ -945,6 +945,7 @@ impl RecvBuf {
     pub fn almost_full(&self) -> bool {
         // Send MAX_STREAM_DATA when at least half of the allowed data since last
         // MAX_STREAM_DATA has been consumed.
+        // max_data - max_data_incr < len < max_data < max_data + max_data_incr
         self.fin_off.is_none() && self.len > self.max_data - self.max_data_incr
     }
 


### PR DESCRIPTION
…ial max_data

See issue #983 

Previous implementation of update_max_data() and related code has an issue that may result in
max_data increments becoming smaller over time and increasing the amount of MAX_STREAM_DATA
frames sent.

Another potential issue would be to have the difference between max_data and max_data_next
increasing over time.

The implemented solution sets a `max_data_incr` that is equal to half the initial `max_data`.
`max_data_incr` is used to determine when the stream is almost full, i.e. `len > max_data -
max_data_incr` and to set the new `max_data`, i.e. `max_data = max_data + max_data_incr`. The
control flow credits always increase by half the initial `max_data` and the unspent control
flow credits (`max_data - len`) is never larger than the initial `max_data`.