### PR TITLE
h3: rename max_header_list to max_field_section

### DIFF
--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -4236,8 +4236,8 @@ index 000000000..30955c4cd
 +        return NGX_CONF_ERROR;
 +    }
 +
-+    quiche_h3_config_set_max_header_list_size(conf->http3,
-+                                              conf->max_header_size);
++    quiche_h3_config_set_max_field_section_size(conf->http3,
++                                                conf->max_header_size);
 +
 +    cln = ngx_pool_cleanup_add(cf->pool, 0);
 +    if (cln == NULL) {

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -615,8 +615,8 @@ typedef struct Http3Config quiche_h3_config;
 // Creates an HTTP/3 config object with default settings values.
 quiche_h3_config *quiche_h3_config_new(void);
 
-// Sets the `SETTINGS_MAX_HEADER_LIST_SIZE` setting.
-void quiche_h3_config_set_max_header_list_size(quiche_h3_config *config, uint64_t v);
+// Sets the `SETTINGS_MAX_FIELD_SECTION_SIZE` setting.
+void quiche_h3_config_set_max_field_section_size(quiche_h3_config *config, uint64_t v);
 
 // Sets the `SETTINGS_QPACK_MAX_TABLE_CAPACITY` setting.
 void quiche_h3_config_set_qpack_max_table_capacity(quiche_h3_config *config, uint64_t v);

--- a/src/h3/ffi.rs
+++ b/src/h3/ffi.rs
@@ -48,10 +48,10 @@ pub extern fn quiche_h3_config_new() -> *mut h3::Config {
 }
 
 #[no_mangle]
-pub extern fn quiche_h3_config_set_max_header_list_size(
+pub extern fn quiche_h3_config_set_max_field_section_size(
     config: &mut h3::Config, v: u64,
 ) {
-    config.set_max_header_list_size(v);
+    config.set_max_field_section_size(v);
 }
 
 #[no_mangle]

--- a/src/h3/frame.rs
+++ b/src/h3/frame.rs
@@ -37,7 +37,7 @@ pub const GOAWAY_FRAME_TYPE_ID: u64 = 0x6;
 pub const MAX_PUSH_FRAME_TYPE_ID: u64 = 0xD;
 
 const SETTINGS_QPACK_MAX_TABLE_CAPACITY: u64 = 0x1;
-const SETTINGS_MAX_HEADER_LIST_SIZE: u64 = 0x6;
+const SETTINGS_MAX_FIELD_SECTION_SIZE: u64 = 0x6;
 const SETTINGS_QPACK_BLOCKED_STREAMS: u64 = 0x7;
 const SETTINGS_H3_DATAGRAM: u64 = 0x276;
 
@@ -59,7 +59,7 @@ pub enum Frame {
     },
 
     Settings {
-        max_header_list_size: Option<u64>,
+        max_field_section_size: Option<u64>,
         qpack_max_table_capacity: Option<u64>,
         qpack_blocked_streams: Option<u64>,
         h3_datagram: Option<u64>,
@@ -148,7 +148,7 @@ impl Frame {
             },
 
             Frame::Settings {
-                max_header_list_size,
+                max_field_section_size,
                 qpack_max_table_capacity,
                 qpack_blocked_streams,
                 h3_datagram,
@@ -156,8 +156,8 @@ impl Frame {
             } => {
                 let mut len = 0;
 
-                if let Some(val) = max_header_list_size {
-                    len += octets::varint_len(SETTINGS_MAX_HEADER_LIST_SIZE);
+                if let Some(val) = max_field_section_size {
+                    len += octets::varint_len(SETTINGS_MAX_FIELD_SECTION_SIZE);
                     len += octets::varint_len(*val);
                 }
 
@@ -184,8 +184,8 @@ impl Frame {
                 b.put_varint(SETTINGS_FRAME_TYPE_ID)?;
                 b.put_varint(len as u64)?;
 
-                if let Some(val) = max_header_list_size {
-                    b.put_varint(SETTINGS_MAX_HEADER_LIST_SIZE)?;
+                if let Some(val) = max_field_section_size {
+                    b.put_varint(SETTINGS_MAX_FIELD_SECTION_SIZE)?;
                     b.put_varint(*val as u64)?;
                 }
 
@@ -259,12 +259,12 @@ impl std::fmt::Debug for Frame {
             },
 
             Frame::Settings {
-                max_header_list_size,
+                max_field_section_size,
                 qpack_max_table_capacity,
                 qpack_blocked_streams,
                 ..
             } => {
-                write!(f, "SETTINGS max_headers={:?}, qpack_max_table={:?}, qpack_blocked={:?} ", max_header_list_size, qpack_max_table_capacity, qpack_blocked_streams)?;
+                write!(f, "SETTINGS max_field_section={:?}, qpack_max_table={:?}, qpack_blocked={:?} ", max_field_section_size, qpack_max_table_capacity, qpack_blocked_streams)?;
             },
 
             Frame::PushPromise {
@@ -299,7 +299,7 @@ impl std::fmt::Debug for Frame {
 fn parse_settings_frame(
     b: &mut octets::Octets, settings_length: usize,
 ) -> Result<Frame> {
-    let mut max_header_list_size = None;
+    let mut max_field_section_size = None;
     let mut qpack_max_table_capacity = None;
     let mut qpack_blocked_streams = None;
     let mut h3_datagram = None;
@@ -318,8 +318,8 @@ fn parse_settings_frame(
                 qpack_max_table_capacity = Some(settings_val);
             },
 
-            SETTINGS_MAX_HEADER_LIST_SIZE => {
-                max_header_list_size = Some(settings_val);
+            SETTINGS_MAX_FIELD_SECTION_SIZE => {
+                max_field_section_size = Some(settings_val);
             },
 
             SETTINGS_QPACK_BLOCKED_STREAMS => {
@@ -344,7 +344,7 @@ fn parse_settings_frame(
     }
 
     Ok(Frame::Settings {
-        max_header_list_size,
+        max_field_section_size,
         qpack_max_table_capacity,
         qpack_blocked_streams,
         h3_datagram,
@@ -457,7 +457,7 @@ mod tests {
         let mut d = [42; 128];
 
         let frame = Frame::Settings {
-            max_header_list_size: Some(0),
+            max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: Some(0),
@@ -490,7 +490,7 @@ mod tests {
         let mut d = [42; 128];
 
         let frame = Frame::Settings {
-            max_header_list_size: Some(0),
+            max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: Some(0),
@@ -499,7 +499,7 @@ mod tests {
 
         // Frame parsing will always ignore GREASE values.
         let frame_parsed = Frame::Settings {
-            max_header_list_size: Some(0),
+            max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: Some(0),
@@ -532,7 +532,7 @@ mod tests {
         let mut d = [42; 128];
 
         let frame = Frame::Settings {
-            max_header_list_size: Some(1024),
+            max_field_section_size: Some(1024),
             qpack_max_table_capacity: None,
             qpack_blocked_streams: None,
             h3_datagram: None,
@@ -565,7 +565,7 @@ mod tests {
         let mut d = [42; 128];
 
         let frame = Frame::Settings {
-            max_header_list_size: None,
+            max_field_section_size: None,
             qpack_max_table_capacity: None,
             qpack_blocked_streams: None,
             h3_datagram: Some(1),
@@ -598,7 +598,7 @@ mod tests {
         let mut d = [42; 128];
 
         let frame = Frame::Settings {
-            max_header_list_size: None,
+            max_field_section_size: None,
             qpack_max_table_capacity: None,
             qpack_blocked_streams: None,
             h3_datagram: Some(5),
@@ -630,7 +630,7 @@ mod tests {
         let mut d = [42; 128];
 
         let frame = Frame::Settings {
-            max_header_list_size: None,
+            max_field_section_size: None,
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: None,

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -580,7 +580,7 @@ mod tests {
         let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let frame = frame::Frame::Settings {
-            max_header_list_size: Some(0),
+            max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: None,
@@ -636,7 +636,7 @@ mod tests {
         let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let frame = frame::Frame::Settings {
-            max_header_list_size: Some(0),
+            max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: None,
@@ -701,7 +701,7 @@ mod tests {
         let goaway = frame::Frame::GoAway { id: 0 };
 
         let settings = frame::Frame::Settings {
-            max_header_list_size: Some(0),
+            max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: None,
@@ -744,7 +744,7 @@ mod tests {
         let hdrs = frame::Frame::Headers { header_block };
 
         let settings = frame::Frame::Settings {
-            max_header_list_size: Some(0),
+            max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: None,


### PR DESCRIPTION
The name of this setting was changed in draft -28 but we never went and
updated it. Since the setting is exposed externally in the API, it could
confuse people that come to implement the more recent drafts. This
change fixes things.

Note that this does not update the qlog crate, since that spec is
lagging behind too; see: https://github.com/quicwg/qlog/issues/175