### PR TITLE
h3: store all received SETTINGS parameters and expose them

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -675,6 +675,16 @@ int quiche_h3_event_for_each_header(quiche_h3_event *ev,
                                               void *argp),
                                     void *argp);
 
+// Iterates over the peer's HTTP/3 settings.
+//
+// The `cb` callback will be called for each setting in `conn`.
+// If `cb` returns any value other than `0`, processing will be interrupted and
+// the value is returned to the caller.
+int quiche_h3_for_each_setting(quiche_h3_conn *conn,
+                               int (*cb)(uint64_t identifier,
+                                         uint64_t value, void *argp),
+                               void *argp);
+
 // Check whether data will follow the headers on the stream.
 bool quiche_h3_event_headers_has_body(quiche_h3_event *ev);
 

--- a/src/h3/ffi.rs
+++ b/src/h3/ffi.rs
@@ -85,6 +85,31 @@ pub extern fn quiche_h3_conn_new_with_transport(
 }
 
 #[no_mangle]
+pub extern fn quiche_h3_for_each_setting(
+    conn: &h3::Connection,
+    cb: extern fn(identifier: u64, value: u64, argp: *mut c_void) -> c_int,
+    argp: *mut c_void,
+) -> c_int {
+    let rc = match conn.peer_settings_raw() {
+        Some(raw) => {
+            for setting in raw {
+                let rc = cb(setting.identifier, setting.value, argp);
+
+                if rc != 0 {
+                    return rc;
+                }
+            }
+
+            0
+        },
+
+        None => -1,
+    };
+
+    rc
+}
+
+#[no_mangle]
 pub extern fn quiche_h3_conn_poll(
     conn: &mut h3::Connection, quic_conn: &mut Connection,
     ev: *mut *const h3::Event,

--- a/src/h3/ffi.rs
+++ b/src/h3/ffi.rs
@@ -90,10 +90,10 @@ pub extern fn quiche_h3_for_each_setting(
     cb: extern fn(identifier: u64, value: u64, argp: *mut c_void) -> c_int,
     argp: *mut c_void,
 ) -> c_int {
-    let rc = match conn.peer_settings_raw() {
+    match conn.peer_settings_raw() {
         Some(raw) => {
             for setting in raw {
-                let rc = cb(setting.identifier, setting.value, argp);
+                let rc = cb(setting.0, setting.1, argp);
 
                 if rc != 0 {
                     return rc;
@@ -104,9 +104,7 @@ pub extern fn quiche_h3_for_each_setting(
         },
 
         None => -1,
-    };
-
-    rc
+    }
 }
 
 #[no_mangle]

--- a/src/h3/frame.rs
+++ b/src/h3/frame.rs
@@ -24,6 +24,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use super::RawSetting;
 use super::Result;
 
 use crate::octets;
@@ -36,10 +37,10 @@ pub const PUSH_PROMISE_FRAME_TYPE_ID: u64 = 0x5;
 pub const GOAWAY_FRAME_TYPE_ID: u64 = 0x6;
 pub const MAX_PUSH_FRAME_TYPE_ID: u64 = 0xD;
 
-const SETTINGS_QPACK_MAX_TABLE_CAPACITY: u64 = 0x1;
-const SETTINGS_MAX_FIELD_SECTION_SIZE: u64 = 0x6;
-const SETTINGS_QPACK_BLOCKED_STREAMS: u64 = 0x7;
-const SETTINGS_H3_DATAGRAM: u64 = 0x276;
+pub const SETTINGS_QPACK_MAX_TABLE_CAPACITY: u64 = 0x1;
+pub const SETTINGS_MAX_FIELD_SECTION_SIZE: u64 = 0x6;
+pub const SETTINGS_QPACK_BLOCKED_STREAMS: u64 = 0x7;
+pub const SETTINGS_H3_DATAGRAM: u64 = 0x276;
 
 // Permit between 16 maximally-encoded and 128 minimally-encoded SETTINGS.
 const MAX_SETTINGS_PAYLOAD_SIZE: usize = 256;
@@ -64,6 +65,7 @@ pub enum Frame {
         qpack_blocked_streams: Option<u64>,
         h3_datagram: Option<u64>,
         grease: Option<(u64, u64)>,
+        raw: Option<Vec<RawSetting>>,
     },
 
     PushPromise {
@@ -153,6 +155,7 @@ impl Frame {
                 qpack_blocked_streams,
                 h3_datagram,
                 grease,
+                ..
             } => {
                 let mut len = 0;
 
@@ -262,9 +265,10 @@ impl std::fmt::Debug for Frame {
                 max_field_section_size,
                 qpack_max_table_capacity,
                 qpack_blocked_streams,
+                raw,
                 ..
             } => {
-                write!(f, "SETTINGS max_field_section={:?}, qpack_max_table={:?}, qpack_blocked={:?} ", max_field_section_size, qpack_max_table_capacity, qpack_blocked_streams)?;
+                write!(f, "SETTINGS max_field_section={:?}, qpack_max_table={:?}, qpack_blocked={:?} raw={:?}", max_field_section_size, qpack_max_table_capacity, qpack_blocked_streams, raw)?;
             },
 
             Frame::PushPromise {
@@ -303,6 +307,7 @@ fn parse_settings_frame(
     let mut qpack_max_table_capacity = None;
     let mut qpack_blocked_streams = None;
     let mut h3_datagram = None;
+    let mut raw = Vec::new();
 
     // Reject SETTINGS frames that are too long.
     if settings_length > MAX_SETTINGS_PAYLOAD_SIZE {
@@ -310,28 +315,32 @@ fn parse_settings_frame(
     }
 
     while b.off() < settings_length {
-        let setting_ty = b.get_varint()?;
-        let settings_val = b.get_varint()?;
+        let identifier = b.get_varint()?;
+        let value = b.get_varint()?;
 
-        match setting_ty {
+        // MAX_SETTINGS_PAYLOAD_SIZE protects us from storing too many raw
+        // settings.
+        raw.push(RawSetting { identifier, value });
+
+        match identifier {
             SETTINGS_QPACK_MAX_TABLE_CAPACITY => {
-                qpack_max_table_capacity = Some(settings_val);
+                qpack_max_table_capacity = Some(value);
             },
 
             SETTINGS_MAX_FIELD_SECTION_SIZE => {
-                max_field_section_size = Some(settings_val);
+                max_field_section_size = Some(value);
             },
 
             SETTINGS_QPACK_BLOCKED_STREAMS => {
-                qpack_blocked_streams = Some(settings_val);
+                qpack_blocked_streams = Some(value);
             },
 
             SETTINGS_H3_DATAGRAM => {
-                if settings_val > 1 {
+                if value > 1 {
                     return Err(super::Error::SettingsError);
                 }
 
-                h3_datagram = Some(settings_val);
+                h3_datagram = Some(value);
             },
 
             // Reserved values overlap with HTTP/2 and MUST be rejected
@@ -349,6 +358,7 @@ fn parse_settings_frame(
         qpack_blocked_streams,
         h3_datagram,
         grease: None,
+        raw: Some(raw),
     })
 }
 
@@ -456,12 +466,32 @@ mod tests {
     fn settings_all_no_grease() {
         let mut d = [42; 128];
 
+        let raw_settings = vec![
+            RawSetting {
+                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_H3_DATAGRAM,
+                value: 0,
+            },
+        ];
+
         let frame = Frame::Settings {
             max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: Some(0),
             grease: None,
+            raw: Some(raw_settings),
         };
 
         let frame_payload_len = 9;
@@ -495,15 +525,41 @@ mod tests {
             qpack_blocked_streams: Some(0),
             h3_datagram: Some(0),
             grease: Some((33, 33)),
+            raw: Default::default(),
         };
 
-        // Frame parsing will always ignore GREASE values.
+        let raw_settings = vec![
+            RawSetting {
+                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_H3_DATAGRAM,
+                value: 0,
+            },
+            RawSetting {
+                identifier: 33,
+                value: 33,
+            },
+        ];
+
+        // Frame parsing will not populate GREASE property but will be in the
+        // raw info.
         let frame_parsed = Frame::Settings {
             max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: Some(0),
             grease: None,
+            raw: Some(raw_settings),
         };
 
         let frame_payload_len = 11;
@@ -531,12 +587,18 @@ mod tests {
     fn settings_h3_only() {
         let mut d = [42; 128];
 
+        let raw_settings = vec![RawSetting {
+            identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
+            value: 1024,
+        }];
+
         let frame = Frame::Settings {
             max_field_section_size: Some(1024),
             qpack_max_table_capacity: None,
             qpack_blocked_streams: None,
             h3_datagram: None,
             grease: None,
+            raw: Some(raw_settings),
         };
 
         let frame_payload_len = 3;
@@ -564,12 +626,18 @@ mod tests {
     fn settings_h3_dgram_only() {
         let mut d = [42; 128];
 
+        let raw_settings = vec![RawSetting {
+            identifier: SETTINGS_H3_DATAGRAM,
+            value: 1,
+        }];
+
         let frame = Frame::Settings {
             max_field_section_size: None,
             qpack_max_table_capacity: None,
             qpack_blocked_streams: None,
             h3_datagram: Some(1),
             grease: None,
+            raw: Some(raw_settings),
         };
 
         let frame_payload_len = 3;
@@ -603,6 +671,7 @@ mod tests {
             qpack_blocked_streams: None,
             h3_datagram: Some(5),
             grease: None,
+            raw: Default::default(),
         };
 
         let frame_payload_len = 3;
@@ -629,12 +698,24 @@ mod tests {
     fn settings_qpack_only() {
         let mut d = [42; 128];
 
+        let raw_settings = vec![
+            RawSetting {
+                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
+                value: 0,
+            },
+        ];
+
         let frame = Frame::Settings {
             max_field_section_size: None,
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: None,
             grease: None,
+            raw: Some(raw_settings),
         };
 
         let frame_payload_len = 4;

--- a/src/h3/frame.rs
+++ b/src/h3/frame.rs
@@ -24,7 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use super::RawSetting;
 use super::Result;
 
 use crate::octets;
@@ -65,7 +64,7 @@ pub enum Frame {
         qpack_blocked_streams: Option<u64>,
         h3_datagram: Option<u64>,
         grease: Option<(u64, u64)>,
-        raw: Option<Vec<RawSetting>>,
+        raw: Option<Vec<(u64, u64)>>,
     },
 
     PushPromise {
@@ -320,7 +319,7 @@ fn parse_settings_frame(
 
         // MAX_SETTINGS_PAYLOAD_SIZE protects us from storing too many raw
         // settings.
-        raw.push(RawSetting { identifier, value });
+        raw.push((identifier, value));
 
         match identifier {
             SETTINGS_QPACK_MAX_TABLE_CAPACITY => {
@@ -467,22 +466,10 @@ mod tests {
         let mut d = [42; 128];
 
         let raw_settings = vec![
-            RawSetting {
-                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_H3_DATAGRAM,
-                value: 0,
-            },
+            (SETTINGS_MAX_FIELD_SECTION_SIZE, 0),
+            (SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0),
+            (SETTINGS_QPACK_BLOCKED_STREAMS, 0),
+            (SETTINGS_H3_DATAGRAM, 0),
         ];
 
         let frame = Frame::Settings {
@@ -529,26 +516,11 @@ mod tests {
         };
 
         let raw_settings = vec![
-            RawSetting {
-                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_H3_DATAGRAM,
-                value: 0,
-            },
-            RawSetting {
-                identifier: 33,
-                value: 33,
-            },
+            (SETTINGS_MAX_FIELD_SECTION_SIZE, 0),
+            (SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0),
+            (SETTINGS_QPACK_BLOCKED_STREAMS, 0),
+            (SETTINGS_H3_DATAGRAM, 0),
+            (33, 33),
         ];
 
         // Frame parsing will not populate GREASE property but will be in the
@@ -587,10 +559,7 @@ mod tests {
     fn settings_h3_only() {
         let mut d = [42; 128];
 
-        let raw_settings = vec![RawSetting {
-            identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
-            value: 1024,
-        }];
+        let raw_settings = vec![(SETTINGS_MAX_FIELD_SECTION_SIZE, 1024)];
 
         let frame = Frame::Settings {
             max_field_section_size: Some(1024),
@@ -626,10 +595,7 @@ mod tests {
     fn settings_h3_dgram_only() {
         let mut d = [42; 128];
 
-        let raw_settings = vec![RawSetting {
-            identifier: SETTINGS_H3_DATAGRAM,
-            value: 1,
-        }];
+        let raw_settings = vec![(SETTINGS_H3_DATAGRAM, 1)];
 
         let frame = Frame::Settings {
             max_field_section_size: None,
@@ -699,14 +665,8 @@ mod tests {
         let mut d = [42; 128];
 
         let raw_settings = vec![
-            RawSetting {
-                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
-                value: 0,
-            },
+            (SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0),
+            (SETTINGS_QPACK_BLOCKED_STREAMS, 0),
         ];
 
         let frame = Frame::Settings {

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -604,11 +604,22 @@ pub enum Event {
     GoAway,
 }
 
+/// An HTTP/3 setting.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RawSetting {
+    /// Setting identifier.
+    pub identifier: u64,
+
+    /// Setting value.
+    pub value: u64,
+}
+
 struct ConnectionSettings {
     pub max_field_section_size: Option<u64>,
     pub qpack_max_table_capacity: Option<u64>,
     pub qpack_blocked_streams: Option<u64>,
     pub h3_datagram: Option<u64>,
+    pub raw: Option<Vec<RawSetting>>,
 }
 
 struct QpackStreams {
@@ -672,6 +683,7 @@ impl Connection {
                 qpack_max_table_capacity: config.qpack_max_table_capacity,
                 qpack_blocked_streams: config.qpack_blocked_streams,
                 h3_datagram,
+                raw: Default::default(),
             },
 
             peer_settings: ConnectionSettings {
@@ -679,6 +691,7 @@ impl Connection {
                 qpack_max_table_capacity: None,
                 qpack_blocked_streams: None,
                 h3_datagram: None,
+                raw: Default::default(),
             },
 
             control_stream_id: None,
@@ -1416,6 +1429,13 @@ impl Connection {
         Ok(())
     }
 
+    /// Gets the raw settings from peer including unknown and reserved types.
+    ///
+    /// The order of settings is the same as received in the SETTINGS frame.
+    pub fn peer_settings_raw(&self) -> Option<Vec<RawSetting>> {
+        self.peer_settings.raw.clone()
+    }
+
     fn open_uni_stream(
         &mut self, conn: &mut super::Connection, ty: u64,
     ) -> Result<u64> {
@@ -1570,6 +1590,7 @@ impl Connection {
             qpack_blocked_streams: self.local_settings.qpack_blocked_streams,
             h3_datagram: self.local_settings.h3_datagram,
             grease,
+            raw: Default::default(),
         };
 
         let mut d = [42; 128];
@@ -1905,6 +1926,7 @@ impl Connection {
                 qpack_max_table_capacity,
                 qpack_blocked_streams,
                 h3_datagram,
+                raw,
                 ..
             } => {
                 self.peer_settings = ConnectionSettings {
@@ -1912,6 +1934,7 @@ impl Connection {
                     qpack_max_table_capacity,
                     qpack_blocked_streams,
                     h3_datagram,
+                    raw,
                 };
 
                 if let Some(1) = h3_datagram {
@@ -3767,6 +3790,7 @@ mod tests {
             qpack_blocked_streams: None,
             h3_datagram: Some(1),
             grease: None,
+            raw: Default::default(),
         };
 
         s.send_frame_client(settings, s.client.control_stream_id.unwrap(), false)

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -604,22 +604,12 @@ pub enum Event {
     GoAway,
 }
 
-/// An HTTP/3 setting.
-#[derive(Clone, Debug, PartialEq)]
-pub struct RawSetting {
-    /// Setting identifier.
-    pub identifier: u64,
-
-    /// Setting value.
-    pub value: u64,
-}
-
 struct ConnectionSettings {
     pub max_field_section_size: Option<u64>,
     pub qpack_max_table_capacity: Option<u64>,
     pub qpack_blocked_streams: Option<u64>,
     pub h3_datagram: Option<u64>,
-    pub raw: Option<Vec<RawSetting>>,
+    pub raw: Option<Vec<(u64, u64)>>,
 }
 
 struct QpackStreams {
@@ -1432,8 +1422,8 @@ impl Connection {
     /// Gets the raw settings from peer including unknown and reserved types.
     ///
     /// The order of settings is the same as received in the SETTINGS frame.
-    pub fn peer_settings_raw(&self) -> Option<Vec<RawSetting>> {
-        self.peer_settings.raw.clone()
+    pub fn peer_settings_raw(&self) -> Option<&[(u64, u64)]> {
+        self.peer_settings.raw.as_deref()
     }
 
     fn open_uni_stream(

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -568,6 +568,9 @@ impl Stream {
 
 #[cfg(test)]
 mod tests {
+    use crate::h3::frame::*;
+    use crate::h3::RawSetting;
+
     use super::*;
 
     #[test]
@@ -579,12 +582,28 @@ mod tests {
         let mut d = vec![42; 40];
         let mut b = octets::OctetsMut::with_slice(&mut d);
 
-        let frame = frame::Frame::Settings {
+        let raw_settings = vec![
+            RawSetting {
+                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
+                value: 0,
+            },
+        ];
+
+        let frame = Frame::Settings {
             max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: None,
             grease: None,
+            raw: Some(raw_settings),
         };
 
         b.put_varint(HTTP3_CONTROL_STREAM_TYPE_ID).unwrap();
@@ -635,12 +654,28 @@ mod tests {
         let mut d = vec![42; 40];
         let mut b = octets::OctetsMut::with_slice(&mut d);
 
+        let raw_settings = vec![
+            RawSetting {
+                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
+                value: 0,
+            },
+        ];
+
         let frame = frame::Frame::Settings {
             max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: None,
             grease: None,
+            raw: Some(raw_settings),
         };
 
         b.put_varint(HTTP3_CONTROL_STREAM_TYPE_ID).unwrap();
@@ -700,12 +735,28 @@ mod tests {
 
         let goaway = frame::Frame::GoAway { id: 0 };
 
+        let raw_settings = vec![
+            RawSetting {
+                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
+                value: 0,
+            },
+        ];
+
         let settings = frame::Frame::Settings {
             max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: None,
             grease: None,
+            raw: Some(raw_settings),
         };
 
         b.put_varint(HTTP3_CONTROL_STREAM_TYPE_ID).unwrap();
@@ -743,12 +794,32 @@ mod tests {
         let header_block = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
         let hdrs = frame::Frame::Headers { header_block };
 
+        let raw_settings = vec![
+            RawSetting {
+                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
+                value: 0,
+            },
+            RawSetting {
+                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
+                value: 0,
+            },
+            RawSetting {
+                identifier: 33,
+                value: 33,
+            },
+        ];
+
         let settings = frame::Frame::Settings {
             max_field_section_size: Some(0),
             qpack_max_table_capacity: Some(0),
             qpack_blocked_streams: Some(0),
             h3_datagram: None,
             grease: None,
+            raw: Some(raw_settings),
         };
 
         b.put_varint(HTTP3_CONTROL_STREAM_TYPE_ID).unwrap();

--- a/src/h3/stream.rs
+++ b/src/h3/stream.rs
@@ -569,7 +569,6 @@ impl Stream {
 #[cfg(test)]
 mod tests {
     use crate::h3::frame::*;
-    use crate::h3::RawSetting;
 
     use super::*;
 
@@ -583,18 +582,9 @@ mod tests {
         let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let raw_settings = vec![
-            RawSetting {
-                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
-                value: 0,
-            },
+            (SETTINGS_MAX_FIELD_SECTION_SIZE, 0),
+            (SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0),
+            (SETTINGS_QPACK_BLOCKED_STREAMS, 0),
         ];
 
         let frame = Frame::Settings {
@@ -655,18 +645,9 @@ mod tests {
         let mut b = octets::OctetsMut::with_slice(&mut d);
 
         let raw_settings = vec![
-            RawSetting {
-                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
-                value: 0,
-            },
+            (SETTINGS_MAX_FIELD_SECTION_SIZE, 0),
+            (SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0),
+            (SETTINGS_QPACK_BLOCKED_STREAMS, 0),
         ];
 
         let frame = frame::Frame::Settings {
@@ -736,18 +717,9 @@ mod tests {
         let goaway = frame::Frame::GoAway { id: 0 };
 
         let raw_settings = vec![
-            RawSetting {
-                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
-                value: 0,
-            },
+            (SETTINGS_MAX_FIELD_SECTION_SIZE, 0),
+            (SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0),
+            (SETTINGS_QPACK_BLOCKED_STREAMS, 0),
         ];
 
         let settings = frame::Frame::Settings {
@@ -795,22 +767,10 @@ mod tests {
         let hdrs = frame::Frame::Headers { header_block };
 
         let raw_settings = vec![
-            RawSetting {
-                identifier: SETTINGS_MAX_FIELD_SECTION_SIZE,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_MAX_TABLE_CAPACITY,
-                value: 0,
-            },
-            RawSetting {
-                identifier: SETTINGS_QPACK_BLOCKED_STREAMS,
-                value: 0,
-            },
-            RawSetting {
-                identifier: 33,
-                value: 33,
-            },
+            (SETTINGS_MAX_FIELD_SECTION_SIZE, 0),
+            (SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0),
+            (SETTINGS_QPACK_BLOCKED_STREAMS, 0),
+            (33, 33),
         ];
 
         let settings = frame::Frame::Settings {


### PR DESCRIPTION
SETTINGS frames can contain parameters with unknown or reserved identifiers.
quiche has no direct usage for these parameters and previously discarded them.
With this change we store all received parameters in the order that they were
sent, and add a new `peer_settings_raw()` to access them,