### PR TITLE
qlog event nits

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -856,7 +856,7 @@ impl Frame {
                 stream_id: *stream_id,
                 offset: data.off() as u64,
                 length: data.len() as u64,
-                fin: data.fin(),
+                fin: data.fin().then(|| true),
                 raw: None,
             },
 
@@ -869,7 +869,7 @@ impl Frame {
                 stream_id: *stream_id,
                 offset: *offset,
                 length: *length as u64,
-                fin: *fin,
+                fin: fin.then(|| true),
                 raw: None,
             },
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -33,6 +33,8 @@ use crate::ranges;
 use crate::stream;
 
 #[cfg(feature = "qlog")]
+use qlog::events::quic::AckedRanges;
+#[cfg(feature = "qlog")]
 use qlog::events::quic::ErrorSpace;
 #[cfg(feature = "qlog")]
 use qlog::events::quic::QuicFrame;
@@ -797,8 +799,9 @@ impl Frame {
                 ranges,
                 ecn_counts,
             } => {
-                let ack_ranges =
-                    ranges.iter().map(|r| (r.start, r.end - 1)).collect();
+                let ack_ranges = AckedRanges::Double(
+                    ranges.iter().map(|r| (r.start, r.end - 1)).collect(),
+                );
 
                 let (ect0, ect1, ce) = match ecn_counts {
                     Some(ecn) => (

--- a/tools/qlog/src/events/mod.rs
+++ b/tools/qlog/src/events/mod.rs
@@ -481,10 +481,10 @@ pub enum EventData {
     ConnectionStateUpdated(connectivity::ConnectionStateUpdated),
 
     // Security
-    #[serde(rename = "security:connection_state_updated")]
+    #[serde(rename = "security:key_updated")]
     KeyUpdated(security::KeyUpdated),
 
-    #[serde(rename = "security:connection_state_updated")]
+    #[serde(rename = "security:key_retired")]
     KeyRetired(security::KeyRetired),
 
     // Transport

--- a/tools/qlog/src/events/quic.rs
+++ b/tools/qlog/src/events/quic.rs
@@ -385,7 +385,7 @@ pub enum QuicFrame {
         stream_id: u64,
         offset: u64,
         length: u64,
-        fin: bool,
+        fin: Option<bool>,
 
         raw: Option<Bytes>,
     },

--- a/tools/qlog/src/events/quic.rs
+++ b/tools/qlog/src/events/quic.rs
@@ -309,6 +309,13 @@ pub enum TimerType {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[serde(untagged)]
+pub enum AckedRanges {
+    Single(Vec<Vec<u64>>),
+    Double(Vec<(u64, u64)>),
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum QuicFrameTypeName {
     Padding,
@@ -351,7 +358,7 @@ pub enum QuicFrame {
 
     Ack {
         ack_delay: Option<f32>,
-        acked_ranges: Option<Vec<(u64, u64)>>,
+        acked_ranges: Option<AckedRanges>,
 
         ect1: Option<u64>,
 

--- a/tools/qlog/src/events/quic.rs
+++ b/tools/qlog/src/events/quic.rs
@@ -295,6 +295,7 @@ pub enum RecoveryEventTrigger {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum LossTimerEventType {
     Set,
     Expired,

--- a/tools/qlog/src/events/security.rs
+++ b/tools/qlog/src/events/security.rs
@@ -53,7 +53,7 @@ pub enum KeyType {
 pub struct KeyUpdated {
     key_type: KeyType,
     old: Option<Bytes>,
-    new: Bytes,
+    new: Option<Bytes>,
     generation: Option<u32>,
 }
 

--- a/tools/qlog/src/events/security.rs
+++ b/tools/qlog/src/events/security.rs
@@ -38,10 +38,13 @@ pub enum KeyType {
     ServerHandshakeSecret,
     ClientHandshakeSecret,
 
+    #[serde(rename = "server_0rtt_secret")]
     Server0RttSecret,
+    #[serde(rename = "client_0rtt_secret")]
     Client0RttSecret,
-
+    #[serde(rename = "server_1rtt_secret")]
     Server1RttSecret,
+    #[serde(rename = "client_1rtt_secret")]
     Client1RttSecret,
 }
 

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -648,7 +648,8 @@ pub struct CommonFields {
     pub group_id: Option<String>,
     pub protocol_type: Option<String>,
 
-    pub reference_time: Option<String>,
+    pub reference_time: Option<f32>,
+    pub time_format: Option<String>,
     /* TODO
      * additionalUserSpecifiedProperty */
 }

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -646,7 +646,7 @@ impl Default for Configuration {
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Debug)]
 pub struct CommonFields {
     pub group_id: Option<String>,
-    pub protocol_type: Option<String>,
+    pub protocol_type: Option<Vec<String>>,
 
     pub reference_time: Option<f32>,
     pub time_format: Option<String>,

--- a/tools/qlog/src/lib.rs
+++ b/tools/qlog/src/lib.rs
@@ -841,7 +841,7 @@ mod tests {
             stream_id: 0,
             offset: 0,
             length: 100,
-            fin: true,
+            fin: Some(true),
             raw: None,
         });
 
@@ -938,7 +938,7 @@ mod tests {
             stream_id: 0,
             offset: 0,
             length: 100,
-            fin: true,
+            fin: Some(true),
             raw: None,
         }];
         let event_data = EventData::PacketSent(PacketSent {

--- a/tools/qlog/src/streamer.rs
+++ b/tools/qlog/src/streamer.rs
@@ -356,7 +356,7 @@ mod tests {
             stream_id: 40,
             offset: 40,
             length: 400,
-            fin: true,
+            fin: Some(true),
             raw: None,
         };
 
@@ -379,7 +379,7 @@ mod tests {
             stream_id: 0,
             offset: 0,
             length: 100,
-            fin: true,
+            fin: Some(true),
             raw: None,
         };
 
@@ -387,7 +387,7 @@ mod tests {
             stream_id: 0,
             offset: 0,
             length: 100,
-            fin: true,
+            fin: Some(true),
             raw: None,
         };
 


### PR DESCRIPTION
Noticed during some interop testing, some of our event definition fields were a bit wrong compared to the spec. I've fixed them up here as individual commits but we can squash before merging as there's nothing really complicated going on.