### PR TITLE
recovery: only log qlog metrics when fields change

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2110,8 +2110,9 @@ impl Connection {
         });
 
         qlog_with!(self.qlog_streamer, q, {
-            let ev = self.recovery.to_qlog();
-            q.add_event_with_instant(ev, now).ok();
+            if let Some(ev) = self.recovery.maybe_qlog() {
+                q.add_event_with_instant(ev, now).ok();
+            }
         });
 
         // Only log the remote transport parameters once the connection is
@@ -3226,8 +3227,9 @@ impl Connection {
         );
 
         qlog_with!(self.qlog_streamer, q, {
-            let ev = self.recovery.to_qlog();
-            q.add_event_with_instant(ev, now).ok();
+            if let Some(ev) = self.recovery.maybe_qlog() {
+                q.add_event_with_instant(ev, now).ok();
+            }
         });
 
         self.pkt_num_spaces[epoch].next_pkt_num += 1;
@@ -4108,8 +4110,9 @@ impl Connection {
                 );
 
                 qlog_with!(self.qlog_streamer, q, {
-                    let ev = self.recovery.to_qlog();
-                    q.add_event_with_instant(ev, now).ok();
+                    if let Some(ev) = self.recovery.maybe_qlog() {
+                        q.add_event_with_instant(ev, now).ok();
+                    }
                 });
 
                 return;


### PR DESCRIPTION
Previously, when the qlog feature was enabled, quiche would log all
recovery metrics (that it cares to log) any time there was a recovery
event. This is legal but increases duplication in the logs.

With this change, we make the event emission smarter by only generating
them if at least one of the event data fields has changed. In testing,
the file size is reduced by up to 25%, the qvis congestion view
continues to work just fine, and the sequence diagram has improved
readability,

builds on https://github.com/cloudflare/quiche/pull/999 so needs to come after it