### PR TITLE
Add sys/socket.h to include list

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -34,6 +34,7 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <sys/socket.h>
 #ifdef __unix__
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
The quiche.h header files use struct sockaddr extensively, meaning that
they rely on having sys/socket.h types defined. This include is missing
in the quiche.h header file, sadly.

This patch adds that include, so that the quiche.h header file stands
alone.