### PR TITLE
cc: add send_quantum API

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -308,6 +308,9 @@ typedef struct {
 ssize_t quiche_conn_send(quiche_conn *conn, uint8_t *out, size_t out_len,
                          quiche_send_info *out_info);
 
+// Returns the size of the send quantum, in bytes.
+size_t quiche_conn_send_quantum(quiche_conn *conn);
+
 // Reads contiguous data from a stream.
 ssize_t quiche_conn_stream_recv(quiche_conn *conn, uint64_t stream_id,
                                 uint8_t *out, size_t buf_len, bool *fin);

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1177,6 +1177,11 @@ pub extern fn quiche_conn_peer_streams_left_uni(conn: &mut Connection) -> u64 {
     conn.peer_streams_left_uni()
 }
 
+#[no_mangle]
+pub extern fn quiche_conn_send_quantum(conn: &mut Connection) -> size_t {
+    conn.send_quantum() as size_t
+}
+
 fn std_addr_from_c(addr: &sockaddr, addr_len: socklen_t) -> SocketAddr {
     unsafe {
         match addr.sa_family as i32 {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3474,6 +3474,19 @@ impl Connection {
         Ok((pkt_type, written))
     }
 
+    /// Returns the size of the send quantum, in bytes.
+    ///
+    /// This represents the maximum size of a packet burst as determined by the
+    /// congestion control algorithm in use.
+    ///
+    /// Applications can, for example, use it in conjuction with segmentatation
+    /// offloading mechanisms as the maximum limit for outgoing aggregates of
+    /// multiple packets.
+    #[inline]
+    pub fn send_quantum(&mut self) -> usize {
+        self.recovery.send_quantum()
+    }
+
     /// Reads contiguous data from a stream into the provided slice.
     ///
     /// The slice must be sized by the caller and will be populated up to its

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -156,6 +156,10 @@ pub struct Recovery {
 
     #[cfg(feature = "qlog")]
     qlog_metrics: QlogMetrics,
+
+    // The maximum size of a data aggregate scheduled and
+    // transmitted together.
+    send_quantum: usize,
 }
 
 impl Recovery {
@@ -240,6 +244,9 @@ impl Recovery {
             last_packet_scheduled_time: None,
 
             prr: prr::PRR::default(),
+
+            send_quantum: config.max_send_udp_payload_size *
+                INITIAL_WINDOW_PACKETS,
 
             #[cfg(feature = "qlog")]
             qlog_metrics: QlogMetrics::default(),
@@ -938,6 +945,10 @@ impl Recovery {
         };
 
         self.qlog_metrics.maybe_update(qlog_metrics)
+    }
+
+    pub fn send_quantum(&self) -> usize {
+        self.send_quantum
     }
 }
 


### PR DESCRIPTION
For higher performance sending multiple packets is a common
practice, such as sendmmsg() or linux sendmsg() GSO. To
help with that, send_quantum is added and it can be modified
in the congestion controller. It's a hint for the application,
it may or may not use the value for controlling the batch
size of packets.

For default value, initcwnd is used(RFC9002 section 7.7).

Also, conn.send_quantum() and C API (quiche_conn_send_quantum())
is provided for the application.