### PR TITLE
lib: fix retrans_count is not updated

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2671,7 +2671,7 @@ impl Connection {
             }
         }
 
-        if stream_retrans_bytes > self.stream_retrans_bytes {
+        if stream_retrans_bytes < self.stream_retrans_bytes {
             self.retrans_count += 1;
         }
 
@@ -5513,8 +5513,8 @@ impl std::fmt::Debug for Stats {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "recv={} sent={} lost={} rtt={:?} cwnd={}",
-            self.recv, self.sent, self.lost, self.rtt, self.cwnd,
+            "recv={} sent={} lost={} retrans={} rtt={:?} cwnd={}",
+            self.recv, self.sent, self.lost, self.retrans, self.rtt, self.cwnd,
         )?;
 
         write!(f, " peer_tps={{")?;
@@ -10349,6 +10349,7 @@ mod tests {
                 data: stream::RangeBuf::from(b"b", 0, false),
             })
         );
+        assert_eq!(pipe.client.stats().retrans, 1);
     }
 
     #[test]


### PR DESCRIPTION
Fix where `retrans_count` is not updated when there is a
retransmit of a stream data. Also add `stats.retrans` to
debug formatter for logging.