### PR TITLE
zero-copy emit scatter API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,6 +351,11 @@ const DEFAULT_MAX_DGRAM_QUEUE_LEN: usize = 0;
 // frames size. We enforce the recommendation for forward compatibility.
 const MAX_DGRAM_FRAME_SIZE: u64 = 65536;
 
+// The minimum payload size that should be emitted when using AEAD scatter
+// seal. For smaller amounts of data, scattering doesn't provide much benefit
+// and would prevent smaller buffers from being merged together.
+const MIN_SCATTER_BUFFER_SIZE: usize = 512;
+
 // The length of the payload length field.
 const PAYLOAD_LENGTH_LEN: usize = 2;
 
@@ -3015,6 +3020,9 @@ impl Connection {
             }
         }
 
+        let mut payload_extra = None;
+        let mut payload_extra_len = 0;
+
         // The preference of data-bearing frame to include in a packet
         // is managed by `self.emit_dgram`. However, whether any frames
         // can be sent depends on the state of their buffers. In the case
@@ -3066,8 +3074,17 @@ impl Connection {
                                 let (mut dgram_hdr, mut dgram_payload) =
                                     b.split_at(hdr_off + hdr_len)?;
 
-                                dgram_payload.as_mut()[..len]
-                                    .copy_from_slice(&data);
+                                if data.len() > MIN_SCATTER_BUFFER_SIZE {
+                                    let buf = stream::RangeBuf::from_vec(
+                                        data, 0, false,
+                                    );
+
+                                    payload_extra_len = buf.len();
+                                    payload_extra = Some(buf);
+                                } else {
+                                    dgram_payload.as_mut()[..len]
+                                        .copy_from_slice(&data);
+                                }
 
                                 // Encode the frame's header.
                                 //
@@ -3084,7 +3101,11 @@ impl Connection {
                                 )?;
 
                                 // Advance the packet buffer's offset.
-                                b.skip(hdr_len + len)?;
+                                b.skip(hdr_len)?;
+
+                                if payload_extra.is_none() {
+                                    b.skip(len)?;
+                                }
 
                                 let frame =
                                     frame::Frame::DatagramHeader { length: len };
@@ -3093,6 +3114,12 @@ impl Connection {
                                     ack_eliciting = true;
                                     in_flight = true;
                                     dgram_emitted = true;
+                                }
+
+                                // The scattered frame must be the last in the
+                                // packet, so avoid pushing more DATAGRAMs.
+                                if payload_extra.is_some() {
+                                    break;
                                 }
                             },
 
@@ -3156,12 +3183,47 @@ impl Connection {
                     None => continue,
                 };
 
+                // Calculate the minimum viable buffer length for AEAD scatter
+                // operation.
+                //
+                // Note that due to the fact that scattering requires the extra
+                // payload to be at the end of the plaintext, no frame can be
+                // encoded afterwards (including PADDING).
+                let min_len = if has_initial {
+                    // When coalescing with Initial packets, make sure we won't
+                    // need to add PADDING frames at the end, by requiring the
+                    // STREAM frame to fill the packet buffer completely.
+                    max_len
+                } else {
+                    MIN_SCATTER_BUFFER_SIZE
+                };
+
                 let (mut stream_hdr, mut stream_payload) =
                     b.split_at(hdr_off + hdr_len)?;
 
-                // Write stream data into the packet buffer.
-                let (len, fin) =
-                    stream.send.emit(&mut stream_payload.as_mut()[..max_len])?;
+                // Try to get a buffer with the required min and max sizes that
+                // can later be used with the AEAD scatter seal API. This avoids
+                // having to copy the plaintext data into the output buffer
+                // before encryption.
+                //
+                // But if that is not available (e.g. the front send buffer is
+                // too small), fallback to writing the stream data directly into
+                // the output buffer.
+                let (len, fin) = match stream.send.emit_owned(min_len, max_len) {
+                    Some((buf, fin)) => {
+                        payload_extra_len = buf.len();
+                        payload_extra = Some(buf);
+
+                        (payload_extra_len, fin)
+                    },
+
+                    None => {
+                        // Write stream data directly into the packet buffer.
+                        stream
+                            .send
+                            .emit(&mut stream_payload.as_mut()[..max_len])?
+                    },
+                };
 
                 // Encode the frame's header.
                 //
@@ -3180,7 +3242,11 @@ impl Connection {
                 )?;
 
                 // Advance the packet buffer's offset.
-                b.skip(hdr_len + len)?;
+                b.skip(hdr_len)?;
+
+                if payload_extra.is_none() {
+                    b.skip(len)?;
+                }
 
                 let frame = frame::Frame::StreamHeader {
                     stream_id,
@@ -3205,7 +3271,9 @@ impl Connection {
 
                 // When fuzzing, try to coalesce multiple STREAM frames in the
                 // same packet, so it's easier to generate fuzz corpora.
-                if cfg!(feature = "fuzzing") && left > frame::MAX_STREAM_OVERHEAD
+                if cfg!(feature = "fuzzing") &&
+                    left > frame::MAX_STREAM_OVERHEAD &&
+                    payload_extra.is_none()
                 {
                     continue;
                 }
@@ -3257,8 +3325,13 @@ impl Connection {
         }
 
         // Pad payload so that it's always at least 4 bytes.
-        if b.off() - payload_offset < PAYLOAD_MIN_LEN {
+        if (b.off() - payload_offset) + payload_extra_len < PAYLOAD_MIN_LEN {
             let payload_len = b.off() - payload_offset;
+
+            // When the extra payload is filled (i.e. `payload_extra_len > 0`)
+            // this point shouldn't be reachable, but account for the extra
+            // length anyway for completeness.
+            let payload_len = payload_len + payload_extra_len;
 
             let frame = frame::Frame::Padding {
                 len: PAYLOAD_MIN_LEN - payload_len,
@@ -3274,7 +3347,7 @@ impl Connection {
 
         // Fill in payload length.
         if pkt_type != packet::Type::Short {
-            let len = pn_len + payload_len + crypto_overhead;
+            let len = pn_len + payload_len + payload_extra_len + crypto_overhead;
 
             let (_, mut payload_with_len) = b.split_at(header_offset)?;
             payload_with_len
@@ -3285,7 +3358,7 @@ impl Connection {
             "{} tx pkt {:?} len={} pn={}",
             self.trace_id,
             hdr,
-            payload_len,
+            payload_len + payload_extra_len,
             pn
         );
 
@@ -3297,7 +3370,8 @@ impl Connection {
                 Some(&hdr.scid),
                 Some(&hdr.dcid),
             );
-            let length = Some(payload_len as u64 + payload_offset as u64);
+            let length =
+                Some((payload_len + payload_extra_len + payload_offset) as u64);
             let payload_length = Some(payload_len as u64);
             let qlog_raw_info = qlog::RawInfo {
                 length,
@@ -3342,7 +3416,7 @@ impl Connection {
             pn_len,
             payload_len,
             payload_offset,
-            None,
+            payload_extra.as_deref(),
             aead,
         )?;
 
@@ -6770,6 +6844,52 @@ mod tests {
         assert_eq!(&b[..12], b"hello, world");
 
         assert!(pipe.server.stream_finished(4));
+    }
+
+    #[test]
+    fn mega_stream() {
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config
+            .set_application_protos(b"\x06proto1\x06proto2")
+            .unwrap();
+        config.set_initial_max_data(1000000);
+        config.set_initial_max_stream_data_bidi_local(1000000);
+        config.set_initial_max_stream_data_bidi_remote(1000000);
+        config.set_initial_max_stream_data_uni(1000000);
+        config.set_initial_max_streams_bidi(3);
+        config.set_initial_max_streams_uni(3);
+        config.set_max_idle_timeout(180_000);
+        config.verify_peer(false);
+        config.set_ack_delay_exponent(8);
+
+        let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
+        assert_eq!(pipe.handshake(), Ok(()));
+
+        const STREAM_DATA_LEN: usize = 12000;
+
+        let stream_data = [0xa; STREAM_DATA_LEN];
+        assert_eq!(
+            pipe.client.stream_send(4, &stream_data, true),
+            Ok(STREAM_DATA_LEN)
+        );
+        assert_eq!(pipe.advance(), Ok(()));
+
+        let mut r = pipe.server.readable();
+        assert_eq!(r.next(), Some(4));
+        assert_eq!(r.next(), None);
+
+        let mut recv_data = [0; STREAM_DATA_LEN];
+        assert_eq!(
+            pipe.server.stream_recv(4, &mut recv_data),
+            Ok((STREAM_DATA_LEN, true))
+        );
+        assert_eq!(&recv_data[..], &stream_data[..]);
     }
 
     #[test]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1163,6 +1163,50 @@ impl SendBuf {
         Ok((out.len() - out_len, fin))
     }
 
+    /// Returns the first contiguous chunk of data from the send buffer.
+    ///
+    /// The returned buffer will be between `min_len` and `max_len` bytes. If no
+    /// buffer is available, or if an available buffer is smaller, `None` is
+    /// returned.
+    pub fn emit_owned(
+        &mut self, min_len: usize, max_len: usize,
+    ) -> Option<(RangeBuf, bool)> {
+        if !self.ready() {
+            return None;
+        }
+
+        let buf = self.data.get_mut(self.pos)?;
+
+        if buf.len() < min_len {
+            return None;
+        }
+
+        let buf_len = cmp::min(buf.len(), max_len);
+        let partial = buf_len < buf.len();
+
+        let out_buf = buf.clone_count(buf_len);
+
+        let next_off = out_buf.off() + buf_len as u64;
+
+        self.len -= buf_len as u64;
+
+        buf.consume(buf_len);
+
+        if !partial {
+            self.pos += 1;
+        }
+
+        // Override the `fin` flag set for the output buffer by matching the
+        // buffer's maximum offset against the stream's final offset (if known).
+        //
+        // This is more efficient than tracking `fin` using the range buffers
+        // themselves, and lets us avoid queueing empty buffers just so we can
+        // propagate the final size.
+        let fin = self.fin_off == Some(next_off);
+
+        Some((out_buf, fin))
+    }
+
     /// Updates the max_data limit to the given value.
     pub fn update_max_data(&mut self, max_data: u64) {
         self.max_data = cmp::max(self.max_data, max_data);
@@ -1444,6 +1488,18 @@ impl RangeBuf {
         }
     }
 
+    /// Creates a new `RangeBuf` from the given Vec.
+    pub fn from_vec(buf: Vec<u8>, off: u64, fin: bool) -> RangeBuf {
+        RangeBuf {
+            len: buf.len(),
+            data: Arc::new(buf),
+            start: 0,
+            pos: 0,
+            off,
+            fin,
+        }
+    }
+
     /// Returns whether `self` holds the final offset in the stream.
     pub fn fin(&self) -> bool {
         self.fin
@@ -1484,7 +1540,7 @@ impl RangeBuf {
         }
 
         let buf = RangeBuf {
-            data: self.data.clone(),
+            data: Arc::clone(&self.data),
             start: self.start + at,
             pos: cmp::max(self.pos, self.start + at),
             len: self.len - at,
@@ -1497,6 +1553,28 @@ impl RangeBuf {
         self.fin = false;
 
         buf
+    }
+
+    /// Clones the given number of bytes in the buffer.
+    ///
+    /// Note that no data is actually cloned, instead the underlying buffer's
+    /// reference count is increased.
+    pub fn clone_count(&self, count: usize) -> RangeBuf {
+        if count > self.len {
+            panic!(
+                "`count` clone index (is {}) should be <= len (is {})",
+                count, self.len
+            );
+        }
+
+        RangeBuf {
+            data: Arc::clone(&self.data),
+            start: self.start,
+            pos: self.pos,
+            len: cmp::min(self.len, (self.pos - self.start) + count),
+            off: self.off,
+            fin: self.fin && self.len <= (self.pos - self.start) + count,
+        }
     }
 }
 
@@ -3055,5 +3133,66 @@ mod tests {
         assert_eq!(new_new_buf.fin(), true);
 
         assert_eq!(&new_new_buf[..], b"");
+    }
+
+    #[test]
+    fn rangebuf_clone_count() {
+        let mut buf = RangeBuf::from(b"helloworld", 5, true);
+        assert_eq!(buf.start, 0);
+        assert_eq!(buf.pos, 0);
+        assert_eq!(buf.len, 10);
+        assert_eq!(buf.off, 5);
+        assert_eq!(buf.fin, true);
+
+        assert_eq!(buf.len(), 10);
+        assert_eq!(buf.off(), 5);
+        assert_eq!(buf.fin(), true);
+
+        assert_eq!(&buf[..], b"helloworld");
+
+        // Clone from start.
+        let new_buf = buf.clone_count(5);
+        assert_eq!(new_buf.start, 0);
+        assert_eq!(new_buf.pos, 0);
+        assert_eq!(new_buf.len, 5);
+        assert_eq!(new_buf.off, 5);
+        assert_eq!(new_buf.fin, false);
+
+        assert_eq!(new_buf.len(), 5);
+        assert_eq!(new_buf.off(), 5);
+        assert_eq!(new_buf.fin(), false);
+
+        assert_eq!(&new_buf[..], b"hello");
+
+        // Advance buffer.
+        buf.consume(3);
+
+        // Clone again.
+        let new_buf = buf.clone_count(5);
+        assert_eq!(new_buf.start, 0);
+        assert_eq!(new_buf.pos, 3);
+        assert_eq!(new_buf.len, 8);
+        assert_eq!(new_buf.off, 5);
+        assert_eq!(new_buf.fin, false);
+
+        assert_eq!(new_buf.len(), 5);
+        assert_eq!(new_buf.off(), 8);
+        assert_eq!(new_buf.fin(), false);
+
+        assert_eq!(&new_buf[..], b"lowor");
+
+        // Clone past the end.
+        let new_buf = buf.clone_count(10);
+        assert_eq!(new_buf.start, 0);
+        assert_eq!(new_buf.pos, 3);
+        assert_eq!(new_buf.len, 10);
+        assert_eq!(new_buf.off, 5);
+        assert_eq!(new_buf.fin, true);
+
+        assert_eq!(new_buf.len(), 7);
+        assert_eq!(new_buf.off(), 8);
+        assert_eq!(new_buf.fin(), true);
+
+        assert_eq!(&new_buf[..], b"loworld");
     }
 }


### PR DESCRIPTION
Instead of copying application data (stream / DATAGRAM) into the output
packet buffer, and then encrypting that in-place, we can use the seal
scatter API exposed by BoringCrypto to avoid the additional data copy,
by passing the data buffer directly to the crypto API.

The limitation is that the "scattered" payload buffer must be at the end
of the packet, so no additional frames can be queued after that. In the
STREAM case this is not a problem as only a single STREAM frame is
queued anyway, but in the DATAGRAM case we need to avoid pushing more
than one. In addition, PADDING frames can't be added either.