### PR TITLE
h3: when frames are too large, generate H3_EXCESSIVE_LOAD

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -3330,7 +3330,7 @@ mod tests {
 
         s.advance().ok();
 
-        assert_eq!(s.server.poll(&mut s.pipe.server), Err(Error::InternalError));
+        assert_eq!(s.server.poll(&mut s.pipe.server), Err(Error::ExcessiveLoad));
     }
 
     #[test]
@@ -3522,7 +3522,7 @@ mod tests {
 
         s.advance().ok();
 
-        assert_eq!(s.server.poll(&mut s.pipe.server), Err(Error::InternalError));
+        assert_eq!(s.server.poll(&mut s.pipe.server), Err(Error::ExcessiveLoad));
 
         // Try to call poll() again after an error occurred.
         assert_eq!(s.server.poll(&mut s.pipe.server), Err(Error::Done));

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -556,7 +556,7 @@ impl Stream {
             // payload size of a GREASE frame), so we need to limit the maximum
             // size to avoid DoS.
             if self.state_len > MAX_STATE_BUF_SIZE {
-                return Err(Error::InternalError);
+                return Err(Error::ExcessiveLoad);
             }
 
             self.state_buf.resize(self.state_len, 0);


### PR DESCRIPTION
quiche applies a limit to the size of some HTTP/3 frames. Previously, if the
limit was exceeded we emitted a CONNECTION_CLOSE with H3_INTERNAL_ERROR code.
Instead use H3_EXCESSIVE_LOAD code.