### PR TITLE
recovery: hystart++ draft 03

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.50 as build
+FROM rust:1.53 as build
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ is disabled by default), by passing ``--features ffi`` to ``cargo``.
 Building
 --------
 
-quiche requires Rust 1.50 or later to build. The latest stable Rust release can
+quiche requires Rust 1.53 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched

--- a/src/recovery/hystart.rs
+++ b/src/recovery/hystart.rs
@@ -28,7 +28,7 @@
 //!
 //! This implementation is based on the following I-D:
 //!
-//! <https://tools.ietf.org/html/draft-balasubramanian-tcpm-hystartplusplus-03>
+//! <https://datatracker.ietf.org/doc/html/draft-ietf-tcpm-hystartplusplus-03>
 
 use std::cmp;
 use std::time::Duration;
@@ -44,9 +44,11 @@ const MIN_RTT_THRESH: Duration = Duration::from_millis(4);
 
 const MAX_RTT_THRESH: Duration = Duration::from_millis(16);
 
-pub const LSS_DIVISOR: f64 = 0.25;
-
 pub const N_RTT_SAMPLE: usize = 8;
+
+pub const CSS_GROWTH_DIVISOR: usize = 4;
+
+pub const CSS_ROUNDS: usize = 5;
 
 #[derive(Default)]
 pub struct Hystart {
@@ -54,13 +56,17 @@ pub struct Hystart {
 
     window_end: Option<u64>,
 
-    last_round_min_rtt: Option<Duration>,
+    last_round_min_rtt: Duration,
 
-    current_round_min_rtt: Option<Duration>,
+    current_round_min_rtt: Duration,
+
+    css_baseline_min_rtt: Duration,
 
     rtt_sample_count: usize,
 
-    lss_start_time: Option<Instant>,
+    css_start_time: Option<Instant>,
+
+    css_round_count: usize,
 }
 
 impl std::fmt::Debug for Hystart {
@@ -68,8 +74,10 @@ impl std::fmt::Debug for Hystart {
         write!(f, "window_end={:?} ", self.window_end)?;
         write!(f, "last_round_min_rtt={:?} ", self.last_round_min_rtt)?;
         write!(f, "current_round_min_rtt={:?} ", self.current_round_min_rtt)?;
+        write!(f, "css_baseline_min_rtt={:?} ", self.css_baseline_min_rtt)?;
         write!(f, "rtt_sample_count={:?} ", self.rtt_sample_count)?;
-        write!(f, "lss_start_time={:?} ", self.lss_start_time)?;
+        write!(f, "css_start_time={:?} ", self.css_start_time)?;
+        write!(f, "css_round_count={:?} ", self.css_round_count)?;
 
         Ok(())
     }
@@ -80,101 +88,125 @@ impl Hystart {
         Self {
             enabled,
 
+            last_round_min_rtt: Duration::MAX,
+
+            current_round_min_rtt: Duration::MAX,
+
+            css_baseline_min_rtt: Duration::MAX,
+
             ..Default::default()
         }
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::new(self.enabled);
     }
 
     pub fn enabled(&self) -> bool {
         self.enabled
     }
 
-    pub fn lss_start_time(&self) -> Option<Instant> {
-        self.lss_start_time
+    pub fn css_start_time(&self) -> Option<Instant> {
+        self.css_start_time
     }
 
-    pub fn in_lss(&self, epoch: packet::Epoch) -> bool {
+    pub fn in_css(&self, epoch: packet::Epoch) -> bool {
         self.enabled &&
             epoch == packet::EPOCH_APPLICATION &&
-            self.lss_start_time().is_some()
+            self.css_start_time().is_some()
     }
 
     pub fn start_round(&mut self, pkt_num: u64) {
         if self.window_end.is_none() {
-            *self = Hystart {
-                enabled: self.enabled,
+            self.window_end = Some(pkt_num);
 
-                window_end: Some(pkt_num),
+            self.last_round_min_rtt = self.current_round_min_rtt;
 
-                last_round_min_rtt: self.current_round_min_rtt,
+            self.current_round_min_rtt = Duration::MAX;
 
-                current_round_min_rtt: None,
-
-                rtt_sample_count: 0,
-
-                lss_start_time: None,
-            };
+            self.rtt_sample_count = 0;
         }
     }
 
-    // Returns true if LSS started.
-    pub fn try_enter_lss(
-        &mut self, packet: &recovery::Acked, rtt: Duration, cwnd: usize,
-        now: Instant, max_datagram_size: usize,
+    // On receiving ACK. Returns true if need to enter Congestion Avoidance.
+    pub fn on_packet_acked(
+        &mut self, epoch: packet::Epoch, packet: &recovery::Acked, rtt: Duration,
+        cwnd: usize, now: Instant, max_datagram_size: usize,
     ) -> bool {
-        if self.lss_start_time().is_none() {
-            if let Some(current_round_min_rtt) = self.current_round_min_rtt {
-                self.current_round_min_rtt =
-                    Some(cmp::min(current_round_min_rtt, rtt));
-            } else {
-                self.current_round_min_rtt = Some(rtt);
-            }
+        if !(self.enabled && epoch == packet::EPOCH_APPLICATION) {
+            return false;
+        }
 
-            self.rtt_sample_count += 1;
+        self.current_round_min_rtt = cmp::min(self.current_round_min_rtt, rtt);
 
+        self.rtt_sample_count += 1;
+
+        // Slow Start.
+        if self.css_start_time().is_none() {
             if cwnd >= (LOW_CWND * max_datagram_size) &&
-                self.rtt_sample_count >= N_RTT_SAMPLE &&
-                self.current_round_min_rtt.is_some() &&
-                self.last_round_min_rtt.is_some()
+                self.rtt_sample_count >= N_RTT_SAMPLE
             {
+                self.rtt_sample_count = 0;
+
                 // clamp(min_rtt_thresh, last_round_min_rtt/8,
                 // max_rtt_thresh)
-                let rtt_thresh = cmp::max(
-                    self.last_round_min_rtt.unwrap() / 8,
-                    MIN_RTT_THRESH,
-                );
+                let rtt_thresh =
+                    cmp::max(self.last_round_min_rtt / 8, MIN_RTT_THRESH);
                 let rtt_thresh = cmp::min(rtt_thresh, MAX_RTT_THRESH);
 
-                // Check if we can exit to LSS.
-                if self.current_round_min_rtt.unwrap() >=
-                    (self.last_round_min_rtt.unwrap() + rtt_thresh)
+                // Check if we can exit to CSS.
+                if self.current_round_min_rtt >=
+                    self.last_round_min_rtt.saturating_add(rtt_thresh)
                 {
-                    self.lss_start_time = Some(now);
+                    self.css_baseline_min_rtt = self.current_round_min_rtt;
+                    self.css_start_time = Some(now);
                 }
             }
+        } else {
+            // Conservative Slow Start.
+            if self.rtt_sample_count >= N_RTT_SAMPLE {
+                self.rtt_sample_count = 0;
 
-            // Check if we reached the end of the round.
-            if let Some(end_pkt_num) = self.window_end {
-                if packet.pkt_num >= end_pkt_num {
-                    // Start of a new round.
-                    self.window_end = None;
+                if self.current_round_min_rtt < self.css_baseline_min_rtt {
+                    self.css_baseline_min_rtt = Duration::MAX;
+
+                    // Back to Slow Start.
+                    self.css_start_time = None;
+                    self.css_round_count = 0;
                 }
             }
         }
 
-        self.lss_start_time.is_some()
+        // Check if we reached the end of the round.
+        if let Some(end_pkt_num) = self.window_end {
+            if packet.pkt_num >= end_pkt_num {
+                // Start of a new round.
+                self.window_end = None;
+
+                if self.css_start_time().is_some() {
+                    self.css_round_count += 1;
+
+                    // End of CSS - exit to congestion avoidance.
+                    if self.css_round_count >= CSS_ROUNDS {
+                        self.css_round_count = 0;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
     }
 
-    // Return a cwnd increment during LSS (Limited Slow Start).
-    pub fn lss_cwnd_inc(
-        &self, pkt_size: usize, cwnd: usize, ssthresh: usize,
-    ) -> usize {
-        pkt_size / (cwnd as f64 / (LSS_DIVISOR * ssthresh as f64)) as usize
+    // Return a cwnd increment during CSS (Conservative Slow Start).
+    pub fn css_cwnd_inc(&self, pkt_size: usize) -> usize {
+        pkt_size / CSS_GROWTH_DIVISOR
     }
 
     // Exit HyStart++ when entering congestion avoidance.
     pub fn congestion_event(&mut self) {
         self.window_end = None;
-        self.lss_start_time = None;
+        self.css_start_time = None;
     }
 }
 
@@ -190,20 +222,17 @@ mod tests {
         hspp.start_round(pkt_num);
 
         assert_eq!(hspp.window_end, Some(pkt_num));
-        assert_eq!(hspp.current_round_min_rtt, None);
+        assert_eq!(hspp.current_round_min_rtt, Duration::MAX);
     }
 
     #[test]
-    fn lss_cwnd_inc() {
+    fn css_cwnd_inc() {
         let hspp = Hystart::default();
-
         let datagram_size = 1200;
-        let cwnd = 24000;
-        let ssthresh = 24000;
 
-        let lss_cwnd_inc = hspp.lss_cwnd_inc(datagram_size, cwnd, ssthresh);
+        let css_cwnd_inc = hspp.css_cwnd_inc(datagram_size);
 
-        assert_eq!((datagram_size as f64 * LSS_DIVISOR) as usize, lss_cwnd_inc);
+        assert_eq!(datagram_size / CSS_GROWTH_DIVISOR, css_cwnd_inc);
     }
 
     #[test]


### PR DESCRIPTION
- Implement hystart++ draft 03 for cubic and reno
- A new mode Conservative Slow Start (CSS) introduced instead of
  Limited Slow Start (LSS). The difference is CSS is still under
  slow start (cwnd < ssthresh)
- Add hystart.reset() hook to be called in collapse_cwnd() CC
  hook to start in a clean state.
- Update hystart test in cubic and test 2 mode transitions:
  SS -> CSS -> SS and SS -> CSS -> CA.
- For various rtt, simply use Duration.
- Bump minimum rust version to 1.53 due to the use of Duration::MAX.