### PR TITLE
ensure stream_send returns Ok(0) only when an empty FIN was submitted

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -790,9 +790,9 @@ impl Connection {
 
             if e == super::Error::Done {
                 return Err(Error::StreamBlocked);
-            } else {
-                return Err(e.into());
             }
+
+            return Err(e.into());
         };
 
         self.send_headers(conn, stream_id, headers, fin)?;


### PR DESCRIPTION
Fixes the problem discussed in issue #1095. 

Now, `stream_send` returns `Ok(0)` only when an empty fin was submitted to the method, accordingly to the spec.

I had to update the test suite a bit as well as the `send_request()` function of h3.