### PR TITLE
Include correct header on windows

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -34,7 +34,13 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#include <winsock2.h>
+#else
 #include <sys/socket.h>
+#endif
+
 #ifdef __unix__
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
Motivation:

https://github.com/cloudflare/quiche/commit/93c1970b2b1d2c4b0f684210bc7253befec72091 added the sys/socket.h header to quiche.h which does break things on windows.

Modifications:

Only use sys/socket.h if not build on windows, if on windows include winsock2.h

Result:

quiche.h can be used on windows again as well