### PR TITLE
pacing: get_packet_send_time() is no longer Option<>

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2572,10 +2572,7 @@ impl Connection {
         let info = SendInfo {
             to: self.peer_addr,
 
-            at: self
-                .recovery
-                .get_packet_send_time()
-                .unwrap_or_else(time::Instant::now),
+            at: self.recovery.get_packet_send_time(),
         };
 
         Ok((done, info))


### PR DESCRIPTION
Since `recovery.last_packet_scheduled_time` always have a
default value (current timestamp), Having it `Option<Instant>`
type doesn't make sense much. No changes on public API.