### PR TITLE
h3: initial support for PRIORITY_UPDATE frame

### DIFF
--- a/quiche/src/h3/frame.rs
+++ b/quiche/src/h3/frame.rs
@@ -35,6 +35,8 @@ pub const SETTINGS_FRAME_TYPE_ID: u64 = 0x4;
 pub const PUSH_PROMISE_FRAME_TYPE_ID: u64 = 0x5;
 pub const GOAWAY_FRAME_TYPE_ID: u64 = 0x6;
 pub const MAX_PUSH_FRAME_TYPE_ID: u64 = 0xD;
+pub const PRIORITY_UPDATE_FRAME_REQUEST_TYPE_ID: u64 = 0xF0700;
+pub const PRIORITY_UPDATE_FRAME_PUSH_TYPE_ID: u64 = 0xF0701;
 
 pub const SETTINGS_QPACK_MAX_TABLE_CAPACITY: u64 = 0x1;
 pub const SETTINGS_MAX_FIELD_SECTION_SIZE: u64 = 0x6;
@@ -80,6 +82,16 @@ pub enum Frame {
         push_id: u64,
     },
 
+    PriorityUpdateRequest {
+        prioritized_element_id: u64,
+        priority_field_value: String,
+    },
+
+    PriorityUpdatePush {
+        prioritized_element_id: u64,
+        priority_field_value: String,
+    },
+
     Unknown,
 }
 
@@ -116,6 +128,10 @@ impl Frame {
             MAX_PUSH_FRAME_TYPE_ID => Frame::MaxPushId {
                 push_id: b.get_varint()?,
             },
+
+            PRIORITY_UPDATE_FRAME_REQUEST_TYPE_ID |
+            PRIORITY_UPDATE_FRAME_PUSH_TYPE_ID =>
+                parse_priority_update(frame_type, payload_length, &mut b)?,
 
             _ => Frame::Unknown,
         };
@@ -238,6 +254,34 @@ impl Frame {
                 b.put_varint(*push_id)?;
             },
 
+            Frame::PriorityUpdateRequest {
+                prioritized_element_id,
+                priority_field_value,
+            } => {
+                let len = octets::varint_len(*prioritized_element_id) +
+                    priority_field_value.as_bytes().len();
+
+                b.put_varint(PRIORITY_UPDATE_FRAME_REQUEST_TYPE_ID)?;
+                b.put_varint(len as u64)?;
+
+                b.put_varint(*prioritized_element_id as u64)?;
+                b.put_bytes(priority_field_value.as_bytes())?;
+            },
+
+            Frame::PriorityUpdatePush {
+                prioritized_element_id,
+                priority_field_value,
+            } => {
+                let len = octets::varint_len(*prioritized_element_id) +
+                    priority_field_value.len();
+
+                b.put_varint(PRIORITY_UPDATE_FRAME_PUSH_TYPE_ID)?;
+                b.put_varint(len as u64)?;
+
+                b.put_varint(*prioritized_element_id as u64)?;
+                b.put_bytes(priority_field_value.as_bytes())?;
+            },
+
             Frame::Unknown => unreachable!(),
         }
 
@@ -288,6 +332,24 @@ impl std::fmt::Debug for Frame {
 
             Frame::MaxPushId { push_id } => {
                 write!(f, "MAX_PUSH_ID push_id={}", push_id)?;
+            },
+
+            Frame::PriorityUpdateRequest {
+                prioritized_element_id,
+                priority_field_value,
+            } => {
+                write!(f, "PRIORITY_UPDATE request_stream_id={}, priority_field_value={}", prioritized_element_id, priority_field_value)?;
+            },
+
+            Frame::PriorityUpdatePush {
+                prioritized_element_id,
+                priority_field_value,
+            } => {
+                write!(
+                    f,
+                    "PRIORITY_UPDATE push_id={}, priority_field_value={}",
+                    prioritized_element_id, priority_field_value
+                )?;
             },
 
             Frame::Unknown => {
@@ -372,6 +434,33 @@ fn parse_push_promise(
         push_id,
         header_block,
     })
+}
+
+fn parse_priority_update(
+    frame_type: u64, payload_length: u64, b: &mut octets::Octets,
+) -> Result<Frame> {
+    let prioritized_element_id = b.get_varint()?;
+    let priority_field_value_length =
+        payload_length - octets::varint_len(prioritized_element_id) as u64;
+    let priority_field_value =
+        b.get_bytes(priority_field_value_length as usize)?.to_vec();
+    let priority_field_value = String::from_utf8(priority_field_value)
+        .map_err(|_| super::Error::InternalError)?;
+
+    match frame_type {
+        PRIORITY_UPDATE_FRAME_REQUEST_TYPE_ID =>
+            Ok(Frame::PriorityUpdateRequest {
+                prioritized_element_id,
+                priority_field_value,
+            }),
+
+        PRIORITY_UPDATE_FRAME_PUSH_TYPE_ID => Ok(Frame::PriorityUpdatePush {
+            prioritized_element_id,
+            priority_field_value,
+        }),
+
+        _ => unreachable!(),
+    }
 }
 
 #[cfg(test)]
@@ -869,6 +958,70 @@ mod tests {
         assert_eq!(
             Frame::from_bytes(
                 MAX_PUSH_FRAME_TYPE_ID,
+                frame_payload_len as u64,
+                &d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn priority_update_request() {
+        let mut d = [42; 128];
+
+        let prioritized_element_id = 4;
+        let priority_field_value = "abcdefghijklm".to_string();
+        let frame_payload_len = 1 + priority_field_value.len();
+        let frame_header_len = 5;
+
+        let frame = Frame::PriorityUpdateRequest {
+            prioritized_element_id,
+            priority_field_value,
+        };
+
+        let wire_len = {
+            let mut b = octets::OctetsMut::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                PRIORITY_UPDATE_FRAME_REQUEST_TYPE_ID,
+                frame_payload_len as u64,
+                &d[frame_header_len..]
+            )
+            .unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn priority_update_push() {
+        let mut d = [42; 128];
+
+        let prioritized_element_id = 6;
+        let priority_field_value = "abcdefghijklm".to_string();
+        let frame_payload_len = 1 + priority_field_value.len();
+        let frame_header_len = 5;
+
+        let frame = Frame::PriorityUpdatePush {
+            prioritized_element_id,
+            priority_field_value,
+        };
+
+        let wire_len = {
+            let mut b = octets::OctetsMut::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, frame_header_len + frame_payload_len);
+
+        assert_eq!(
+            Frame::from_bytes(
+                PRIORITY_UPDATE_FRAME_PUSH_TYPE_ID,
                 frame_payload_len as u64,
                 &d[frame_header_len..]
             )

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -2113,6 +2113,80 @@ impl Connection {
                 // TODO: implement CANCEL_PUSH frame
             },
 
+            frame::Frame::PriorityUpdateRequest {
+                prioritized_element_id,
+                ..
+            } => {
+                if !self.is_server {
+                    conn.close(
+                        true,
+                        Error::FrameUnexpected.to_wire(),
+                        b"PRIORITY_UPDATE received by client",
+                    )?;
+
+                    return Err(Error::FrameUnexpected);
+                }
+
+                if Some(stream_id) != self.peer_control_stream_id {
+                    conn.close(
+                        true,
+                        Error::FrameUnexpected.to_wire(),
+                        b"PRIORITY_UPDATE received on non-control stream",
+                    )?;
+
+                    return Err(Error::FrameUnexpected);
+                }
+
+                if prioritized_element_id % 4 != 0 {
+                    conn.close(
+                        true,
+                        Error::FrameUnexpected.to_wire(),
+                        b"PRIORITY_UPDATE for request stream type with wrong ID",
+                    )?;
+
+                    return Err(Error::FrameUnexpected);
+                }
+
+                // TODO: decide how to handle valid frames: generate an event?
+            },
+
+            frame::Frame::PriorityUpdatePush {
+                prioritized_element_id,
+                ..
+            } => {
+                if !self.is_server {
+                    conn.close(
+                        true,
+                        Error::FrameUnexpected.to_wire(),
+                        b"PRIORITY_UPDATE received by client",
+                    )?;
+
+                    return Err(Error::FrameUnexpected);
+                }
+
+                if Some(stream_id) != self.peer_control_stream_id {
+                    conn.close(
+                        true,
+                        Error::FrameUnexpected.to_wire(),
+                        b"PRIORITY_UPDATE received on non-control stream",
+                    )?;
+
+                    return Err(Error::FrameUnexpected);
+                }
+
+                if prioritized_element_id % 3 != 0 {
+                    conn.close(
+                        true,
+                        Error::FrameUnexpected.to_wire(),
+                        b"PRIORITY_UPDATE for push stream type with wrong ID",
+                    )?;
+
+                    return Err(Error::FrameUnexpected);
+                }
+
+                // TODO: we only implement this if we implement server push
+            },
+
             frame::Frame::Unknown => (),
         }
 
@@ -3147,6 +3221,122 @@ mod tests {
         assert_eq!(s.poll_client(), Ok((0, Event::GoAway)));
 
         assert_eq!(s.poll_client(), Err(Error::IdError));
+    }
+
+    #[test]
+    /// Send a PRIORITY_UPDATE for request stream from the client.
+    fn priority_update_request() {
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        s.send_frame_client(
+            frame::Frame::PriorityUpdateRequest {
+                prioritized_element_id: 0,
+                priority_field_value: "u=3".to_string(),
+            },
+            s.client.control_stream_id.unwrap(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(s.poll_server(), Err(Error::Done));
+    }
+
+    #[test]
+    /// Send a PRIORITY_UPDATE for push stream from the client.
+    fn priority_update_push() {
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        s.send_frame_client(
+            frame::Frame::PriorityUpdatePush {
+                prioritized_element_id: 3,
+                priority_field_value: "u=3".to_string(),
+            },
+            s.client.control_stream_id.unwrap(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(s.poll_server(), Err(Error::Done));
+    }
+
+    #[test]
+    /// Send a PRIORITY_UPDATE for request stream from the client but for an
+    /// incorrect stream type.
+    fn priority_update_request_bad_stream() {
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        s.send_frame_client(
+            frame::Frame::PriorityUpdateRequest {
+                prioritized_element_id: 5,
+                priority_field_value: "u=3".to_string(),
+            },
+            s.client.control_stream_id.unwrap(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(s.poll_server(), Err(Error::FrameUnexpected));
+    }
+
+    #[test]
+    /// Send a PRIORITY_UPDATE for push stream from the client but for an
+    /// incorrect stream type.
+    fn priority_update_push_bad_stream() {
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        s.send_frame_client(
+            frame::Frame::PriorityUpdatePush {
+                prioritized_element_id: 5,
+                priority_field_value: "u=3".to_string(),
+            },
+            s.client.control_stream_id.unwrap(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(s.poll_server(), Err(Error::FrameUnexpected));
+    }
+
+    #[test]
+    /// Send a PRIORITY_UPDATE for request stream from the server.
+    fn priority_update_request_from_server() {
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        s.send_frame_server(
+            frame::Frame::PriorityUpdateRequest {
+                prioritized_element_id: 0,
+                priority_field_value: "u=3".to_string(),
+            },
+            s.server.control_stream_id.unwrap(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(s.poll_client(), Err(Error::FrameUnexpected));
+    }
+
+    #[test]
+    /// Send a PRIORITY_UPDATE for request stream from the server.
+    fn priority_update_push_from_server() {
+        let mut s = Session::default().unwrap();
+        s.handshake().unwrap();
+
+        s.send_frame_server(
+            frame::Frame::PriorityUpdatePush {
+                prioritized_element_id: 0,
+                priority_field_value: "u=3".to_string(),
+            },
+            s.server.control_stream_id.unwrap(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(s.poll_client(), Err(Error::FrameUnexpected));
     }
 
     #[test]


### PR DESCRIPTION
Introduce support for the two PRIORITY_UPDATE frames defined in
  https://datatracker.ietf.org/doc/draft-ietf-httpbis-priority/12/.
  
  This change only includes basic frame handling and verification.
  Acting on frame contents, such as generating a new event in `poll()` is
  left as a TODO.