### PR TITLE
lib: send STREAM_DATA_BLOCKED frames less often

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3693,8 +3693,12 @@ impl Connection {
         if sent < buf.len() {
             let max_off = stream.send.max_off();
 
-            self.streams.mark_blocked(stream_id, true, max_off);
+            if stream.send.blocked_at() != Some(max_off) {
+                stream.send.update_blocked_at(Some(max_off));
+                self.streams.mark_blocked(stream_id, true, max_off);
+            }
         } else {
+            stream.send.update_blocked_at(None);
             self.streams.mark_blocked(stream_id, false, 0);
         }
 
@@ -9575,12 +9579,57 @@ mod tests {
 
         assert_eq!(iter.next(), None);
 
-        // Send again from blocked stream and make sure it is marked as blocked
-        // again.
+        // Send again from blocked stream and make sure it is not marked as
+        // blocked again.
         assert_eq!(
             pipe.client.stream_send(0, b"aaaaaa", false),
             Err(Error::Done)
         );
+        assert_eq!(pipe.client.streams.blocked().len(), 0);
+        assert_eq!(pipe.client.send(&mut buf), Err(Error::Done));
+    }
+
+    #[test]
+    fn stream_data_blocked_unblocked_flow_control() {
+        let mut buf = [0; 65535];
+        let mut pipe = testing::Pipe::default().unwrap();
+        assert_eq!(pipe.handshake(), Ok(()));
+
+        assert_eq!(
+            pipe.client.stream_send(0, b"aaaaaaaaaaaaaaah", false),
+            Ok(15)
+        );
+        assert_eq!(pipe.client.streams.blocked().len(), 1);
+        assert_eq!(pipe.advance(), Ok(()));
+        assert_eq!(pipe.client.streams.blocked().len(), 0);
+
+        // Send again on blocked stream. It's blocked at the same offset as
+        // previously, so it should not be marked as blocked again.
+        assert_eq!(pipe.client.stream_send(0, b"h", false), Err(Error::Done));
+        assert_eq!(pipe.client.streams.blocked().len(), 0);
+
+        // No matter how many times we try to write stream data tried, no
+        // packets containing STREAM_BLOCKED should be emitted.
+        assert_eq!(pipe.client.stream_send(0, b"h", false), Err(Error::Done));
+        assert_eq!(pipe.client.send(&mut buf), Err(Error::Done));
+
+        assert_eq!(pipe.client.stream_send(0, b"h", false), Err(Error::Done));
+        assert_eq!(pipe.client.send(&mut buf), Err(Error::Done));
+
+        assert_eq!(pipe.client.stream_send(0, b"h", false), Err(Error::Done));
+        assert_eq!(pipe.client.send(&mut buf), Err(Error::Done));
+
+        // Now read some data at the server to release flow control.
+        let mut r = pipe.server.readable();
+        assert_eq!(r.next(), Some(0));
+        assert_eq!(r.next(), None);
+
+        let mut b = [0; 10];
+        assert_eq!(pipe.server.stream_recv(0, &mut b), Ok((10, false)));
+        assert_eq!(&b[..10], b"aaaaaaaaaa");
+        assert_eq!(pipe.advance(), Ok(()));
+
+        assert_eq!(pipe.client.stream_send(0, b"hhhhhhhhhh!", false), Ok(10));
         assert_eq!(pipe.client.streams.blocked().len(), 1);
 
         let (len, _) = pipe.client.send(&mut buf).unwrap();
@@ -9595,13 +9644,15 @@ mod tests {
             iter.next(),
             Some(&frame::Frame::StreamDataBlocked {
                 stream_id: 0,
-                limit: 15,
+                limit: 25,
             })
         );
 
-        assert_eq!(iter.next(), Some(&frame::Frame::Padding { len: 1 }));
+        // don't care about remaining received frames
 
-        assert_eq!(iter.next(), None);
+        assert_eq!(pipe.client.stream_send(0, b"!", false), Err(Error::Done));
+        assert_eq!(pipe.client.streams.blocked().len(), 0);
+        assert_eq!(pipe.client.send(&mut buf), Err(Error::Done));
     }
 
     #[test]

--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -1244,7 +1244,7 @@ impl SendBuf {
         self.blocked_at = blocked_at;
     }
 
-    /// The last offset the stream blocked at, if any.
+    /// The last offset the stream was blocked at, if any.
     pub fn blocked_at(&self) -> Option<u64> {
         self.blocked_at
     }

--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -1239,7 +1239,7 @@ impl SendBuf {
         self.max_data = cmp::max(self.max_data, max_data);
     }
 
-    /// Updates the last offset the stream was blocked_at, if any.
+    /// Updates the last offset the stream was blocked at, if any.
     pub fn update_blocked_at(&mut self, blocked_at: Option<u64>) {
         self.blocked_at = blocked_at;
     }

--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -1239,12 +1239,12 @@ impl SendBuf {
         self.max_data = cmp::max(self.max_data, max_data);
     }
 
-    /// Updates the last offset we were blocked_at, if any.
+    /// Updates the last offset the stream was blocked_at, if any.
     pub fn update_blocked_at(&mut self, blocked_at: Option<u64>) {
         self.blocked_at = blocked_at;
     }
 
-    /// The last offset we were blocked at, if any.
+    /// The last offset the stream blocked at, if any.
     pub fn blocked_at(&self) -> Option<u64> {
         self.blocked_at
     }

--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -1082,7 +1082,7 @@ pub struct SendBuf {
     /// The maximum offset we are allowed to send to the peer.
     max_data: u64,
 
-    /// The last offset we were blocked at, if any.
+    /// The last offset the stream was blocked at, if any.
     blocked_at: Option<u64>,
 
     /// The final stream offset written to the stream, if any.

--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -1082,6 +1082,9 @@ pub struct SendBuf {
     /// The maximum offset we are allowed to send to the peer.
     max_data: u64,
 
+    /// The last offset we were blocked at, if any.
+    blocked_at: Option<u64>,
+
     /// The final stream offset written to the stream, if any.
     fin_off: Option<u64>,
 
@@ -1234,6 +1237,16 @@ impl SendBuf {
     /// Updates the max_data limit to the given value.
     pub fn update_max_data(&mut self, max_data: u64) {
         self.max_data = cmp::max(self.max_data, max_data);
+    }
+
+    /// Updates the last offset we were blocked_at, if any.
+    pub fn update_blocked_at(&mut self, blocked_at: Option<u64>) {
+        self.blocked_at = blocked_at;
+    }
+
+    /// The last offset we were blocked at, if any.
+    pub fn blocked_at(&self) -> Option<u64> {
+        self.blocked_at
     }
 
     /// Increments the acked data offset.


### PR DESCRIPTION
NB: this reduces the frequency of blocked frames at the same offset from "every send()" to once. If we want a middle ground, like every N packets, that is feasible too.

When applications try to send stream data with `stream_send()`, the
number of bytes actually written might be less than supplied due to
insufficient stream or connection capacity. In these cases, quiche
internally marks the stream as blocked and, when `conn.send()` is next
called the mark causes a STREAM_DATA_BLOCKED frame to be emitted in a
new packet.

Previously, every call to `stream_send()` would cause the stream to be
marked and therefore generate a STREAM_DATA_BLOCKED frame. In cases,
where `conn.send()` is called frequently, the blocked frame might be the
only frame in the packet, which is wasteful.

This change reduces the frequency of STREAM_DATA_BLOCKED frames by
avoiding sending them when the offset of sent stream data is unchanged.
When a stream is first blocked during `stream_send()`, a frame is
emitted and the blocked offset is recorded. Subsequent blocked frames
are only emitted if the application is able to write more data and get
blocked at a new offset.

