### PR TITLE
cc: pass lost_bytes to congestion_event() hook

### DIFF
--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -341,7 +341,8 @@ fn on_packet_acked(
 }
 
 fn congestion_event(
-    r: &mut Recovery, time_sent: Instant, epoch: packet::Epoch, now: Instant,
+    r: &mut Recovery, _lost_bytes: usize, time_sent: Instant,
+    epoch: packet::Epoch, now: Instant,
 ) {
     let in_congestion_recovery = r.in_congestion_recovery(time_sent);
 
@@ -561,7 +562,12 @@ mod tests {
         let now = Instant::now();
         let prev_cwnd = r.cwnd();
 
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(
+            r.max_datagram_size,
+            now,
+            packet::EPOCH_APPLICATION,
+            now,
+        );
 
         // In CUBIC, after congestion event, cwnd will be reduced by (1 -
         // CUBIC_BETA)
@@ -583,7 +589,12 @@ mod tests {
         }
 
         // Trigger congestion event to update ssthresh
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(
+            r.max_datagram_size,
+            now,
+            packet::EPOCH_APPLICATION,
+            now,
+        );
 
         // After congestion event, cwnd will be reduced.
         let cur_cwnd = (prev_cwnd as f64 * BETA_CUBIC) as usize;
@@ -628,7 +639,12 @@ mod tests {
         r.on_packet_sent_cc(30000, now);
 
         // Trigger congestion event to update ssthresh
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(
+            r.max_datagram_size,
+            now,
+            packet::EPOCH_APPLICATION,
+            now,
+        );
 
         // After persistent congestion, cwnd should be the minimum window
         r.collapse_cwnd();
@@ -927,7 +943,12 @@ mod tests {
         }
 
         // Trigger congestion event to update ssthresh
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(
+            r.max_datagram_size,
+            now,
+            packet::EPOCH_APPLICATION,
+            now,
+        );
 
         // After congestion event, cwnd will be reduced.
         let cur_cwnd = (prev_cwnd as f64 * BETA_CUBIC) as usize;
@@ -959,7 +980,12 @@ mod tests {
 
         // Trigger another congestion event.
         let prev_cwnd = r.cwnd();
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(
+            r.max_datagram_size,
+            now,
+            packet::EPOCH_APPLICATION,
+            now,
+        );
 
         // After congestion event, cwnd will be reduced.
         let cur_cwnd = (cur_cwnd as f64 * BETA_CUBIC) as usize;
@@ -1003,7 +1029,12 @@ mod tests {
         }
 
         // Trigger congestion event to update ssthresh
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(
+            r.max_datagram_size,
+            now,
+            packet::EPOCH_APPLICATION,
+            now,
+        );
 
         // After 1st congestion event, cwnd will be reduced.
         let cur_cwnd = (prev_cwnd as f64 * BETA_CUBIC) as usize;
@@ -1039,7 +1070,12 @@ mod tests {
         // Fast convergence: now there is 2nd congestion event and
         // cwnd is not fully recovered to w_max, w_max will be
         // further reduced.
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(
+            r.max_datagram_size,
+            now,
+            packet::EPOCH_APPLICATION,
+            now,
+        );
 
         // After 2nd congestion event, cwnd will be reduced.
         let cur_cwnd = (prev_cwnd as f64 * BETA_CUBIC) as usize;

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -899,7 +899,7 @@ impl Recovery {
     ) {
         self.bytes_in_flight = self.bytes_in_flight.saturating_sub(lost_bytes);
 
-        self.congestion_event(largest_lost_pkt.time_sent, epoch, now);
+        self.congestion_event(lost_bytes, largest_lost_pkt.time_sent, epoch, now);
 
         if self.in_persistent_congestion(largest_lost_pkt.pkt_num) {
             self.collapse_cwnd();
@@ -907,13 +907,14 @@ impl Recovery {
     }
 
     fn congestion_event(
-        &mut self, time_sent: Instant, epoch: packet::Epoch, now: Instant,
+        &mut self, lost_bytes: usize, time_sent: Instant, epoch: packet::Epoch,
+        now: Instant,
     ) {
         if !self.in_congestion_recovery(time_sent) {
             (self.cc_ops.checkpoint)(self);
         }
 
-        (self.cc_ops.congestion_event)(self, time_sent, epoch, now);
+        (self.cc_ops.congestion_event)(self, lost_bytes, time_sent, epoch, now);
     }
 
     fn collapse_cwnd(&mut self) {
@@ -993,6 +994,7 @@ pub struct CongestionControlOps {
 
     pub congestion_event: fn(
         r: &mut Recovery,
+        lost_bytes: usize,
         time_sent: Instant,
         epoch: packet::Epoch,
         now: Instant,

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -103,7 +103,8 @@ fn on_packet_acked(
 }
 
 fn congestion_event(
-    r: &mut Recovery, time_sent: Instant, epoch: packet::Epoch, now: Instant,
+    r: &mut Recovery, _lost_bytes: usize, time_sent: Instant,
+    epoch: packet::Epoch, now: Instant,
 ) {
     // Start a new congestion event if packet was sent after the
     // start of the previous congestion recovery period.
@@ -296,7 +297,12 @@ mod tests {
 
         let now = Instant::now();
 
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(
+            r.max_datagram_size,
+            now,
+            packet::EPOCH_APPLICATION,
+            now,
+        );
 
         // In Reno, after congestion event, cwnd will be cut in half.
         assert_eq!(prev_cwnd / 2, r.cwnd());
@@ -315,7 +321,12 @@ mod tests {
         r.on_packet_sent_cc(20000, now);
 
         // Trigger congestion event to update ssthresh
-        r.congestion_event(now, packet::EPOCH_APPLICATION, now);
+        r.congestion_event(
+            r.max_datagram_size,
+            now,
+            packet::EPOCH_APPLICATION,
+            now,
+        );
 
         // After congestion event, cwnd will be reduced.
         let cur_cwnd =


### PR DESCRIPTION
`lost_bytes` is the total payload size of lost packets
detected by an ACK. This can be used as a hint for the congestion
controller when needed.