### PR TITLE
qlog: update docs and bump to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ libm = "0.2"
 ring = "0.16"
 lazy_static = "1"
 boring-sys = { version = "1.0.2", optional = true }
-qlog = { version = "0.4", path = "tools/qlog", optional = true }
+qlog = { version = "0.5", path = "tools/qlog", optional = true }
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3", features = ["wincrypt"] }

--- a/tools/qlog/Cargo.toml
+++ b/tools/qlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qlog"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Lucas Pardue <lucaspardue.24.7@gmail.com>"]
 edition = "2018"
 description = "qlog data model for QUIC and HTTP/3"

--- a/tools/qlog/README.md
+++ b/tools/qlog/README.md
@@ -1,13 +1,16 @@
-The qlog crate is an implementation of the [qlog main schema] and [qlog QUIC and
-HTTP/3 events] that attempts to closely follow the format of the qlog
-[TypeScript schema]. This is just a data model and no support is provided for
-logging IO, applications can decide themselves the most appropriate method.
+The qlog crate is an implementation of the qlog [main logging schema],
+[QUIC event definitions], and [HTTP/3 and QPACK event definitions].
+The crate provides a qlog data model that can be used for traces with
+events. It supports serialization and deserialization but defers logging IO
+choices to applications.
 
 The crate uses Serde for conversion between Rust and JSON.
 
-[qlog main schema]: https://tools.ietf.org/html/draft-marx-qlog-main-schema
-[qlog QUIC and HTTP/3 events]: https://quiclog.github.io/internet-drafts/draft-marx-qlog-event-definitions-quic-h3
-[TypeScript schema]: https://github.com/quiclog/qlog/blob/master/TypeScript/draft-01/QLog.ts
+[main logging schema]: https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-main-schema
+[QUIC event definitions]:
+https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-quic-events.html
+[HTTP/3 and QPACK event definitions]:
+https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-h3-events.html
 
 Overview
 --------
@@ -24,22 +27,7 @@ different connections into the same Log.
 ## Traces
 
 A [`Trace`] contains metadata such as the [`VantagePoint`] of capture and
-the [`Configuration`] of the `Trace`.
-
-A very important part of the `Trace` is the definition of `event_fields`. A
-qlog Event is a vector of [`EventField`]; this provides great flexibility to
-log events with any number of `EventFields` in any order. The `event_fields`
-property describes the format of event logging and it is important that
-events comply with that format. Failing to do so it going to cause problems
-for qlog analysis tools. For information is available at
-https://tools.ietf.org/html/draft-marx-qlog-main-schema-01#section-3.3.4
-
-In order to make using qlog a bit easier, this crate expects a qlog Event to
-consist of the following EventFields in the following order:
-[`EventField::RelativeTime`], [`EventField::Category`],
-[`EventField::Event`] and [`EventField::Data`]. A set of methods are
-provided to assist in creating a Trace and appending events to it in this
-format.
+the [`Configuration`], and protocol event data in the [`Event`] array.
 
 ## Writing out logs
 As events occur during the connection, the application appends them to the
@@ -63,8 +51,7 @@ let mut trace = qlog::Trace::new(
     Some("Example qlog trace".to_string()),
     Some("Example qlog trace description".to_string()),
     Some(qlog::Configuration {
-        time_offset: Some("0".to_string()),
-        time_units: Some(qlog::TimeUnits::Ms),
+        time_offset: Some(0.0),
         original_uris: None,
     }),
     None,
@@ -73,40 +60,50 @@ let mut trace = qlog::Trace::new(
 
 ### Adding events
 
-Qlog Events are added to `qlog::Trace.events`.
+Qlog `Event` objects are added to `qlog::Trace.events`.
 
-It is recommended to use the provided utility methods to append semantically
-valid events to a trace. However, there is nothing preventing you from
-creating the events manually.
-
-The following example demonstrates how to log a QUIC packet
-containing a single Crypto frame. It uses the [`QuicFrame::crypto()`],
-[`packet_sent_min()`] and [`push_event()`] methods to create and log a
-PacketSent event and its EventData.
+The following example demonstrates how to log a qlog QUIC `packet_sent` event
+containing a single Crypto frame. It constructs the necessary elements of the
+[`Event`], then appends it to the trace with [`push_event()`].
 
 ```rust
 let scid = [0x7e, 0x37, 0xe4, 0xdc, 0xc6, 0x68, 0x2d, 0xa8];
 let dcid = [0x36, 0xce, 0x10, 0x4e, 0xee, 0x50, 0x10, 0x1c];
 
 let pkt_hdr = qlog::PacketHeader::new(
-    0,
-    Some(1251),
-    Some(1224),
+    qlog::PacketType::Initial,
+    0,                         // packet_number
+    None,                      // flags
+    None,                      // token
+    None,                      // length
     Some(0xff00001b),
     Some(b"7e37e4dcc6682da8"),
     Some(&dcid),
 );
 
-let frames =
-    vec![qlog::QuicFrame::crypto("0".to_string(), "1000".to_string())];
+let frames = let frames = vec![qlog::QuicFrame::Crypto {
+    offset: 0,
+    length: 0,
+}];
 
-let event = qlog::event::Event::packet_sent_min(
-    qlog::PacketType::Initial,
-    pkt_hdr,
-    Some(frames),
-);
+let raw = qlog::RawInfo {
+    length: Some(1251),
+    payload_length: Some(1224),
+    data: None,
+};
 
-trace.push_event(std::time::Duration::new(0, 0), event);
+let event_data = qlog::EventData::PacketSent {
+    header: pkt_hdr,
+    frames: Some(frames),
+    is_coalesced: None,
+    retry_token: None,
+    stateless_reset_token: None,
+    supported_versions: None,
+    raw: Some(raw),
+    datagram_id: None,
+};
+
+trace.push_event(qlog::Event::with_time(0.0, event_data));
 ```
 
 ### Serializing
@@ -123,51 +120,46 @@ serde_json::to_string_pretty(&trace).unwrap();
 would generate the following:
 
 ```
-{
-  "vantage_point": {
-    "name": "Example client",
-    "type": "client"
-  },
-  "title": "Example qlog trace",
-  "description": "Example qlog trace description",
-  "configuration": {
-    "time_units": "ms",
-    "time_offset": "0"
-  },
-  "event_fields": [
-    "relative_time",
-    "category",
-    "event",
-    "data"
-  ],
-  "events": [
-    [
-      "0",
-      "transport",
-      "packet_sent",
-      {
-        "packet_type": "initial",
-        "header": {
-          "packet_number": "0",
-          "packet_size": 1251,
-          "payload_length": 1224,
-          "version": "0xff00001b",
-          "scil": "8",
-          "dcil": "8",
-          "scid": "7e37e4dcc6682da8",
-          "dcid": "36ce104eee50101c"
-        },
-        "frames": [
-          {
-            "frame_type": "crypto",
-            "offset": "0",
-            "length": "100",
-          }
-        ]
-      }
-    ]
-  ]
-}
+ {
+   "vantage_point": {
+     "name": "Example client",
+     "type": "client"
+   },
+   "title": "Example qlog trace",
+   "description": "Example qlog trace description",
+   "configuration": {
+     "time_offset": 0.0
+   },
+   "events": [
+     [
+       0,
+       "transport",
+       "packet_sent",
+       {
+         "header": {
+           "packet_type": "initial",
+           "packet_number": 0,
+           "version": "ff00001d",
+           "scil": 8,
+           "dcil": 8,
+           "scid": "7e37e4dcc6682da8",
+           "dcid": "36ce104eee50101c"
+         },
+         "raw": {
+             "length": 1251,
+             "payload_length": 1224
+         },
+         "frames": [
+           {
+             "frame_type": "crypto",
+             "offset": 0,
+             "length": 100,
+           }
+         ]
+       }
+     ]
+   ]
+ }
 ```
 
 Streaming Mode
@@ -185,8 +177,7 @@ let mut trace = qlog::Trace::new(
     Some("Example qlog trace".to_string()),
     Some("Example qlog trace description".to_string()),
     Some(qlog::Configuration {
-        time_offset: Some("0".to_string()),
-        time_units: Some(qlog::TimeUnits::Ms),
+        time_offset: Some(0.0),
         original_uris: None,
     }),
     None,
@@ -210,11 +201,11 @@ let mut streamer = qlog::QlogStreamer::new(
     None,
     std::time::Instant::now(),
     trace,
+    qlog::EventImportance::Base,
     Box::new(file),
 );
 
 streamer.start_log().ok();
-
 ```
 
 ### Adding simple events
@@ -223,7 +214,20 @@ Once logging has started you can stream events. Simple events can be written in
 one step using [`add_event()`]:
 
 ```rust
-let event = qlog::event::Event::metrics_updated_min();
+let event_data = qlog::EventData::MetricsUpdated {
+    min_rtt: Some(1.0),
+    smoothed_rtt: Some(1.0),
+    latest_rtt: Some(1.0),
+    rtt_variance: Some(1.0),
+    pto_count: Some(1),
+    congestion_window: Some(1234),
+    bytes_in_flight: Some(5678),
+    ssthresh: None,
+    packets_in_flight: None,
+    pacing_rate: None,
+};
+
+let event = qlog::Event::with_time(0.0, event_data);
 streamer.add_event(event).ok();
 ```
 
@@ -232,28 +236,32 @@ Some events contain optional arrays of QUIC frames. If the event has
 `Some(Vec<QuicFrame>)`, even if it is empty, the streamer enters a frame
 serializing mode that must be finalized before other events can be logged.
 
-In this example, a PacketSent event is created with an empty frame array and
+In this example, a `PacketSent` event is created with an empty frame array and
 frames are written out later:
 
 ```rust
-let qlog_pkt_hdr = qlog::PacketHeader::with_type(
+let pkt_hdr = qlog::PacketHeader::with_type(
     qlog::PacketType::OneRtt,
     0,
-    Some(1251),
-    Some(1224),
-    Some(0xff00001b),
+    Some(0x00000001),
     Some(b"7e37e4dcc6682da8"),
     Some(b"36ce104eee50101c"),
 );
 
-let event = qlog::event::Event::packet_sent_min(
-    qlog::PacketType::OneRtt,
-    qlog_pkt_hdr,
-    Some(Vec::new()),
-);
+let event_data = qlog::EventData::PacketSent {
+    header: pkt_hdr,
+    frames: Some(vec![]),
+    is_coalesced: None,
+    retry_token: None,
+    stateless_reset_token: None,
+    supported_versions: None,
+    raw: None,
+    datagram_id: None,
+};
+
+let event = qlog::Event::with_time(0.0, event_data);
 
 streamer.add_event(event).ok();
-
 ```
 
 In this example, the frames contained in the QUIC packet
@@ -262,8 +270,8 @@ are PING and PADDING. Each frame is written using the
 [`finish_frames()`].
 
 ```rust
-let ping = qlog::QuicFrame::ping();
-let padding = qlog::QuicFrame::padding();
+let ping = qlog::QuicFrame::Ping;
+let padding = qlog::QuicFrame::Padding;
 
 streamer.add_frame(ping, false).ok();
 streamer.add_frame(padding, false).ok();
@@ -286,11 +294,6 @@ are called. No additional steps are required.
 [`Trace`]: struct.Trace.html
 [`VantagePoint`]: struct.VantagePoint.html
 [`Configuration`]: struct.Configuration.html
-[`EventField`]: enum.EventField.html
-[`EventField::RelativeTime`]: enum.EventField.html#variant.RelativeTime
-[`EventField::Category`]: enum.EventField.html#variant.Category
-[`EventField::Type`]: enum.EventField.html#variant.Type
-[`EventField::Data`]: enum.EventField.html#variant.Data
 [`qlog::Trace.events`]: struct.Trace.html#structfield.events
 [`push_event()`]: struct.Trace.html#method.push_event
 [`packet_sent_min()`]: event/struct.Event.html#method.packet_sent_min
@@ -299,6 +302,7 @@ are called. No additional steps are required.
 [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 [`start_log()`]: struct.QlogStreamer.html#method.start_log
 [`add_event()`]: struct.QlogStreamer.html#method.add_event
+[`add_event_with_instant()`]: struct.QlogStreamer.html#method.add_event
 [`add_frame()`]: struct.QlogStreamer.html#method.add_frame
 [`finish_frames()`]: struct.QlogStreamer.html#method.finish_frames
 [`finish_log()`]: struct.QlogStreamer.html#method.finish_log

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -24,19 +24,19 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//! The qlog crate is an implementation of the [qlog main schema] and [qlog QUIC
-//! and HTTP/3 events] that attempts to closely follow the format of the qlog
-//! [TypeScript schema]. This is just a data model and no support is provided
-//! for logging IO, applications can decide themselves the most appropriate
-//! method.
+//! The qlog crate is an implementation of the qlog [main logging schema],
+//! [QUIC event definitions], and [HTTP/3 and QPACK event definitions].
+//! The crate provides a qlog data model that can be used for traces with
+//! events. It supports serialization and deserialization but defers logging IO
+//! choices to applications.
 //!
 //! The crate uses Serde for conversion between Rust and JSON.
 //!
-//! [qlog main schema]: https://tools.ietf.org/html/draft-marx-qlog-main-schema
-//! [qlog QUIC and HTTP/3 events]:
-//! https://quiclog.github.io/internet-drafts/draft-marx-qlog-event-definitions-quic-h3
-//! [TypeScript schema]:
-//! https://github.com/quiclog/qlog/blob/master/TypeScript/draft-01/QLog.ts
+//! [main logging schema]: https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-main-schema
+//! [QUIC event definitions]:
+//! https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-quic-events.html
+//! [HTTP/3 and QPACK event definitions]:
+//! https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-h3-events.html
 //!
 //! Overview
 //! ---------------
@@ -117,7 +117,7 @@
 //!     None,                      // flags
 //!     None,                      // token
 //!     None,                      // length
-//!     Some(0xff00001d),          // version
+//!     Some(0x00000001),          // version
 //!     Some(b"7e37e4dcc6682da8"), // scid
 //!     Some(&dcid),
 //! );
@@ -194,7 +194,7 @@
 //!         "header": {
 //!           "packet_type": "initial",
 //!           "packet_number": 0,
-//!           "version": "ff00001d",
+//!           "version": "1",
 //!           "scil": 8,
 //!           "dcil": 8,
 //!           "scid": "7e37e4dcc6682da8",
@@ -363,7 +363,7 @@
 //! let pkt_hdr = qlog::PacketHeader::with_type(
 //!     qlog::PacketType::OneRtt,
 //!     0,
-//!     Some(0xff00001d),
+//!     Some(0x00000001),
 //!     Some(b"7e37e4dcc6682da8"),
 //!     Some(b"36ce104eee50101c"),
 //! );
@@ -2831,7 +2831,7 @@ pub mod testing {
             None,
             None,
             None,
-            Some(0xff00_001d),
+            Some(0x0000_0001),
             Some(&scid),
             Some(&dcid),
         )
@@ -2867,7 +2867,7 @@ mod tests {
         let log_string = r#"{
   "packet_type": "initial",
   "packet_number": 0,
-  "version": "ff00001d",
+  "version": "1",
   "scil": 8,
   "dcil": 8,
   "scid": "7e37e4dcc6682da8",
@@ -2886,7 +2886,7 @@ mod tests {
     "header": {
       "packet_type": "initial",
       "packet_number": 0,
-      "version": "ff00001d",
+      "version": "1",
       "scil": 8,
       "dcil": 8,
       "scid": "7e37e4dcc6682da8",
@@ -2929,7 +2929,7 @@ mod tests {
     "header": {
       "packet_type": "initial",
       "packet_number": 0,
-      "version": "ff00001d",
+      "version": "1",
       "scil": 8,
       "dcil": 8,
       "scid": "7e37e4dcc6682da8",
@@ -3031,7 +3031,7 @@ mod tests {
         "header": {
           "packet_type": "initial",
           "packet_number": 0,
-          "version": "ff00001d",
+          "version": "1",
           "scil": 8,
           "dcil": 8,
           "scid": "7e37e4dcc6682da8",
@@ -3281,7 +3281,7 @@ mod tests {
         let r = s.writer();
         let w: &Box<std::io::Cursor<Vec<u8>>> = unsafe { std::mem::transmute(r) };
 
-        let log_string = r#"{"qlog_version":"version","qlog_format":"JSON","title":"title","description":"description","traces":[{"vantage_point":{"type":"server"},"title":"Quiche qlog trace","description":"Quiche qlog trace description","configuration":{"time_offset":0.0},"events":[{"time":0.0,"name":"transport:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"ff00001d","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":40,"offset":40,"length":400,"fin":true}]}},{"time":0.0,"name":"transport:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"ff00001d","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":0,"offset":0,"length":100,"fin":true}]}},{"time":0.0,"name":"transport:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"ff00001d","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"stateless_reset_token":"reset_token","raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":0,"offset":0,"length":100,"fin":true}]}},{"time":0.0,"name":"transport:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"ff00001d","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"stateless_reset_token":"reset_token","raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":0,"offset":0,"length":100,"fin":true}]}}]}]}"#;
+        let log_string = r#"{"qlog_version":"version","qlog_format":"JSON","title":"title","description":"description","traces":[{"vantage_point":{"type":"server"},"title":"Quiche qlog trace","description":"Quiche qlog trace description","configuration":{"time_offset":0.0},"events":[{"time":0.0,"name":"transport:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"1","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":40,"offset":40,"length":400,"fin":true}]}},{"time":0.0,"name":"transport:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"1","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":0,"offset":0,"length":100,"fin":true}]}},{"time":0.0,"name":"transport:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"1","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"stateless_reset_token":"reset_token","raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":0,"offset":0,"length":100,"fin":true}]}},{"time":0.0,"name":"transport:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"1","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"stateless_reset_token":"reset_token","raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":0,"offset":0,"length":100,"fin":true}]}}]}]}"#;
 
         let written_string = std::str::from_utf8(w.as_ref().get_ref()).unwrap();
 


### PR DESCRIPTION
The qlog README.md was stale, so I pulled over the equivalent docs from lib.rs. I also updated them both to use QUIC v1 now that it's an RFC.