### PR TITLE
ci: use windows-2019 for windows build

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -126,7 +126,7 @@ jobs:
           args: --target=${{ matrix.target }} --verbose
 
   quiche_windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         target: ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]


### PR DESCRIPTION
Today I see `windows-latest` is updated to `windows-2022` and the
build start to fail on 32bit build. Until we figure it out, pin the version
to 2019.