### PR TITLE
ffi: remove quiche_conn_session() and quiche_conn_peer_cert() for now

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -369,12 +369,6 @@ void quiche_conn_destination_id(quiche_conn *conn, const uint8_t **out, size_t *
 void quiche_conn_application_proto(quiche_conn *conn, const uint8_t **out,
                                    size_t *out_len);
 
-// Returns the peer's leaf certificate (if any) as a DER-encoded buffer.
-void quiche_conn_peer_cert(quiche_conn *conn, const uint8_t **out, size_t *out_len);
-
-// Returns the serialized cryptographic session for the connection.
-void quiche_conn_session(quiche_conn *conn, const uint8_t **out, size_t *out_len);
-
 // Returns true if the connection handshake is complete.
 bool quiche_conn_is_established(quiche_conn *conn);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -886,34 +886,6 @@ pub extern fn quiche_conn_application_proto(
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_peer_cert(
-    conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
-) {
-    match conn.peer_cert() {
-        Some(peer_cert) => {
-            *out = peer_cert.as_ptr();
-            *out_len = peer_cert.len();
-        },
-
-        None => *out_len = 0,
-    }
-}
-
-#[no_mangle]
-pub extern fn quiche_conn_session(
-    conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
-) {
-    match conn.session() {
-        Some(session) => {
-            *out = session.as_ptr();
-            *out_len = session.len();
-        },
-
-        None => *out_len = 0,
-    }
-}
-
-#[no_mangle]
 pub extern fn quiche_conn_is_established(conn: &mut Connection) -> bool {
     conn.is_established()
 }


### PR DESCRIPTION
While we figure out a better way to implement these, we should remove
them so people don't accidentally use them. See  issue #1127 for more
details.

Fixes #1127.