### PR TITLE
add DATAGRAM APIs to work with Vec<u8> directly

### DIFF
--- a/src/dgram.rs
+++ b/src/dgram.rs
@@ -46,13 +46,14 @@ impl DatagramQueue {
         }
     }
 
-    pub fn push(&mut self, data: &[u8]) -> Result<()> {
+    pub fn push(&mut self, data: Vec<u8>) -> Result<()> {
         if self.is_full() {
             return Err(Error::Done);
         }
 
-        self.queue.push_back(data.to_vec());
         self.queue_bytes_size += data.len();
+        self.queue.push_back(data);
+
         Ok(())
     }
 

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -1086,7 +1086,7 @@ impl Connection {
         b.put_varint(flow_id)?;
         b.put_bytes(buf)?;
 
-        conn.dgram_send(&d)?;
+        conn.dgram_send_vec(d)?;
 
         Ok(())
     }


### PR DESCRIPTION
These can be used by applications to avoid copying DATAGRAM data, and
instead provide or receive an owned Vec<u8> directly.

This also prevents an intermediate copy when writing HTTP/3 DATAGRAMs,
as well as when receiving DATAGRAM frames.