### PR TITLE
qlog: convert numbers to actual numbers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1550,7 +1550,7 @@ impl Connection {
             Some(title.to_string()),
             Some(description.to_string()),
             Some(qlog::Configuration {
-                time_offset: Some("0".to_string()),
+                time_offset: Some(0.0),
                 original_uris: None,
             }),
             None,
@@ -3370,8 +3370,8 @@ impl Connection {
 
         qlog_with!(self.qlog_streamer, q, {
             let ev = qlog::event::Event::h3_data_moved(
-                stream_id.to_string(),
-                Some(offset.to_string()),
+                stream_id,
+                Some(offset),
                 Some(read as u64),
                 Some(qlog::H3DataRecipient::Transport),
                 None,
@@ -3519,8 +3519,8 @@ impl Connection {
 
         qlog_with!(self.qlog_streamer, q, {
             let ev = qlog::event::Event::h3_data_moved(
-                stream_id.to_string(),
-                Some(offset.to_string()),
+                stream_id,
+                Some(offset),
                 Some(sent as u64),
                 None,
                 Some(qlog::H3DataRecipient::Transport),
@@ -5620,16 +5620,16 @@ impl TransportParams {
             stateless_reset_token,
             Some(self.disable_active_migration),
             Some(self.max_idle_timeout),
-            Some(self.max_udp_payload_size),
-            Some(self.ack_delay_exponent),
-            Some(self.max_ack_delay),
+            Some(self.max_udp_payload_size as u32),
+            Some(self.ack_delay_exponent as u16),
+            Some(self.max_ack_delay as u16),
             Some(self.active_conn_id_limit),
-            Some(self.initial_max_data.to_string()),
-            Some(self.initial_max_stream_data_bidi_local.to_string()),
-            Some(self.initial_max_stream_data_bidi_remote.to_string()),
-            Some(self.initial_max_stream_data_uni.to_string()),
-            Some(self.initial_max_streams_bidi.to_string()),
-            Some(self.initial_max_streams_uni.to_string()),
+            Some(self.initial_max_data),
+            Some(self.initial_max_stream_data_bidi_local),
+            Some(self.initial_max_stream_data_bidi_remote),
+            Some(self.initial_max_stream_data_uni),
+            Some(self.initial_max_streams_bidi),
+            Some(self.initial_max_streams_uni),
             None, // preferred address
         )
     }

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -858,10 +858,10 @@ impl Recovery {
     pub fn to_qlog(&self) -> qlog::event::Event {
         // QVis can't use all these fields and they can be large.
         qlog::event::Event::metrics_updated(
-            Some(self.min_rtt.as_millis() as u64),
-            Some(self.rtt().as_millis() as u64),
-            Some(self.latest_rtt.as_millis() as u64),
-            Some(self.rttvar.as_millis() as u64),
+            Some(self.min_rtt.as_secs_f32() * 1000.0),
+            Some(self.rtt().as_secs_f32() * 1000.0),
+            Some(self.latest_rtt.as_secs_f32() * 1000.0),
+            Some(self.rttvar.as_secs_f32() * 1000.0),
             None, // delay
             None, // probe_count
             Some(self.cwnd() as u64),

--- a/tools/qlog/src/event.rs
+++ b/tools/qlog/src/event.rs
@@ -56,7 +56,7 @@ impl Event {
     /// * `EventType`=`ConnectivityEventType::ServerListening`
     /// * `EventData`=`ServerListening`.
     pub fn server_listening(
-        ip_v4: Option<String>, ip_v6: Option<String>, port_v4: u64, port_v6: u64,
+        ip_v4: Option<String>, ip_v6: Option<String>, port_v4: u32, port_v6: u32,
         quic_versions: Option<Vec<String>>, alpn_values: Option<Vec<String>>,
         stateless_reset_required: Option<bool>,
     ) -> Self {
@@ -77,7 +77,7 @@ impl Event {
         }
     }
 
-    pub fn server_listening_min(port_v4: u64, port_v6: u64) -> Self {
+    pub fn server_listening_min(port_v4: u32, port_v6: u32) -> Self {
         Event::server_listening(None, None, port_v4, port_v6, None, None, None)
     }
 
@@ -87,7 +87,7 @@ impl Event {
     /// * `EventData`=`ConnectionStarted`.
     pub fn connection_started(
         ip_version: String, src_ip: String, dst_ip: String,
-        protocol: Option<String>, src_port: u64, dst_port: u64,
+        protocol: Option<String>, src_port: u32, dst_port: u32,
         quic_version: Option<String>, src_cid: Option<String>,
         dst_cid: Option<String>,
     ) -> Self {
@@ -111,8 +111,8 @@ impl Event {
     }
 
     pub fn connection_started_min(
-        ip_version: String, src_ip: String, dst_ip: String, src_port: u64,
-        dst_port: u64,
+        ip_version: String, src_ip: String, dst_ip: String, src_port: u32,
+        dst_port: u32,
     ) -> Self {
         Event::connection_started(
             ip_version, src_ip, dst_ip, None, src_port, dst_port, None, None,
@@ -193,14 +193,14 @@ impl Event {
         original_connection_id: Option<String>,
         stateless_reset_token: Option<String>,
         disable_active_migration: Option<bool>, idle_timeout: Option<u64>,
-        max_packet_size: Option<u64>, ack_delay_exponent: Option<u64>,
-        max_ack_delay: Option<u64>, active_connection_id_limit: Option<u64>,
-        initial_max_data: Option<String>,
-        initial_max_stream_data_bidi_local: Option<String>,
-        initial_max_stream_data_bidi_remote: Option<String>,
-        initial_max_stream_data_uni: Option<String>,
-        initial_max_streams_bidi: Option<String>,
-        initial_max_streams_uni: Option<String>,
+        max_udp_payload_size: Option<u32>, ack_delay_exponent: Option<u16>,
+        max_ack_delay: Option<u16>, active_connection_id_limit: Option<u64>,
+        initial_max_data: Option<u64>,
+        initial_max_stream_data_bidi_local: Option<u64>,
+        initial_max_stream_data_bidi_remote: Option<u64>,
+        initial_max_stream_data_uni: Option<u64>,
+        initial_max_streams_bidi: Option<u64>,
+        initial_max_streams_uni: Option<u64>,
         preferred_address: Option<PreferredAddress>,
     ) -> Self {
         Event {
@@ -220,7 +220,7 @@ impl Event {
                 disable_active_migration,
 
                 idle_timeout,
-                max_packet_size,
+                max_udp_payload_size,
                 ack_delay_exponent,
                 max_ack_delay,
                 active_connection_id_limit,
@@ -249,7 +249,7 @@ impl Event {
     /// * `EventType`=`TransportEventType::DatagramsReceived`
     /// * `EventData`=`DatagramsReceived`.
     pub fn datagrams_received(
-        count: Option<u64>, byte_length: Option<u64>,
+        count: Option<u16>, byte_length: Option<u64>,
     ) -> Self {
         Event {
             category: EventCategory::Transport,
@@ -268,7 +268,7 @@ impl Event {
     /// * `EventCategory`=`Transport`
     /// * `EventType`=`TransportEventType::DatagramsSent`
     /// * `EventData`=`DatagramsSent`.
-    pub fn datagrams_sent(count: Option<u64>, byte_length: Option<u64>) -> Self {
+    pub fn datagrams_sent(count: Option<u16>, byte_length: Option<u64>) -> Self {
         Event {
             category: EventCategory::Transport,
             ty: EventType::TransportEventType(TransportEventType::DatagramsSent),
@@ -406,7 +406,7 @@ impl Event {
     /// * `EventType`=`TransportEventType::StreamStateUpdated`
     /// * `EventData`=`StreamStateUpdated`.
     pub fn stream_state_updated(
-        stream_id: String, stream_type: Option<StreamType>,
+        stream_id: u64, stream_type: Option<StreamType>,
         old: Option<StreamState>, new: StreamState,
         stream_side: Option<StreamSide>,
     ) -> Self {
@@ -425,7 +425,7 @@ impl Event {
         }
     }
 
-    pub fn stream_state_updated_min(stream_id: String, new: StreamState) -> Self {
+    pub fn stream_state_updated_min(stream_id: u64, new: StreamState) -> Self {
         Event::stream_state_updated(stream_id, None, None, new, None)
     }
 
@@ -450,12 +450,12 @@ impl Event {
     /// * `EventType`=`RecoveryEventType::ParametersSet`
     /// * `EventData`=`RecoveryParametersSet`.
     pub fn recovery_parameters_set(
-        reordering_threshold: Option<u64>, time_threshold: Option<u64>,
-        timer_granularity: Option<u64>, initial_rtt: Option<u64>,
-        max_datagram_size: Option<u64>, initial_congestion_window: Option<u64>,
-        minimum_congestion_window: Option<u64>,
-        loss_reduction_factor: Option<u64>,
-        persistent_congestion_threshold: Option<u64>,
+        reordering_threshold: Option<u16>, time_threshold: Option<f32>,
+        timer_granularity: Option<u16>, initial_rtt: Option<f32>,
+        max_datagram_size: Option<u32>, initial_congestion_window: Option<u64>,
+        minimum_congestion_window: Option<u32>,
+        loss_reduction_factor: Option<f32>,
+        persistent_congestion_threshold: Option<u16>,
     ) -> Self {
         Event {
             category: EventCategory::Recovery,
@@ -485,9 +485,9 @@ impl Event {
     /// * `EventType`=`RecoveryEventType::MetricsUpdated`
     /// * `EventData`=`MetricsUpdated`.
     pub fn metrics_updated(
-        min_rtt: Option<u64>, smoothed_rtt: Option<u64>, latest_rtt: Option<u64>,
-        rtt_variance: Option<u64>, max_ack_delay: Option<u64>,
-        pto_count: Option<u64>, congestion_window: Option<u64>,
+        min_rtt: Option<f32>, smoothed_rtt: Option<f32>, latest_rtt: Option<f32>,
+        rtt_variance: Option<f32>, max_ack_delay: Option<u64>,
+        pto_count: Option<u16>, congestion_window: Option<u64>,
         bytes_in_flight: Option<u64>, ssthresh: Option<u64>,
         packets_in_flight: Option<u64>, in_recovery: Option<bool>,
         pacing_rate: Option<u64>,
@@ -632,7 +632,7 @@ impl Event {
     /// * `EventType`=`Http3EventType::StreamTypeSet`
     /// * `EventData`=`H3StreamTypeSet`.
     pub fn h3_stream_type_set(
-        stream_id: String, owner: Option<H3Owner>, old: Option<H3StreamType>,
+        stream_id: u64, owner: Option<H3Owner>, old: Option<H3StreamType>,
         new: H3StreamType,
     ) -> Self {
         Event {
@@ -647,7 +647,7 @@ impl Event {
         }
     }
 
-    pub fn h3_stream_type_set_min(stream_id: String, new: H3StreamType) -> Self {
+    pub fn h3_stream_type_set_min(stream_id: u64, new: H3StreamType) -> Self {
         Event::h3_stream_type_set(stream_id, None, None, new)
     }
 
@@ -656,7 +656,7 @@ impl Event {
     /// * `EventType`=`Http3EventType::FrameCreated`
     /// * `EventData`=`H3FrameCreated`.
     pub fn h3_frame_created(
-        stream_id: String, frame: Http3Frame, byte_length: Option<String>,
+        stream_id: u64, frame: Http3Frame, byte_length: Option<u64>,
         raw: Option<String>,
     ) -> Self {
         Event {
@@ -671,7 +671,7 @@ impl Event {
         }
     }
 
-    pub fn h3_frame_created_min(stream_id: String, frame: Http3Frame) -> Self {
+    pub fn h3_frame_created_min(stream_id: u64, frame: Http3Frame) -> Self {
         Event::h3_frame_created(stream_id, frame, None, None)
     }
 
@@ -680,7 +680,7 @@ impl Event {
     /// * `EventType`=`Http3EventType::FrameParsed`
     /// * `EventData`=`H3FrameParsed`.
     pub fn h3_frame_parsed(
-        stream_id: String, frame: Http3Frame, byte_length: Option<String>,
+        stream_id: u64, frame: Http3Frame, byte_length: Option<u64>,
         raw: Option<String>,
     ) -> Self {
         Event {
@@ -695,7 +695,7 @@ impl Event {
         }
     }
 
-    pub fn h3_frame_parsed_min(stream_id: String, frame: Http3Frame) -> Self {
+    pub fn h3_frame_parsed_min(stream_id: u64, frame: Http3Frame) -> Self {
         Event::h3_frame_parsed(stream_id, frame, None, None)
     }
 
@@ -704,7 +704,7 @@ impl Event {
     /// * `EventType`=`Http3EventType::DataMoved`
     /// * `EventData`=`H3DataMoved`.
     pub fn h3_data_moved(
-        stream_id: String, offset: Option<String>, length: Option<u64>,
+        stream_id: u64, offset: Option<u64>, length: Option<u64>,
         from: Option<H3DataRecipient>, to: Option<H3DataRecipient>,
         raw: Option<String>,
     ) -> Self {
@@ -722,7 +722,7 @@ impl Event {
         }
     }
 
-    pub fn h3_data_moved_min(stream_id: String) -> Self {
+    pub fn h3_data_moved_min(stream_id: u64) -> Self {
         Event::h3_data_moved(stream_id, None, None, None, None, None)
     }
 
@@ -731,7 +731,7 @@ impl Event {
     /// * `EventType`=`Http3EventType::PushResolved`
     /// * `EventData`=`H3PushResolved`.
     pub fn h3_push_resolved(
-        push_id: Option<String>, stream_id: Option<String>,
+        push_id: Option<u64>, stream_id: Option<u64>,
         decision: Option<H3PushDecision>,
     ) -> Self {
         Event {
@@ -782,7 +782,7 @@ impl Event {
     /// * `EventType`=`QpackEventType::StreamStateUpdated`
     /// * `EventData`=`QpackStreamStateUpdated`.
     pub fn qpack_stream_state_updated(
-        stream_id: String, state: QpackStreamState,
+        stream_id: u64, state: QpackStreamState,
     ) -> Self {
         Event {
             category: EventCategory::Qpack,
@@ -813,7 +813,7 @@ impl Event {
     /// * `EventType`=`QpackEventType::HeadersEncoded`
     /// * `EventData`=`QpackHeadersEncoded`.
     pub fn qpack_headers_encoded(
-        stream_id: Option<String>, headers: Option<HttpHeader>,
+        stream_id: Option<u64>, headers: Option<HttpHeader>,
         block_prefix: QpackHeaderBlockPrefix,
         header_block: Vec<QpackHeaderBlockRepresentation>, raw: Option<String>,
     ) -> Self {
@@ -842,7 +842,7 @@ impl Event {
     /// * `EventType`=`QpackEventType::HeadersDecoded`
     /// * `EventData`=`QpackHeadersDecoded`.
     pub fn qpack_headers_decoded(
-        stream_id: Option<String>, headers: Option<HttpHeader>,
+        stream_id: Option<u64>, headers: Option<HttpHeader>,
         block_prefix: QpackHeaderBlockPrefix,
         header_block: Vec<QpackHeaderBlockRepresentation>, raw: Option<String>,
     ) -> Self {
@@ -871,7 +871,7 @@ impl Event {
     /// * `EventType`=`QpackEventType::InstructionSent`
     /// * `EventData`=`QpackInstructionSent`.
     pub fn qpack_instruction_sent(
-        instruction: QPackInstruction, byte_length: Option<String>,
+        instruction: QPackInstruction, byte_length: Option<u32>,
         raw: Option<String>,
     ) -> Self {
         Event {
@@ -894,7 +894,7 @@ impl Event {
     /// * `EventType`=`QpackEventType::InstructionReceived`
     /// * `EventData`=`QpackInstructionReceived`.
     pub fn qpack_instruction_received(
-        instruction: QPackInstruction, byte_length: Option<String>,
+        instruction: QPackInstruction, byte_length: Option<u32>,
         raw: Option<String>,
     ) -> Self {
         Event {

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -92,7 +92,7 @@
 //!     Some("Example qlog trace".to_string()),
 //!     Some("Example qlog trace description".to_string()),
 //!     Some(qlog::Configuration {
-//!         time_offset: Some("0".to_string()),
+//!         time_offset: Some(0.0),
 //!         original_uris: None,
 //!     }),
 //!     None,
@@ -122,7 +122,7 @@
 //! #     Some("Example qlog trace".to_string()),
 //! #     Some("Example qlog trace description".to_string()),
 //! #     Some(qlog::Configuration {
-//! #         time_offset: Some("0".to_string()),
+//! #         time_offset: Some(0.0),
 //! #         original_uris: None,
 //! #     }),
 //! #     None
@@ -140,8 +140,7 @@
 //!     Some(&dcid),
 //! );
 //!
-//! let frames =
-//!     vec![qlog::QuicFrame::crypto("0".to_string(), "1000".to_string())];
+//! let frames = vec![qlog::QuicFrame::crypto(0, 0)];
 //!
 //! let event = qlog::event::Event::packet_sent_min(
 //!     qlog::PacketType::Initial,
@@ -169,7 +168,7 @@
 //! #     Some("Example qlog trace".to_string()),
 //! #     Some("Example qlog trace description".to_string()),
 //! #     Some(qlog::Configuration {
-//! #         time_offset: Some("0".to_string()),
+//! #         time_offset: Some(0.0),
 //! #         original_uris: None,
 //! #     }),
 //! #     None
@@ -188,7 +187,7 @@
 //!   "title": "Example qlog trace",
 //!   "description": "Example qlog trace description",
 //!   "configuration": {
-//!     "time_offset": "0"
+//!     "time_offset": 0.0
 //!   },
 //!   "event_fields": [
 //!     "relative_time",
@@ -198,26 +197,26 @@
 //!   ],
 //!   "events": [
 //!     [
-//!       "0",
+//!       0,
 //!       "transport",
 //!       "packet_sent",
 //!       {
 //!         "packet_type": "initial",
 //!         "header": {
-//!           "packet_number": "0",
+//!           "packet_number": 0,
 //!           "packet_size": 1251,
 //!           "payload_length": 1224,
 //!           "version": "ff00001b",
-//!           "scil": "8",
-//!           "dcil": "8",
+//!           "scil": 8,
+//!           "dcil": 8,
 //!           "scid": "7e37e4dcc6682da8",
 //!           "dcid": "36ce104eee50101c"
 //!         },
 //!         "frames": [
 //!           {
 //!             "frame_type": "crypto",
-//!             "offset": "0",
-//!             "length": "100",
+//!             "offset": 0,
+//!             "length": 100,
 //!           }
 //!         ]
 //!       }
@@ -241,7 +240,7 @@
 //!     Some("Example qlog trace".to_string()),
 //!     Some("Example qlog trace description".to_string()),
 //!     Some(qlog::Configuration {
-//!         time_offset: Some("0".to_string()),
+//!         time_offset: Some(0.0),
 //!         original_uris: None,
 //!     }),
 //!     None,
@@ -266,7 +265,7 @@
 //! #    Some("Example qlog trace".to_string()),
 //! #    Some("Example qlog trace description".to_string()),
 //! #    Some(qlog::Configuration {
-//! #        time_offset: Some("0".to_string()),
+//! #        time_offset: Some(0.0),
 //! #        original_uris: None,
 //! #    }),
 //! #    None,
@@ -300,7 +299,7 @@
 //! #    Some("Example qlog trace".to_string()),
 //! #    Some("Example qlog trace description".to_string()),
 //! #    Some(qlog::Configuration {
-//! #        time_offset: Some("0".to_string()),
+//! #        time_offset: Some(0.0),
 //! #        original_uris: None,
 //! #    }),
 //! #    None,
@@ -338,7 +337,7 @@
 //! #    Some("Example qlog trace".to_string()),
 //! #    Some("Example qlog trace description".to_string()),
 //! #    Some(qlog::Configuration {
-//! #        time_offset: Some("0".to_string()),
+//! #        time_offset: Some(0.0),
 //! #        original_uris: None,
 //! #    }),
 //! #    None,
@@ -387,7 +386,7 @@
 //! #    Some("Example qlog trace".to_string()),
 //! #    Some("Example qlog trace description".to_string()),
 //! #    Some(qlog::Configuration {
-//! #        time_offset: Some("0".to_string()),
+//! #        time_offset: Some(0.0),
 //! #        original_uris: None,
 //! #    }),
 //! #    None,
@@ -425,7 +424,7 @@
 //! #    Some("Example qlog trace".to_string()),
 //! #    Some("Example qlog trace description".to_string()),
 //! #    Some(qlog::Configuration {
-//! #        time_offset: Some("0".to_string()),
+//! #        time_offset: Some(0.0),
 //! #        original_uris: None,
 //! #    }),
 //! #    None,
@@ -711,8 +710,8 @@ impl QlogStreamer {
         } else {
             now.duration_since(self.start_time)
         };
-        let rel_time = dur.as_secs_f64() * 1000.0;
-        let rel_ev_time = EventField::RelativeTime(rel_time.to_string());
+        let rel_time = dur.as_secs_f32() * 1000.0;
+        let rel_ev_time = EventField::RelativeTime(rel_time);
         let ev_time = serde_json::to_string(&rel_ev_time).ok();
         let ev_cat =
             serde_json::to_string(&EventField::Category(event.category)).ok();
@@ -833,16 +832,18 @@ impl Trace {
     pub fn push_event(
         &mut self, relative_time: std::time::Duration, event: crate::event::Event,
     ) {
-        let rel_ev_time = relative_time.as_micros() as f64 / 1000.0;
+        let rel_ev_time = relative_time.as_secs_f32() * 1000.0;
 
         self.events.push(vec![
-            EventField::RelativeTime(rel_ev_time.to_string()),
+            EventField::RelativeTime(rel_ev_time),
             EventField::Category(event.category),
             EventField::Event(event.ty),
             EventField::Data(event.data),
         ]);
     }
 }
+
+pub type Bytes = String;
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone)]
@@ -874,7 +875,7 @@ pub enum TimeUnits {
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone)]
 pub struct Configuration {
-    pub time_offset: Option<String>,
+    pub time_offset: Option<f64>,
 
     pub original_uris: Option<Vec<String>>,
     /* TODO
@@ -884,7 +885,7 @@ pub struct Configuration {
 impl Default for Configuration {
     fn default() -> Self {
         Configuration {
-            time_offset: Some("0".to_string()),
+            time_offset: Some(0.0),
             original_uris: None,
         }
     }
@@ -923,7 +924,7 @@ pub enum EventType {
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum EventField {
-    RelativeTime(String),
+    RelativeTime(f32),
 
     Category(EventCategory),
 
@@ -1194,8 +1195,8 @@ pub enum EventData {
     ServerListening {
         ip_v4: Option<String>,
         ip_v6: Option<String>,
-        port_v4: u64,
-        port_v6: u64,
+        port_v4: u32,
+        port_v6: u32,
 
         quic_versions: Option<Vec<String>>,
         alpn_values: Option<Vec<String>>,
@@ -1209,8 +1210,8 @@ pub enum EventData {
         dst_ip: String,
 
         protocol: Option<String>,
-        src_port: u64,
-        dst_port: u64,
+        src_port: u32,
+        dst_port: u32,
 
         quic_version: Option<String>,
         src_cid: Option<String>,
@@ -1218,11 +1219,11 @@ pub enum EventData {
     },
 
     ConnectionIdUpdated {
-        src_old: Option<String>,
-        src_new: Option<String>,
+        src_old: Option<Bytes>,
+        src_new: Option<Bytes>,
 
-        dst_old: Option<String>,
-        dst_new: Option<String>,
+        dst_old: Option<Bytes>,
+        dst_new: Option<Bytes>,
     },
 
     SpinBitUpdated {
@@ -1238,15 +1239,15 @@ pub enum EventData {
     // SECURITY
     KeyUpdated {
         key_type: KeyType,
-        old: Option<String>,
-        new: String,
-        generation: Option<u64>,
+        old: Option<Bytes>,
+        new: Bytes,
+        generation: Option<u32>,
     },
 
     KeyRetired {
         key_type: KeyType,
-        key: Option<String>,
-        generation: Option<u64>,
+        key: Option<Bytes>,
+        generation: Option<u32>,
     },
 
     // ================================================================== //
@@ -1260,33 +1261,33 @@ pub enum EventData {
         version: Option<String>,
         tls_cipher: Option<String>,
 
-        original_connection_id: Option<String>,
-        stateless_reset_token: Option<String>,
+        original_connection_id: Option<Bytes>,
+        stateless_reset_token: Option<Bytes>,
         disable_active_migration: Option<bool>,
 
         idle_timeout: Option<u64>,
-        max_packet_size: Option<u64>,
-        ack_delay_exponent: Option<u64>,
-        max_ack_delay: Option<u64>,
+        max_udp_payload_size: Option<u32>,
+        ack_delay_exponent: Option<u16>,
+        max_ack_delay: Option<u16>,
         active_connection_id_limit: Option<u64>,
 
-        initial_max_data: Option<String>,
-        initial_max_stream_data_bidi_local: Option<String>,
-        initial_max_stream_data_bidi_remote: Option<String>,
-        initial_max_stream_data_uni: Option<String>,
-        initial_max_streams_bidi: Option<String>,
-        initial_max_streams_uni: Option<String>,
+        initial_max_data: Option<u64>,
+        initial_max_stream_data_bidi_local: Option<u64>,
+        initial_max_stream_data_bidi_remote: Option<u64>,
+        initial_max_stream_data_uni: Option<u64>,
+        initial_max_streams_bidi: Option<u64>,
+        initial_max_streams_uni: Option<u64>,
 
         preferred_address: Option<PreferredAddress>,
     },
 
     DatagramsReceived {
-        count: Option<u64>,
+        count: Option<u16>,
         byte_length: Option<u64>,
     },
 
     DatagramsSent {
-        count: Option<u64>,
+        count: Option<u16>,
         byte_length: Option<u64>,
     },
 
@@ -1302,8 +1303,8 @@ pub enum EventData {
         // so we define it there and depend on serde's preserve_order feature.
         is_coalesced: Option<bool>,
 
-        raw_encrypted: Option<String>,
-        raw_decrypted: Option<String>,
+        raw_encrypted: Option<Bytes>,
+        raw_decrypted: Option<Bytes>,
         frames: Option<Vec<QuicFrame>>,
     },
 
@@ -1315,8 +1316,8 @@ pub enum EventData {
         // so we define it there and depend on serde's preserve_order feature.
         is_coalesced: Option<bool>,
 
-        raw_encrypted: Option<String>,
-        raw_decrypted: Option<String>,
+        raw_encrypted: Option<Bytes>,
+        raw_decrypted: Option<Bytes>,
         frames: Option<Vec<QuicFrame>>,
     },
 
@@ -1324,7 +1325,7 @@ pub enum EventData {
         packet_type: Option<PacketType>,
         packet_size: Option<u64>,
 
-        raw: Option<String>,
+        raw: Option<Bytes>,
     },
 
     PacketBuffered {
@@ -1333,7 +1334,7 @@ pub enum EventData {
     },
 
     StreamStateUpdated {
-        stream_id: String,
+        stream_id: u64,
         stream_type: Option<StreamType>,
 
         old: Option<StreamState>,
@@ -1349,26 +1350,26 @@ pub enum EventData {
     // ================================================================== //
     // RECOVERY
     RecoveryParametersSet {
-        reordering_threshold: Option<u64>,
-        time_threshold: Option<u64>,
-        timer_granularity: Option<u64>,
-        initial_rtt: Option<u64>,
+        reordering_threshold: Option<u16>,
+        time_threshold: Option<f32>,
+        timer_granularity: Option<u16>,
+        initial_rtt: Option<f32>,
 
-        max_datagram_size: Option<u64>,
+        max_datagram_size: Option<u32>,
         initial_congestion_window: Option<u64>,
-        minimum_congestion_window: Option<u64>,
-        loss_reduction_factor: Option<u64>,
-        persistent_congestion_threshold: Option<u64>,
+        minimum_congestion_window: Option<u32>,
+        loss_reduction_factor: Option<f32>,
+        persistent_congestion_threshold: Option<u16>,
     },
 
     MetricsUpdated {
-        min_rtt: Option<u64>,
-        smoothed_rtt: Option<u64>,
-        latest_rtt: Option<u64>,
-        rtt_variance: Option<u64>,
+        min_rtt: Option<f32>,
+        smoothed_rtt: Option<f32>,
+        latest_rtt: Option<f32>,
+        rtt_variance: Option<f32>,
 
         max_ack_delay: Option<u64>,
-        pto_count: Option<u64>,
+        pto_count: Option<u16>,
 
         congestion_window: Option<u64>,
         bytes_in_flight: Option<u64>,
@@ -1419,7 +1420,7 @@ pub enum EventData {
     },
 
     H3StreamTypeSet {
-        stream_id: String,
+        stream_id: u64,
         owner: Option<H3Owner>,
 
         old: Option<H3StreamType>,
@@ -1427,24 +1428,24 @@ pub enum EventData {
     },
 
     H3FrameCreated {
-        stream_id: String,
+        stream_id: u64,
         frame: Http3Frame,
-        byte_length: Option<String>,
+        byte_length: Option<u64>,
 
         raw: Option<String>,
     },
 
     H3FrameParsed {
-        stream_id: String,
+        stream_id: u64,
         frame: Http3Frame,
-        byte_length: Option<String>,
+        byte_length: Option<u64>,
 
         raw: Option<String>,
     },
 
     H3DataMoved {
-        stream_id: String,
-        offset: Option<String>,
+        stream_id: u64,
+        offset: Option<u64>,
         length: Option<u64>,
 
         from: Option<H3DataRecipient>,
@@ -1454,8 +1455,8 @@ pub enum EventData {
     },
 
     H3PushResolved {
-        push_id: Option<String>,
-        stream_id: Option<String>,
+        push_id: Option<u64>,
+        stream_id: Option<u64>,
 
         decision: Option<H3PushDecision>,
     },
@@ -1473,7 +1474,7 @@ pub enum EventData {
     },
 
     QpackStreamStateUpdated {
-        stream_id: String,
+        stream_id: u64,
 
         state: QpackStreamState,
     },
@@ -1485,39 +1486,39 @@ pub enum EventData {
     },
 
     QpackHeadersEncoded {
-        stream_id: Option<String>,
+        stream_id: Option<u64>,
 
         headers: Option<HttpHeader>,
 
         block_prefix: QpackHeaderBlockPrefix,
         header_block: Vec<QpackHeaderBlockRepresentation>,
 
-        raw: Option<String>,
+        raw: Option<Bytes>,
     },
 
     QpackHeadersDecoded {
-        stream_id: Option<String>,
+        stream_id: Option<u64>,
 
         headers: Option<HttpHeader>,
 
         block_prefix: QpackHeaderBlockPrefix,
         header_block: Vec<QpackHeaderBlockRepresentation>,
 
-        raw: Option<String>,
+        raw: Option<Bytes>,
     },
 
     QpackInstructionSent {
         instruction: QPackInstruction,
-        byte_length: Option<String>,
+        byte_length: Option<u32>,
 
-        raw: Option<String>,
+        raw: Option<Bytes>,
     },
 
     QpackInstructionReceived {
         instruction: QPackInstruction,
-        byte_length: Option<String>,
+        byte_length: Option<u32>,
 
-        raw: Option<String>,
+        raw: Option<Bytes>,
     },
 
     // ================================================================== //
@@ -1643,14 +1644,14 @@ pub enum QuicFrameTypeName {
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Serialize)]
 pub struct PacketHeader {
-    pub packet_number: String,
+    pub packet_number: u64,
     pub packet_size: Option<u64>,
     pub payload_length: Option<u64>,
     pub version: Option<String>,
-    pub scil: Option<String>,
-    pub dcil: Option<String>,
-    pub scid: Option<String>,
-    pub dcid: Option<String>,
+    pub scil: Option<u8>,
+    pub dcil: Option<u8>,
+    pub scid: Option<Bytes>,
+    pub dcid: Option<Bytes>,
 }
 
 impl PacketHeader {
@@ -1662,7 +1663,7 @@ impl PacketHeader {
     ) -> Self {
         let (scil, scid) = match scid {
             Some(cid) => (
-                Some(cid.len().to_string()),
+                Some(cid.len() as u8),
                 Some(format!("{}", HexSlice::new(&cid))),
             ),
 
@@ -1671,7 +1672,7 @@ impl PacketHeader {
 
         let (dcil, dcid) = match dcid {
             Some(cid) => (
-                Some(cid.len().to_string()),
+                Some(cid.len() as u8),
                 Some(format!("{}", HexSlice::new(&cid))),
             ),
 
@@ -1681,7 +1682,7 @@ impl PacketHeader {
         let version = version.map(|v| format!("{:x?}", v));
 
         PacketHeader {
-            packet_number: packet_number.to_string(),
+            packet_number,
             packet_size,
             payload_length,
             version,
@@ -1827,33 +1828,33 @@ pub enum QuicFrame {
 
     Ack {
         frame_type: QuicFrameTypeName,
-        ack_delay: Option<String>,
+        ack_delay: Option<f32>,
         acked_ranges: Option<Vec<(u64, u64)>>,
 
-        ect1: Option<String>,
+        ect1: Option<u64>,
 
-        ect0: Option<String>,
+        ect0: Option<u64>,
 
-        ce: Option<String>,
+        ce: Option<u64>,
     },
 
     ResetStream {
         frame_type: QuicFrameTypeName,
-        stream_id: String,
+        stream_id: u64,
         error_code: u64,
-        final_size: String,
+        final_size: u64,
     },
 
     StopSending {
         frame_type: QuicFrameTypeName,
-        stream_id: String,
+        stream_id: u64,
         error_code: u64,
     },
 
     Crypto {
         frame_type: QuicFrameTypeName,
-        offset: String,
-        length: String,
+        offset: u64,
+        length: u64,
     },
 
     NewToken {
@@ -1864,52 +1865,52 @@ pub enum QuicFrame {
 
     Stream {
         frame_type: QuicFrameTypeName,
-        stream_id: String,
-        offset: String,
-        length: String,
+        stream_id: u64,
+        offset: u64,
+        length: u64,
         fin: bool,
 
-        raw: Option<String>,
+        raw: Option<Bytes>,
     },
 
     MaxData {
         frame_type: QuicFrameTypeName,
-        maximum: String,
+        maximum: u64,
     },
 
     MaxStreamData {
         frame_type: QuicFrameTypeName,
-        stream_id: String,
-        maximum: String,
+        stream_id: u64,
+        maximum: u64,
     },
 
     MaxStreams {
         frame_type: QuicFrameTypeName,
         stream_type: StreamType,
-        maximum: String,
+        maximum: u64,
     },
 
     DataBlocked {
         frame_type: QuicFrameTypeName,
-        limit: String,
+        limit: u64,
     },
 
     StreamDataBlocked {
         frame_type: QuicFrameTypeName,
-        stream_id: String,
-        limit: String,
+        stream_id: u64,
+        limit: u64,
     },
 
     StreamsBlocked {
         frame_type: QuicFrameTypeName,
         stream_type: StreamType,
-        limit: String,
+        limit: u64,
     },
 
     NewConnectionId {
         frame_type: QuicFrameTypeName,
-        sequence_number: String,
-        retire_prior_to: String,
+        sequence_number: u32,
+        retire_prior_to: u32,
         length: u64,
         connection_id: String,
         reset_token: String,
@@ -1917,29 +1918,29 @@ pub enum QuicFrame {
 
     RetireConnectionId {
         frame_type: QuicFrameTypeName,
-        sequence_number: String,
+        sequence_number: u32,
     },
 
     PathChallenge {
         frame_type: QuicFrameTypeName,
 
-        data: Option<String>,
+        data: Option<Bytes>,
     },
 
     PathResponse {
         frame_type: QuicFrameTypeName,
 
-        data: Option<String>,
+        data: Option<Bytes>,
     },
 
     ConnectionClose {
         frame_type: QuicFrameTypeName,
         error_space: ErrorSpace,
         error_code: u64,
-        raw_error_code: u64,
-        reason: String,
+        raw_error_code: Option<u64>,
+        reason: Option<String>,
 
-        trigger_frame_type: Option<String>,
+        trigger_frame_type: Option<u64>,
     },
 
     HandshakeDone {
@@ -1948,9 +1949,9 @@ pub enum QuicFrame {
 
     Datagram {
         frame_type: QuicFrameTypeName,
-        length: String,
+        length: u64,
 
-        raw: Option<String>,
+        raw: Option<Bytes>,
     },
 
     Unknown {
@@ -1973,8 +1974,8 @@ impl QuicFrame {
     }
 
     pub fn ack(
-        ack_delay: Option<String>, acked_ranges: Option<Vec<(u64, u64)>>,
-        ect1: Option<String>, ect0: Option<String>, ce: Option<String>,
+        ack_delay: Option<f32>, acked_ranges: Option<Vec<(u64, u64)>>,
+        ect1: Option<u64>, ect0: Option<u64>, ce: Option<u64>,
     ) -> Self {
         QuicFrame::Ack {
             frame_type: QuicFrameTypeName::Ack,
@@ -1987,7 +1988,7 @@ impl QuicFrame {
     }
 
     pub fn reset_stream(
-        stream_id: String, error_code: u64, final_size: String,
+        stream_id: u64, error_code: u64, final_size: u64,
     ) -> Self {
         QuicFrame::ResetStream {
             frame_type: QuicFrameTypeName::ResetStream,
@@ -1997,7 +1998,7 @@ impl QuicFrame {
         }
     }
 
-    pub fn stop_sending(stream_id: String, error_code: u64) -> Self {
+    pub fn stop_sending(stream_id: u64, error_code: u64) -> Self {
         QuicFrame::StopSending {
             frame_type: QuicFrameTypeName::StopSending,
             stream_id,
@@ -2005,7 +2006,7 @@ impl QuicFrame {
         }
     }
 
-    pub fn crypto(offset: String, length: String) -> Self {
+    pub fn crypto(offset: u64, length: u64) -> Self {
         QuicFrame::Crypto {
             frame_type: QuicFrameTypeName::Crypto,
             offset,
@@ -2022,8 +2023,7 @@ impl QuicFrame {
     }
 
     pub fn stream(
-        stream_id: String, offset: String, length: String, fin: bool,
-        raw: Option<String>,
+        stream_id: u64, offset: u64, length: u64, fin: bool, raw: Option<Bytes>,
     ) -> Self {
         QuicFrame::Stream {
             frame_type: QuicFrameTypeName::Stream,
@@ -2035,14 +2035,14 @@ impl QuicFrame {
         }
     }
 
-    pub fn max_data(maximum: String) -> Self {
+    pub fn max_data(maximum: u64) -> Self {
         QuicFrame::MaxData {
             frame_type: QuicFrameTypeName::MaxData,
             maximum,
         }
     }
 
-    pub fn max_stream_data(stream_id: String, maximum: String) -> Self {
+    pub fn max_stream_data(stream_id: u64, maximum: u64) -> Self {
         QuicFrame::MaxStreamData {
             frame_type: QuicFrameTypeName::MaxStreamData,
             stream_id,
@@ -2050,7 +2050,7 @@ impl QuicFrame {
         }
     }
 
-    pub fn max_streams(stream_type: StreamType, maximum: String) -> Self {
+    pub fn max_streams(stream_type: StreamType, maximum: u64) -> Self {
         QuicFrame::MaxStreams {
             frame_type: QuicFrameTypeName::MaxStreams,
             stream_type,
@@ -2058,14 +2058,14 @@ impl QuicFrame {
         }
     }
 
-    pub fn data_blocked(limit: String) -> Self {
+    pub fn data_blocked(limit: u64) -> Self {
         QuicFrame::DataBlocked {
             frame_type: QuicFrameTypeName::DataBlocked,
             limit,
         }
     }
 
-    pub fn stream_data_blocked(stream_id: String, limit: String) -> Self {
+    pub fn stream_data_blocked(stream_id: u64, limit: u64) -> Self {
         QuicFrame::StreamDataBlocked {
             frame_type: QuicFrameTypeName::StreamDataBlocked,
             stream_id,
@@ -2073,7 +2073,7 @@ impl QuicFrame {
         }
     }
 
-    pub fn streams_blocked(stream_type: StreamType, limit: String) -> Self {
+    pub fn streams_blocked(stream_type: StreamType, limit: u64) -> Self {
         QuicFrame::StreamsBlocked {
             frame_type: QuicFrameTypeName::StreamsBlocked,
             stream_type,
@@ -2082,7 +2082,7 @@ impl QuicFrame {
     }
 
     pub fn new_connection_id(
-        sequence_number: String, retire_prior_to: String, length: u64,
+        sequence_number: u32, retire_prior_to: u32, length: u64,
         connection_id: String, reset_token: String,
     ) -> Self {
         QuicFrame::NewConnectionId {
@@ -2095,21 +2095,21 @@ impl QuicFrame {
         }
     }
 
-    pub fn retire_connection_id(sequence_number: String) -> Self {
+    pub fn retire_connection_id(sequence_number: u32) -> Self {
         QuicFrame::RetireConnectionId {
             frame_type: QuicFrameTypeName::RetireConnectionId,
             sequence_number,
         }
     }
 
-    pub fn path_challenge(data: Option<String>) -> Self {
+    pub fn path_challenge(data: Option<Bytes>) -> Self {
         QuicFrame::PathChallenge {
             frame_type: QuicFrameTypeName::PathChallenge,
             data,
         }
     }
 
-    pub fn path_response(data: Option<String>) -> Self {
+    pub fn path_response(data: Option<Bytes>) -> Self {
         QuicFrame::PathResponse {
             frame_type: QuicFrameTypeName::PathResponse,
             data,
@@ -2117,8 +2117,8 @@ impl QuicFrame {
     }
 
     pub fn connection_close(
-        error_space: ErrorSpace, error_code: u64, raw_error_code: u64,
-        reason: String, trigger_frame_type: Option<String>,
+        error_space: ErrorSpace, error_code: u64, raw_error_code: Option<u64>,
+        reason: Option<String>, trigger_frame_type: Option<u64>,
     ) -> Self {
         QuicFrame::ConnectionClose {
             frame_type: QuicFrameTypeName::ConnectionClose,
@@ -2136,7 +2136,7 @@ impl QuicFrame {
         }
     }
 
-    pub fn datagram(length: String, raw: Option<String>) -> Self {
+    pub fn datagram(length: u64, raw: Option<Bytes>) -> Self {
         QuicFrame::Datagram {
             frame_type: QuicFrameTypeName::Datagram,
             length,
@@ -2185,7 +2185,7 @@ pub enum Http3Frame {
     Data {
         frame_type: Http3FrameTypeName,
 
-        raw: Option<String>,
+        raw: Option<Bytes>,
     },
 
     Headers {
@@ -2234,7 +2234,7 @@ pub enum Http3Frame {
 }
 
 impl Http3Frame {
-    pub fn data(raw: Option<String>) -> Self {
+    pub fn data(raw: Option<Bytes>) -> Self {
         Http3Frame::Data {
             frame_type: Http3FrameTypeName::Data,
             raw,
@@ -2487,7 +2487,7 @@ pub mod testing {
             Some("Quiche qlog trace".to_string()),
             Some("Quiche qlog trace description".to_string()),
             Some(Configuration {
-                time_offset: Some("0".to_string()),
+                time_offset: Some(0.0),
                 original_uris: None,
             }),
             None,
@@ -2505,12 +2505,12 @@ mod tests {
         let pkt_hdr = make_pkt_hdr();
 
         let log_string = r#"{
-  "packet_number": "0",
+  "packet_number": 0,
   "packet_size": 1251,
   "payload_length": 1224,
   "version": "ff000018",
-  "scil": "8",
-  "dcil": "8",
+  "scil": 8,
+  "dcil": 8,
   "scid": "7e37e4dcc6682da8",
   "dcid": "36ce104eee50101c"
 }"#;
@@ -2523,12 +2523,12 @@ mod tests {
         let log_string = r#"{
   "packet_type": "initial",
   "header": {
-    "packet_number": "0",
+    "packet_number": 0,
     "packet_size": 1251,
     "payload_length": 1224,
     "version": "ff00001b",
-    "scil": "8",
-    "dcil": "8",
+    "scil": 8,
+    "dcil": 8,
     "scid": "7e37e4dcc6682da8",
     "dcid": "36ce104eee50101c"
   }
@@ -2565,12 +2565,12 @@ mod tests {
         let log_string = r#"{
   "packet_type": "initial",
   "header": {
-    "packet_number": "0",
+    "packet_number": 0,
     "packet_size": 1251,
     "payload_length": 1224,
     "version": "ff000018",
-    "scil": "8",
-    "dcil": "8",
+    "scil": 8,
+    "dcil": 8,
     "scid": "7e37e4dcc6682da8",
     "dcid": "36ce104eee50101c"
   },
@@ -2583,9 +2583,9 @@ mod tests {
     },
     {
       "frame_type": "stream",
-      "stream_id": "0",
-      "offset": "0",
-      "length": "100",
+      "stream_id": 0,
+      "offset": 0,
+      "length": 100,
       "fin": true
     }
   ]
@@ -2598,13 +2598,7 @@ mod tests {
 
         frames.push(QuicFrame::ping());
 
-        frames.push(QuicFrame::stream(
-            "0".to_string(),
-            "0".to_string(),
-            "100".to_string(),
-            true,
-            None,
-        ));
+        frames.push(QuicFrame::stream(0, 0, 100, true, None));
 
         let pkt_sent_evt = EventData::PacketSent {
             raw_encrypted: None,
@@ -2630,7 +2624,7 @@ mod tests {
   "title": "Quiche qlog trace",
   "description": "Quiche qlog trace description",
   "configuration": {
-    "time_offset": "0"
+    "time_offset": 0.0
   },
   "event_fields": [
     "relative_time",
@@ -2655,7 +2649,7 @@ mod tests {
   "title": "Quiche qlog trace",
   "description": "Quiche qlog trace description",
   "configuration": {
-    "time_offset": "0"
+    "time_offset": 0.0
   },
   "event_fields": [
     "relative_time",
@@ -2665,27 +2659,27 @@ mod tests {
   ],
   "events": [
     [
-      "0",
+      0.0,
       "transport",
       "packet_sent",
       {
         "packet_type": "initial",
         "header": {
-          "packet_number": "0",
+          "packet_number": 0,
           "packet_size": 1251,
           "payload_length": 1224,
           "version": "ff000018",
-          "scil": "8",
-          "dcil": "8",
+          "scil": 8,
+          "dcil": 8,
           "scid": "7e37e4dcc6682da8",
           "dcid": "36ce104eee50101c"
         },
         "frames": [
           {
             "frame_type": "stream",
-            "stream_id": "0",
-            "offset": "0",
-            "length": "100",
+            "stream_id": 0,
+            "offset": 0,
+            "length": 100,
             "fin": true
           }
         ]
@@ -2698,13 +2692,7 @@ mod tests {
 
         let pkt_hdr = make_pkt_hdr();
 
-        let frames = vec![QuicFrame::stream(
-            "0".to_string(),
-            "0".to_string(),
-            "100".to_string(),
-            true,
-            None,
-        )];
+        let frames = vec![QuicFrame::stream(0, 0, 100, true, None)];
         let event = event::Event::packet_sent_min(
             PacketType::Initial,
             pkt_hdr,
@@ -2789,13 +2777,7 @@ mod tests {
         let mut trace = make_trace();
         let pkt_hdr = make_pkt_hdr();
 
-        let frame1 = QuicFrame::stream(
-            "40".to_string(),
-            "40".to_string(),
-            "400".to_string(),
-            true,
-            None,
-        );
+        let frame1 = QuicFrame::stream(40, 40, 400, true, None);
 
         let event1 = event::Event::packet_sent_min(
             PacketType::Handshake,
@@ -2805,21 +2787,9 @@ mod tests {
 
         trace.push_event(std::time::Duration::new(0, 0), event1);
 
-        let frame2 = QuicFrame::stream(
-            "0".to_string(),
-            "0".to_string(),
-            "100".to_string(),
-            true,
-            None,
-        );
+        let frame2 = QuicFrame::stream(0, 0, 100, true, None);
 
-        let frame3 = QuicFrame::stream(
-            "0".to_string(),
-            "0".to_string(),
-            "100".to_string(),
-            true,
-            None,
-        );
+        let frame3 = QuicFrame::stream(0, 0, 100, true, None);
 
         let event2 = event::Event::packet_sent_min(
             PacketType::Initial,
@@ -2945,7 +2915,7 @@ mod tests {
         let r = s.writer();
         let w: &Box<std::io::Cursor<Vec<u8>>> = unsafe { std::mem::transmute(r) };
 
-        let log_string = r#"{"qlog_version":"version","title":"title","description":"description","traces":[{"vantage_point":{"type":"server"},"title":"Quiche qlog trace","description":"Quiche qlog trace description","configuration":{"time_offset":"0"},"event_fields":["relative_time","category","event","data"],"events":[["0","transport","packet_sent",{"packet_type":"handshake","header":{"packet_number":"0","packet_size":1251,"payload_length":1224,"version":"ff000018","scil":"8","dcil":"8","scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"frames":[{"frame_type":"stream","stream_id":"40","offset":"40","length":"400","fin":true}]}],["0","transport","packet_sent",{"packet_type":"initial","header":{"packet_number":"0","packet_size":1251,"payload_length":1224,"version":"ff000018","scil":"8","dcil":"8","scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"frames":[{"frame_type":"stream","stream_id":"0","offset":"0","length":"100","fin":true}]}],["0","transport","packet_sent",{"packet_type":"initial","header":{"packet_number":"0","packet_size":1251,"payload_length":1224,"version":"ff000018","scil":"8","dcil":"8","scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw_encrypted":"encrypted_foo","raw_decrypted":"decrypted_foo","frames":[{"frame_type":"stream","stream_id":"0","offset":"0","length":"100","fin":true}]}],["0","transport","packet_sent",{"packet_type":"initial","header":{"packet_number":"0","packet_size":1251,"payload_length":1224,"version":"ff000018","scil":"8","dcil":"8","scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw_encrypted":"encrypted_foo","raw_decrypted":"decrypted_foo","frames":[{"frame_type":"stream","stream_id":"0","offset":"0","length":"100","fin":true}]}]]}]}"#;
+        let log_string = r#"{"qlog_version":"version","title":"title","description":"description","traces":[{"vantage_point":{"type":"server"},"title":"Quiche qlog trace","description":"Quiche qlog trace description","configuration":{"time_offset":0.0},"event_fields":["relative_time","category","event","data"],"events":[[0.0,"transport","packet_sent",{"packet_type":"handshake","header":{"packet_number":0,"packet_size":1251,"payload_length":1224,"version":"ff000018","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"frames":[{"frame_type":"stream","stream_id":40,"offset":40,"length":400,"fin":true}]}],[0.0,"transport","packet_sent",{"packet_type":"initial","header":{"packet_number":0,"packet_size":1251,"payload_length":1224,"version":"ff000018","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"frames":[{"frame_type":"stream","stream_id":0,"offset":0,"length":100,"fin":true}]}],[0.0,"transport","packet_sent",{"packet_type":"initial","header":{"packet_number":0,"packet_size":1251,"payload_length":1224,"version":"ff000018","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw_encrypted":"encrypted_foo","raw_decrypted":"decrypted_foo","frames":[{"frame_type":"stream","stream_id":0,"offset":0,"length":100,"fin":true}]}],[0.0,"transport","packet_sent",{"packet_type":"initial","header":{"packet_number":0,"packet_size":1251,"payload_length":1224,"version":"ff000018","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw_encrypted":"encrypted_foo","raw_decrypted":"decrypted_foo","frames":[{"frame_type":"stream","stream_id":0,"offset":0,"length":100,"fin":true}]}]]}]}"#;
 
         let written_string = std::str::from_utf8(w.as_ref().get_ref()).unwrap();
 


### PR DESCRIPTION
In qlog-01, many of the fields that carry numbers were basically defined
as string in order to accommodate perceived problems with JSON and 64-bit
numbers. QUIC is rife with potentially 64-bit numbers but in practice,
many of these fields will contain values that are perfectly legal for
the duration of a connection. In later versions of qlog, many of the
fields have been changed to actual number types.

This change updates many qlog fields and API parameters to be closer the
qlog specifications today by using numbers e.g. stream IDs are now u64
rather than String . There general several benefits to this, we no
longer need to create owned Strings to pass around, we don't waste
effort creating strings that are immediately serialized again by the
streaming serializer, we save space in the serialized logs because
numbers are no longer surrounded with pointless quotes, and we save
space in the buffered serializer.

This change also builds on the recent update to qlog time units.
Several fields in the metrics_updated event are now represented as f32
which encodes milliseconds with decimal precision.

While working through the commit, I was affected by the overloading of
String for qlog numbers and bytes see
https://quicwg.org/qlog/draft-ietf-quic-qlog-main-schema.html#name-bytes.
In order to capture all the cases where we explicitly want to log bytes,
I added a simple type definition, `Bytes`, for disambiguation. In
future, we might substitute this for a more complex type that can
satisfy the qlog requirements.