### PR TITLE
Make qlog packet event logging atomic

### DIFF
--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -281,64 +281,10 @@
 //! streamer.start_log().ok();
 //! ```
 //!
-//! ### Adding simple events
+//! ### Adding events
 //!
-//! Once logging has started you can stream events. Simple events
-//! can be written in one step using [`add_event()`]:
-//!
-//! ```
-//! # let mut trace = qlog::TraceSeq::new(
-//! #    qlog::VantagePoint {
-//! #        name: Some("Example client".to_string()),
-//! #        ty: qlog::VantagePointType::Client,
-//! #        flow: None,
-//! #    },
-//! #    Some("Example qlog trace".to_string()),
-//! #    Some("Example qlog trace description".to_string()),
-//! #    Some(qlog::Configuration {
-//! #        time_offset: Some(0.0),
-//! #        original_uris: None,
-//! #    }),
-//! #    None,
-//! # );
-//! # let mut file = std::fs::File::create("foo.qlog").unwrap();
-//! # let mut streamer = qlog::streamer::QlogStreamer::new(
-//! #     qlog::QLOG_VERSION.to_string(),
-//! #     Some("Example qlog".to_string()),
-//! #     Some("Example qlog description".to_string()),
-//! #     None,
-//! #     std::time::Instant::now(),
-//! #     trace,
-//! #     qlog::events::EventImportance::Base,
-//! #     Box::new(file),
-//! # );
-//! let event_data = qlog::events::EventData::MetricsUpdated(
-//!     qlog::events::quic::MetricsUpdated {
-//!         min_rtt: Some(1.0),
-//!         smoothed_rtt: Some(1.0),
-//!         latest_rtt: Some(1.0),
-//!         rtt_variance: Some(1.0),
-//!         pto_count: Some(1),
-//!         congestion_window: Some(1234),
-//!         bytes_in_flight: Some(5678),
-//!         ssthresh: None,
-//!         packets_in_flight: None,
-//!         pacing_rate: None,
-//!     },
-//! );
-//!
-//! let event = qlog::events::Event::with_time(0.0, event_data);
-//! streamer.add_event(event).ok();
-//! ```
-//!
-//! ### Adding events with frames
-//! Some events contain optional arrays of QUIC frames. If the
-//! event has `Some(Vec<QuicFrame>)`, even if it is empty, the
-//! streamer enters a frame serializing mode that must be
-//! finalized before other events can be logged.
-//!
-//! In this example, a `PacketSent` event is created with an
-//! empty frame array and frames are written out later:
+//! Once logging has started you can stream events. Events
+//! are written in one step using [`add_event()`]:
 //!
 //! ```
 //! # let mut trace = qlog::TraceSeq::new(
@@ -378,10 +324,13 @@
 //!     Some(&dcid),
 //! );
 //!
+//! let ping = qlog::events::quic::QuicFrame::Ping;
+//! let padding = qlog::events::quic::QuicFrame::Padding;
+//!
 //! let event_data =
 //!     qlog::events::EventData::PacketSent(qlog::events::quic::PacketSent {
 //!         header: pkt_hdr,
-//!         frames: Some(vec![]),
+//!         frames: Some(vec![ping, padding]),
 //!         is_coalesced: None,
 //!         retry_token: None,
 //!         stateless_reset_token: None,
@@ -393,47 +342,6 @@
 //! let event = qlog::events::Event::with_time(0.0, event_data);
 //!
 //! streamer.add_event(event).ok();
-//! ```
-//!
-//! In this example, the frames contained in the QUIC packet
-//! are PING and PADDING. Each frame is written using the
-//! [`add_frame()`] method. Frame writing is concluded with
-//! [`finish_frames()`].
-//!
-//! ```
-//! # let mut trace = qlog::TraceSeq::new(
-//! #    qlog::VantagePoint {
-//! #        name: Some("Example client".to_string()),
-//! #        ty: qlog::VantagePointType::Client,
-//! #        flow: None,
-//! #    },
-//! #    Some("Example qlog trace".to_string()),
-//! #    Some("Example qlog trace description".to_string()),
-//! #    Some(qlog::Configuration {
-//! #        time_offset: Some(0.0),
-//! #        original_uris: None,
-//! #    }),
-//! #    None,
-//! # );
-//! # let mut file = std::fs::File::create("foo.qlog").unwrap();
-//! # let mut streamer = qlog::streamer::QlogStreamer::new(
-//! #     qlog::QLOG_VERSION.to_string(),
-//! #     Some("Example qlog".to_string()),
-//! #     Some("Example qlog description".to_string()),
-//! #     None,
-//! #     std::time::Instant::now(),
-//! #     trace,
-//! #     qlog::events::EventImportance::Base,
-//! #     Box::new(file),
-//! # );
-//!
-//! let ping = qlog::events::quic::QuicFrame::Ping;
-//! let padding = qlog::events::quic::QuicFrame::Padding;
-//!
-//! streamer.add_frame(ping, false).ok();
-//! streamer.add_frame(padding, false).ok();
-//!
-//! streamer.finish_frames().ok();
 //! ```
 //!
 //! Once all events have have been written, the log

--- a/qlog/src/streamer.rs
+++ b/qlog/src/streamer.rs
@@ -24,7 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::events::quic::QuicFrame;
 use crate::events::EventData;
 use crate::events::EventImportance;
 use crate::events::EventType;
@@ -36,12 +35,7 @@ use crate::events::EventType;
 /// provided `Trace`.
 ///
 /// Serialization is progressively driven by method calls; once log streaming
-/// is started, `event::Events` can be written using `add_event()`. Some
-/// events can contain an array of `QuicFrame`s, when writing such an event,
-/// the streamer enters a frame-serialization mode where frames are be
-/// progressively written using `add_frame()`. This mode is concluded using
-/// `finished_frames()`. While serializing frames, any attempts to log
-/// additional events are ignored.
+/// is started, `event::Events` can be written using `add_event()`.
 ///
 /// [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 use super::*;
@@ -50,7 +44,6 @@ use super::*;
 pub enum StreamerState {
     Initial,
     Ready,
-    WritingFrames,
     Finished,
 }
 
@@ -60,7 +53,6 @@ pub struct QlogStreamer {
     qlog: QlogSeq,
     state: StreamerState,
     log_level: EventImportance,
-    first_frame: bool,
 }
 
 impl QlogStreamer {
@@ -93,7 +85,6 @@ impl QlogStreamer {
             qlog,
             state: StreamerState::Initial,
             log_level,
-            first_frame: false,
         }
     }
 
@@ -136,14 +127,7 @@ impl QlogStreamer {
     }
 
     /// Writes a JSON-serialized `Event` using `std::time::Instant::now()`.
-    ///
-    /// Some qlog events can contain `QuicFrames`. If this is detected `true` is
-    /// returned and the streamer enters a frame-serialization mode that is only
-    /// concluded by `finish_frames()`. In this mode, attempts to log additional
-    /// events are ignored.
-    ///
-    /// If the event contains no array of `QuicFrames` return `false`.
-    pub fn add_event_now(&mut self, event: Event) -> Result<bool> {
+    pub fn add_event_now(&mut self, event: Event) -> Result<()> {
         let now = std::time::Instant::now();
 
         self.add_event_with_instant(event, now)
@@ -151,16 +135,9 @@ impl QlogStreamer {
 
     /// Writes a JSON-serialized `Event` using the provided EventData and
     /// Instant.
-    ///
-    /// Some qlog events can contain `QuicFrames`. If this is detected `true` is
-    /// returned and the streamer enters a frame-serialization mode that is only
-    /// concluded by `finish_frames()`. In this mode, attempts to log additional
-    /// events are ignored.
-    ///
-    /// If the event contains no array of `QuicFrames` return `false`.
     pub fn add_event_with_instant(
         &mut self, mut event: Event, now: std::time::Instant,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         if self.state != StreamerState::Ready {
             return Err(Error::InvalidState);
         }
@@ -191,7 +168,7 @@ impl QlogStreamer {
     /// If the event contains no array of `QuicFrames` return `false`.
     pub fn add_event_data_with_instant(
         &mut self, event_data: EventData, now: std::time::Instant,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         if self.state != StreamerState::Ready {
             return Err(Error::InvalidState);
         }
@@ -221,7 +198,7 @@ impl QlogStreamer {
     /// events are ignored.
     ///
     /// If the event contains no array of `QuicFrames` return `false`.
-    pub fn add_event(&mut self, event: Event) -> Result<bool> {
+    pub fn add_event(&mut self, event: Event) -> Result<()> {
         if self.state != StreamerState::Ready {
             return Err(Error::InvalidState);
         }
@@ -231,78 +208,9 @@ impl QlogStreamer {
         }
 
         self.writer.as_mut().write_all(b"")?;
-
-        match event.data.contains_quic_frames() {
-            // If the event contains frames, we need to remove the closing JSON
-            // delimiters before writing out. These will be later restored by
-            // `finish_frames()`.
-            Some(frames_count) => {
-                match serde_json::to_string(&event) {
-                    Ok(mut ev_out) => {
-                        ev_out.truncate(ev_out.len() - 3);
-
-                        if frames_count == 0 {
-                            self.first_frame = true;
-                        }
-
-                        self.writer.as_mut().write_all(ev_out.as_bytes())?;
-                    },
-
-                    _ => return Err(Error::Done),
-                }
-
-                self.state = StreamerState::WritingFrames;
-            },
-
-            // If the event does not contain frames, it can be written
-            // immediately in full.
-            None => {
-                serde_json::to_writer(self.writer.as_mut(), &event)
-                    .map_err(|_| Error::Done)?;
-                self.writer.as_mut().write_all(b"\n")?;
-
-                self.state = StreamerState::Ready
-            },
-        }
-
-        Ok(event.data.contains_quic_frames().is_some())
-    }
-
-    /// Writes a JSON-serialized `QuicFrame`.
-    ///
-    /// Only valid while in the frame-serialization mode.
-    pub fn add_frame(&mut self, frame: QuicFrame, last: bool) -> Result<()> {
-        if self.state != StreamerState::WritingFrames {
-            return Err(Error::InvalidState);
-        }
-
-        if !self.first_frame {
-            self.writer.as_mut().write_all(b",")?;
-        } else {
-            self.first_frame = false;
-        }
-
-        serde_json::to_writer(self.writer.as_mut(), &frame)
+        serde_json::to_writer(self.writer.as_mut(), &event)
             .map_err(|_| Error::Done)?;
-
-        if last {
-            self.finish_frames()?;
-        }
-
-        Ok(())
-    }
-
-    /// Concludes `QuicFrame` streaming serialization.
-    ///
-    /// Only valid while in the frame-serialization mode.
-    pub fn finish_frames(&mut self) -> Result<()> {
-        if self.state != StreamerState::WritingFrames {
-            return Err(Error::InvalidState);
-        }
-
-        self.writer.as_mut().write_all(b"]}}\n")?;
-
-        self.state = StreamerState::Ready;
+        self.writer.as_mut().write_all(b"\n")?;
 
         Ok(())
     }
@@ -318,6 +226,7 @@ impl QlogStreamer {
 mod tests {
     use super::*;
     use crate::events::quic;
+    use crate::events::quic::QuicFrame;
     use crate::events::RawInfo;
     use testing::*;
 
@@ -374,7 +283,7 @@ mod tests {
 
         let event_data2 = EventData::PacketSent(quic::PacketSent {
             header: pkt_hdr.clone(),
-            frames: Some(vec![]),
+            frames: Some(vec![frame2]),
             is_coalesced: None,
             retry_token: None,
             stateless_reset_token: None,
@@ -387,7 +296,7 @@ mod tests {
 
         let event_data3 = EventData::PacketSent(quic::PacketSent {
             header: pkt_hdr,
-            frames: Some(vec![]),
+            frames: Some(vec![frame3]),
             is_coalesced: None,
             retry_token: None,
             stateless_reset_token: Some("reset_token".to_string()),
@@ -411,52 +320,22 @@ mod tests {
 
         // Before the log is started all other operations should fail.
         assert!(matches!(s.add_event(ev2.clone()), Err(Error::InvalidState)));
-        assert!(matches!(
-            s.add_frame(frame2.clone(), false),
-            Err(Error::InvalidState)
-        ));
-        assert!(matches!(s.finish_frames(), Err(Error::InvalidState)));
         assert!(matches!(s.finish_log(), Err(Error::InvalidState)));
 
-        // Once a log is started, can't write frames before an event.
+        // Start log and add a simple event.
         assert!(matches!(s.start_log(), Ok(())));
-        assert!(matches!(
-            s.add_frame(frame2.clone(), false),
-            Err(Error::InvalidState)
-        ));
-        assert!(matches!(s.finish_frames(), Err(Error::InvalidState)));
+        assert!(matches!(s.add_event(ev1), Ok(())));
 
-        // Initiate log with simple event.
-        assert!(matches!(s.add_event(ev1), Ok(true)));
-        assert!(matches!(s.finish_frames(), Ok(())));
-
-        // Some events hold frames; can't write any more events until frame
-        // writing is concluded.
-        assert!(matches!(s.add_event(ev2.clone()), Ok(true)));
-        assert!(matches!(s.add_event(ev2.clone()), Err(Error::InvalidState)));
-
-        // While writing frames, can't write events.
-        assert!(matches!(s.add_frame(frame2.clone(), false), Ok(())));
-        assert!(matches!(s.add_event(ev2.clone()), Err(Error::InvalidState)));
-        assert!(matches!(s.finish_frames(), Ok(())));
-
-        // Adding an event that includes both frames and raw data should
-        // be allowed.
-        assert!(matches!(s.add_event(ev3.clone()), Ok(true)));
-        assert!(matches!(s.add_frame(frame3.clone(), false), Ok(())));
-        assert!(matches!(s.finish_frames(), Ok(())));
+        // Add some more events.
+        assert!(matches!(s.add_event(ev2), Ok(())));
+        assert!(matches!(s.add_event(ev3.clone()), Ok(())));
 
         // Adding an event with an external time should work too.
         // For tests, it will resolve to 0 but we care about proving the API
         // here, not timing specifics.
         let now = std::time::Instant::now();
 
-        assert!(matches!(
-            s.add_event_with_instant(ev3.clone(), now),
-            Ok(true)
-        ));
-        assert!(matches!(s.add_frame(frame3.clone(), false), Ok(())));
-        assert!(matches!(s.finish_frames(), Ok(())));
+        assert!(matches!(s.add_event_with_instant(ev3.clone(), now), Ok(())));
 
         assert!(matches!(s.finish_log(), Ok(())));
 

--- a/qlog/src/streamer.rs
+++ b/qlog/src/streamer.rs
@@ -164,8 +164,6 @@ impl QlogStreamer {
     /// returned and the streamer enters a frame-serialization mode that is only
     /// concluded by `finish_frames()`. In this mode, attempts to log additional
     /// events are ignored.
-    ///
-    /// If the event contains no array of `QuicFrames` return `false`.
     pub fn add_event_data_with_instant(
         &mut self, event_data: EventData, now: std::time::Instant,
     ) -> Result<()> {
@@ -196,8 +194,6 @@ impl QlogStreamer {
     /// returned and the streamer enters a frame-serialization mode that is only
     /// concluded by `finish_frames()`. In this mode, attempts to log additional
     /// events are ignored.
-    ///
-    /// If the event contains no array of `QuicFrames` return `false`.
     pub fn add_event(&mut self, event: Event) -> Result<()> {
         if self.state != StreamerState::Ready {
             return Err(Error::InvalidState);

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2213,7 +2213,7 @@ impl Connection {
         );
 
         #[cfg(feature = "qlog")]
-        let mut qlog_frames = self.qlog.streamer.as_ref().map(|_| vec![]);
+        let mut qlog_frames = vec![];
 
         let mut payload = packet::decrypt_pkt(
             &mut b,
@@ -2278,9 +2278,7 @@ impl Connection {
             let frame = frame::Frame::from_bytes(&mut payload, hdr.ty)?;
 
             qlog_with_type!(QLOG_PACKET_RX, self.qlog, _q, {
-                if let Some(frames) = &mut qlog_frames {
-                    frames.push(frame.to_qlog());
-                }
+                qlog_frames.push(frame.to_qlog());
             });
 
             if frame.ack_eliciting() {
@@ -2313,7 +2311,7 @@ impl Connection {
             let ev_data =
                 EventData::PacketReceived(qlog::events::quic::PacketReceived {
                     header: qlog_pkt_hdr,
-                    frames: Some(qlog_frames.unwrap_or_default()),
+                    frames: Some(qlog_frames),
                     is_coalesced: None,
                     retry_token: None,
                     stateless_reset_token: None,
@@ -3423,15 +3421,13 @@ impl Connection {
         );
 
         #[cfg(feature = "qlog")]
-        let mut qlog_frames = self.qlog.streamer.as_ref().map(|_| vec![]);
+        let mut qlog_frames = vec![];
 
         for frame in &mut frames {
             trace!("{} tx frm {:?}", self.trace_id, frame);
 
             qlog_with_type!(QLOG_PACKET_TX, self.qlog, _q, {
-                if let Some(frames) = &mut qlog_frames {
-                    frames.push(frame.to_qlog());
-                }
+                qlog_frames.push(frame.to_qlog());
             });
         }
 
@@ -3457,7 +3453,7 @@ impl Connection {
 
             let ev_data = EventData::PacketSent(qlog::events::quic::PacketSent {
                 header: qlog_pkt_hdr,
-                frames: Some(qlog_frames.unwrap_or_default()),
+                frames: Some(qlog_frames),
                 is_coalesced: None,
                 retry_token: None,
                 stateless_reset_token: None,

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3421,7 +3421,7 @@ impl Connection {
         );
 
         #[cfg(feature = "qlog")]
-        let mut qlog_frames = vec![];
+        let mut qlog_frames = Vec::with_capacity(frames.len());
 
         for frame in &mut frames {
             trace!("{} tx frm {:?}", self.trace_id, frame);

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2212,37 +2212,8 @@ impl Connection {
             pn
         );
 
-        qlog_with_type!(QLOG_PACKET_RX, self.qlog, q, {
-            let packet_size = b.len();
-
-            let qlog_pkt_hdr = qlog::events::quic::PacketHeader::with_type(
-                hdr.ty.to_qlog(),
-                pn,
-                Some(hdr.version),
-                Some(&hdr.scid),
-                Some(&hdr.dcid),
-            );
-
-            let qlog_raw_info = RawInfo {
-                length: Some(packet_size as u64),
-                payload_length: Some(payload_len as u64),
-                data: None,
-            };
-
-            let ev_data =
-                EventData::PacketReceived(qlog::events::quic::PacketReceived {
-                    header: qlog_pkt_hdr,
-                    frames: Some(vec![]),
-                    is_coalesced: None,
-                    retry_token: None,
-                    stateless_reset_token: None,
-                    supported_versions: None,
-                    raw: Some(qlog_raw_info),
-                    datagram_id: None,
-                });
-
-            q.add_event_data_with_instant(ev_data, now).ok();
-        });
+        #[cfg(feature = "qlog")]
+        let mut qlog_frames = self.qlog.streamer.as_ref().map(|_| vec![]);
 
         let mut payload = packet::decrypt_pkt(
             &mut b,
@@ -2299,12 +2270,17 @@ impl Connection {
         // ACK and PADDING.
         let mut ack_elicited = false;
 
-        // Process packet payload.
+        // Process packet payload. If a frame cannot be processed, store the
+        // error and stop further packet processing.
+        let mut frame_processing_err = None;
+
         while payload.cap() > 0 {
             let frame = frame::Frame::from_bytes(&mut payload, hdr.ty)?;
 
-            qlog_with_type!(QLOG_PACKET_RX, self.qlog, q, {
-                q.add_frame(frame.to_qlog(), false).ok();
+            qlog_with_type!(QLOG_PACKET_RX, self.qlog, _q, {
+                if let Some(frames) = &mut qlog_frames {
+                    frames.push(frame.to_qlog());
+                }
             });
 
             if frame.ack_eliciting() {
@@ -2312,18 +2288,41 @@ impl Connection {
             }
 
             if let Err(e) = self.process_frame(frame, epoch, now) {
-                qlog_with_type!(QLOG_PACKET_RX, self.qlog, q, {
-                    // Always conclude frame writing on error.
-                    q.finish_frames().ok();
-                });
-
-                return Err(e);
+                frame_processing_err = Some(e);
+                break;
             }
         }
 
         qlog_with_type!(QLOG_PACKET_RX, self.qlog, q, {
-            // Always conclude frame writing.
-            q.finish_frames().ok();
+            let packet_size = b.len();
+
+            let qlog_pkt_hdr = qlog::events::quic::PacketHeader::with_type(
+                hdr.ty.to_qlog(),
+                pn,
+                Some(hdr.version),
+                Some(&hdr.scid),
+                Some(&hdr.dcid),
+            );
+
+            let qlog_raw_info = RawInfo {
+                length: Some(packet_size as u64),
+                payload_length: Some(payload_len as u64),
+                data: None,
+            };
+
+            let ev_data =
+                EventData::PacketReceived(qlog::events::quic::PacketReceived {
+                    header: qlog_pkt_hdr,
+                    frames: Some(qlog_frames.unwrap_or_default()),
+                    is_coalesced: None,
+                    retry_token: None,
+                    stateless_reset_token: None,
+                    supported_versions: None,
+                    raw: Some(qlog_raw_info),
+                    datagram_id: None,
+                });
+
+            q.add_event_data_with_instant(ev_data, now).ok();
         });
 
         qlog_with_type!(QLOG_PACKET_RX, self.qlog, q, {
@@ -2331,6 +2330,11 @@ impl Connection {
                 q.add_event_data_with_instant(ev_data, now).ok();
             }
         });
+
+        if let Some(e) = frame_processing_err {
+            // Any frame error is terminal, so now just return.
+            return Err(e);
+        }
 
         // Only log the remote transport parameters once the connection is
         // established (i.e. after frames have been fully parsed) and only
@@ -3418,6 +3422,19 @@ impl Connection {
             pn
         );
 
+        #[cfg(feature = "qlog")]
+        let mut qlog_frames = self.qlog.streamer.as_ref().map(|_| vec![]);
+
+        for frame in &mut frames {
+            trace!("{} tx frm {:?}", self.trace_id, frame);
+
+            qlog_with_type!(QLOG_PACKET_TX, self.qlog, _q, {
+                if let Some(frames) = &mut qlog_frames {
+                    frames.push(frame.to_qlog());
+                }
+            });
+        }
+
         qlog_with_type!(QLOG_PACKET_TX, self.qlog, q, {
             let qlog_pkt_hdr = qlog::events::quic::PacketHeader::with_type(
                 hdr.ty.to_qlog(),
@@ -3440,7 +3457,7 @@ impl Connection {
 
             let ev_data = EventData::PacketSent(qlog::events::quic::PacketSent {
                 header: qlog_pkt_hdr,
-                frames: Some(vec![]),
+                frames: Some(qlog_frames.unwrap_or_default()),
                 is_coalesced: None,
                 retry_token: None,
                 stateless_reset_token: None,
@@ -3450,18 +3467,6 @@ impl Connection {
             });
 
             q.add_event_data_with_instant(ev_data, now).ok();
-        });
-
-        for frame in &mut frames {
-            trace!("{} tx frm {:?}", self.trace_id, frame);
-
-            qlog_with_type!(QLOG_PACKET_TX, self.qlog, q, {
-                q.add_frame(frame.to_qlog(), false).ok();
-            });
-        }
-
-        qlog_with_type!(QLOG_PACKET_TX, self.qlog, q, {
-            q.finish_frames().ok();
         });
 
         let aead = match self.pkt_num_spaces[epoch].crypto_seal {


### PR DESCRIPTION
When we switched from JSON to JSON-SEQ, we modified the qlog serializer but didn't change it's behaviour wrt QUIC Packet events (rx/tx). The old behaviour TL;DR was:

1. qlog streamer user passes streamer a packet event
2. Streamer writes out packet header information. Then it locks itself into frame writing mode.
2. While locked, no other events cand be written.
3. qlog streamer user passes 0 or more frames.
4. qlog streamer user finalizes frames write. Streamer unlocks itself.

There are a few downsides to that approach:

* Locking prevents other events being written. For example, while processing frames, any additional events would be ignored by the serializer. While callers could buffer events themselves and log them later, it adds complication and we decided never to do that inside quiche.
* Related to the above. We had several places where processing might shortcircuit or terminate. We ended up peppering quiche with calls to finalize frame writing.
* It's possible to produce an incomplete log line if the connection is destroyed before.
* It's less efficient to write a partial JSON object out.

The changes in the PR make packet event logging atomic. The qlog streamer is simplified by removing all locking and frame-specific logic. As a consequence, the quiche library requires updates in the packet send() and receive() function. Rather than serialize individual frames as they are added or read from a packet, we buffer the qlog representation of a frame, and then later pass that in a single call to the streamer.