### PR TITLE
Remove `no_mangle` from `new_session`

### DIFF
--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -934,7 +934,6 @@ extern fn select_alpn(
     3 // SSL_TLSEXT_ERR_NOACK
 }
 
-#[no_mangle]
 extern fn new_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int {
     let conn =
         match get_ex_data_from_ptr::<Connection>(ssl, *QUICHE_EX_DATA_INDEX) {


### PR DESCRIPTION
I ran into the following error while updating quiche a while back:

```
= note: /usr/bin/ld: target/debug/deps/libquiche-aebddac5b5b78042.rlib(quiche-aebddac5b5b78042.quiche.2dd0d882-cgu.7.rcgu.o): in function `new_session':
        /home/builder/.cargo/git/checkouts/quiche-3a3206f14f25c564/a0088a9/quiche/src/tls.rs:1010: multiple definition of `new_session'; target/debug/deps/libquiche-7702398d4219d80f.rlib(quiche-7702398d4219d80f.quiche.1f33b6b3-cgu.5.rcgu.o):/home/builder/.cargo/git/checkouts/quiche-3a3206f14f25c564/df3fac0/src/tls.rs:1010: first defined here
```

That's not a particularly helpful error - the issue was that that we had two versions of quiche in
the dependency tree. This removes the unnecessary `no_mangle` attribute from `new_session` -
it's only ever used as a function pointer, so it doesn't need to have a well-known name for the linker.

Eventually we might want to consider adding a `links` attribute, or consider separating the FFI bits
into a new `quiche-sys` crate, but I don't have time to drive that currently.