### PR TITLE
h3: return InternalError in a case of stream read logic failure

### DIFF
--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -358,7 +358,11 @@ impl Stream {
     pub fn try_fill_buffer(
         &mut self, conn: &mut crate::Connection,
     ) -> Result<()> {
-        let buf = &mut self.state_buf[self.state_off..self.state_len];
+        let buf = match self.state_buf.get_mut(self.state_off..self.state_len) {
+            Some(v) => v,
+
+            None => return Err(Error::InternalError),
+        };
 
         let read = match conn.stream_recv(self.id, buf) {
             Ok((len, _)) => len,
@@ -409,7 +413,11 @@ impl Stream {
     fn try_fill_buffer_for_tests(
         &mut self, stream: &mut std::io::Cursor<Vec<u8>>,
     ) -> Result<()> {
-        let buf = &mut self.state_buf[self.state_off..self.state_len];
+        let buf = match self.state_buf.get_mut(self.state_off..self.state_len) {
+            Some(v) => v,
+
+            None => return Err(Error::InternalError),
+        };
 
         let read = std::io::Read::read(stream, buf).unwrap();
 


### PR DESCRIPTION
Applications read H3 streams via the `poll()` method. The quiche H3
stream struct provides indirect access to a backing buffer that is used
to read data from the QUIC stream, depending on the context of the H3
stream (control, request, etc.). These methods provide some guardrails
against inconsistent state.

This change extends the current behavior by returning a
quiche::h3:InternalError if the buffer reading code detects a logical
mismatch.