### PR TITLE
ci: reduce CI warning on quiche_multiarch

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -168,14 +168,6 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}
-          target: ${{ matrix.target }}
-          override: true
-
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Since multi-arch build are done in `cross` docker container,
no need to install rust.

It will reduce `tool rustfmt is already installed...` warning and
save a little build time.