### PR TITLE
avoid calling is_in_early_data() unnecessarily

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4560,7 +4560,8 @@ impl Connection {
                 self.streams.has_reset() ||
                 self.streams.has_stopped())
         {
-            if self.is_in_early_data() && !self.is_server {
+            // Only clients can send 0-RTT packets.
+            if !self.is_server && self.is_in_early_data() {
                 return Ok(packet::Type::ZeroRTT);
             }
 


### PR DESCRIPTION
Since servers cannot send 0-RTT packets, `is_in_early_data()` will be
called unnecessarily. While it's not a huge cost, avoiding it is pretty
simple and as a side-effect, it also reduces noise in flamegraphs.