### PR TITLE
Handle Key Update Request - RFC 9001/6

### DIFF
--- a/quiche/src/crypto.rs
+++ b/quiche/src/crypto.rs
@@ -131,45 +131,38 @@ impl Algorithm {
 pub struct Open {
     alg: Algorithm,
 
-    ctx: EVP_AEAD_CTX,
+    secret: Vec<u8>,
 
-    hp_key: aead::quic::HeaderProtectionKey,
+    header: HeaderProtectionKey,
 
-    nonce: Vec<u8>,
+    packet: PacketKey,
 }
 
 impl Open {
     pub fn new(
-        alg: Algorithm, key: &[u8], iv: &[u8], hp_key: &[u8],
+        alg: Algorithm, key: &[u8], iv: &[u8], hp_key: &[u8], secret: &[u8],
     ) -> Result<Open> {
         Ok(Open {
             alg,
 
-            ctx: make_aead_ctx(alg, key)?,
+            secret: Vec::from(secret),
 
-            hp_key: aead::quic::HeaderProtectionKey::new(
-                alg.get_ring_hp(),
-                hp_key,
-            )
-            .map_err(|_| Error::CryptoFail)?,
+            header: HeaderProtectionKey::new(alg, hp_key)?,
 
-            nonce: Vec::from(iv),
+            packet: PacketKey::new(alg, key, iv)?,
         })
     }
 
     pub fn from_secret(aead: Algorithm, secret: &[u8]) -> Result<Open> {
-        let key_len = aead.key_len();
-        let nonce_len = aead.nonce_len();
+        Ok(Open {
+            alg: aead,
 
-        let mut key = vec![0; key_len];
-        let mut iv = vec![0; nonce_len];
-        let mut pn_key = vec![0; key_len];
+            secret: Vec::from(secret),
 
-        derive_pkt_key(aead, secret, &mut key)?;
-        derive_pkt_iv(aead, secret, &mut iv)?;
-        derive_hdr_key(aead, secret, &mut pn_key)?;
+            header: HeaderProtectionKey::from_secret(aead, secret)?,
 
-        Open::new(aead, &key, &iv, &pn_key)
+            packet: PacketKey::from_secret(aead, secret)?,
+        })
     }
 
     pub fn open_with_u64_counter(
@@ -185,11 +178,11 @@ impl Open {
 
         let max_out_len = out_len;
 
-        let nonce = make_nonce(&self.nonce, counter);
+        let nonce = make_nonce(&self.packet.nonce, counter);
 
         let rc = unsafe {
             EVP_AEAD_CTX_open(
-                &self.ctx,          // ctx
+                &self.packet.ctx,   // ctx
                 buf.as_mut_ptr(),   // out
                 &mut out_len,       // out_len
                 max_out_len,        // max_out_len
@@ -215,7 +208,8 @@ impl Open {
         }
 
         let mask = self
-            .hp_key
+            .header
+            .hpk
             .new_mask(sample)
             .map_err(|_| Error::CryptoFail)?;
 
@@ -225,50 +219,60 @@ impl Open {
     pub fn alg(&self) -> Algorithm {
         self.alg
     }
+
+    #[allow(dead_code)] // For now this logic is not used (see: https://github.com/cloudflare/quiche/issues/1115)
+    pub fn derive_next_packet_key(&self) -> Result<Open> {
+        let next_secret = derive_next_secret(self.alg, &self.secret)?;
+
+        let next_packet_key = PacketKey::from_secret(self.alg, &next_secret)?;
+
+        Ok(Open {
+            alg: self.alg,
+
+            secret: next_secret,
+
+            header: HeaderProtectionKey::new(self.alg, &self.header.hp_key)?,
+
+            packet: next_packet_key,
+        })
+    }
 }
 
 pub struct Seal {
     alg: Algorithm,
 
-    ctx: EVP_AEAD_CTX,
+    secret: Vec<u8>,
 
-    hp_key: aead::quic::HeaderProtectionKey,
+    header: HeaderProtectionKey,
 
-    nonce: Vec<u8>,
+    packet: PacketKey,
 }
 
 impl Seal {
     pub fn new(
-        alg: Algorithm, key: &[u8], iv: &[u8], hp_key: &[u8],
+        alg: Algorithm, key: &[u8], iv: &[u8], hp_key: &[u8], secret: &[u8],
     ) -> Result<Seal> {
         Ok(Seal {
             alg,
 
-            ctx: make_aead_ctx(alg, key)?,
+            secret: Vec::from(secret),
 
-            hp_key: aead::quic::HeaderProtectionKey::new(
-                alg.get_ring_hp(),
-                hp_key,
-            )
-            .map_err(|_| Error::CryptoFail)?,
+            header: HeaderProtectionKey::new(alg, hp_key)?,
 
-            nonce: Vec::from(iv),
+            packet: PacketKey::new(alg, key, iv)?,
         })
     }
 
     pub fn from_secret(aead: Algorithm, secret: &[u8]) -> Result<Seal> {
-        let key_len = aead.key_len();
-        let nonce_len = aead.nonce_len();
+        Ok(Seal {
+            alg: aead,
 
-        let mut key = vec![0; key_len];
-        let mut iv = vec![0; nonce_len];
-        let mut pn_key = vec![0; key_len];
+            secret: Vec::from(secret),
 
-        derive_pkt_key(aead, secret, &mut key)?;
-        derive_pkt_iv(aead, secret, &mut iv)?;
-        derive_hdr_key(aead, secret, &mut pn_key)?;
+            header: HeaderProtectionKey::from_secret(aead, secret)?,
 
-        Seal::new(aead, &key, &iv, &pn_key)
+            packet: PacketKey::from_secret(aead, secret)?,
+        })
     }
 
     pub fn seal_with_u64_counter(
@@ -299,11 +303,11 @@ impl Seal {
             return Err(Error::CryptoFail);
         }
 
-        let nonce = make_nonce(&self.nonce, counter);
+        let nonce = make_nonce(&self.packet.nonce, counter);
 
         let rc = unsafe {
             EVP_AEAD_CTX_seal_scatter(
-                &self.ctx,                  // ctx
+                &self.packet.ctx,           // ctx
                 buf.as_mut_ptr(),           // out
                 buf[in_len..].as_mut_ptr(), // out_tag
                 &mut out_tag_len,           // out_tag_len
@@ -332,7 +336,8 @@ impl Seal {
         }
 
         let mask = self
-            .hp_key
+            .header
+            .hpk
             .new_mask(sample)
             .map_err(|_| Error::CryptoFail)?;
 
@@ -342,12 +347,86 @@ impl Seal {
     pub fn alg(&self) -> Algorithm {
         self.alg
     }
+
+    #[allow(dead_code)] // For now this logic is not used (see: https://github.com/cloudflare/quiche/issues/1115)
+    pub fn derive_next_packet_key(&self) -> Result<Seal> {
+        let next_secret = derive_next_secret(self.alg, &self.secret)?;
+
+        let next_packet_key = PacketKey::from_secret(self.alg, &next_secret)?;
+
+        Ok(Seal {
+            alg: self.alg,
+
+            secret: next_secret,
+
+            header: HeaderProtectionKey::new(self.alg, &self.header.hp_key)?,
+
+            packet: next_packet_key,
+        })
+    }
+}
+
+pub struct HeaderProtectionKey {
+    hpk: aead::quic::HeaderProtectionKey,
+
+    hp_key: Vec<u8>,
+}
+
+impl HeaderProtectionKey {
+    pub fn new(alg: Algorithm, hp_key: &[u8]) -> Result<Self> {
+        aead::quic::HeaderProtectionKey::new(alg.get_ring_hp(), hp_key)
+            .map(|hpk| Self {
+                hpk,
+                hp_key: Vec::from(hp_key),
+            })
+            .map_err(|_| Error::CryptoFail)
+    }
+
+    pub fn from_secret(aead: Algorithm, secret: &[u8]) -> Result<Self> {
+        let key_len = aead.key_len();
+
+        let mut hp_key = vec![0; key_len];
+
+        derive_hdr_key(aead, secret, &mut hp_key)?;
+
+        Self::new(aead, &hp_key)
+    }
+}
+
+pub struct PacketKey {
+    ctx: EVP_AEAD_CTX,
+
+    nonce: Vec<u8>,
+}
+
+impl PacketKey {
+    pub fn new(alg: Algorithm, key: &[u8], iv: &[u8]) -> Result<Self> {
+        Ok(Self {
+            ctx: make_aead_ctx(alg, key)?,
+
+            nonce: Vec::from(iv),
+        })
+    }
+
+    pub fn from_secret(aead: Algorithm, secret: &[u8]) -> Result<Self> {
+        let key_len = aead.key_len();
+        let nonce_len = aead.nonce_len();
+
+        let mut key = vec![0; key_len];
+        let mut iv = vec![0; nonce_len];
+
+        derive_pkt_key(aead, secret, &mut key)?;
+        derive_pkt_iv(aead, secret, &mut iv)?;
+
+        Self::new(aead, &key, &iv)
+    }
 }
 
 pub fn derive_initial_key_material(
     cid: &[u8], version: u32, is_server: bool,
 ) -> Result<(Open, Seal)> {
-    let mut secret = [0; 32];
+    let mut client_secret = [0; 32];
+    let mut server_secret = [0; 32];
 
     let aead = Algorithm::AES128_GCM;
 
@@ -361,30 +440,54 @@ pub fn derive_initial_key_material(
     let mut client_iv = vec![0; nonce_len];
     let mut client_hp_key = vec![0; key_len];
 
-    derive_client_initial_secret(&initial_secret, &mut secret)?;
-    derive_pkt_key(aead, &secret, &mut client_key)?;
-    derive_pkt_iv(aead, &secret, &mut client_iv)?;
-    derive_hdr_key(aead, &secret, &mut client_hp_key)?;
+    derive_client_initial_secret(&initial_secret, &mut client_secret)?;
+    derive_pkt_key(aead, &client_secret, &mut client_key)?;
+    derive_pkt_iv(aead, &client_secret, &mut client_iv)?;
+    derive_hdr_key(aead, &client_secret, &mut client_hp_key)?;
 
     // Server.
     let mut server_key = vec![0; key_len];
     let mut server_iv = vec![0; nonce_len];
     let mut server_hp_key = vec![0; key_len];
 
-    derive_server_initial_secret(&initial_secret, &mut secret)?;
-    derive_pkt_key(aead, &secret, &mut server_key)?;
-    derive_pkt_iv(aead, &secret, &mut server_iv)?;
-    derive_hdr_key(aead, &secret, &mut server_hp_key)?;
+    derive_server_initial_secret(&initial_secret, &mut server_secret)?;
+    derive_pkt_key(aead, &server_secret, &mut server_key)?;
+    derive_pkt_iv(aead, &server_secret, &mut server_iv)?;
+    derive_hdr_key(aead, &server_secret, &mut server_hp_key)?;
 
     let (open, seal) = if is_server {
         (
-            Open::new(aead, &client_key, &client_iv, &client_hp_key)?,
-            Seal::new(aead, &server_key, &server_iv, &server_hp_key)?,
+            Open::new(
+                aead,
+                &client_key,
+                &client_iv,
+                &client_hp_key,
+                &client_secret,
+            )?,
+            Seal::new(
+                aead,
+                &server_key,
+                &server_iv,
+                &server_hp_key,
+                &server_secret,
+            )?,
         )
     } else {
         (
-            Open::new(aead, &server_key, &server_iv, &server_hp_key)?,
-            Seal::new(aead, &client_key, &client_iv, &client_hp_key)?,
+            Open::new(
+                aead,
+                &server_key,
+                &server_iv,
+                &server_hp_key,
+                &server_secret,
+            )?,
+            Seal::new(
+                aead,
+                &client_key,
+                &client_iv,
+                &client_hp_key,
+                &client_secret,
+            )?,
         )
     };
 
@@ -428,6 +531,17 @@ fn derive_client_initial_secret(prk: &hkdf::Prk, out: &mut [u8]) -> Result<()> {
 fn derive_server_initial_secret(prk: &hkdf::Prk, out: &mut [u8]) -> Result<()> {
     const LABEL: &[u8] = b"server in";
     hkdf_expand_label(prk, LABEL, out)
+}
+
+fn derive_next_secret(aead: Algorithm, secret: &[u8]) -> Result<Vec<u8>> {
+    const LABEL: &[u8] = b"quic ku";
+
+    let mut next_secret = vec![0; secret.len()];
+
+    let secret_prk = hkdf::Prk::new_less_safe(aead.get_ring_digest(), secret);
+    hkdf_expand_label(&secret_prk, LABEL, &mut next_secret)?;
+
+    Ok(next_secret)
 }
 
 pub fn derive_hdr_key(

--- a/quiche/src/crypto.rs
+++ b/quiche/src/crypto.rs
@@ -220,7 +220,6 @@ impl Open {
         self.alg
     }
 
-    #[allow(dead_code)] // For now this logic is not used (see: https://github.com/cloudflare/quiche/issues/1115)
     pub fn derive_next_packet_key(&self) -> Result<Open> {
         let next_secret = derive_next_secret(self.alg, &self.secret)?;
 
@@ -348,7 +347,6 @@ impl Seal {
         self.alg
     }
 
-    #[allow(dead_code)] // For now this logic is not used (see: https://github.com/cloudflare/quiche/issues/1115)
     pub fn derive_next_packet_key(&self) -> Result<Seal> {
         let next_secret = derive_next_secret(self.alg, &self.secret)?;
 

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -815,6 +815,18 @@ fn compute_retry_integrity_tag(
         .map_err(|_| Error::CryptoFail)
 }
 
+pub struct CryptoPrev {
+    pub crypto_open: crypto::Open,
+
+    /// The packet number triggered the latest key-update.
+    ///
+    /// Incoming packets with lower pn should use this (prev) crypto key.
+    pub pn_on_update: u64,
+
+    /// Whether ACK frame for key-update has been sent.
+    pub update_acked: bool,
+}
+
 pub struct PktNumSpace {
     pub largest_rx_pkt_num: u64,
 
@@ -830,6 +842,13 @@ pub struct PktNumSpace {
 
     pub crypto_open: Option<crypto::Open>,
     pub crypto_seal: Option<crypto::Seal>,
+
+    /// 1-RTT keys used prior to a key update
+    pub crypto_prev: Option<CryptoPrev>,
+
+    /// 1-RTT keys to be used for the next key update
+    pub crypto_open_next: Option<crypto::Open>,
+    pub crypto_seal_next: Option<crypto::Seal>,
 
     pub crypto_0rtt_open: Option<crypto::Open>,
     pub crypto_0rtt_seal: Option<crypto::Seal>,
@@ -854,6 +873,11 @@ impl PktNumSpace {
 
             crypto_open: None,
             crypto_seal: None,
+
+            crypto_prev: None,
+
+            crypto_open_next: None,
+            crypto_seal_next: None,
 
             crypto_0rtt_open: None,
             crypto_0rtt_seal: None,

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -737,7 +737,14 @@ extern fn set_read_secret(
             return 1;
         }
 
+        let open_next = match open.derive_next_packet_key() {
+            Ok(n) => n,
+
+            Err(_) => return 0,
+        };
+
         space.crypto_open = Some(open);
+        space.crypto_open_next = Some(open_next);
     }
 
     1
@@ -782,7 +789,14 @@ extern fn set_write_secret(
             Err(_) => return 0,
         };
 
+        let seal_next = match seal.derive_next_packet_key() {
+            Ok(n) => n,
+
+            Err(_) => return 0,
+        };
+
         space.crypto_seal = Some(seal);
+        space.crypto_seal_next = Some(seal_next);
     }
 
     1


### PR DESCRIPTION
Logic for handling peer-initiated key update requests, as described in [RFC-9001#6](https://datatracker.ietf.org/doc/html/rfc9001#section-6).

In short, this includes the logic for handling key-update requested by peers.

It does not include logic for initiating key-update (based on AEAD confidentiality value). It might be proposed in a dedicated PR. However, most of the logic should be already included in this PR.

- [x] [Responding to a Key Update](https://datatracker.ietf.org/doc/html/rfc9001#section-6.2);
- [x] [Timing of Receive Key Generation](https://datatracker.ietf.org/doc/html/rfc9001#section-6.3);
- [x] [Sending with Updated Keys](https://datatracker.ietf.org/doc/html/rfc9001#section-6.4);
- [x] [Receiving with Different Keys](https://datatracker.ietf.org/doc/html/rfc9001#section-6.5);
  - [ ] [`SHOULD`] timeout retain old read keys (see `TODO` in the code).


This should fix #1115.

Therefore, QUIC-quiche implementation should work without any disruption even with other QUIC implementations using AEAD ciphers.

*Any feedback/suggestions are of course more than welcome.*