### PR TITLE
add method to return the server name requested by the client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4218,6 +4218,12 @@ impl Connection {
         self.alpn.as_ref()
     }
 
+    /// Returns the server name requested by the client.
+    #[inline]
+    pub fn server_name(&self) -> Option<&str> {
+        self.handshake.server_name()
+    }
+
     /// Returns the peer's leaf certificate (if any) as a DER-encoded buffer.
     #[inline]
     pub fn peer_cert(&self) -> Option<Vec<u8>> {
@@ -6169,6 +6175,8 @@ mod tests {
             pipe.client.application_proto(),
             pipe.server.application_proto()
         );
+
+        assert_eq!(pipe.server.server_name(), Some("quic.tech"));
     }
 
     #[test]


### PR DESCRIPTION
We currently support specifying a server name (via SNI) on the client
side, but there is no API for the server to read it, so add one.