### PR TITLE
expose boringssl ctx

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -32,6 +32,8 @@ default = ["boringssl-vendored"]
 # Build vendored BoringSSL library.
 boringssl-vendored = []
 
+boring-sys = ["boring", "foreign-types-shared"]
+
 # Generate pkg-config metadata file for libquiche.
 pkg-config-meta = []
 
@@ -53,7 +55,8 @@ libc = "0.2"
 libm = "0.2"
 ring = "0.16"
 lazy_static = "1"
-boring-sys = { version = "2.0.0", optional = true }
+boring = { version = "2.0.0", optional = true }
+foreign-types-shared = { version = "0.3.0", optional = true }
 qlog = { version = "0.6", path = "../qlog", optional = true }
 
 [target."cfg(windows)".dependencies]

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -610,19 +610,19 @@ impl Config {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn new(version: u32) -> Result<Config> {
-        Self::_new_for_tls_ctx(version, tls::Context::new()?)
+        Self::with_tls_ctx(version, tls::Context::new()?)
     }
 
     /// Creates a config object with the given version and SslContext. This is
-    /// useful for applications which wish to manually configure SslContext
-    #[cfg(feature = "boring")]
-    pub fn new_for_tls_ctx(
+    /// useful for applications that wish to manually configure SslContext
+    #[cfg(feature = "boring-sys")]
+    pub fn with_boring_ssl_ctx(
         version: u32, tls_ctx: boring::ssl::SslContext,
     ) -> Result<Config> {
-        Self::_new_for_tls_ctx(version, tls::Context::from_boring(tls_ctx))
+        Self::with_tls_ctx(version, tls::Context::from_boring(tls_ctx))
     }
 
-    fn _new_for_tls_ctx(version: u32, tls_ctx: tls::Context) -> Result<Config> {
+    fn with_tls_ctx(version: u32, tls_ctx: tls::Context) -> Result<Config> {
         if !is_reserved_version(version) && !version_is_supported(version) {
             return Err(Error::UnknownVersion);
         }
@@ -11159,6 +11159,71 @@ mod tests {
         assert_eq!(pipe.server.tx_cap, 0);
 
         assert_eq!(pipe.advance(), Ok(()));
+    }
+
+    #[cfg(feature = "boring-sys")]
+    #[test]
+    fn user_provided_boring_ctx() -> Result<()> {
+        // Manually construct boring ssl ctx for server
+        let server_tls_ctx = {
+            let mut builder = boring::ssl::SslContextBuilder::new(
+                boring::ssl::SslMethod::tls(),
+            )
+            .unwrap();
+            builder
+                .set_certificate_chain_file("examples/cert.crt")
+                .unwrap();
+            builder
+                .set_private_key_file(
+                    "examples/cert.key",
+                    boring::ssl::SslFiletype::PEM,
+                )
+                .unwrap();
+            builder.build()
+        };
+
+        let mut server_config =
+            Config::with_boring_ssl_ctx(crate::PROTOCOL_VERSION, server_tls_ctx)?;
+        let mut client_config = Config::new(crate::PROTOCOL_VERSION)?;
+        client_config.load_cert_chain_from_pem_file("examples/cert.crt")?;
+        client_config.load_priv_key_from_pem_file("examples/cert.key")?;
+
+        for config in [&mut client_config, &mut server_config] {
+            config.set_application_protos(b"\x06proto1\x06proto2")?;
+            config.set_initial_max_data(30);
+            config.set_initial_max_stream_data_bidi_local(15);
+            config.set_initial_max_stream_data_bidi_remote(15);
+            config.set_initial_max_stream_data_uni(10);
+            config.set_initial_max_streams_bidi(3);
+            config.set_initial_max_streams_uni(3);
+            config.set_max_idle_timeout(180_000);
+            config.verify_peer(false);
+            config.set_ack_delay_exponent(8);
+        }
+
+        let mut client_scid = [0; 16];
+        rand::rand_bytes(&mut client_scid[..]);
+        let client_scid = ConnectionId::from_ref(&client_scid);
+        let client_addr = "127.0.0.1:1234".parse().unwrap();
+
+        let mut server_scid = [0; 16];
+        rand::rand_bytes(&mut server_scid[..]);
+        let server_scid = ConnectionId::from_ref(&server_scid);
+        let server_addr = "127.0.0.1:4321".parse().unwrap();
+
+        let mut pipe = testing::Pipe {
+            client: connect(
+                Some("quic.tech"),
+                &client_scid,
+                client_addr,
+                &mut client_config,
+            )?,
+            server: accept(&server_scid, None, server_addr, &mut server_config)?,
+        };
+
+        assert_eq!(pipe.handshake(), Ok(()));
+
+        Ok(())
     }
 }
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -610,11 +610,22 @@ impl Config {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     pub fn new(version: u32) -> Result<Config> {
+        Self::_new_for_tls_ctx(version, tls::Context::new()?)
+    }
+
+    /// Creates a config object with the given version and SslContext. This is
+    /// useful for applications which wish to manually configure SslContext
+    #[cfg(feature = "boring")]
+    pub fn new_for_tls_ctx(
+        version: u32, tls_ctx: boring::ssl::SslContext,
+    ) -> Result<Config> {
+        Self::_new_for_tls_ctx(version, tls::Context::from_boring(tls_ctx))
+    }
+
+    fn _new_for_tls_ctx(version: u32, tls_ctx: tls::Context) -> Result<Config> {
         if !is_reserved_version(version) && !version_is_supported(version) {
             return Err(Error::UnknownVersion);
         }
-
-        let tls_ctx = tls::Context::new()?;
 
         Ok(Config {
             local_transport_params: TransportParams::default(),
@@ -11174,3 +11185,6 @@ mod ranges;
 mod recovery;
 mod stream;
 mod tls;
+
+#[cfg(feature = "boring-sys")]
+pub use tls::QUICHE_EX_DATA_INDEX;

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -124,7 +124,8 @@ struct SSL_QUIC_METHOD {
 }
 
 lazy_static::lazy_static! {
-    static ref QUICHE_EX_DATA_INDEX: c_int = unsafe {
+    /// BoringSSL Extra Data Index for Quiche Connections
+    pub static ref QUICHE_EX_DATA_INDEX: c_int = unsafe {
         SSL_get_ex_new_index(0, ptr::null(), ptr::null(), ptr::null(), ptr::null())
     };
 }
@@ -152,6 +153,19 @@ impl Context {
 
             Ok(ctx)
         }
+    }
+
+    #[cfg(feature = "boring")]
+    pub fn from_boring(mut ssl_ctx: boring::ssl::SslContext) -> Context {
+        use foreign_types_shared::ForeignTypeRef;
+        let mut ctx = Context(ssl_ctx.as_mut().as_ptr() as _);
+
+        // Prevent the SslContext from manually dropping (which would invalidate
+        // the pointer by calling SSL_CTX_free)
+        std::mem::forget(ssl_ctx);
+
+        ctx.set_session_callback();
+        ctx
     }
 
     pub fn new_handshake(&mut self) -> Result<Handshake> {

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -155,7 +155,7 @@ impl Context {
         }
     }
 
-    #[cfg(feature = "boring")]
+    #[cfg(feature = "boring-sys")]
     pub fn from_boring(mut ssl_ctx: boring::ssl::SslContext) -> Context {
         use foreign_types_shared::ForeignTypeRef;
         let mut ctx = Context(ssl_ctx.as_mut().as_ptr() as _);


### PR DESCRIPTION
Allow clients to configure boring SslContext ahead of time. This is useful when you'd like to configure things that quiche's API doesn't expose (e.g. SNI callback).