### PR TITLE
examples: fix MacOS X C examples and add to CI

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -80,6 +80,15 @@ jobs:
           command: test
           args: --tests --examples --verbose --features ffi,qlog
 
+      - name: Install libev
+        run: brew install libev
+
+      - name: Install uthash
+        run: curl -o examples/uthash.h https://raw.githubusercontent.com/troydhanson/uthash/master/src/uthash.h
+
+      - name: Build C examples
+        run: make -C examples
+
   quiche_ios:
     runs-on: macos-latest
     strategy:

--- a/examples/http3-client.c
+++ b/examples/http3-client.c
@@ -100,7 +100,7 @@ static void flush_egress(struct ev_loop *loop, struct conn_io *conn_io) {
 
 static int for_each_setting(uint64_t identifier, uint64_t value,
                            void *argp) {
-    fprintf(stderr, "got HTTP/3 SETTING: %lu=%lu\n",
+    fprintf(stderr, "got HTTP/3 SETTING: %" PRIu64 "=%" PRIu64 "\n",
             identifier, value);
 
     return 0;


### PR DESCRIPTION
Fix a build error (not caught in linux) and add C example build
to macOS X CI.