### PR TITLE
lib: window-based flow control

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -202,6 +202,12 @@ void quiche_config_enable_dgram(quiche_config *config, bool enabled,
                                 size_t recv_queue_len,
                                 size_t send_queue_len);
 
+// Sets the maximum connection window.
+void quiche_config_set_max_connection_window(quiche_config *config, uint64_t v);
+
+// Sets the maximum stream window.
+void quiche_config_set_max_stream_window(quiche_config *config, uint64_t v);
+
 // Frees the config object.
 void quiche_config_free(quiche_config *config);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -304,6 +304,18 @@ pub extern fn quiche_config_set_max_send_udp_payload_size(
 }
 
 #[no_mangle]
+pub extern fn quiche_config_set_max_connection_window(
+    config: &mut Config, v: u64,
+) {
+    config.set_max_connection_window(v);
+}
+
+#[no_mangle]
+pub extern fn quiche_config_set_max_stream_window(config: &mut Config, v: u64) {
+    config.set_max_stream_window(v);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_free(config: *mut Config) {
     unsafe { Box::from_raw(config) };
 }

--- a/src/flowcontrol.rs
+++ b/src/flowcontrol.rs
@@ -1,0 +1,220 @@
+// Copyright (C) 2021, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::time::Duration;
+use std::time::Instant;
+
+// When autotuning the receiver window, decide how much
+// we increase the window.
+const WINDOW_INCREASE_FACTOR: u64 = 2;
+
+// When autotuning the receiver window, check if the last
+// update is within RTT * this constant.
+const WINDOW_TRIGGER_FACTOR: u32 = 2;
+
+#[derive(Default, Debug)]
+pub struct FlowControl {
+    /// Total consumed bytes by the receiver.
+    consumed: u64,
+
+    /// Flow control limit.
+    max_data: u64,
+
+    /// The receive window. This value is used for updating
+    /// flow control limit.
+    window: u64,
+
+    /// The maximum receive window.
+    max_window: u64,
+
+    /// Last update time of max_data for autotuning the window.
+    last_update: Option<Instant>,
+}
+
+impl FlowControl {
+    pub fn new(max_data: u64, window: u64, max_window: u64) -> Self {
+        Self {
+            max_data,
+
+            window,
+
+            max_window,
+
+            ..Default::default()
+        }
+    }
+
+    /// Returns the current window size.
+    pub fn window(&self) -> u64 {
+        self.window
+    }
+
+    /// Returns the current flow limit.
+    pub fn max_data(&self) -> u64 {
+        self.max_data
+    }
+
+    /// Update consumed bytes.
+    pub fn add_consumed(&mut self, consumed: u64) {
+        self.consumed += consumed;
+    }
+
+    /// Returns true if the flow control needs to update max_data.
+    ///
+    /// This happens when the available window is smaller than the half
+    /// of the current window.
+    pub fn should_update_max_data(&self) -> bool {
+        let available_window = self.max_data - self.consumed;
+
+        available_window < (self.window / 2)
+    }
+
+    /// Returns the new max_data limit.
+    pub fn max_data_next(&self) -> u64 {
+        self.consumed + self.window
+    }
+
+    /// Commits the new max_data limit.
+    pub fn update_max_data(&mut self, now: Instant) {
+        self.max_data = self.max_data_next();
+        self.last_update = Some(now);
+    }
+
+    /// Autotune the window size. When there is an another update
+    /// within RTT x 2, bump the window x 1.5, capped by
+    /// max_window.
+    pub fn autotune_window(&mut self, now: Instant, rtt: Duration) {
+        if let Some(last_update) = self.last_update {
+            if now - last_update < rtt * WINDOW_TRIGGER_FACTOR {
+                self.window = std::cmp::min(
+                    self.window * WINDOW_INCREASE_FACTOR,
+                    self.max_window,
+                );
+            }
+        }
+    }
+
+    /// Make sure the lower bound of the window is same to
+    /// the current window.
+    pub fn ensure_window_lower_bound(&mut self, min_window: u64) {
+        if min_window > self.window {
+            self.window = min_window;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_data() {
+        let fc = FlowControl::new(100, 20, 100);
+
+        assert_eq!(fc.max_data(), 100);
+    }
+
+    #[test]
+    fn should_update_max_data() {
+        let mut fc = FlowControl::new(100, 20, 100);
+
+        fc.add_consumed(85);
+        assert_eq!(fc.should_update_max_data(), false);
+
+        fc.add_consumed(10);
+        assert_eq!(fc.should_update_max_data(), true);
+    }
+
+    #[test]
+    fn max_data_next() {
+        let mut fc = FlowControl::new(100, 20, 100);
+
+        let consumed = 95;
+
+        fc.add_consumed(consumed);
+        assert_eq!(fc.should_update_max_data(), true);
+        assert_eq!(fc.max_data_next(), consumed + 20);
+    }
+
+    #[test]
+    fn update_max_data() {
+        let mut fc = FlowControl::new(100, 20, 100);
+
+        let consumed = 95;
+
+        fc.add_consumed(consumed);
+        assert_eq!(fc.should_update_max_data(), true);
+
+        let max_data_next = fc.max_data_next();
+        assert_eq!(fc.max_data_next(), consumed + 20);
+
+        fc.update_max_data(Instant::now());
+        assert_eq!(fc.max_data(), max_data_next);
+    }
+
+    #[test]
+    fn autotune_window() {
+        let w = 20;
+        let mut fc = FlowControl::new(100, w, 100);
+
+        let consumed = 95;
+
+        fc.add_consumed(consumed);
+        assert_eq!(fc.should_update_max_data(), true);
+
+        let max_data_next = fc.max_data_next();
+        assert_eq!(max_data_next, consumed + w);
+
+        fc.update_max_data(Instant::now());
+        assert_eq!(fc.max_data(), max_data_next);
+
+        // Window size should be doubled.
+        fc.autotune_window(Instant::now(), Duration::from_millis(100));
+
+        let w = w * 2;
+        let consumed_inc = 15;
+
+        fc.add_consumed(consumed_inc);
+        assert_eq!(fc.should_update_max_data(), true);
+
+        let max_data_next = fc.max_data_next();
+        assert_eq!(max_data_next, consumed + consumed_inc + w);
+    }
+
+    #[test]
+    fn ensure_window_lower_bound() {
+        let w = 20;
+        let mut fc = FlowControl::new(100, w, 100);
+
+        // Window doesn't change.
+        fc.ensure_window_lower_bound(w);
+        assert_eq!(fc.window(), 20);
+
+        // Window changed to the new value.
+        fc.ensure_window_lower_bound(w * 2);
+        assert_eq!(fc.window(), 40);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,6 +359,16 @@ const MAX_UNDECRYPTABLE_PACKETS: usize = 10;
 
 const RESERVED_VERSION_MASK: u32 = 0xfafafafa;
 
+// The default size of the receiver connection flow control window.
+const DEFAULT_CONNECTION_WINDOW: u64 = 48 * 1024;
+
+// The maximum size of the receiver connection flow control window.
+const MAX_CONNECTION_WINDOW: u64 = 24 * 1024 * 1024;
+
+// How much larger the connection flow control window need to be larger than
+// the stream flow control window.
+const CONNECTION_WINDOW_FACTOR: f64 = 1.5;
+
 /// A specialized [`Result`] type for quiche operations.
 ///
 /// This type is used throughout quiche's public API for any operation that
@@ -563,6 +573,9 @@ pub struct Config {
     dgram_send_max_queue_len: usize,
 
     max_send_udp_payload_size: usize,
+
+    max_connection_window: u64,
+    max_stream_window: u64,
 }
 
 // See https://quicwg.org/base-drafts/rfc9000.html#section-15
@@ -599,6 +612,9 @@ impl Config {
             dgram_send_max_queue_len: DEFAULT_MAX_DGRAM_QUEUE_LEN,
 
             max_send_udp_payload_size: MAX_SEND_UDP_PAYLOAD_SIZE,
+
+            max_connection_window: MAX_CONNECTION_WINDOW,
+            max_stream_window: stream::MAX_STREAM_WINDOW,
         })
     }
 
@@ -924,6 +940,20 @@ impl Config {
         self.dgram_recv_max_queue_len = recv_queue_len;
         self.dgram_send_max_queue_len = send_queue_len;
     }
+
+    /// Sets the maximum size of the connection window.
+    ///
+    /// The default value is MAX_CONNECTION_WINDOW (24MBytes).
+    pub fn set_max_connection_window(&mut self, v: u64) {
+        self.max_connection_window = v;
+    }
+
+    /// Sets the maximum size of the stream window.
+    ///
+    /// The default value is MAX_STREAM_WINDOW (16MBytes).
+    pub fn set_max_stream_window(&mut self, v: u64) {
+        self.max_stream_window = v;
+    }
 }
 
 /// A QUIC connection.
@@ -978,12 +1008,8 @@ pub struct Connection {
     /// Total number of bytes received from the peer.
     rx_data: u64,
 
-    /// Local flow control limit for the connection.
-    max_rx_data: u64,
-
-    /// Updated local flow control limit for the connection. This is used to
-    /// trigger sending MAX_DATA frames after a certain threshold.
-    max_rx_data_next: u64,
+    /// Receiver flow controller.
+    flow_control: flowcontrol::FlowControl,
 
     /// Whether we send MAX_DATA frame.
     almost_full: bool,
@@ -1424,8 +1450,11 @@ impl Connection {
             recv_bytes: 0,
 
             rx_data: 0,
-            max_rx_data,
-            max_rx_data_next: max_rx_data,
+            flow_control: flowcontrol::FlowControl::new(
+                max_rx_data,
+                cmp::min(max_rx_data / 2 * 3, DEFAULT_CONNECTION_WINDOW),
+                config.max_connection_window,
+            ),
             almost_full: false,
 
             tx_cap: 0,
@@ -1440,6 +1469,7 @@ impl Connection {
             streams: stream::StreamMap::new(
                 config.local_transport_params.initial_max_streams_bidi,
                 config.local_transport_params.initial_max_streams_uni,
+                config.max_stream_window,
             ),
 
             odcid: None,
@@ -2803,18 +2833,29 @@ impl Connection {
                     },
                 };
 
+                // Autotune the stream window size.
+                stream.recv.autotune_window(now, self.recovery.rtt());
+
                 let frame = frame::Frame::MaxStreamData {
                     stream_id,
                     max: stream.recv.max_data_next(),
                 };
 
                 if push_frame_to_pkt!(b, frames, frame, left) {
-                    stream.recv.update_max_data();
+                    let recv_win = stream.recv.window();
+
+                    stream.recv.update_max_data(now);
 
                     self.streams.mark_almost_full(stream_id, false);
 
                     ack_eliciting = true;
                     in_flight = true;
+
+                    // Make sure the connection window always has some
+                    // room compared to the stream window.
+                    self.flow_control.ensure_window_lower_bound(
+                        (recv_win as f64 * CONNECTION_WINDOW_FACTOR) as u64,
+                    );
 
                     // Also send MAX_DATA when MAX_STREAM_DATA is sent, to avoid a
                     // potential race condition.
@@ -2823,16 +2864,19 @@ impl Connection {
             }
 
             // Create MAX_DATA frame as needed.
-            if self.almost_full && self.max_rx_data < self.max_rx_data_next {
+            if self.almost_full && self.max_rx_data() < self.max_rx_data_next() {
+                // Autotune the connection window size.
+                self.flow_control.autotune_window(now, self.recovery.rtt());
+
                 let frame = frame::Frame::MaxData {
-                    max: self.max_rx_data_next,
+                    max: self.max_rx_data_next(),
                 };
 
                 if push_frame_to_pkt!(b, frames, frame, left) {
                     self.almost_full = false;
 
                     // Commits the new max_rx_data limit.
-                    self.max_rx_data = self.max_rx_data_next;
+                    self.flow_control.update_max_data(now);
 
                     ack_eliciting = true;
                     in_flight = true;
@@ -3471,7 +3515,7 @@ impl Connection {
             },
         };
 
-        self.max_rx_data_next = self.max_rx_data_next.saturating_add(read as u64);
+        self.flow_control.add_consumed(read as u64);
 
         let readable = stream.is_readable();
 
@@ -4905,7 +4949,7 @@ impl Connection {
                     return Err(Error::InvalidStreamState(stream_id));
                 }
 
-                let max_rx_data_left = self.max_rx_data - self.rx_data;
+                let max_rx_data_left = self.max_rx_data() - self.rx_data;
 
                 // Get existing stream or create a new one, but if the stream
                 // has already been closed and collected, ignore the frame.
@@ -5028,7 +5072,7 @@ impl Connection {
                     return Err(Error::InvalidStreamState(stream_id));
                 }
 
-                let max_rx_data_left = self.max_rx_data - self.rx_data;
+                let max_rx_data_left = self.max_rx_data() - self.rx_data;
 
                 // Get existing stream or create a new one, but if the stream
                 // has already been closed and collected, ignore the frame.
@@ -5240,8 +5284,17 @@ impl Connection {
     /// This happens when the new max data limit is at least double the amount
     /// of data that can be received before blocking.
     fn should_update_max_data(&self) -> bool {
-        self.max_rx_data_next != self.max_rx_data &&
-            self.max_rx_data_next / 2 > self.max_rx_data - self.rx_data
+        self.flow_control.should_update_max_data()
+    }
+
+    /// Returns the connection level flow control limit.
+    fn max_rx_data(&self) -> u64 {
+        self.flow_control.max_data()
+    }
+
+    /// Returns the updated connection level flow control limit.
+    fn max_rx_data_next(&self) -> u64 {
+        self.flow_control.max_data_next()
     }
 
     /// Returns true if the HANDSHAKE_DONE frame needs to be sent.
@@ -7147,7 +7200,7 @@ mod tests {
                 max: 30
             })
         );
-        assert_eq!(iter.next(), Some(&frame::Frame::MaxData { max: 46 }));
+        assert_eq!(iter.next(), Some(&frame::Frame::MaxData { max: 61 }));
     }
 
     #[test]
@@ -7231,7 +7284,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"aaaaaaa", 0, false),
+            data: stream::RangeBuf::from(b"aaaaaaaaa", 0, false),
         }];
 
         let pkt_type = packet::Type::Short;
@@ -7242,7 +7295,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"a", 7, false),
+            data: stream::RangeBuf::from(b"a", 9, false),
         }];
 
         let len = pipe
@@ -7262,7 +7315,7 @@ mod tests {
             iter.next(),
             Some(&frame::Frame::MaxStreamData {
                 stream_id: 4,
-                max: 22,
+                max: 24,
             })
         );
     }
@@ -11051,6 +11104,7 @@ mod crypto;
 mod dgram;
 #[cfg(feature = "ffi")]
 mod ffi;
+mod flowcontrol;
 mod frame;
 pub mod h3;
 mod minmax;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -862,13 +862,19 @@ impl PktNumSpace {
                 std::u64::MAX,
                 true,
                 true,
+                stream::MAX_STREAM_WINDOW,
             ),
         }
     }
 
     pub fn clear(&mut self) {
-        self.crypto_stream =
-            stream::Stream::new(std::u64::MAX, std::u64::MAX, true, true);
+        self.crypto_stream = stream::Stream::new(
+            std::u64::MAX,
+            std::u64::MAX,
+            true,
+            true,
+            stream::MAX_STREAM_WINDOW,
+        );
 
         self.ack_elicited = false;
     }

--- a/tools/apps/src/args.rs
+++ b/tools/apps/src/args.rs
@@ -34,7 +34,9 @@ pub trait Args {
 pub struct CommonArgs {
     pub alpns: Vec<u8>,
     pub max_data: u64,
+    pub max_window: u64,
     pub max_stream_data: u64,
+    pub max_stream_window: u64,
     pub max_streams_bidi: u64,
     pub max_streams_uni: u64,
     pub idle_timeout: u64,
@@ -54,7 +56,9 @@ pub struct CommonArgs {
 ///
 /// --http-version VERSION      HTTP version to use.
 /// --max-data BYTES            Connection-wide flow control limit.
+/// --max-window BYTES          Connection-wide max receiver window.
 /// --max-stream-data BYTES     Per-stream flow control limit.
+/// --max-stream-window BYTES   Per-stream max receiver window.
 /// --max-streams-bidi STREAMS  Number of allowed concurrent streams.
 /// --max-streams-uni STREAMS   Number of allowed concurrent streams.
 /// --dump-packets PATH         Dump the incoming packets in PATH.
@@ -63,7 +67,7 @@ pub struct CommonArgs {
 /// --disable-hystart           Disable HyStart++.
 /// --dgram-proto PROTO         DATAGRAM application protocol.
 /// --dgram-count COUNT         Number of DATAGRAMs to send.
-///  --dgram-data DATA          DATAGRAM data to send.
+/// --dgram-data DATA           DATAGRAM data to send.
 ///
 /// [`Docopt`]: https://docs.rs/docopt/1.1.0/docopt/
 impl Args for CommonArgs {
@@ -107,8 +111,14 @@ impl Args for CommonArgs {
         let max_data = args.get_str("--max-data");
         let max_data = max_data.parse::<u64>().unwrap();
 
+        let max_window = args.get_str("--max-window");
+        let max_window = max_window.parse::<u64>().unwrap();
+
         let max_stream_data = args.get_str("--max-stream-data");
         let max_stream_data = max_stream_data.parse::<u64>().unwrap();
+
+        let max_stream_window = args.get_str("--max-stream-window");
+        let max_stream_window = max_stream_window.parse::<u64>().unwrap();
 
         let max_streams_bidi = args.get_str("--max-streams-bidi");
         let max_streams_bidi = max_streams_bidi.parse::<u64>().unwrap();
@@ -136,7 +146,9 @@ impl Args for CommonArgs {
         CommonArgs {
             alpns,
             max_data,
+            max_window,
             max_stream_data,
+            max_stream_window,
             max_streams_bidi,
             max_streams_uni,
             idle_timeout,
@@ -157,7 +169,9 @@ impl Default for CommonArgs {
         CommonArgs {
             alpns: alpns::length_prefixed(&alpns::HTTP_3),
             max_data: 10000000,
+            max_window: 25165824,
             max_stream_data: 1000000,
+            max_stream_window: 16777216,
             max_streams_bidi: 100,
             max_streams_uni: 100,
             idle_timeout: 30000,
@@ -181,7 +195,9 @@ Options:
   --method METHOD          Use the given HTTP request method [default: GET].
   --body FILE              Send the given file as request body.
   --max-data BYTES         Connection-wide flow control limit [default: 10000000].
+  --max-window BYTES       Connection-wide max receiver window [default: 25165824].
   --max-stream-data BYTES  Per-stream flow control limit [default: 1000000].
+  --max-stream-window BYTES   Per-stream max receiver window [default: 16777216].
   --max-streams-bidi STREAMS  Number of allowed concurrent streams [default: 100].
   --max-streams-uni STREAMS   Number of allowed concurrent streams [default: 100].
   --idle-timeout TIMEOUT   Idle timeout in milliseconds [default: 30000].
@@ -328,10 +344,12 @@ Options:
   --index <name>              The file that will be used as index [default: index.html].
   --name <str>                Name of the server [default: quic.tech]
   --max-data BYTES            Connection-wide flow control limit [default: 10000000].
+  --max-window BYTES          Connection-wide max receiver window [default: 25165824].
   --max-stream-data BYTES     Per-stream flow control limit [default: 1000000].
+  --max-stream-window BYTES   Per-stream max receiver window [default: 16777216].
   --max-streams-bidi STREAMS  Number of allowed concurrent streams [default: 100].
   --max-streams-uni STREAMS   Number of allowed concurrent streams [default: 100].
-  --idle-timeout TIMEOUT   Idle timeout in milliseconds [default: 30000].
+  --idle-timeout TIMEOUT      Idle timeout in milliseconds [default: 30000].
   --dump-packets PATH         Dump the incoming packets as files in the given directory.
   --early-data                Enable receiving early data.
   --no-retry                  Disable stateless retry.

--- a/tools/apps/src/bin/quiche-server.rs
+++ b/tools/apps/src/bin/quiche-server.rs
@@ -97,6 +97,9 @@ fn main() {
     config.set_initial_max_streams_uni(conn_args.max_streams_uni);
     config.set_disable_active_migration(true);
 
+    config.set_max_connection_window(conn_args.max_window);
+    config.set_max_stream_window(conn_args.max_stream_window);
+
     let mut keylog = None;
 
     if let Some(keylog_path) = std::env::var_os("SSLKEYLOGFILE") {

--- a/tools/apps/src/client.rs
+++ b/tools/apps/src/client.rs
@@ -109,6 +109,9 @@ pub fn connect(
     config.set_initial_max_streams_uni(conn_args.max_streams_uni);
     config.set_disable_active_migration(true);
 
+    config.set_max_connection_window(conn_args.max_window);
+    config.set_max_stream_window(conn_args.max_stream_window);
+
     let mut keylog = None;
 
     if let Some(keylog_path) = std::env::var_os("SSLKEYLOGFILE") {


### PR DESCRIPTION
This PR reimplments #529 which tried to implement a QUIC flow
control specified in https://docs.google.com/document/d/1F2YfdDXKpy20WVKJueEf4abn_LVZHhMUMS5gX6Pgjl4/edit?usp=sharing

It's basically window-based approach where window size is determined
by current receiving speed.

Since lot of things changed from #529, I tried to minimize the
changes in the existing code. Most of the logic is in src/flowcontrol.rs
and it will replace max_data and max_data_next logic.