### PR TITLE
Fix typo *unidirectional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8989,7 +8989,7 @@ mod tests {
     }
 
     #[test]
-    /// Tests that the MAX_STREAMS frame is sent for unirectional streams.
+    /// Tests that the MAX_STREAMS frame is sent for unidirectional streams.
     fn stream_limit_update_uni() {
         let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
         config


### PR DESCRIPTION
I guess 'unirectional' is just a typo for 'unidirectional,' but let me know if it's not.  (Honestly, I'm a beginner of Rust/QUIC and have little understanding of the code itself.)