### PR TITLE
Check payload size before decryption

### DIFF
--- a/quiche/src/crypto.rs
+++ b/quiche/src/crypto.rs
@@ -181,7 +181,10 @@ impl Open {
 
         let tag_len = self.alg().tag_len();
 
-        let mut out_len = buf.len() - tag_len;
+        let mut out_len = match buf.len().checked_sub(tag_len) {
+            Some(n) => n,
+            None => return Err(Error::CryptoFail),
+        };
 
         let max_out_len = out_len;
 


### PR DESCRIPTION
In `packet::decrypt_pkt()`, when `payload` is to small and
no space in `ciphertext`, it may cause overflow in
`max_out_len` in `crypto::open_with_u64_counter()`, can lead
a crash.

This can happen when the received packet payload is corrupted.
To fix it, an overflow check for `max_out_len` is added.