### PR TITLE
remove outdated sentence in peer_error() docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4306,13 +4306,9 @@ impl Connection {
 
     /// Returns the error received from the peer, if any.
     ///
-    /// The values contained in the tuple are symmetric with the [`close()`]
-    /// method.
-    ///
     /// Note that a `Some` return value does not necessarily imply
     /// [`is_closed()`] or any other connection state.
     ///
-    /// [`close()`]: struct.Connection.html#method.close
     /// [`is_closed()`]: struct.Connection.html#method.is_closed
     #[inline]
     pub fn peer_error(&self) -> Option<&ConnectionError> {


### PR DESCRIPTION
IIRC this method was changed before merging, so this sentence doesn't
make sense anymore, as a single value is returned rather than a tuple.