### PR TITLE
h3: change priority type to byte array and use sfv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.53 as build
+FROM rust:1.54 as build
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ is disabled by default), by passing ``--features ffi`` to ``cargo``.
 Building
 --------
 
-quiche requires Rust 1.53 or later to build. The latest stable Rust release can
+quiche requires Rust 1.54 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -19,6 +19,7 @@ boringssl-boring-crate = ["quiche/boringssl-boring-crate"]
 sfv = ["quiche/sfv"]
 
 default = ["qlog", "sfv"]
+
 [dependencies]
 docopt = "1"
 env_logger = "0.6"

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -15,8 +15,10 @@ qlog = ["quiche/qlog"]
 # Use BoringSSL provided by the boring crate.
 boringssl-boring-crate = ["quiche/boringssl-boring-crate"]
 
-default = ["qlog"]
+# Enable sfv support.
+sfv = ["quiche/sfv"]
 
+default = ["qlog", "sfv"]
 [dependencies]
 docopt = "1"
 env_logger = "0.6"

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -62,6 +62,7 @@ octets = { version = "0.1", path = "../octets" }
 boring = { version = "2.0.0", optional = true }
 foreign-types-shared = { version = "0.3.0", optional = true }
 qlog = { version = "0.6", path = "../qlog", optional = true }
+sfv = { version = "0.9", optional = true }
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3", features = ["wincrypt"] }

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -798,7 +798,7 @@ ssize_t quiche_h3_send_body(quiche_h3_conn *conn, quiche_conn *quic_conn,
 ssize_t quiche_h3_recv_body(quiche_h3_conn *conn, quiche_conn *quic_conn,
                             uint64_t stream_id, uint8_t *out, size_t out_len);
 
-// Try to parse Extensible Priority field value.
+// Try to parse an Extensible Priority field value.
 int quiche_h3_parse_extensible_priority(uint8_t *priority,
                                             size_t priority_len,
                                             quiche_h3_priority *parsed);

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -768,6 +768,7 @@ typedef struct {
     size_t value_len;
 } quiche_h3_header;
 
+// Extensible Priorities parameters.
 typedef struct {
     uint8_t urgency;
     bool incremental;
@@ -800,8 +801,8 @@ ssize_t quiche_h3_recv_body(quiche_h3_conn *conn, quiche_conn *quic_conn,
 
 // Try to parse an Extensible Priority field value.
 int quiche_h3_parse_extensible_priority(uint8_t *priority,
-                                            size_t priority_len,
-                                            quiche_h3_priority *parsed);
+                                        size_t priority_len,
+                                        quiche_h3_priority *parsed);
 
 // Returns whether the peer enabled HTTP/3 DATAGRAM frame support.
 bool quiche_h3_dgram_enabled_by_peer(quiche_h3_conn *conn,

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -768,6 +768,11 @@ typedef struct {
     size_t value_len;
 } quiche_h3_header;
 
+typedef struct {
+    uint8_t urgency;
+    bool incremental;
+} quiche_h3_priority;
+
 // Sends an HTTP/3 request.
 int64_t quiche_h3_send_request(quiche_h3_conn *conn, quiche_conn *quic_conn,
                                quiche_h3_header *headers, size_t headers_len,
@@ -782,7 +787,7 @@ int quiche_h3_send_response(quiche_h3_conn *conn, quiche_conn *quic_conn,
 int quiche_h3_send_response_with_priority(quiche_h3_conn *conn,
                             quiche_conn *quic_conn, uint64_t stream_id,
                             quiche_h3_header *headers, size_t headers_len,
-                            const char *priority, bool fin);
+                            quiche_h3_priority *priority, bool fin);
 
 // Sends an HTTP/3 body chunk on the given stream.
 ssize_t quiche_h3_send_body(quiche_h3_conn *conn, quiche_conn *quic_conn,
@@ -792,6 +797,11 @@ ssize_t quiche_h3_send_body(quiche_h3_conn *conn, quiche_conn *quic_conn,
 // Reads request or response body data into the provided buffer.
 ssize_t quiche_h3_recv_body(quiche_h3_conn *conn, quiche_conn *quic_conn,
                             uint64_t stream_id, uint8_t *out, size_t out_len);
+
+// Try to parse Extensible Priority field value.
+int quiche_h3_parse_extensible_priority(uint8_t *priority,
+                                            size_t priority_len,
+                                            quiche_h3_priority *parsed);
 
 // Returns whether the peer enabled HTTP/3 DATAGRAM frame support.
 bool quiche_h3_dgram_enabled_by_peer(quiche_h3_conn *conn,

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -279,6 +279,9 @@
 
 use std::collections::VecDeque;
 
+#[cfg(feature = "sfv")]
+use std::convert::TryFrom;
+
 /// List of ALPN tokens of supported HTTP/3 versions.
 ///
 /// This can be passed directly to the [`Config::set_application_protos()`]
@@ -290,6 +293,14 @@ pub const APPLICATION_PROTOCOL: &[u8] = b"\x02h3\x05h3-29\x05h3-28\x05h3-27";
 
 // The offset used when converting HTTP/3 urgency to quiche urgency.
 const PRIORITY_URGENCY_OFFSET: u8 = 124;
+
+// Parameter values as specified in [Extensible Priorities].
+//
+// [Extensible Priorities]: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-priority-12#section-4.
+const PRIORITY_URGENCY_LOWER_BOUND: u8 = 0;
+const PRIORITY_URGENCY_UPPER_BOUND: u8 = 7;
+const PRIORITY_URGENCY_DEFAULT: u8 = 3;
+const PRIORITY_INCREMENTAL_DEFAULT: bool = false;
 
 /// A specialized [`Result`] type for quiche HTTP/3 operations.
 ///
@@ -603,6 +614,98 @@ pub enum Event {
     GoAway,
 }
 
+/// Extensible Priorities parameters.
+#[derive(Debug, PartialEq)]
+#[repr(C)]
+pub struct Priority {
+    urgency: u8,
+    incremental: bool,
+}
+
+impl Default for Priority {
+    fn default() -> Self {
+        Priority {
+            urgency: PRIORITY_URGENCY_DEFAULT as u8,
+            incremental: PRIORITY_INCREMENTAL_DEFAULT,
+        }
+    }
+}
+
+impl Priority {
+    /// Creates a new Priority.
+    pub fn new(urgency: u8, incremental: bool) -> Self {
+        Priority {
+            urgency,
+            incremental,
+        }
+    }
+}
+
+#[cfg(feature = "sfv")]
+impl TryFrom<&[u8]> for Priority {
+    type Error = crate::h3::Error;
+
+    /// Try to parse Extensible Priority field value.
+    ///
+    /// The field value is expected to be a Structured Fields Dictionary; see
+    /// [Extensible Priorities].
+    ///
+    /// If the `u` or `i` fields are contained with correct types, a constructed
+    /// Priority object is returned. Note that urgency values outside of valid
+    /// range (0 through 7) are clamped to 7.
+    ///
+    /// If the `u` or `i` fields are contained with the wrong types,
+    /// Error::Done is returned.
+    ///
+    /// Omitted parameters will yield default values.
+    ///
+    /// [Extensible Priorities]: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-priority-12#section-4.
+    fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
+        let dict = match sfv::Parser::parse_dictionary(value) {
+            Ok(v) => v,
+
+            Err(_) => return Err(Error::Done),
+        };
+
+        let urgency = match dict.get("u") {
+            // If there is a u parameter, try to read it as an Item of type
+            // Integer. If the value out of the spec's allowed range
+            // (0 through 7), that's an error so set it to the upper
+            // bound (lowest priority) to avoid interference with
+            // other streams.
+            Some(sfv::ListEntry::Item(item)) => match item.bare_item.as_int() {
+                Some(v) => {
+                    if !(PRIORITY_URGENCY_LOWER_BOUND as i64..=
+                        PRIORITY_URGENCY_UPPER_BOUND as i64)
+                        .contains(&v)
+                    {
+                        PRIORITY_URGENCY_UPPER_BOUND
+                    } else {
+                        v as u8
+                    }
+                },
+
+                None => return Err(Error::Done),
+            },
+
+            Some(sfv::ListEntry::InnerList(_)) => return Err(Error::Done),
+
+            // Omitted so use default value.
+            None => PRIORITY_URGENCY_DEFAULT,
+        };
+
+        let incremental = match dict.get("i") {
+            Some(sfv::ListEntry::Item(item)) =>
+                item.bare_item.as_bool().ok_or(Error::Done)?,
+
+            // Omitted so use default value.
+            _ => false,
+        };
+
+        Ok(Priority::new(urgency as u8, incremental))
+    }
+}
+
 struct ConnectionSettings {
     pub max_field_section_size: Option<u64>,
     pub qpack_max_table_capacity: Option<u64>,
@@ -823,10 +926,10 @@ impl Connection {
         &mut self, conn: &mut super::Connection, stream_id: u64, headers: &[T],
         fin: bool,
     ) -> Result<()> {
-        let priority = "u=3";
+        let priority = Default::default();
 
         self.send_response_with_priority(
-            conn, stream_id, headers, priority, fin,
+            conn, stream_id, headers, &priority, fin,
         )?;
 
         Ok(())
@@ -835,56 +938,32 @@ impl Connection {
     /// Sends an HTTP/3 response on the specified stream with specified
     /// priority.
     ///
+    /// The `priority` parameter represents [Extensible Priority]
+    /// parameters. If the urgency is outside the range 0-7, it will be clamped
+    /// to 7.
+    ///
     /// The [`StreamBlocked`] error is returned when the underlying QUIC stream
     /// doesn't have enough capacity for the operation to complete. When this
     /// happens the application should retry the operation once the stream is
     /// reported as writable again.
     ///
     /// [`StreamBlocked`]: enum.Error.html#variant.StreamBlocked
+    /// [Extensible Priority]: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-priority-12#section-4.
     pub fn send_response_with_priority<T: NameValue>(
         &mut self, conn: &mut super::Connection, stream_id: u64, headers: &[T],
-        priority: &str, fin: bool,
+        priority: &Priority, fin: bool,
     ) -> Result<()> {
         if !self.streams.contains_key(&stream_id) {
             return Err(Error::FrameUnexpected);
         }
 
-        let mut urgency = 3u8.saturating_add(PRIORITY_URGENCY_OFFSET);
-        let mut incremental = false;
+        // Clamp and shift urgency into quiche-priority space
+        let urgency = priority
+            .urgency
+            .clamp(PRIORITY_URGENCY_LOWER_BOUND, PRIORITY_URGENCY_UPPER_BOUND) +
+            PRIORITY_URGENCY_OFFSET;
 
-        for param in priority.split(',') {
-            if param.trim() == "i" {
-                incremental = true;
-                continue;
-            }
-
-            if param.trim().starts_with("u=") {
-                // u is an sh-integer (an i64) but it has a constrained range of
-                // 0-7. So detect anything outside that range and clamp it to
-                // the lowest urgency in order to avoid it interfering with
-                // valid items.
-                //
-                // TODO: this also detects when u is not an sh-integer and
-                // clamps it in the same way. A real structured header parser
-                // would actually fail to parse.
-                let mut u = param
-                    .rsplit('=')
-                    .next()
-                    .unwrap()
-                    .parse::<i64>()
-                    .unwrap_or(7);
-
-                if !(0..=7).contains(&u) {
-                    u = 7;
-                }
-
-                // The HTTP/3 urgency needs to be shifted into the quiche
-                // urgency range.
-                urgency = (u as u8).saturating_add(PRIORITY_URGENCY_OFFSET);
-            }
-        }
-
-        conn.stream_priority(stream_id, urgency, incremental)?;
+        conn.stream_priority(stream_id, urgency, priority.incremental)?;
 
         self.send_headers(conn, stream_id, headers, fin)?;
 
@@ -3146,6 +3225,92 @@ mod tests {
         assert_eq!(s.poll_client(), Ok((0, Event::GoAway)));
 
         assert_eq!(s.poll_client(), Err(Error::IdError));
+    }
+
+    #[test]
+    #[cfg(feature = "sfv")]
+    fn parse_priority_field_value() {
+        // Legal dicts
+        assert_eq!(
+            Ok(Priority::new(0, false)),
+            Priority::try_from(b"u=0".as_slice())
+        );
+        assert_eq!(
+            Ok(Priority::new(3, false)),
+            Priority::try_from(b"u=3".as_slice())
+        );
+        assert_eq!(
+            Ok(Priority::new(7, false)),
+            Priority::try_from(b"u=7".as_slice())
+        );
+
+        assert_eq!(
+            Ok(Priority::new(0, true)),
+            Priority::try_from(b"u=0, i".as_slice())
+        );
+        assert_eq!(
+            Ok(Priority::new(3, true)),
+            Priority::try_from(b"u=3, i".as_slice())
+        );
+        assert_eq!(
+            Ok(Priority::new(7, true)),
+            Priority::try_from(b"u=7, i".as_slice())
+        );
+
+        assert_eq!(
+            Ok(Priority::new(0, true)),
+            Priority::try_from(b"u=0, i=?1".as_slice())
+        );
+        assert_eq!(
+            Ok(Priority::new(3, true)),
+            Priority::try_from(b"u=3, i=?1".as_slice())
+        );
+        assert_eq!(
+            Ok(Priority::new(7, true)),
+            Priority::try_from(b"u=7, i=?1".as_slice())
+        );
+
+        assert_eq!(
+            Ok(Priority::new(3, false)),
+            Priority::try_from(b"".as_slice())
+        );
+
+        assert_eq!(
+            Ok(Priority::new(0, true)),
+            Priority::try_from(b"u=0;foo, i;bar".as_slice())
+        );
+        assert_eq!(
+            Ok(Priority::new(3, true)),
+            Priority::try_from(b"u=3;hello, i;world".as_slice())
+        );
+        assert_eq!(
+            Ok(Priority::new(7, true)),
+            Priority::try_from(b"u=7;croeso, i;gymru".as_slice())
+        );
+
+        assert_eq!(
+            Ok(Priority::new(0, true)),
+            Priority::try_from(b"u=0, i, spinaltap=11".as_slice())
+        );
+
+        // Illegal formats
+        assert_eq!(Err(Error::Done), Priority::try_from(b"0".as_slice()));
+        assert_eq!(
+            Ok(Priority::new(7, false)),
+            Priority::try_from(b"u=-1".as_slice())
+        );
+        assert_eq!(Err(Error::Done), Priority::try_from(b"u=0.2".as_slice()));
+        assert_eq!(
+            Ok(Priority::new(7, false)),
+            Priority::try_from(b"u=100".as_slice())
+        );
+        assert_eq!(
+            Err(Error::Done),
+            Priority::try_from(b"u=3, i=true".as_slice())
+        );
+
+        // Trailing comma in dict is malformed
+        assert_eq!(Err(Error::Done), Priority::try_from(b"u=7, ".as_slice()));
     }
 
     #[test]

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -615,6 +615,11 @@ pub enum Event {
 }
 
 /// Extensible Priorities parameters.
+///
+/// The `TryFrom` trait supports constructing this object from the serialized
+/// Structured Fields Dictionary field value. I.e, use `TryFrom` to parse the
+/// value of a Priority header field or a PRIORITY_UPDATE frame. Using this
+/// trait requires the `sfv` feature to be enabled.
 #[derive(Debug, PartialEq)]
 #[repr(C)]
 pub struct Priority {
@@ -646,7 +651,7 @@ impl Priority {
 impl TryFrom<&[u8]> for Priority {
     type Error = crate::h3::Error;
 
-    /// Try to parse Extensible Priority field value.
+    /// Try to parse an Extensible Priority field value.
     ///
     /// The field value is expected to be a Structured Fields Dictionary; see
     /// [Extensible Priorities].

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -642,6 +642,7 @@ impl Priority {
 }
 
 #[cfg(feature = "sfv")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sfv")))]
 impl TryFrom<&[u8]> for Priority {
     type Error = crate::h3::Error;
 


### PR DESCRIPTION
h3: change priority type and add optional parser

The `quiche::h3::send_response_with_priority()` method allows
applications to specify a stream priority that is used by quiche's
stream prioritization.

Previously, the priority was passed as a String value that was expected
to contain Extensible Priority parameters in a serialized Structured
Fields Dictionary format; see
https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-priority-12#section-4.
Internally, the String was manually parsed to extract the "u" and "i"
parameters.

With this change, we convert the priority parameter from a String to a
new `quiche::h3::Priority` type that holds only the parameters we use
inside quiche. Applications are now required to handle Extensible
Priorities field values themselves. A `TryFrom<&[u8]>` trait
implementation can be used by applications for parsing the serialized
format NB: in the C API, the equivalent is the
`parse_extensible_priority()` method. This relies on the sfv crate,
which can be included as an optional dependency for quiche (and thus
controlled via features). sfv offers a Structured Fields compliant
parser, if it fails to read the expected Extensible Priority format, an
error is returned. If the format is ok but values are outside the
allowed range, they get clamped. Using sfv already caught a few bugs in
the old approach and I've added test cases for those.