### PR TITLE
cc: on_packets_acked() hook

### DIFF
--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -47,7 +47,7 @@ use crate::recovery::Recovery;
 pub static CUBIC: CongestionControlOps = CongestionControlOps {
     on_init,
     on_packet_sent,
-    on_packet_acked,
+    on_packets_acked,
     congestion_event,
     collapse_cwnd,
     checkpoint,
@@ -189,6 +189,14 @@ fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, now: Instant) {
     cubic.last_sent_time = Some(now);
 
     reno::on_packet_sent(r, sent_bytes, now);
+}
+
+fn on_packets_acked(
+    r: &mut Recovery, packets: &[Acked], epoch: packet::Epoch, now: Instant,
+) {
+    for pkt in packets {
+        on_packet_acked(r, pkt, epoch, now);
+    }
 }
 
 fn on_packet_acked(

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -866,9 +866,7 @@ impl Recovery {
     fn on_packets_acked(
         &mut self, acked: Vec<Acked>, epoch: packet::Epoch, now: Instant,
     ) {
-        for pkt in acked {
-            (self.cc_ops.on_packet_acked)(self, &pkt, epoch, now);
-        }
+        (self.cc_ops.on_packets_acked)(self, &acked, epoch, now);
     }
 
     fn in_congestion_recovery(&self, sent_time: Instant) -> bool {
@@ -983,8 +981,12 @@ pub struct CongestionControlOps {
 
     pub on_packet_sent: fn(r: &mut Recovery, sent_bytes: usize, now: Instant),
 
-    pub on_packet_acked:
-        fn(r: &mut Recovery, packet: &Acked, epoch: packet::Epoch, now: Instant),
+    pub on_packets_acked: fn(
+        r: &mut Recovery,
+        packets: &[Acked],
+        epoch: packet::Epoch,
+        now: Instant,
+    ),
 
     pub congestion_event: fn(
         r: &mut Recovery,

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -41,7 +41,7 @@ use crate::recovery::Recovery;
 pub static RENO: CongestionControlOps = CongestionControlOps {
     on_init,
     on_packet_sent,
-    on_packet_acked,
+    on_packets_acked,
     congestion_event,
     collapse_cwnd,
     checkpoint,
@@ -54,6 +54,14 @@ pub fn on_init(_r: &mut Recovery) {}
 
 pub fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
     r.bytes_in_flight += sent_bytes;
+}
+
+fn on_packets_acked(
+    r: &mut Recovery, packets: &[Acked], epoch: packet::Epoch, now: Instant,
+) {
+    for pkt in packets {
+        on_packet_acked(r, pkt, epoch, now);
+    }
 }
 
 fn on_packet_acked(


### PR DESCRIPTION
Currently we have on_packet_acked() called by each ACK'ed data
packet and it will be called multiple times if an ACK range
contains many data packets. Sometimes there is a need to process
an ACK itself, not the all data packet ACK'ed this time.

To support it, on_packets_acked() hook is introduced in place
of on_packet_acked(). Only difference is passing a list of Acked
instead of each Acked and the hook need to process all packets
in the Acked list if needed, for example to get the total size
of ACK'ed payload.

reno and cubic is updated to use a new hook.