### PR TITLE
add C-API quiche_conn_set_token

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -282,6 +282,9 @@ void quiche_conn_set_qlog_fd(quiche_conn *conn, int fd, const char *log_title,
 // Configures the given session for resumption.
 int quiche_conn_set_session(quiche_conn *conn, const uint8_t *buf, size_t buf_len);
 
+// Configures the given token for Initial Packet
+void quiche_conn_set_token(quiche_conn *conn, const uint8_t *token, size_t token_len);
+
 typedef struct {
     struct sockaddr *from;
     socklen_t from_len;

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -612,6 +612,14 @@ pub extern fn quiche_conn_set_session(
     }
 }
 
+#[no_mangle]
+pub extern fn quiche_conn_set_token(
+    conn: &mut Connection, token: *const u8, token_len: size_t
+) {
+    let token = unsafe { slice::from_raw_parts(token, token_len) };
+    conn.set_token(token);
+}
+
 #[repr(C)]
 pub struct RecvInfo<'a> {
     from: &'a sockaddr,

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -614,7 +614,7 @@ pub extern fn quiche_conn_set_session(
 
 #[no_mangle]
 pub extern fn quiche_conn_set_token(
-    conn: &mut Connection, token: *const u8, token_len: size_t
+    conn: &mut Connection, token: *const u8, token_len: size_t,
 ) {
     let token = unsafe { slice::from_raw_parts(token, token_len) };
     conn.set_token(token);

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1731,6 +1731,17 @@ impl Connection {
         Ok(())
     }
 
+    /// Configures the given token for address validation.
+    ///
+    /// On the client, this can be used to set the given token to Initial Packet.
+    ///
+    /// This must only be called immediately after creating a connection, that
+    /// is, before any packet is sent or received.
+    #[inline]
+    pub fn set_token(&mut self, token: &[u8]) {
+        self.token = Some(token.to_vec());
+    }
+
     /// Processes QUIC packets received from the peer.
     ///
     /// On success the number of bytes processed from the input buffer is

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1733,7 +1733,8 @@ impl Connection {
 
     /// Configures the given token for address validation.
     ///
-    /// On the client, this can be used to set the given token to Initial Packet.
+    /// On the client, this can be used to set the given token to Initial
+    /// Packet.
     ///
     /// This must only be called immediately after creating a connection, that
     /// is, before any packet is sent or received.


### PR DESCRIPTION
As client may cache token for address validation for future connections, we may need to set token to the very first Initial packet, so let's expose this API.