### PR TITLE
ci: macOS and iOS fix

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -115,6 +115,10 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
+      - name: Remove cdylib from iOS build
+        run: |
+          sed -i -e 's/, "cdylib"//g' quiche/Cargo.toml
+
       - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:

--- a/quiche/src/build.rs
+++ b/quiche/src/build.rs
@@ -229,7 +229,8 @@ fn main() {
     }
 
     // MacOS: Allow cdylib to link with undefined symbols
-    if cfg!(target_os = "macos") {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if target_os == "macos" {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-undefined,dynamic_lookup");
     }
 


### PR DESCRIPTION
- Use an actual `target_os` for build script to handle macOS build option correctly
- Reduce iOS build warning.