### PR TITLE
prefer arrays for small fixed-size fields

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -24,6 +24,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::convert::TryInto;
+
 use crate::Error;
 use crate::Result;
 
@@ -141,7 +143,7 @@ pub enum Frame {
         seq_num: u64,
         retire_prior_to: u64,
         conn_id: Vec<u8>,
-        reset_token: Vec<u8>,
+        reset_token: [u8; 16],
     },
 
     RetireConnectionId {
@@ -149,11 +151,11 @@ pub enum Frame {
     },
 
     PathChallenge {
-        data: Vec<u8>,
+        data: [u8; 8],
     },
 
     PathResponse {
-        data: Vec<u8>,
+        data: [u8; 8],
     },
 
     ConnectionClose {
@@ -266,7 +268,7 @@ impl Frame {
                 seq_num: b.get_varint()?,
                 retire_prior_to: b.get_varint()?,
                 conn_id: b.get_bytes_with_u8_length()?.to_vec(),
-                reset_token: b.get_bytes(16)?.to_vec(),
+                reset_token: b.get_bytes(16)?.buf().try_into().unwrap(),
             },
 
             0x19 => Frame::RetireConnectionId {
@@ -274,11 +276,11 @@ impl Frame {
             },
 
             0x1a => Frame::PathChallenge {
-                data: b.get_bytes(8)?.to_vec(),
+                data: b.get_bytes(8)?.buf().try_into().unwrap(),
             },
 
             0x1b => Frame::PathResponse {
-                data: b.get_bytes(8)?.to_vec(),
+                data: b.get_bytes(8)?.buf().try_into().unwrap(),
             },
 
             0x1c => Frame::ConnectionClose {
@@ -1827,7 +1829,7 @@ mod tests {
             seq_num: 123_213,
             retire_prior_to: 122_211,
             conn_id: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
-            reset_token: vec![0x42; 16],
+            reset_token: [0x42; 16],
         };
 
         let wire_len = {
@@ -1881,7 +1883,7 @@ mod tests {
         let mut d = [42; 128];
 
         let frame = Frame::PathChallenge {
-            data: vec![1, 2, 3, 4, 5, 6, 7, 8],
+            data: [1, 2, 3, 4, 5, 6, 7, 8],
         };
 
         let wire_len = {
@@ -1909,7 +1911,7 @@ mod tests {
         let mut d = [42; 128];
 
         let frame = Frame::PathResponse {
-            data: vec![1, 2, 3, 4, 5, 6, 7, 8],
+            data: [1, 2, 3, 4, 5, 6, 7, 8],
         };
 
         let wire_len = {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -268,7 +268,11 @@ impl Frame {
                 seq_num: b.get_varint()?,
                 retire_prior_to: b.get_varint()?,
                 conn_id: b.get_bytes_with_u8_length()?.to_vec(),
-                reset_token: b.get_bytes(16)?.buf().try_into().unwrap(),
+                reset_token: b
+                    .get_bytes(16)?
+                    .buf()
+                    .try_into()
+                    .map_err(|_| Error::BufferTooShort)?,
             },
 
             0x19 => Frame::RetireConnectionId {
@@ -276,11 +280,19 @@ impl Frame {
             },
 
             0x1a => Frame::PathChallenge {
-                data: b.get_bytes(8)?.buf().try_into().unwrap(),
+                data: b
+                    .get_bytes(8)?
+                    .buf()
+                    .try_into()
+                    .map_err(|_| Error::BufferTooShort)?,
             },
 
             0x1b => Frame::PathResponse {
-                data: b.get_bytes(8)?.buf().try_into().unwrap(),
+                data: b
+                    .get_bytes(8)?
+                    .buf()
+                    .try_into()
+                    .map_err(|_| Error::BufferTooShort)?,
             },
 
             0x1c => Frame::ConnectionClose {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1079,7 +1079,7 @@ pub struct Connection {
     peer_error: Option<ConnectionError>,
 
     /// Received path challenge.
-    challenge: Option<Vec<u8>>,
+    challenge: Option<[u8; 8]>,
 
     /// The connection-level limit at which send blocking occurred.
     blocked_limit: Option<u64>,
@@ -2997,10 +2997,8 @@ impl Connection {
         }
 
         // Create PATH_RESPONSE frame.
-        if let Some(ref challenge) = self.challenge {
-            let frame = frame::Frame::PathResponse {
-                data: challenge.clone(),
-            };
+        if let Some(challenge) = self.challenge {
+            let frame = frame::Frame::PathResponse { data: challenge };
 
             if push_frame_to_pkt!(b, frames, frame, left) {
                 self.challenge = None;
@@ -7844,9 +7842,7 @@ mod tests {
         let mut pipe = testing::Pipe::default().unwrap();
         assert_eq!(pipe.handshake(), Ok(()));
 
-        let frames = [frame::Frame::PathChallenge {
-            data: vec![0xba; 8],
-        }];
+        let frames = [frame::Frame::PathChallenge { data: [0xba; 8] }];
 
         let pkt_type = packet::Type::Short;
 
@@ -7865,9 +7861,7 @@ mod tests {
 
         assert_eq!(
             iter.next(),
-            Some(&frame::Frame::PathResponse {
-                data: vec![0xba; 8],
-            })
+            Some(&frame::Frame::PathResponse { data: [0xba; 8] })
         );
     }
 


### PR DESCRIPTION
Path Challenge/Response data is exactly 8 bytes. Stateless Reset Token is exactly 16 bytes. If we know the sizes in advance, there's no reason for the dynamic allocation.