### PR TITLE
Resolve "unknown specifier socklen_t" and "uses undefined struct 'timespec'" build errors on Windows.

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -37,6 +37,8 @@ extern "C" {
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #include <winsock2.h>
+#include <ws2tcpip.h>
+#include <time.h>
 #else
 #include <sys/socket.h>
 #endif


### PR DESCRIPTION
I noticed that while compiling this library into a Qt project with the MSVC toolchain that `socklen_t` and `struct timespec` are undefined. They are defined appropriately in `ws2tcpip.h` and `time.h` on Windows systems. This pull request adds the appropriate headers to the `WIN32` includes of `quiche.h`.

* Includes ws2tcpip.h to provide socklen_t on Windows machines.
* Includes time.h to provide timespec struct on Windows machines.

Resolves #1048