### PR TITLE
cc: add on_init() hook

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1586,6 +1586,8 @@ impl Connection {
             conn.derived_initial_secrets = true;
         }
 
+        conn.recovery.on_init();
+
         Ok(conn)
     }
 

--- a/src/recovery/cubic.rs
+++ b/src/recovery/cubic.rs
@@ -45,6 +45,7 @@ use crate::recovery::CongestionControlOps;
 use crate::recovery::Recovery;
 
 pub static CUBIC: CongestionControlOps = CongestionControlOps {
+    on_init,
     on_packet_sent,
     on_packet_acked,
     congestion_event,
@@ -145,6 +146,8 @@ impl State {
         self.alpha_aimd * (acked as f64 / cwnd as f64) * max_datagram_size as f64
     }
 }
+
+fn on_init(_r: &mut Recovery) {}
 
 fn collapse_cwnd(r: &mut Recovery) {
     let cubic = &mut r.cubic_state;

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -243,6 +243,10 @@ impl Recovery {
         }
     }
 
+    pub fn on_init(&mut self) {
+        (self.cc_ops.on_init)(self);
+    }
+
     pub fn on_packet_sent(
         &mut self, mut pkt: Sent, epoch: packet::Epoch,
         handshake_status: HandshakeStatus, now: Instant, trace_id: &str,
@@ -965,6 +969,8 @@ impl FromStr for CongestionControlAlgorithm {
 }
 
 pub struct CongestionControlOps {
+    pub on_init: fn(r: &mut Recovery),
+
     pub on_packet_sent: fn(r: &mut Recovery, sent_bytes: usize, now: Instant),
 
     pub on_packet_acked:

--- a/src/recovery/reno.rs
+++ b/src/recovery/reno.rs
@@ -39,6 +39,7 @@ use crate::recovery::CongestionControlOps;
 use crate::recovery::Recovery;
 
 pub static RENO: CongestionControlOps = CongestionControlOps {
+    on_init,
     on_packet_sent,
     on_packet_acked,
     congestion_event,
@@ -47,6 +48,8 @@ pub static RENO: CongestionControlOps = CongestionControlOps {
     rollback,
     has_custom_pacing,
 };
+
+pub fn on_init(_r: &mut Recovery) {}
 
 pub fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
     r.bytes_in_flight += sent_bytes;


### PR DESCRIPTION
on_init() congestion control hook can be used for a custom
initialization of the congestion control states.