### PR TITLE
http3_test: add RESET_STREAM testing capability

### DIFF
--- a/tools/http3_test/Cargo.toml
+++ b/tools/http3_test/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "http3_test"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Lucas Pardue <lucaspardue.24.7@gmail.com>"]
 edition = "2018"
 publish = false
+
+[features]
+test_resets = []
 
 [dependencies]
 docopt = "1"

--- a/tools/http3_test/src/lib.rs
+++ b/tools/http3_test/src/lib.rs
@@ -245,6 +245,7 @@ pub struct Http3Req {
     pub expect_resp_hdrs: Option<Vec<Header>>,
     pub resp_hdrs: Vec<Header>,
     pub resp_body: Vec<u8>,
+    pub reset_stream_code: Option<u64>,
 }
 
 impl Http3Req {
@@ -280,6 +281,7 @@ impl Http3Req {
             expect_resp_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         }
     }
 }
@@ -480,6 +482,13 @@ impl Http3Test {
     ) {
         let i = self.issued_reqs.get(&stream_id).unwrap();
         self.reqs[*i].resp_body.extend_from_slice(&data[..data_len]);
+    }
+
+    /// Sets the error code when a RESET_STREAM was received for an issued
+    /// request.
+    pub fn set_reset_stream_error(&mut self, stream_id: u64, error: u64) {
+        let i = self.issued_reqs.get(&stream_id).unwrap();
+        self.reqs[*i].reset_stream_code = Some(error);
     }
 
     /// Execute the test assertion(s).

--- a/tools/http3_test/tests/httpbin_tests.rs
+++ b/tools/http3_test/tests/httpbin_tests.rs
@@ -319,10 +319,11 @@ mod httpbin_tests {
         let req = Http3Req {
             url: url.clone(),
             hdrs,
-            body: None,
             expect_resp_hdrs: expect_hdrs,
+            body: None,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -357,6 +358,7 @@ mod httpbin_tests {
             expect_resp_hdrs: expect_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -391,6 +393,7 @@ mod httpbin_tests {
             expect_resp_hdrs: expect_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -424,6 +427,7 @@ mod httpbin_tests {
             expect_resp_hdrs: expect_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -458,6 +462,7 @@ mod httpbin_tests {
             expect_resp_hdrs: expect_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -492,6 +497,7 @@ mod httpbin_tests {
             expect_resp_hdrs: expect_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -525,6 +531,7 @@ mod httpbin_tests {
             expect_resp_hdrs: expect_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -559,6 +566,7 @@ mod httpbin_tests {
             expect_resp_hdrs: expect_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -591,6 +599,7 @@ mod httpbin_tests {
             expect_resp_hdrs: expect_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -624,6 +633,7 @@ mod httpbin_tests {
             expect_resp_hdrs: expect_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -658,6 +668,7 @@ mod httpbin_tests {
             expect_resp_hdrs: expect_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -693,6 +704,7 @@ mod httpbin_tests {
             expect_resp_hdrs: expect_hdrs,
             resp_hdrs: Vec::new(),
             resp_body: Vec::new(),
+            reset_stream_code: None,
         };
 
         reqs.push(req);
@@ -1307,6 +1319,26 @@ mod httpbin_tests {
         }
 
         assert_eq!(Ok(()), do_test(reqs, assert_headers_only, false));
+    }
+
+    #[test]
+    #[cfg(feature = "test_resets")]
+    fn drip_delay_reset() {
+        let mut reqs = Vec::new();
+
+        let expect_hdrs = Some(vec![Header::new(b":status", b"200")]);
+        let mut url = endpoint(Some("drip"));
+        url.set_query(Some("duration=30&numbytes=2&delay=1"));
+
+        reqs.push(Http3Req::new("GET", &url, None, expect_hdrs));
+
+        let assert = |reqs: &[Http3Req]| {
+            assert_headers!(reqs[0]);
+
+            assert_eq!(reqs[0].reset_stream_code, Some(256));
+        };
+
+        assert_eq!(Ok(()), do_test(reqs, assert, false));
     }
 
     #[test]


### PR DESCRIPTION
Previously, http3_test just ignored any Event::ResetStream occurrences
that might happen at the client.

With this change we mark reset streams as complete and store the
received error code in the request object, which tests can access for
post exchange asserts.

We use this new capability to add an optional `drip_delay_reset` test to
httpbin_tests, which can be enabled with the `test_resets` feature flag.
