### PR TITLE
Restore FFI functions to return TLS session and peer cert

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -373,6 +373,12 @@ void quiche_conn_destination_id(quiche_conn *conn, const uint8_t **out, size_t *
 void quiche_conn_application_proto(quiche_conn *conn, const uint8_t **out,
                                    size_t *out_len);
 
+// Returns the peer's leaf certificate (if any) as a DER-encoded buffer.
+void quiche_conn_peer_cert(quiche_conn *conn, const uint8_t **out, size_t *out_len);
+
+// Returns the serialized cryptographic session for the connection.
+void quiche_conn_session(quiche_conn *conn, const uint8_t **out, size_t *out_len);
+
 // Returns true if the connection handshake is complete.
 bool quiche_conn_is_established(quiche_conn *conn);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -899,6 +899,34 @@ pub extern fn quiche_conn_application_proto(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_peer_cert(
+    conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
+) {
+    match conn.peer_cert() {
+        Some(peer_cert) => {
+            *out = peer_cert.as_ptr();
+            *out_len = peer_cert.len();
+        },
+
+        None => *out_len = 0,
+    }
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_session(
+    conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
+) {
+    match conn.session() {
+        Some(session) => {
+            *out = session.as_ptr();
+            *out_len = session.len();
+        },
+
+        None => *out_len = 0,
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_is_established(conn: &mut Connection) -> bool {
     conn.is_established()
 }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4503,7 +4503,7 @@ impl Connection {
 
     /// Returns the peer's leaf certificate (if any) as a DER-encoded buffer.
     #[inline]
-    pub fn peer_cert(&self) -> Option<Vec<u8>> {
+    pub fn peer_cert(&self) -> Option<&[u8]> {
         self.handshake.peer_cert()
     }
 
@@ -4514,8 +4514,8 @@ impl Connection {
     ///
     /// [`set_session()`]: struct.Connection.html#method.set_session
     #[inline]
-    pub fn session(&self) -> Option<Vec<u8>> {
-        self.session.clone()
+    pub fn session(&self) -> Option<&[u8]> {
+        self.session.as_deref()
     }
 
     /// Returns the source connection ID.

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -609,7 +609,7 @@ impl Handshake {
         Some(sigalg.to_string())
     }
 
-    pub fn peer_cert(&self) -> Option<Vec<u8>> {
+    pub fn peer_cert(&self) -> Option<&[u8]> {
         let peer_cert = unsafe {
             let chain =
                 map_result_ptr(SSL_get0_peer_certificates(self.as_ptr())).ok()?;
@@ -620,14 +620,14 @@ impl Handshake {
             let buffer =
                 map_result_ptr(sk_value(chain, 0) as *const CRYPTO_BUFFER)
                     .ok()?;
+
             let out_len = CRYPTO_BUFFER_len(buffer);
             if out_len == 0 {
                 return None;
             }
 
             let out = CRYPTO_BUFFER_data(buffer);
-            let der = slice::from_raw_parts(out, out_len as usize);
-            der.to_vec()
+            slice::from_raw_parts(out, out_len as usize)
         };
 
         Some(peer_cert)


### PR DESCRIPTION
There's a slight change to the Rust API as well, but I think this is better anyway (see commit message).