### PR TITLE
Include missing header

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -37,8 +37,10 @@ extern "C" {
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #include <winsock2.h>
+#include <time.h>
 #else
 #include <sys/socket.h>
+#include <sys/time.h>
 #endif
 
 #ifdef __unix__


### PR DESCRIPTION
Motivation:

As the quiche_recv_info and quiche_send_info structs use timespec we need to also include the time header.

Modifications:

Include the missing header

Result:

quiche.h can be used on windows / linux / macOS without the need of the user to include the time header