### PR TITLE
Allow to query if the connection was timed out

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -380,6 +380,9 @@ uint64_t quiche_conn_peer_streams_left_uni(quiche_conn *conn);
 // Returns true if the connection is closed.
 bool quiche_conn_is_closed(quiche_conn *conn);
 
+// Returns true if the connection was closed due to the idle timeout.
+bool quiche_conn_is_timed_out(quiche_conn *conn);
+
 // Returns true if a connection error was received, and updates the provided
 // parameters accordingly.
 bool quiche_conn_peer_error(quiche_conn *conn,
@@ -395,10 +398,6 @@ bool quiche_conn_local_error(quiche_conn *conn,
                             uint64_t *error_code,
                             const uint8_t **reason,
                             size_t *reason_len);
-
-// Returns true if the connection was timed out because of the idle timeout
-// that was used.
-bool quiche_conn_is_timed_out(quiche_conn *conn);
 
 // Initializes the stream's application data.
 //

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -908,6 +908,11 @@ pub extern fn quiche_conn_is_closed(conn: &mut Connection) -> bool {
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_is_timed_out(conn: &mut Connection) -> bool {
+    conn.is_timed_out()
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_peer_error(
     conn: &mut Connection, is_app: *mut bool, error_code: *mut u64,
     reason: &mut *const u8, reason_len: &mut size_t,
@@ -943,11 +948,6 @@ pub extern fn quiche_conn_local_error(
 
         None => false,
     }
-}
-
-#[no_mangle]
-pub extern fn quiche_conn_is_timed_out(conn: &mut Connection) -> bool {
-    conn.is_timed_out()
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1095,6 +1095,9 @@ pub struct Connection {
     /// Whether the connection is closed.
     closed: bool,
 
+    // Whether the connection was timed out
+    timed_out: bool,
+
     /// Whether to send GREASE.
     grease: bool,
 
@@ -1489,6 +1492,8 @@ impl Connection {
             ack_eliciting_sent: false,
 
             closed: false,
+
+            timed_out: false,
 
             grease: config.grease,
 
@@ -4278,6 +4283,7 @@ impl Connection {
                 });
 
                 self.closed = true;
+                self.timed_out = true;
                 return;
             }
         }
@@ -4453,6 +4459,12 @@ impl Connection {
         self.closed
     }
 
+    /// Returns true if the connection was closed due to the idle timeout.
+    #[inline]
+    pub fn is_timed_out(&self) -> bool {
+        self.timed_out
+    }
+
     /// Returns the error received from the peer, if any.
     ///
     /// Note that a `Some` return value does not necessarily imply
@@ -4477,16 +4489,6 @@ impl Connection {
     #[inline]
     pub fn local_error(&self) -> Option<&ConnectionError> {
         self.local_error.as_ref()
-    }
-
-    /// Returns true if the connection was timed out because of the idle timeout
-    /// that was used.
-    #[inline]
-    pub fn is_timed_out(&self) -> bool {
-        match self.idle_timer {
-            Some(timer) => timer <= time::Instant::now(),
-            None => false,
-        }
     }
 
     /// Collects and returns statistics about the connection.


### PR DESCRIPTION
Motivation:

At the moment it is impossible to know if a connection was closed because of the idle-timeout.

Modifications:

Add function to be able to query if a connection timed out

Result:

Be able to know if a connection was closed because of the idle-timeout