### PR TITLE
ffi: expose transport-related HTTP/3 errors

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -631,56 +631,56 @@ enum quiche_h3_error {
     QUICHE_H3_ERR_VERSION_FALLBACK = -20,
 
     // QUIC transport had no more work to do.
-    QUICHE_H3_TRANSPORT_ERR_DONE = -1001,
+    QUICHE_H3_TRANSPORT_ERR_DONE = QUICHE_ERR_DONE - 1000,
 
     // The provided buffer is too short for QUIC transport.
-    QUICHE_H3_TRANSPORT_ERR_BUFFER_TOO_SHORT = -1002,
+    QUICHE_H3_TRANSPORT_ERR_BUFFER_TOO_SHORT = QUICHE_ERR_BUFFER_TOO_SHORT - 1000,
 
     // The provided packet cannot be parsed by QUIC transport because its
     // version is unknown.
-    QUICHE_H3_TRANSPORT_ERR_UNKNOWN_VERSION = -1003,
+    QUICHE_H3_TRANSPORT_ERR_UNKNOWN_VERSION = QUICHE_ERR_UNKNOWN_VERSION - 1000,
 
     // The provided packet cannot be parsed by QUIC transport because it
     // contains an invalid frame.
-    QUICHE_H3_TRANSPORT_ERR_INVALID_FRAME = -1004,
+    QUICHE_H3_TRANSPORT_ERR_INVALID_FRAME = QUICHE_ERR_INVALID_FRAME - 1000,
 
     // The provided packet cannot be parsed by QUIC transport.
-    QUICHE_H3_TRANSPORT_ERR_INVALID_PACKET = -1005,
+    QUICHE_H3_TRANSPORT_ERR_INVALID_PACKET = QUICHE_ERR_INVALID_PACKET - 1000,
 
     // The operation cannot be completed by QUIC transport because the
     // connection is in an invalid state.
-    QUICHE_H3_TRANSPORT_ERR_INVALID_STATE = -1006,
+    QUICHE_H3_TRANSPORT_ERR_INVALID_STATE = QUICHE_ERR_INVALID_STATE - 1000,
 
     // The operation cannot be completed by QUIC transport because the stream is
     // in an invalid state.
-    QUICHE_H3_TRANSPORT_ERR_INVALID_STREAM_STATE = -1007,
+    QUICHE_H3_TRANSPORT_ERR_INVALID_STREAM_STATE = QUICHE_ERR_INVALID_STREAM_STATE - 1000,
 
     // The peer's QUIC transport params cannot be parsed.
-    QUICHE_H3_TRANSPORT_ERR_INVALID_TRANSPORT_PARAM = -1008,
+    QUICHE_H3_TRANSPORT_ERR_INVALID_TRANSPORT_PARAM = QUICHE_ERR_INVALID_TRANSPORT_PARAM - 1000,
 
     // A QUIC transport cryptographic operation failed.
-    QUICHE_H3_TRANSPORT_ERR_CRYPTO_FAIL = -1009,
+    QUICHE_H3_TRANSPORT_ERR_CRYPTO_FAIL = QUICHE_ERR_CRYPTO_FAIL - 1000,
 
     // The QUIC transport TLS handshake failed.
-    QUICHE_H3_TRANSPORT_ERR_TLS_FAIL = -1010,
+    QUICHE_H3_TRANSPORT_ERR_TLS_FAIL = QUICHE_ERR_TLS_FAIL - 1000,
 
     // The peer violated the QUIC transport local flow control limits.
-    QUICHE_H3_TRANSPORT_ERR_FLOW_CONTROL = -1011,
+    QUICHE_H3_TRANSPORT_ERR_FLOW_CONTROL = QUICHE_ERR_FLOW_CONTROL - 1000,
 
     // The peer violated the QUIC transport local stream limits.
-    QUICHE_H3_TRANSPORT_ERR_STREAM_LIMIT = -1012,
+    QUICHE_H3_TRANSPORT_ERR_STREAM_LIMIT = QUICHE_ERR_STREAM_LIMIT - 1000,
 
     // The specified QUIC transport  stream was stopped by the peer.
-    QUICHE_H3_TRANSPORT_ERR_STREAM_STOPPED = -1015,
+    QUICHE_H3_TRANSPORT_ERR_STREAM_STOPPED = QUICHE_ERR_STREAM_STOPPED - 1000,
 
     // The specified QUIC transport  stream was reset by the peer.
-    QUICHE_H3_TRANSPORT_ERR_STREAM_RESET = -1016,
+    QUICHE_H3_TRANSPORT_ERR_STREAM_RESET = QUICHE_ERR_STREAM_RESET - 1000,
 
     // The received data exceeds the QUIC transport stream's final size.
-    QUICHE_H3_TRANSPORT_ERR_FINAL_SIZE = -1013,
+    QUICHE_H3_TRANSPORT_ERR_FINAL_SIZE = QUICHE_ERR_FINAL_SIZE - 1000,
 
     // Error in QUIC transport congestion control.
-    QUICHE_H3_TRANSPORT_ERR_CONGESTION_CONTROL = -1014,
+    QUICHE_H3_TRANSPORT_ERR_CONGESTION_CONTROL = QUICHE_ERR_CONGESTION_CONTROL - 1000,
 };
 
 // Stores configuration shared between multiple connections.

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -600,8 +600,7 @@ enum quiche_h3_error {
     // QPACK Header block decompression failure.
     QUICHE_H3_ERR_QPACK_DECOMPRESSION_FAILED = -11,
 
-    // Error originated from the transport layer.
-    QUICHE_H3_ERR_TRANSPORT_ERROR = -12,
+    // -12 was previously used for TransportError, skip it
 
     // The underlying QUIC stream (or connection) doesn't have enough capacity
     // for the operation to complete. The application should retry later on.
@@ -630,6 +629,58 @@ enum quiche_h3_error {
     // The requested operation cannot be served over HTTP/3. Peer should retry
     // over HTTP/1.1.
     QUICHE_H3_ERR_VERSION_FALLBACK = -20,
+
+    // QUIC transport had no more work to do.
+    QUICHE_H3_TRANSPORT_ERR_DONE = -1001,
+
+    // The provided buffer is too short for QUIC transport.
+    QUICHE_H3_TRANSPORT_ERR_BUFFER_TOO_SHORT = -1002,
+
+    // The provided packet cannot be parsed by QUIC transport because its
+    // version is unknown.
+    QUICHE_H3_TRANSPORT_ERR_UNKNOWN_VERSION = -1003,
+
+    // The provided packet cannot be parsed by QUIC transport because it
+    // contains an invalid frame.
+    QUICHE_H3_TRANSPORT_ERR_INVALID_FRAME = -1004,
+
+    // The provided packet cannot be parsed by QUIC transport.
+    QUICHE_H3_TRANSPORT_ERR_INVALID_PACKET = -1005,
+
+    // The operation cannot be completed by QUIC transport because the
+    // connection is in an invalid state.
+    QUICHE_H3_TRANSPORT_ERR_INVALID_STATE = -1006,
+
+    // The operation cannot be completed by QUIC transport because the stream is
+    // in an invalid state.
+    QUICHE_H3_TRANSPORT_ERR_INVALID_STREAM_STATE = -1007,
+
+    // The peer's QUIC transport params cannot be parsed.
+    QUICHE_H3_TRANSPORT_ERR_INVALID_TRANSPORT_PARAM = -1008,
+
+    // A QUIC transport cryptographic operation failed.
+    QUICHE_H3_TRANSPORT_ERR_CRYPTO_FAIL = -1009,
+
+    // The QUIC transport TLS handshake failed.
+    QUICHE_H3_TRANSPORT_ERR_TLS_FAIL = -1010,
+
+    // The peer violated the QUIC transport local flow control limits.
+    QUICHE_H3_TRANSPORT_ERR_FLOW_CONTROL = -1011,
+
+    // The peer violated the QUIC transport local stream limits.
+    QUICHE_H3_TRANSPORT_ERR_STREAM_LIMIT = -1012,
+
+    // The specified QUIC transport  stream was stopped by the peer.
+    QUICHE_H3_TRANSPORT_ERR_STREAM_STOPPED = -1015,
+
+    // The specified QUIC transport  stream was reset by the peer.
+    QUICHE_H3_TRANSPORT_ERR_STREAM_RESET = -1016,
+
+    // The received data exceeds the QUIC transport stream's final size.
+    QUICHE_H3_TRANSPORT_ERR_FINAL_SIZE = -1013,
+
+    // Error in QUIC transport congestion control.
+    QUICHE_H3_TRANSPORT_ERR_CONGESTION_CONTROL = -1014,
 };
 
 // Stores configuration shared between multiple connections.

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -630,56 +630,55 @@ enum quiche_h3_error {
     // over HTTP/1.1.
     QUICHE_H3_ERR_VERSION_FALLBACK = -20,
 
-    // QUIC transport had no more work to do.
+    // The following QUICHE_H3_TRANSPORT_ERR_* errors are propagated
+    // from the QUIC transport layer.
+
+    // See QUICHE_ERR_DONE.
     QUICHE_H3_TRANSPORT_ERR_DONE = QUICHE_ERR_DONE - 1000,
 
-    // The provided buffer is too short for QUIC transport.
+    // See QUICHE_ERR_BUFFER_TOO_SHORT.
     QUICHE_H3_TRANSPORT_ERR_BUFFER_TOO_SHORT = QUICHE_ERR_BUFFER_TOO_SHORT - 1000,
 
-    // The provided packet cannot be parsed by QUIC transport because its
-    // version is unknown.
+    // See QUICHE_ERR_UNKNOWN_VERSION.
     QUICHE_H3_TRANSPORT_ERR_UNKNOWN_VERSION = QUICHE_ERR_UNKNOWN_VERSION - 1000,
 
-    // The provided packet cannot be parsed by QUIC transport because it
-    // contains an invalid frame.
+    // See QUICHE_ERR_INVALID_FRAME.
     QUICHE_H3_TRANSPORT_ERR_INVALID_FRAME = QUICHE_ERR_INVALID_FRAME - 1000,
 
-    // The provided packet cannot be parsed by QUIC transport.
+    // See QUICHE_ERR_INVALID_PACKET.
     QUICHE_H3_TRANSPORT_ERR_INVALID_PACKET = QUICHE_ERR_INVALID_PACKET - 1000,
 
-    // The operation cannot be completed by QUIC transport because the
-    // connection is in an invalid state.
+    // See QUICHE_ERR_INVALID_STATE.
     QUICHE_H3_TRANSPORT_ERR_INVALID_STATE = QUICHE_ERR_INVALID_STATE - 1000,
 
-    // The operation cannot be completed by QUIC transport because the stream is
-    // in an invalid state.
+    // See QUICHE_ERR_INVALID_STREAM_STATE.
     QUICHE_H3_TRANSPORT_ERR_INVALID_STREAM_STATE = QUICHE_ERR_INVALID_STREAM_STATE - 1000,
 
-    // The peer's QUIC transport params cannot be parsed.
+    // See QUICHE_ERR_INVALID_TRANSPORT_PARAM.
     QUICHE_H3_TRANSPORT_ERR_INVALID_TRANSPORT_PARAM = QUICHE_ERR_INVALID_TRANSPORT_PARAM - 1000,
 
-    // A QUIC transport cryptographic operation failed.
+    // See QUICHE_ERR_CRYPTO_FAIL.
     QUICHE_H3_TRANSPORT_ERR_CRYPTO_FAIL = QUICHE_ERR_CRYPTO_FAIL - 1000,
 
-    // The QUIC transport TLS handshake failed.
+    // See QUICHE_ERR_TLS_FAIL.
     QUICHE_H3_TRANSPORT_ERR_TLS_FAIL = QUICHE_ERR_TLS_FAIL - 1000,
 
-    // The peer violated the QUIC transport local flow control limits.
+    // See QUICHE_ERR_FLOW_CONTROL.
     QUICHE_H3_TRANSPORT_ERR_FLOW_CONTROL = QUICHE_ERR_FLOW_CONTROL - 1000,
 
-    // The peer violated the QUIC transport local stream limits.
+    // See QUICHE_ERR_STREAM_LIMIT.
     QUICHE_H3_TRANSPORT_ERR_STREAM_LIMIT = QUICHE_ERR_STREAM_LIMIT - 1000,
 
-    // The specified QUIC transport  stream was stopped by the peer.
+    // See QUICHE_ERR_STREAM_STOPPED.
     QUICHE_H3_TRANSPORT_ERR_STREAM_STOPPED = QUICHE_ERR_STREAM_STOPPED - 1000,
 
-    // The specified QUIC transport  stream was reset by the peer.
+    // See QUICHE_ERR_STREAM_RESET.
     QUICHE_H3_TRANSPORT_ERR_STREAM_RESET = QUICHE_ERR_STREAM_RESET - 1000,
 
-    // The received data exceeds the QUIC transport stream's final size.
+    // See QUICHE_ERR_FINAL_SIZE.
     QUICHE_H3_TRANSPORT_ERR_FINAL_SIZE = QUICHE_ERR_FINAL_SIZE - 1000,
 
-    // Error in QUIC transport congestion control.
+    // See QUICHE_ERR_CONGESTION_CONTROL.
     QUICHE_H3_TRANSPORT_ERR_CONGESTION_CONTROL = QUICHE_ERR_CONGESTION_CONTROL - 1000,
 };
 

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -413,7 +413,7 @@ impl Error {
             Error::FrameUnexpected => -9,
             Error::FrameError => -10,
             Error::QpackDecompressionFailed => -11,
-            Error::TransportError { .. } => -12,
+            // -12 was previously used for TransportError, skip it
             Error::StreamBlocked => -13,
             Error::SettingsError => -14,
             Error::RequestRejected => -15,
@@ -422,6 +422,8 @@ impl Error {
             Error::MessageError => -18,
             Error::ConnectError => -19,
             Error::VersionFallback => -20,
+
+            Error::TransportError(quic_error) => quic_error.to_c() - 1000,
         }
     }
 }


### PR DESCRIPTION
An HTTP/3 operation might fail due to a transport-related reason. This
usually happens if a stream write can't occur because the peer stopped
it. This should be expected behaviour and not a critical error for
applications. In Rust, the quiche::h3::Error::TransportError
encapsulates the underlying QUIC error, so applications can match only
quiche::Error and swallow certain types. In contrast, the FFI interface
collapses all HTTP/3 transport-related errors into a single value,
preventing FFI-based applications from being able to also swallow.

This change exposes the encapsulated QUIC transport errors to the FFI by
applying a simple numerical shift to the QUIC error codes.
