### PR TITLE
fix needless_borrow clippy warnings

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -216,7 +216,7 @@ fn main() {
                 );
 
                 print!("{}", unsafe {
-                    std::str::from_utf8_unchecked(&stream_buf)
+                    std::str::from_utf8_unchecked(stream_buf)
                 });
 
                 // The server reported that it has no more data to send, which

--- a/examples/http3-server.rs
+++ b/examples/http3-server.rs
@@ -622,7 +622,7 @@ fn handle_writable(client: &mut Client, stream_id: u64) {
     let resp = client.partial_responses.get_mut(&stream_id).unwrap();
 
     if let Some(ref headers) = resp.headers {
-        match http3_conn.send_response(conn, stream_id, &headers, false) {
+        match http3_conn.send_response(conn, stream_id, headers, false) {
             Ok(_) => (),
 
             Err(quiche::h3::Error::StreamBlocked) => {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -499,7 +499,7 @@ fn handle_writable(client: &mut Client, stream_id: u64) {
     let resp = client.partial_responses.get_mut(&stream_id).unwrap();
     let body = &resp.body[resp.written..];
 
-    let written = match conn.stream_send(stream_id, &body, true) {
+    let written = match conn.stream_send(stream_id, body, true) {
         Ok(v) => v,
 
         Err(quiche::Error::Done) => 0,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -165,9 +165,9 @@ impl Open {
         let mut iv = vec![0; nonce_len];
         let mut pn_key = vec![0; key_len];
 
-        derive_pkt_key(aead, &secret, &mut key)?;
-        derive_pkt_iv(aead, &secret, &mut iv)?;
-        derive_hdr_key(aead, &secret, &mut pn_key)?;
+        derive_pkt_key(aead, secret, &mut key)?;
+        derive_pkt_iv(aead, secret, &mut iv)?;
+        derive_hdr_key(aead, secret, &mut pn_key)?;
 
         Open::new(aead, &key, &iv, &pn_key)
     }
@@ -264,9 +264,9 @@ impl Seal {
         let mut iv = vec![0; nonce_len];
         let mut pn_key = vec![0; key_len];
 
-        derive_pkt_key(aead, &secret, &mut key)?;
-        derive_pkt_iv(aead, &secret, &mut iv)?;
-        derive_hdr_key(aead, &secret, &mut pn_key)?;
+        derive_pkt_key(aead, secret, &mut key)?;
+        derive_pkt_iv(aead, secret, &mut iv)?;
+        derive_hdr_key(aead, secret, &mut pn_key)?;
 
         Seal::new(aead, &key, &iv, &pn_key)
     }
@@ -354,7 +354,7 @@ pub fn derive_initial_key_material(
     let key_len = aead.key_len();
     let nonce_len = aead.nonce_len();
 
-    let initial_secret = derive_initial_secret(&cid, version);
+    let initial_secret = derive_initial_secret(cid, version);
 
     // Client.
     let mut client_key = vec![0; key_len];
@@ -520,7 +520,7 @@ fn hkdf_expand_label(
 
 fn make_nonce(iv: &[u8], counter: u64) -> [u8; aead::NONCE_LEN] {
     let mut nonce = [0; aead::NONCE_LEN];
-    nonce.copy_from_slice(&iv);
+    nonce.copy_from_slice(iv);
 
     // XOR the last bytes of the IV with the counter. This is equivalent to
     // left-padding the counter with zero bytes.

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -386,7 +386,7 @@ impl Frame {
             Frame::Crypto { data } => {
                 encode_crypto_header(data.off() as u64, data.len() as u64, b)?;
 
-                b.put_bytes(&data)?;
+                b.put_bytes(data)?;
             },
 
             Frame::CryptoHeader { .. } => (),
@@ -395,7 +395,7 @@ impl Frame {
                 b.put_varint(0x07)?;
 
                 b.put_varint(token.len() as u64)?;
-                b.put_bytes(&token)?;
+                b.put_bytes(token)?;
             },
 
             Frame::Stream { stream_id, data } => {
@@ -407,7 +407,7 @@ impl Frame {
                     b,
                 )?;
 
-                b.put_bytes(&data)?;
+                b.put_bytes(data)?;
             },
 
             Frame::StreamHeader { .. } => (),

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -897,7 +897,7 @@ impl Connection {
         let mut header_block = vec![0; headers_len];
         let len = self
             .qpack_encoder
-            .encode(&headers, &mut header_block)
+            .encode(headers, &mut header_block)
             .map_err(|_| Error::InternalError)?;
 
         header_block.truncate(len);
@@ -2159,8 +2159,8 @@ pub mod testing {
             let server_dgram = pipe.server.dgram_enabled();
             Ok(Session {
                 pipe,
-                client: Connection::new(&h3_config, false, client_dgram)?,
-                server: Connection::new(&h3_config, true, server_dgram)?,
+                client: Connection::new(h3_config, false, client_dgram)?,
+                server: Connection::new(h3_config, true, server_dgram)?,
             })
         }
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -695,9 +695,9 @@ pub fn negotiate_version(
     b.put_u32(0)?;
 
     b.put_u8(scid.len() as u8)?;
-    b.put_bytes(&scid)?;
+    b.put_bytes(scid)?;
     b.put_u8(dcid.len() as u8)?;
-    b.put_bytes(&dcid)?;
+    b.put_bytes(dcid)?;
     b.put_u32(crate::PROTOCOL_VERSION_V1)?;
     b.put_u32(crate::PROTOCOL_VERSION_DRAFT29)?;
     b.put_u32(crate::PROTOCOL_VERSION_DRAFT28)?;

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -429,7 +429,7 @@ impl Recovery {
                     self.in_flight_count[epoch] =
                         self.in_flight_count[epoch].saturating_sub(1);
 
-                    self.delivery_rate.on_packet_acked(&unacked, now);
+                    self.delivery_rate.on_packet_acked(unacked, now);
                 }
 
                 newly_acked.push(Acked {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -713,7 +713,7 @@ extern fn set_read_secret(
     if level != crypto::Level::ZeroRTT || conn.is_server {
         let secret = unsafe { slice::from_raw_parts(secret, secret_len) };
 
-        let open = match crypto::Open::from_secret(aead, &secret) {
+        let open = match crypto::Open::from_secret(aead, secret) {
             Ok(v) => v,
 
             Err(_) => return 0,
@@ -763,7 +763,7 @@ extern fn set_write_secret(
     if level != crypto::Level::ZeroRTT || !conn.is_server {
         let secret = unsafe { slice::from_raw_parts(secret, secret_len) };
 
-        let seal = match crypto::Seal::from_secret(aead, &secret) {
+        let seal = match crypto::Seal::from_secret(aead, secret) {
             Ok(v) => v,
 
             Err(_) => return 0,
@@ -959,7 +959,7 @@ extern fn new_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int {
         return 0;
     }
 
-    if buffer.write(&peer_params).is_err() {
+    if buffer.write(peer_params).is_err() {
         std::mem::forget(handshake);
         return 0;
     }

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -383,7 +383,7 @@ fn main() {
                 // we need the value and if something fails at this stage, there
                 // is not much anyone can do to recover.
                 let app_proto = client.conn.application_proto();
-                let app_proto = &std::str::from_utf8(&app_proto).unwrap();
+                let app_proto = &std::str::from_utf8(app_proto).unwrap();
 
                 if alpns::HTTP_09.contains(app_proto) {
                     client.http_conn = Some(Box::new(Http09Conn::default()));

--- a/tools/apps/src/client.rs
+++ b/tools/apps/src/client.rs
@@ -322,7 +322,7 @@ pub fn connect(
             // is not much anyone can do to recover.
 
             let app_proto = conn.application_proto();
-            let app_proto = &std::str::from_utf8(&app_proto).unwrap();
+            let app_proto = &std::str::from_utf8(app_proto).unwrap();
 
             if alpns::HTTP_09.contains(app_proto) {
                 http_conn = Some(Http09Conn::with_urls(

--- a/tools/apps/src/common.rs
+++ b/tools/apps/src/common.rs
@@ -741,7 +741,7 @@ impl HttpConn for Http09Conn {
         let resp = partial_responses.get_mut(&stream_id).unwrap();
         let body = &resp.body[resp.written..];
 
-        let written = match conn.stream_send(stream_id, &body, true) {
+        let written = match conn.stream_send(stream_id, body, true) {
             Ok(v) => v,
 
             Err(quiche::Error::Done) => 0,
@@ -816,7 +816,7 @@ impl Http3Conn {
                     quiche::h3::Header::new(b":authority", authority.as_bytes()),
                     quiche::h3::Header::new(
                         b":path",
-                        &url[url::Position::BeforePath..].as_bytes(),
+                        url[url::Position::BeforePath..].as_bytes(),
                     ),
                     quiche::h3::Header::new(b"user-agent", b"quiche"),
                 ];
@@ -1441,7 +1441,7 @@ impl HttpConn for Http3Conn {
         let resp = partial_responses.get_mut(&stream_id).unwrap();
 
         if let Some(ref headers) = resp.headers {
-            match self.h3_conn.send_response(conn, stream_id, &headers, false) {
+            match self.h3_conn.send_response(conn, stream_id, headers, false) {
                 Ok(_) => (),
 
                 Err(quiche::h3::Error::StreamBlocked) => {


### PR DESCRIPTION
There's a new Rust stable release, so it's time again to fix all the new clippy warnings.