### PR TITLE
delivery rate estimation: draft 01

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -5553,6 +5553,11 @@ pub struct Stats {
     pub pmtu: usize,
 
     /// The most recent data delivery rate estimate in bytes/s.
+    ///
+    /// Note that this value could be inaccurate if the application does not
+    /// respect pacing hints (see [`SendInfo.at`]).
+    ///
+    /// [`SendInfo.at`]: struct.SendInfo.html#structfield.at
     pub delivery_rate: u64,
 
     /// The maximum idle timeout.

--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -482,7 +482,7 @@ mod tests {
             in_flight: true,
             delivered: 0,
             delivered_time: now,
-            recent_delivered_packet_sent_time: now,
+            first_sent_time: now,
             is_app_limited: false,
             has_data: false,
         };
@@ -498,6 +498,11 @@ mod tests {
             pkt_num: p.pkt_num,
             time_sent: p.time_sent,
             size: p.size,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            rtt: Duration::ZERO,
         }];
 
         r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
@@ -525,7 +530,7 @@ mod tests {
             in_flight: true,
             delivered: 0,
             delivered_time: now,
-            recent_delivered_packet_sent_time: now,
+            first_sent_time: now,
             is_app_limited: false,
             has_data: false,
         };
@@ -542,16 +547,31 @@ mod tests {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             },
             Acked {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             },
             Acked {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             },
         ];
 
@@ -626,6 +646,11 @@ mod tests {
                 pkt_num: 0,
                 time_sent: now,
                 size: r.max_datagram_size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             }];
 
             r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
@@ -666,6 +691,11 @@ mod tests {
             // To exit from recovery
             time_sent: now + Duration::from_millis(1),
             size: r.max_datagram_size,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            rtt: Duration::ZERO,
         }];
 
         r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
@@ -698,7 +728,7 @@ mod tests {
             in_flight: true,
             delivered: 0,
             delivered_time: now,
-            recent_delivered_packet_sent_time: now,
+            first_sent_time: now,
             is_app_limited: false,
             has_data: false,
         };
@@ -727,6 +757,11 @@ mod tests {
                 pkt_num: ack_pn,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             }];
 
             r.on_packets_acked(acked, epoch, now);
@@ -759,6 +794,11 @@ mod tests {
                 pkt_num: ack_pn,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             }];
 
             r.on_packets_acked(acked, epoch, now);
@@ -794,6 +834,11 @@ mod tests {
                 pkt_num: ack_pn,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             }];
 
             r.on_packets_acked(acked, epoch, now);
@@ -831,7 +876,7 @@ mod tests {
             in_flight: true,
             delivered: 0,
             delivered_time: now,
-            recent_delivered_packet_sent_time: now,
+            first_sent_time: now,
             is_app_limited: false,
             has_data: false,
         };
@@ -860,6 +905,11 @@ mod tests {
                 pkt_num: ack_pn,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             }];
 
             r.on_packets_acked(acked, epoch, now);
@@ -892,6 +942,11 @@ mod tests {
                 pkt_num: ack_pn,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             }];
 
             r.on_packets_acked(acked, epoch, now);
@@ -925,6 +980,11 @@ mod tests {
                     pkt_num: ack_pn,
                     time_sent: p.time_sent,
                     size: p.size,
+                    delivered: 0,
+                    delivered_time: now,
+                    first_sent_time: now,
+                    is_app_limited: false,
+                    rtt: Duration::ZERO,
                 }];
 
                 r.on_packets_acked(acked, epoch, now);
@@ -969,6 +1029,11 @@ mod tests {
             // To exit from recovery
             time_sent: now + rtt,
             size: r.max_datagram_size,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            rtt: Duration::ZERO,
         }];
 
         // Ack more than cwnd bytes with rtt=100ms
@@ -1006,6 +1071,11 @@ mod tests {
             // To exit from recovery
             time_sent: now + rtt,
             size: r.max_datagram_size,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            rtt: Duration::ZERO,
         }];
 
         // Ack more than cwnd bytes with rtt=100ms.
@@ -1065,6 +1135,11 @@ mod tests {
                 pkt_num: 0,
                 time_sent: now,
                 size: r.max_datagram_size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             }];
 
             r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -214,7 +214,7 @@ mod tests {
             in_flight: true,
             delivered: 0,
             delivered_time: std::time::Instant::now(),
-            recent_delivered_packet_sent_time: std::time::Instant::now(),
+            first_sent_time: std::time::Instant::now(),
             is_app_limited: false,
             has_data: false,
         };
@@ -230,6 +230,11 @@ mod tests {
             pkt_num: p.pkt_num,
             time_sent: p.time_sent,
             size: p.size,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            rtt: Duration::ZERO,
         }];
 
         r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
@@ -258,7 +263,7 @@ mod tests {
             in_flight: true,
             delivered: 0,
             delivered_time: std::time::Instant::now(),
-            recent_delivered_packet_sent_time: std::time::Instant::now(),
+            first_sent_time: std::time::Instant::now(),
             is_app_limited: false,
             has_data: false,
         };
@@ -275,16 +280,31 @@ mod tests {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             },
             Acked {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             },
             Acked {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
                 size: p.size,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                rtt: Duration::ZERO,
             },
         ];
 
@@ -349,6 +369,11 @@ mod tests {
             time_sent: now + rtt,
             // More than cur_cwnd to increase cwnd
             size: 8000,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            rtt: Duration::ZERO,
         }];
 
         // Ack more than cwnd bytes with rtt=100ms


### PR DESCRIPTION
- Update delivery rate implementation to draft 01.
- Major rework on delivery rate estimation.
- `estimate()` is removed - it will be done in `generate_rate_sample()` after calling `update_rate_sample()` in each ack, as specified in the draft.
- Rate estimation is only checked in Application packet number space.
 - Expose some functions for later use, such as
   `recovery.delivery_rate.app_limited()` returns `C.app_limited != 0`,
   `recovery.delivery_rate._delivered()` returns `rs.delivered`,
   `recovery.delivery_rate.sample_is_app_limited()` returns `rs.is_app_limited`.
- `C.app_limited`: now we use the packet number instead of the byte
    range. `largest_acked` and `last_sent_packet` is added for
    tracking packet number. This is used for rate sample and
    separately from `recovery.app_limited`.
- Custom debug fmt() is removed and use a default Debug trait.
- Tests are rewritten.

TODOs
- [x] fix app_limited
- [x] update test