### PR TITLE
ci: fix nginx build failure

### DIFF
--- a/extras/nginx/nginx-1.16.patch
+++ b/extras/nginx/nginx-1.16.patch
@@ -118,7 +118,7 @@ index 000000000..23219d92a
 +
 +    CORE_INCS="$CORE_INCS $QUICHE/include"
 +    CORE_DEPS="$CORE_DEPS $QUICHE/target/$QUICHE_BUILD_TARGET/libquiche.a"
-+    CORE_LIBS="$CORE_LIBS $QUICHE/target/$QUICHE_BUILD_TARGET/libquiche.a $NGX_LIBPTHREAD"
++    CORE_LIBS="$CORE_LIBS $QUICHE/target/$QUICHE_BUILD_TARGET/libquiche.a $NGX_LIBPTHREAD -lm"
 +
 +    if [ "$NGX_SYSTEM" = "Darwin" ]; then
 +        CORE_LIBS+=" -framework Security"


### PR DESCRIPTION
To fix the following nginx build error:
```
/usr/bin/ld: ../target/debug/libquiche.a(std-008055cc7d873802.std.cf1c8f7e-cgu.0.rcgu.o): in function `std::f32::<impl f32>::lerp':
/rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b//library/std/src/f32.rs:914: undefined reference to `fmaf'
/usr/bin/ld: ../target/debug/libquiche.a(std-008055cc7d873802.std.cf1c8f7e-cgu.0.rcgu.o): in function `std::f64::<impl f64>::lerp':
/rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b//library/std/src/f64.rs:916: undefined reference to `fma'
collect2: error: ld returned 1 exit status
```

It seems like related with recent rust (1.55) release.