### PR TITLE
apps: print header lists as strings not bytes

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -242,6 +242,17 @@ fn dump_json(reqs: &[Http3Request], output_sink: &mut dyn FnMut(String)) {
     output_sink(out);
 }
 
+pub fn hdrs_to_strings(hdrs: &[quiche::h3::Header]) -> Vec<(String, String)> {
+    hdrs.iter()
+        .map(|h| {
+            (
+                String::from_utf8(h.name().into()).unwrap(),
+                String::from_utf8(h.value().into()).unwrap(),
+            )
+        })
+        .collect()
+}
+
 pub trait HttpConn {
     fn send_requests(
         &mut self, conn: &mut quiche::Connection, target_path: &Option<String>,
@@ -1111,7 +1122,8 @@ impl HttpConn for Http3Conn {
                 Ok((stream_id, quiche::h3::Event::Headers { list, .. })) => {
                     debug!(
                         "got response headers {:?} on stream id {}",
-                        list, stream_id
+                        hdrs_to_strings(&list),
+                        stream_id
                     );
 
                     let req = self
@@ -1275,7 +1287,7 @@ impl HttpConn for Http3Conn {
                     info!(
                         "{} got request {:?} on stream id {}",
                         conn.trace_id(),
-                        &list,
+                        hdrs_to_strings(&list),
                         stream_id
                     );
 

--- a/quiche/examples/http3-client.rs
+++ b/quiche/examples/http3-client.rs
@@ -29,6 +29,8 @@ extern crate log;
 
 use std::net::ToSocketAddrs;
 
+use quiche::h3::NameValue;
+
 use ring::rand::*;
 
 const MAX_DATAGRAM_SIZE: usize = 1350;
@@ -238,7 +240,8 @@ fn main() {
                     Ok((stream_id, quiche::h3::Event::Headers { list, .. })) => {
                         info!(
                             "got response headers {:?} on stream id {}",
-                            list, stream_id
+                            hdrs_to_strings(&list),
+                            stream_id
                         );
                     },
 
@@ -336,4 +339,15 @@ fn hex_dump(buf: &[u8]) -> String {
     let vec: Vec<String> = buf.iter().map(|b| format!("{:02x}", b)).collect();
 
     vec.join("")
+}
+
+fn hdrs_to_strings(hdrs: &[quiche::h3::Header]) -> Vec<(String, String)> {
+    hdrs.iter()
+        .map(|h| {
+            (
+                String::from_utf8(h.name().into()).unwrap(),
+                String::from_utf8(h.value().into()).unwrap(),
+            )
+        })
+        .collect()
 }

--- a/quiche/examples/http3-server.rs
+++ b/quiche/examples/http3-server.rs
@@ -502,7 +502,7 @@ fn handle_request(
     info!(
         "{} got request {:?} on stream id {}",
         conn.trace_id(),
-        headers,
+        hdrs_to_strings(headers),
         stream_id
     );
 
@@ -658,4 +658,15 @@ fn handle_writable(client: &mut Client, stream_id: u64) {
     if resp.written == resp.body.len() {
         client.partial_responses.remove(&stream_id);
     }
+}
+
+fn hdrs_to_strings(hdrs: &[quiche::h3::Header]) -> Vec<(String, String)> {
+    hdrs.iter()
+        .map(|h| {
+            (
+                String::from_utf8(h.name().into()).unwrap(),
+                String::from_utf8(h.value().into()).unwrap(),
+            )
+        })
+        .collect()
 }

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -24,6 +24,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use quiche::h3::NameValue;
+
 use ring::rand::*;
 
 use crate::Http3TestError;
@@ -265,7 +267,8 @@ pub fn run(
                     Ok((stream_id, quiche::h3::Event::Headers { list, .. })) => {
                         info!(
                             "got response headers {:?} on stream id {}",
-                            &list, stream_id
+                            hdrs_to_strings(&list),
+                            stream_id
                         );
 
                         test.add_response_headers(stream_id, &list);
@@ -405,4 +408,15 @@ pub fn run(
     }
 
     Ok(())
+}
+
+fn hdrs_to_strings(hdrs: &[quiche::h3::Header]) -> Vec<(String, String)> {
+    hdrs.iter()
+        .map(|h| {
+            (
+                String::from_utf8(h.name().into()).unwrap(),
+                String::from_utf8(h.value().into()).unwrap(),
+            )
+        })
+        .collect()
 }


### PR DESCRIPTION
When quiche switched headers to bytes, some of our debug printing
started displaying the headers as bytes, which isn't helpful.

This change restores the header list display back to strings.