### PR TITLE
clean-up clippy warnings

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --examples -- -D warnings
+          args: --examples --features=ffi,qlog -- -D warnings
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -1170,7 +1170,6 @@ fn parse_ack_frame(ty: u64, b: &mut octets::Octets) -> Result<Frame> {
 
     let mut ranges = ranges::RangeSet::default();
 
-    #[allow(clippy::range_plus_one)]
     ranges.insert(smallest_ack..largest_ack + 1);
 
     for _i in 0..block_count {
@@ -1189,7 +1188,6 @@ fn parse_ack_frame(ty: u64, b: &mut octets::Octets) -> Result<Frame> {
 
         smallest_ack = largest_ack - ack_block;
 
-        #[allow(clippy::range_plus_one)]
         ranges.insert(smallest_ack..largest_ack + 1);
     }
 

--- a/quiche/src/h3/ffi.rs
+++ b/quiche/src/h3/ffi.rs
@@ -242,7 +242,7 @@ pub extern fn quiche_h3_send_response_with_priority(
         quic_conn,
         stream_id,
         &resp_headers,
-        &priority,
+        priority,
         fin,
     ) {
         Ok(_) => 0,

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -635,7 +635,6 @@ pub struct Connection {
     qpack_encoder: qpack::Encoder,
     qpack_decoder: qpack::Decoder,
 
-    #[allow(dead_code)]
     local_qpack_streams: QpackStreams,
     peer_qpack_streams: QpackStreams,
 
@@ -652,7 +651,6 @@ pub struct Connection {
 }
 
 impl Connection {
-    #[allow(clippy::unnecessary_wraps)]
     fn new(
         config: &Config, is_server: bool, enable_dgram: bool,
     ) -> Result<Connection> {

--- a/quiche/src/h3/qpack/huffman/table.rs
+++ b/quiche/src/h3/qpack/huffman/table.rs
@@ -1,5 +1,3 @@
-#[allow(clippy::unreadable_literal)]
-
 // (num-bits, bits)
 pub const ENCODE_TABLE: [(usize, u64); 257] = [
     (13, 0x1ff8),

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -287,8 +287,6 @@
 //!
 //! [`CongestionControlAlgorithm`]: enum.CongestionControlAlgorithm.html
 
-#![allow(improper_ctypes)]
-#![allow(clippy::suspicious_operation_groupings)]
 #![allow(clippy::upper_case_acronyms)]
 #![warn(missing_docs)]
 

--- a/quiche/src/octets.rs
+++ b/quiche/src/octets.rs
@@ -24,8 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#![allow(dead_code)]
-
 /// Zero-copy abstraction for parsing and constructing network packets.
 use std::mem;
 use std::ptr;
@@ -95,7 +93,6 @@ macro_rules! put_u {
 
         let v = $v;
 
-        #[allow(clippy::range_plus_one)]
         let dst = &mut $b.buf[$b.off..($b.off + len)];
 
         unsafe {

--- a/quiche/src/ranges.rs
+++ b/quiche/src/ranges.rs
@@ -108,7 +108,6 @@ impl RangeSet {
     }
 
     pub fn push_item(&mut self, item: u64) {
-        #[allow(clippy::range_plus_one)]
         self.insert(item..item + 1);
     }
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -675,7 +675,6 @@ impl Recovery {
         let mut time = self.loss_time[epoch];
 
         // Iterate over all packet number spaces starting from Handshake.
-        #[allow(clippy::needless_range_loop)]
         for e in packet::EPOCH_HANDSHAKE..packet::EPOCH_COUNT {
             let new_time = self.loss_time[e];
 


### PR DESCRIPTION
Many of the warnings that we explicitly allow have been disabled by
default. In addition, we weren't running clippy with the "ffi" and
"qlog" features enabled.