### PR TITLE
Add support for QLOG JSON-SEQ

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -148,7 +148,7 @@ pub fn make_qlog_writer(
     dir: &std::ffi::OsStr, role: &str, id: &str,
 ) -> std::io::BufWriter<std::fs::File> {
     let mut path = std::path::PathBuf::from(dir);
-    let filename = format!("{}-{}.qlog", role, id);
+    let filename = format!("{}-{}.sqlog", role, id);
     path.push(filename);
 
     match std::fs::File::create(&path) {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1621,7 +1621,8 @@ impl Connection {
 
     /// Sets qlog output to the designated [`Writer`].
     ///
-    /// Only events included in `QlogLevel::Base` are written.
+    /// Only events included in `QlogLevel::Base` are written. The serialization
+    /// format is JSON-SEQ.
     ///
     /// This needs to be called as soon as the connection is created, to avoid
     /// missing some early logs.
@@ -1637,7 +1638,8 @@ impl Connection {
 
     /// Sets qlog output to the designated [`Writer`].
     ///
-    /// Only qlog events included in the specified `QlogLevel` are written
+    /// Only qlog events included in the specified `QlogLevel` are written. The
+    /// serialization format is JSON-SEQ.
     ///
     /// This needs to be called as soon as the connection is created, to avoid
     /// missing some early logs.
@@ -1664,7 +1666,7 @@ impl Connection {
 
         self.qlog.level = level;
 
-        let trace = qlog::Trace::new(
+        let trace = qlog::TraceSeq::new(
             qlog::VantagePoint {
                 name: None,
                 ty: vp,


### PR DESCRIPTION
Introduces the `QlogFileSeq` and `TraceSeq` types defined in draft-ietf-quic-qlog-main-schema-01, and changes the qlog version to `0.3`. Default the streaming serializer to JSON-SEQ format.
