### PR TITLE
h3: initial support for PRIORITY_UPDATE event

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -1381,6 +1381,17 @@ impl HttpConn for Http3Conn {
                     }
                 },
 
+                Ok((
+                    prioritized_element_id,
+                    quiche::h3::Event::PriorityUpdate,
+                )) => {
+                    info!(
+                        "{} PRIORITY_UPDATE triggered for element ID={}",
+                        conn.trace_id(),
+                        prioritized_element_id
+                    );
+                },
+
                 Ok((goaway_id, quiche::h3::Event::GoAway)) => {
                     info!(
                         "{} got GOAWAY with ID {} ",
@@ -1548,6 +1559,17 @@ impl HttpConn for Http3Conn {
                             buf[flow_id_len..len].to_vec()
                         );
                     }
+                },
+
+                Ok((
+                    prioritized_element_id,
+                    quiche::h3::Event::PriorityUpdate,
+                )) => {
+                    info!(
+                        "{} PRIORITY_UPDATE triggered for element ID={}",
+                        conn.trace_id(),
+                        prioritized_element_id
+                    );
                 },
 
                 Ok((goaway_id, quiche::h3::Event::GoAway)) => {

--- a/nginx/nginx-1.16.patch
+++ b/nginx/nginx-1.16.patch
@@ -1613,7 +1613,7 @@ new file mode 100644
 index 000000000..1a05d4e01
 --- /dev/null
 +++ b/src/http/v3/ngx_http_v3.c
-@@ -0,0 +1,2231 @@
+@@ -0,0 +1,2234 @@
 +
 +/*
 + * Copyright (C) Cloudflare, Inc.
@@ -2078,6 +2078,9 @@ index 000000000..1a05d4e01
 +
 +                break;
 +            }
++
++            case QUICHE_H3_EVENT_PRIORITY_UPDATE:
++                break;
 +
 +            case QUICHE_H3_EVENT_DATAGRAM:
 +                break;

--- a/quiche/examples/http3-client.c
+++ b/quiche/examples/http3-client.c
@@ -305,6 +305,9 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                     }
                     break;
 
+                case QUICHE_H3_EVENT_PRIORITY_UPDATE:
+                    break;
+
                 case QUICHE_H3_EVENT_DATAGRAM:
                     break;
 

--- a/quiche/examples/http3-client.rs
+++ b/quiche/examples/http3-client.rs
@@ -275,6 +275,8 @@ fn main() {
 
                     Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
 
+                    Ok((_, quiche::h3::Event::PriorityUpdate)) => unreachable!(),
+
                     Ok((goaway_id, quiche::h3::Event::GoAway)) => {
                         info!("GOAWAY id={}", goaway_id);
                     },

--- a/quiche/examples/http3-server.c
+++ b/quiche/examples/http3-server.c
@@ -445,6 +445,9 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                     case QUICHE_H3_EVENT_RESET:
                         break;
 
+                    case QUICHE_H3_EVENT_PRIORITY_UPDATE:
+                        break;
+
                     case QUICHE_H3_EVENT_DATAGRAM:
                         break;
 

--- a/quiche/examples/http3-server.rs
+++ b/quiche/examples/http3-server.rs
@@ -359,6 +359,11 @@ fn main() {
 
                         Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
 
+                        Ok((
+                            _prioritized_element_id,
+                            quiche::h3::Event::PriorityUpdate,
+                        )) => (),
+
                         Ok((_goaway_id, quiche::h3::Event::GoAway)) => (),
 
                         Err(quiche::h3::Error::Done) => {

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -721,6 +721,7 @@ enum quiche_h3_event_type {
     QUICHE_H3_EVENT_DATAGRAM,
     QUICHE_H3_EVENT_GOAWAY,
     QUICHE_H3_EVENT_RESET,
+    QUICHE_H3_EVENT_PRIORITY_UPDATE,
 };
 
 typedef struct Http3Event quiche_h3_event;
@@ -803,6 +804,18 @@ ssize_t quiche_h3_recv_body(quiche_h3_conn *conn, quiche_conn *quic_conn,
 int quiche_h3_parse_extensible_priority(uint8_t *priority,
                                         size_t priority_len,
                                         quiche_h3_priority *parsed);
+
+// Take the last received PRIORITY_UPDATE frame for a stream.
+//
+// The `cb` callback will be called once. `cb` should check the validity of
+// priority field value contents. If `cb` returns any value other than `0`,
+// processing will be interrupted and the value is returned to the caller.
+int quiche_h3_take_last_priority_update(quiche_h3_conn *conn,
+                                        uint64_t prioritized_element_id,
+                                        int (*cb)(uint8_t  *priority_field_value,
+                                                  uint64_t priority_field_value_len,
+                                                  void *argp),
+                                        void *argp);
 
 // Returns whether the peer enabled HTTP/3 DATAGRAM frame support.
 bool quiche_h3_dgram_enabled_by_peer(quiche_h3_conn *conn,

--- a/quiche/src/h3/stream.rs
+++ b/quiche/src/h3/stream.rs
@@ -139,6 +139,9 @@ pub struct Stream {
 
     /// Whether a `Data` event has been triggered for this stream.
     data_event_triggered: bool,
+
+    /// The last `PRIORITY_UPDATE` frame encoded field value, if any.
+    last_priority_update: Option<Vec<u8>>,
 }
 
 impl Stream {
@@ -177,6 +180,8 @@ impl Stream {
             local_initialized: false,
 
             data_event_triggered: false,
+
+            last_priority_update: None,
         }
     }
 
@@ -531,6 +536,21 @@ impl Stream {
     /// Resets the data triggered state.
     fn reset_data_event(&mut self) {
         self.data_event_triggered = false;
+    }
+
+    /// Set the last priority update for the stream.
+    pub fn set_last_priority_update(&mut self, priority_update: Option<Vec<u8>>) {
+        self.last_priority_update = priority_update;
+    }
+
+    /// Take the last priority update and leave `None` in its place.
+    pub fn take_last_priority_update(&mut self) -> Option<Vec<u8>> {
+        self.last_priority_update.take()
+    }
+
+    /// Returns `true` if there is a priority update.
+    pub fn has_last_priority_update(&self) -> bool {
+        self.last_priority_update.is_some()
     }
 
     /// Returns true if the state buffer has enough data to complete the state.

--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -472,6 +472,11 @@ impl StreamMap {
         self.local_max_streams_bidi = self.local_max_streams_bidi_next;
     }
 
+    /// Returns the current max_streams_bidi limit.
+    pub fn max_streams_bidi(&self) -> u64 {
+        self.local_max_streams_bidi
+    }
+
     /// Returns the new max_streams_bidi limit.
     pub fn max_streams_bidi_next(&mut self) -> u64 {
         self.local_max_streams_bidi_next
@@ -548,6 +553,11 @@ impl StreamMap {
     /// Creates an iterator over streams that need to send STOP_SENDING.
     pub fn stopped(&self) -> hash_map::Iter<u64, u64> {
         self.stopped.iter()
+    }
+
+    /// Returns true if the stream has been collected.
+    pub fn is_collected(&self, stream_id: u64) -> bool {
+        self.collected.contains(&stream_id)
     }
 
     /// Returns true if there are any streams that have data to write.

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -361,6 +361,8 @@ pub fn run(
 
                     Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
 
+                    Ok((_, quiche::h3::Event::PriorityUpdate)) => (),
+
                     Ok((_goaway_id, quiche::h3::Event::GoAway)) => (),
 
                     Err(quiche::h3::Error::Done) => {


### PR DESCRIPTION
In one commit, introduce support for the two PRIORITY_UPDATE frames defined in
https://datatracker.ietf.org/doc/draft-ietf-httpbis-priority/12/.

In an additional commit, add a new Event::PriorityUpdate that is returned by the
`poll()` method. It only occurs on servers because only clients can send
PRIORITY_UPDATE frames.

Event:PriorityUpdate behaves like other edge-triggered events. The first
time a server receives a PRIORITY_UPDATE frame, the event is fired and
subsequent `poll()` will not generate more events. Application are
required to use the new `take_last_priority_update()` method to read all
received PRIORITY_UPDATE frames before the trigger is rearmed.

PRIORITY_UPDATE frames are sent on the control stream and include a
reference to request stream IDs. Due to reordering, it is possible that
a PRIORITY_UPDATE frame can be received before the HEADERS of the
request. Because there are no ordering guarantees at the wire, the
ordering of events is unimportant. This commit chooses to present
Event::PriorityUpdate ahead of other events.

Clients might send multiple PRIORITY_UPDATE frames between server reads,
but only the most up to date value matters. To accommodate this, only
the single most recent PRIORITY_UPDATE is stored in quiche until it is
read via `take_last_priority_update()`.

Although, PRIORITY_UPDATE frames can reference streams unknown at the
server (see above). There are limits to the streams that they refer to.
A PRIORITY_UPDATE frame that exceeds the server's maximum bidi stream ID
is treated as an error, as defined in the spec. A PRIORITY_UPDATE that
refers to a collected stream is completely ignored and will not cause an
Event::PriorityUpdate to be generated. In order to apply these
restrictions, the quiche library has had a minor change to expose the
required information about streams.