### PR TITLE
Modify the certificate path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ After cloning the project according to the command mentioned in the [building](#
 while the server can be run as follows:
 
 ```bash
- $ cargo run --bin quiche-server -- --cert tools/apps/src/bin/cert.crt --key tools/apps/src/bin/cert.key
+ $ cargo run --bin quiche-server -- --cert apps/src/bin/cert.crt --key apps/src/bin/cert.key
 ```
 
 (note that the certificate provided is self-signed and should not be used in


### PR DESCRIPTION
Hello, 👋🏽 

I think the certificate paths in README haven't caught up with some refactors.

Best,

![image](https://user-images.githubusercontent.com/44393661/150688328-6bc804a3-8e93-49b3-a33a-32f015cd69f8.png)
