### PR TITLE
cc: debug info

### DIFF
--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -53,6 +53,7 @@ pub static CUBIC: CongestionControlOps = CongestionControlOps {
     checkpoint,
     rollback,
     has_custom_pacing,
+    debug_write,
 };
 
 /// CUBIC Constants.
@@ -434,6 +435,14 @@ fn rollback(r: &mut Recovery) -> bool {
 
 fn has_custom_pacing() -> bool {
     false
+}
+
+fn debug_write(r: &Recovery, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    write!(
+        f,
+        "cubic={{ k={} w_max={} max_bytes_in_flight={} }} ",
+        r.cubic_state.k, r.cubic_state.w_max, r.cubic_state.max_bytes_in_flight,
+    )
 }
 
 #[cfg(test)]

--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -53,7 +53,7 @@ pub static CUBIC: CongestionControlOps = CongestionControlOps {
     checkpoint,
     rollback,
     has_custom_pacing,
-    debug_write,
+    debug_fmt,
 };
 
 /// CUBIC Constants.
@@ -437,7 +437,7 @@ fn has_custom_pacing() -> bool {
     false
 }
 
-fn debug_write(r: &Recovery, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+fn debug_fmt(r: &Recovery, f: &mut std::fmt::Formatter) -> std::fmt::Result {
     write!(
         f,
         "cubic={{ k={} w_max={} max_bytes_in_flight={} }} ",

--- a/src/recovery/hystart.rs
+++ b/src/recovery/hystart.rs
@@ -77,7 +77,7 @@ impl std::fmt::Debug for Hystart {
         write!(f, "css_baseline_min_rtt={:?} ", self.css_baseline_min_rtt)?;
         write!(f, "rtt_sample_count={:?} ", self.rtt_sample_count)?;
         write!(f, "css_start_time={:?} ", self.css_start_time)?;
-        write!(f, "css_round_count={:?} ", self.css_round_count)?;
+        write!(f, "css_round_count={:?}", self.css_round_count)?;
 
         Ok(())
     }

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -994,7 +994,7 @@ pub struct CongestionControlOps {
 
     pub has_custom_pacing: fn() -> bool,
 
-    pub debug_write:
+    pub debug_fmt:
         fn(r: &Recovery, formatter: &mut std::fmt::Formatter) -> std::fmt::Result,
 }
 
@@ -1054,7 +1054,7 @@ impl std::fmt::Debug for Recovery {
         }
 
         // CC-specific debug info
-        (self.cc_ops.debug_write)(self, f)?;
+        (self.cc_ops.debug_fmt)(self, f)?;
 
         Ok(())
     }

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -993,6 +993,9 @@ pub struct CongestionControlOps {
     pub rollback: fn(r: &mut Recovery) -> bool,
 
     pub has_custom_pacing: fn() -> bool,
+
+    pub debug_write:
+        fn(r: &Recovery, formatter: &mut std::fmt::Formatter) -> std::fmt::Result,
 }
 
 impl From<CongestionControlAlgorithm> for &'static CongestionControlOps {
@@ -1049,6 +1052,9 @@ impl std::fmt::Debug for Recovery {
         if self.hystart.enabled() {
             write!(f, "hystart={:?} ", self.hystart)?;
         }
+
+        // CC-specific debug info
+        (self.cc_ops.debug_write)(self, f)?;
 
         Ok(())
     }

--- a/src/recovery/reno.rs
+++ b/src/recovery/reno.rs
@@ -47,6 +47,7 @@ pub static RENO: CongestionControlOps = CongestionControlOps {
     checkpoint,
     rollback,
     has_custom_pacing,
+    debug_write,
 };
 
 pub fn on_init(_r: &mut Recovery) {}
@@ -147,6 +148,10 @@ fn rollback(_r: &mut Recovery) -> bool {
 
 fn has_custom_pacing() -> bool {
     false
+}
+
+fn debug_write(_r: &Recovery, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/recovery/reno.rs
+++ b/src/recovery/reno.rs
@@ -47,7 +47,7 @@ pub static RENO: CongestionControlOps = CongestionControlOps {
     checkpoint,
     rollback,
     has_custom_pacing,
-    debug_write,
+    debug_fmt,
 };
 
 pub fn on_init(_r: &mut Recovery) {}
@@ -150,7 +150,7 @@ fn has_custom_pacing() -> bool {
     false
 }
 
-fn debug_write(_r: &Recovery, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+fn debug_fmt(_r: &Recovery, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
     Ok(())
 }
 


### PR DESCRIPTION
For congestion control specific debug log, add debug_string()
hook to the congestion control operations.