### PR TITLE
lib: fix retrans_count again

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2625,8 +2625,6 @@ impl Connection {
 
         let epoch = pkt_type.to_epoch()?;
 
-        let stream_retrans_bytes = self.stream_retrans_bytes;
-
         // Process lost frames.
         for lost in self.recovery.lost[epoch].drain(..) {
             match lost {
@@ -2637,6 +2635,8 @@ impl Connection {
                         .retransmit(offset, length);
 
                     self.stream_retrans_bytes += length as u64;
+
+                    self.retrans_count += 1;
                 },
 
                 frame::Frame::StreamHeader {
@@ -2673,6 +2673,8 @@ impl Connection {
                     }
 
                     self.stream_retrans_bytes += length as u64;
+
+                    self.retrans_count += 1;
                 },
 
                 frame::Frame::ACK { .. } => {
@@ -2707,10 +2709,6 @@ impl Connection {
 
                 _ => (),
             }
-        }
-
-        if stream_retrans_bytes < self.stream_retrans_bytes {
-            self.retrans_count += 1;
         }
 
         let mut left = b.cap();


### PR DESCRIPTION
Previously `Stats.lost` is much higher than `Stats.retrans`.
It is because `retrans_count` increases when there is
some retransmitted bytes in the lost packet list, not counting per
retransmitted range.

Now it counts for each lost data frame. `lost` and `retrans`
may not match but in a simple case (e.g. lost 1 packet,
retransmit the same range) it will be same.

Before: `lost=2814 retrans=10`
```
[2022-03-04T09:55:16.694598762Z INFO  quiche_server] 6d66c30c86018d28a71aea8d1e6d4a9ae2d2d6d6 connection collected recv=446 sent=10845 lost=2814 retrans=10 rtt=52.978034ms cwnd=782252 peer_tps={ max_idle_timeout=30000, max_udp_payload_size=65527, initial_max_data=1073741823, initial_max_stream_data_bidi_local=67108863, initial_max_stream_data_bidi_remote=0, initial_max_stream_data_uni=67108863, initial_max_streams_bidi=0, initial_max_streams_uni=100, ack_delay_exponent=3, max_ack_delay=25, disable_active_migration=false, active_conn_id_limit=2, max_datagram_frame_size=None }
```

After: `lost=2769 retrans=2769`
```
[2022-03-04T09:44:18.008565802Z INFO  quiche_server] 68ec2636c75d858d08d8192f17383aab147bf784 connection collected recv=456 sent=10794 lost=2769 retrans=2769 rtt=75.099656ms cwnd=843204 peer_tps={ max_idle_timeout=30000, max_udp_payload_size=65527, initial_max_data=1073741823, initial_max_stream_data_bidi_local=67108863, initial_max_stream_data_bidi_remote=0, initial_max_stream_data_uni=67108863, initial_max_streams_bidi=0, initial_max_streams_uni=100, ack_delay_exponent=3, max_ack_delay=25, disable_active_migration=false, active_conn_id_limit=2, max_datagram_frame_size=None }
```