### PR TITLE
stream: use FxHash for stream maps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ log = { version = "0.4", features = ["std"] }
 libc = "0.2"
 libm = "0.2"
 ring = "0.16"
+rustc-hash = "1"
 lazy_static = "1"
 boring-sys = { version = "1.0.2", optional = true }
 qlog = { version = "0.4", path = "tools/qlog", optional = true }

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -277,7 +277,6 @@
 //! [`send_response()`]: struct.Connection.html#method.send_response
 //! [`send_body()`]: struct.Connection.html#method.send_body
 
-use std::collections::HashMap;
 use std::collections::VecDeque;
 
 use crate::octets;
@@ -623,7 +622,7 @@ pub struct Connection {
     next_request_stream_id: u64,
     next_uni_stream_id: u64,
 
-    streams: HashMap<u64, stream::Stream>,
+    streams: rustc_hash::FxHashMap<u64, stream::Stream>,
 
     local_settings: ConnectionSettings,
     peer_settings: ConnectionSettings,
@@ -665,7 +664,7 @@ impl Connection {
 
             next_uni_stream_id: initial_uni_stream_id,
 
-            streams: HashMap::new(),
+            streams: rustc_hash::FxHashMap::default(),
 
             local_settings: ConnectionSettings {
                 max_header_list_size: config.max_header_list_size,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -32,8 +32,6 @@ use std::collections::hash_map;
 
 use std::collections::BTreeMap;
 use std::collections::BinaryHeap;
-use std::collections::HashMap;
-use std::collections::HashSet;
 use std::collections::VecDeque;
 
 use crate::Error;
@@ -53,14 +51,14 @@ const SEND_BUFFER_SIZE: usize = 4096;
 #[derive(Default)]
 pub struct StreamMap {
     /// Map of streams indexed by stream ID.
-    streams: HashMap<u64, Stream>,
+    streams: rustc_hash::FxHashMap<u64, Stream>,
 
     /// Set of streams that were completed and garbage collected.
     ///
     /// Instead of keeping the full stream state forever, we collect completed
     /// streams to save memory, but we still need to keep track of previously
     /// created streams, to prevent peers from re-creating them.
-    collected: HashSet<u64>,
+    collected: rustc_hash::FxHashSet<u64>,
 
     /// Peer's maximum bidirectional stream count limit.
     peer_max_streams_bidi: u64,
@@ -104,34 +102,34 @@ pub struct StreamMap {
     /// Set of stream IDs corresponding to streams that have outstanding data
     /// to read. This is used to generate a `StreamIter` of streams without
     /// having to iterate over the full list of streams.
-    readable: HashSet<u64>,
+    readable: rustc_hash::FxHashSet<u64>,
 
     /// Set of stream IDs corresponding to streams that have enough flow control
     /// capacity to be written to, and is not finished. This is used to generate
     /// a `StreamIter` of streams without having to iterate over the full list
     /// of streams.
-    writable: HashSet<u64>,
+    writable: rustc_hash::FxHashSet<u64>,
 
     /// Set of stream IDs corresponding to streams that are almost out of flow
     /// control credit and need to send MAX_STREAM_DATA. This is used to
     /// generate a `StreamIter` of streams without having to iterate over the
     /// full list of streams.
-    almost_full: HashSet<u64>,
+    almost_full: rustc_hash::FxHashSet<u64>,
 
     /// Set of stream IDs corresponding to streams that are blocked. The value
     /// of the map elements represents the offset of the stream at which the
     /// blocking occurred.
-    blocked: HashMap<u64, u64>,
+    blocked: rustc_hash::FxHashMap<u64, u64>,
 
     /// Set of stream IDs corresponding to streams that are reset. The value
     /// of the map elements is a tuple of the error code and final size values
     /// to include in the RESET_STREAM frame.
-    reset: HashMap<u64, (u64, u64)>,
+    reset: rustc_hash::FxHashMap<u64, (u64, u64)>,
 
     /// Set of stream IDs corresponding to streams that are shutdown on the
     /// receive side, and need to send a STOP_SENDING frame. The value of the
     /// map elements is the error code to include in the STOP_SENDING frame.
-    stopped: HashMap<u64, u64>,
+    stopped: rustc_hash::FxHashMap<u64, u64>,
 }
 
 impl StreamMap {
@@ -653,7 +651,7 @@ pub struct StreamIter {
 
 impl StreamIter {
     #[inline]
-    fn from(streams: &HashSet<u64>) -> Self {
+    fn from<T>(streams: &std::collections::HashSet<u64, T>) -> Self {
         StreamIter {
             streams: streams.iter().copied().collect(),
         }


### PR DESCRIPTION
Stream IDs are just numbers, so using the default HashMap hasher is kind
of pointless and unnecessarily expensive. FxHash is supposedly faster
for this kind of input.