### PR TITLE
Connection ID handling

### DIFF
--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -48,6 +48,7 @@ pub struct CommonArgs {
     pub dgrams_enabled: bool,
     pub dgram_count: u64,
     pub dgram_data: String,
+    pub max_active_cids: u64,
 }
 
 /// Creates a new `CommonArgs` structure using the provided [`Docopt`].
@@ -68,6 +69,7 @@ pub struct CommonArgs {
 /// --dgram-proto PROTO         DATAGRAM application protocol.
 /// --dgram-count COUNT         Number of DATAGRAMs to send.
 /// --dgram-data DATA           DATAGRAM data to send.
+/// --max-active-cids NUM       Maximum number of active Connection IDs.
 ///
 /// [`Docopt`]: https://docs.rs/docopt/1.1.0/docopt/
 impl Args for CommonArgs {
@@ -143,6 +145,9 @@ impl Args for CommonArgs {
 
         let disable_hystart = args.get_bool("--disable-hystart");
 
+        let max_active_cids = args.get_str("--max-active-cids");
+        let max_active_cids = max_active_cids.parse::<u64>().unwrap();
+
         CommonArgs {
             alpns,
             max_data,
@@ -160,6 +165,7 @@ impl Args for CommonArgs {
             dgrams_enabled,
             dgram_count,
             dgram_data,
+            max_active_cids,
         }
     }
 }
@@ -183,6 +189,7 @@ impl Default for CommonArgs {
             dgrams_enabled: false,
             dgram_count: 0,
             dgram_data: "quack".to_string(),
+            max_active_cids: 2,
         }
     }
 }
@@ -216,6 +223,7 @@ Options:
   --no-grease              Don't send GREASE.
   --cc-algorithm NAME      Specify which congestion control algorithm to use [default: cubic].
   --disable-hystart        Disable HyStart++.
+  --max-active-cids NUM    The maximum number of active Connection IDs we can support [default: 2].
   -H --header HEADER ...   Add a request header.
   -n --requests REQUESTS   Send the given number of identical requests [default: 1].
   --session-file PATH      File used to cache a TLS session for resumption.
@@ -360,6 +368,7 @@ Options:
   --dgram-data DATA           Data to send for certain types of DATAGRAM application protocol [default: brrr].
   --cc-algorithm NAME         Specify which congestion control algorithm to use [default: cubic].
   --disable-hystart           Disable HyStart++.
+  --max-active-cids NUM       The maximum number of active Connection IDs we can support [default: 2].
   -h --help                   Show this screen.
 ";
 

--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -89,6 +89,8 @@ pub struct Client {
 
     pub http_conn: Option<Box<dyn HttpConn>>,
 
+    pub id: u64,
+
     pub siduck_conn: Option<SiDuckConn>,
 
     pub app_proto_selected: bool,
@@ -100,7 +102,8 @@ pub struct Client {
     pub bytes_sent: usize,
 }
 
-pub type ClientMap = HashMap<ConnectionId<'static>, Client>;
+pub type ClientIdMap = HashMap<ConnectionId<'static>, u64>;
+pub type ClientMap = HashMap<u64, Client>;
 
 /// Makes a buffered writer for a resource with a target URL.
 ///

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -222,6 +222,15 @@ void quiche_config_set_max_connection_window(quiche_config *config, uint64_t v);
 // Sets the maximum stream window.
 void quiche_config_set_max_stream_window(quiche_config *config, uint64_t v);
 
+// Sets the limit of active connection IDs.
+void quiche_config_set_active_connection_id_limit(quiche_config *config, uint64_t v);
+
+// Sets the initial stateless reset token.
+void quiche_config_set_stateless_reset_token(quiche_config *config, const uint8_t *v);
+
+// Configures the generation of QUIC events.
+void quiche_config_enable_events(quiche_config *config, bool v);
+
 // Frees the config object.
 void quiche_config_free(quiche_config *config);
 
@@ -311,6 +320,28 @@ ssize_t quiche_conn_send(quiche_conn *conn, uint8_t *out, size_t out_len,
 // Returns the size of the send quantum, in bytes.
 size_t quiche_conn_send_quantum(quiche_conn *conn);
 
+// Provides additional source Connection IDs that the peer can use to reach
+// this host.
+int64_t quiche_conn_new_source_id(quiche_conn *conn, const uint8_t *scid,
+                                  size_t scid_len, const uint8_t *reset_token,
+                                  bool retire_if_needed);
+
+// Returns the number of source Connection IDs that are active.
+uint64_t quiche_conn_active_source_cids(quiche_conn *conn);
+
+// Returns the maximum number of concurrently active source Connection IDs that
+// can be provided to the peer.
+uint64_t quiche_conn_max_active_source_cids(quiche_conn *conn);
+
+// Requests the retirement of the destination Connection ID used by the host to
+// reach its peer.
+int64_t quiche_conn_retire_destination_cid(quiche_conn *conn, uint64_t dcid_seq);
+
+typedef struct QuicEvent quiche_quic_event;
+
+// Processes QUIC-specific events.
+int64_t quiche_conn_poll(quiche_conn *conn, quiche_quic_event **ev);
+
 // Reads contiguous data from a stream.
 ssize_t quiche_conn_stream_recv(quiche_conn *conn, uint64_t stream_id,
                                 uint8_t *out, size_t buf_len, bool *fin);
@@ -367,10 +398,10 @@ int quiche_conn_close(quiche_conn *conn, bool app, uint64_t err,
 void quiche_conn_trace_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
 // Returns the source connection ID.
-void quiche_conn_source_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
+int quiche_conn_source_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
 // Returns the destination connection ID.
-void quiche_conn_destination_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
+int quiche_conn_destination_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
 // Returns the negotiated ALPN protocol.
 void quiche_conn_application_proto(quiche_conn *conn, const uint8_t **out,

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -398,10 +398,10 @@ int quiche_conn_close(quiche_conn *conn, bool app, uint64_t err,
 void quiche_conn_trace_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
 // Returns the source connection ID.
-int quiche_conn_source_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
+void quiche_conn_source_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
 // Returns the destination connection ID.
-int quiche_conn_destination_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
+void quiche_conn_destination_id(quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
 // Returns the negotiated ALPN protocol.
 void quiche_conn_application_proto(quiche_conn *conn, const uint8_t **out,

--- a/quiche/src/cid.rs
+++ b/quiche/src/cid.rs
@@ -1,0 +1,744 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::Error;
+use crate::Result;
+
+use crate::frame;
+use crate::packet::ConnectionId;
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+
+/// A Connection Id-specific event.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConnectionIdEvent {
+    /// The related `ConnectionId`, with the associated sequence number as
+    /// `u64` and stateless reset token as `u128`, can now be used to reach the
+    /// peer.
+    NewDestination(u64, ConnectionId<'static>, u128),
+    /// The related Connection ID with the associated sequence number as
+    /// `u64`, must be retired because the peer required us to do so.
+    RetiredDestination(u64),
+    /// The related Source `ConnectionId` has been retired by the peer.
+    RetiredSource(ConnectionId<'static>),
+}
+
+/// A structure holding a `ConnectionId` and all its related metadata.
+#[derive(Debug)]
+pub struct ConnectionIdEntry {
+    /// The Connection ID.
+    pub cid: ConnectionId<'static>,
+    /// Its associated sequence number.
+    pub seq: u64,
+    /// Its associated reset token. Initial CIDs may not have any reset token.
+    pub reset_token: Option<u128>,
+    /// The path identifier using this CID, if any.
+    pub path_id: Option<usize>,
+}
+
+/// A simple no-op hasher for Connection ID sequence numbers.
+///
+/// The QUIC protocol and quiche library guarantees Connection ID sequence
+/// number uniqueness, so we can save effort by avoiding using a more
+/// complicated algorithm.
+#[derive(Default)]
+pub struct ConnectionIdSeqHasher {
+    id: u64,
+}
+
+impl std::hash::Hasher for ConnectionIdSeqHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.id
+    }
+
+    #[inline]
+    fn write_u64(&mut self, id: u64) {
+        self.id = id;
+    }
+
+    #[inline]
+    fn write(&mut self, _: &[u8]) {
+        // We need a default write() for the trait but Connection ID sequence
+        // number will always be a u64 so we just delegate to write_u64.
+        unimplemented!()
+    }
+}
+
+type BuildConnectionIdSeqHasher =
+    std::hash::BuildHasherDefault<ConnectionIdSeqHasher>;
+
+type ConnectionIdSeqHashMap<V> = HashMap<u64, V, BuildConnectionIdSeqHasher>;
+
+#[derive(Default)]
+pub struct ConnectionIdentifiers {
+    /// All the Destination Connection IDs provided by our peer.
+    dcids: ConnectionIdSeqHashMap<ConnectionIdEntry>,
+    /// All the Source Connection IDs we provide to our peer.
+    scids: ConnectionIdSeqHashMap<ConnectionIdEntry>,
+
+    /// Source Connection IDs that should be announced to the peer.
+    new_scids: VecDeque<u64>,
+    /// Retired Destination Connection IDs that should be announced to the peer.
+    retire_dcids: VecDeque<u64>,
+
+    /// All Connection ID related events that should be notified to the
+    /// application.
+    events: Option<VecDeque<ConnectionIdEvent>>,
+
+    /// Largest "Retire Prior To" we received from the peer.
+    largest_peer_retire_prior_to: u64,
+    /// Largest sequence number we received from the peer.
+    largest_destination_seq: u64,
+    /// Next sequence number to use.
+    next_scid_seq: u64,
+    /// "Retire Prior To" value to advertise to the peer.
+    retire_prior_to: u64,
+
+    /// The maximum number of destination Connection IDs we allow.
+    destination_conn_id_limit: usize,
+    /// The maximum number of source Connection IDs our peer allows us.
+    source_conn_id_limit: usize,
+
+    /// Does the host use zero-length source Connection ID.
+    zero_length_scid: bool,
+    /// Does the host use zero-length destination Connection ID.
+    zero_length_dcid: bool,
+}
+
+impl ConnectionIdentifiers {
+    /// Creates a new `ConnectionIdentifiers` with the specified destination
+    /// connection ID limit.
+    pub fn new(
+        mut destination_conn_id_limit: usize, enable_events: bool,
+    ) -> ConnectionIdentifiers {
+        // It must be at least 2.
+        if destination_conn_id_limit < 2 {
+            destination_conn_id_limit = 2;
+        }
+        let events = if enable_events {
+            Some(VecDeque::new())
+        } else {
+            None
+        };
+        ConnectionIdentifiers {
+            destination_conn_id_limit,
+            source_conn_id_limit: 2,
+            events,
+            ..Default::default()
+        }
+    }
+
+    /// Sets the maximum number of source connection IDs our peer allows us.
+    pub fn set_source_conn_id_limit(&mut self, v: u64) {
+        // It must be at least 2.
+        if v >= 2 {
+            self.source_conn_id_limit = v as usize;
+        }
+    }
+
+    /// Gets the source Connection ID associated with the provided sequence
+    /// number.
+    #[inline]
+    pub fn get_scid(&self, seq_num: u64) -> Result<&ConnectionIdEntry> {
+        self.scids.get(&seq_num).ok_or(Error::InvalidState)
+    }
+
+    /// Adds a new source identifier, and indicates whether it should be
+    /// advertised through a `NEW_CONNECTION_ID` frame or not.
+    ///
+    /// At any time, the peer cannot have more Destination Connection IDs than
+    /// the maximum number of active Connection IDs it negotiated. In such case
+    /// (i.e., when [`active_source_cids()`] - `peer_active_conn_id_limit` = 0,
+    /// if the caller agrees to request the removal of previous connection IDs,
+    /// it sets the `retire_if_needed` parameter. Otherwhise, an [`IdLimit`] is
+    /// returned.
+    ///
+    /// Note that setting `retire_if_needed` does not prevent this function from
+    /// returning an [`IdLimit`] in the case the caller wants to retire still
+    /// unannounced Connection IDs.
+    ///
+    /// When setting the initial Source Connection ID, the `reset_token` may be
+    /// `None`. However, other Source CIDs must have an associated
+    /// `reset_token`. Providing `None` as the `reset_token` for non-initial
+    /// SCIDs raises an [`InvalidState`].
+    ///
+    /// In the case the provided `cid` is already present, it does not add it.
+    /// If the provided `reset_token` differs from the one already registered,
+    /// returns an `InvalidState`.
+    ///
+    /// Returns the sequence number associated to that new source identifier.
+    ///
+    /// [`active_source_cids()`]:  struct.ConnectionIdentifiers.html#method.active_source_cids
+    /// [`InvalidState`]: enum.Error.html#InvalidState
+    /// [`IdLimit`]: enum.Error.html#IdLimit
+    pub fn new_scid(
+        &mut self, cid: ConnectionId<'static>, reset_token: Option<u128>,
+        advertise: bool, path_id: Option<usize>, retire_if_needed: bool,
+    ) -> Result<u64> {
+        if self.zero_length_scid {
+            return Err(Error::InvalidState);
+        }
+
+        if self.scids.len() >= self.source_conn_id_limit {
+            if !retire_if_needed {
+                return Err(Error::IdLimit);
+            }
+
+            // Avoid buggy applications from driving the stack crazy.
+            let wrap_around_limit = 2 * self.source_conn_id_limit;
+            if self.scids.len() >= wrap_around_limit {
+                return Err(Error::IdLimit);
+            }
+
+            // We need to retire the lowest one.
+            self.retire_prior_to = self.lowest_usable_scid_seq()? + 1;
+        }
+
+        let seq = self.next_scid_seq;
+
+        if reset_token.is_none() && seq != 0 {
+            return Err(Error::InvalidState);
+        }
+
+        if seq == 0 {
+            // Record the zero-length SCID status.
+            self.zero_length_scid = cid.is_empty();
+        }
+
+        // Check first that the SCID has not been inserted before.
+        if let Some((s, e)) = self.scids.iter().find(|(_, e)| e.cid == cid) {
+            if e.reset_token != reset_token {
+                return Err(Error::InvalidState);
+            }
+            return Ok(*s);
+        }
+
+        self.scids.insert(seq, ConnectionIdEntry {
+            cid,
+            seq,
+            reset_token,
+            path_id,
+        });
+        self.next_scid_seq += 1;
+
+        self.mark_new_scids(seq, advertise);
+
+        Ok(seq)
+    }
+
+    /// Sets the initial destination identifier.
+    pub fn set_initial_dcid(
+        &mut self, cid: ConnectionId<'static>, reset_token: Option<u128>,
+        path_id: Option<usize>,
+    ) {
+        self.dcids.clear();
+        // Record the zero-length DCID status.
+        self.zero_length_dcid = cid.is_empty();
+        self.dcids.insert(0, ConnectionIdEntry {
+            cid,
+            seq: 0,
+            reset_token,
+            path_id,
+        });
+    }
+
+    /// Adds a new Destination Connection ID (originating from a
+    /// NEW_CONNECTION_ID frame) and process all its related metadata.
+    ///
+    /// Returns an error if the provided Connection ID or its metadata are
+    /// invalid.
+    ///
+    /// Returns a list of tuples (DCID sequence number, Path ID), containing the
+    /// sequence number of retired DCIDs that were linked to their respective
+    /// Path ID.
+    pub fn new_dcid(
+        &mut self, cid: ConnectionId<'static>, seq: u64, reset_token: u128,
+        retire_prior_to: u64,
+    ) -> Result<Vec<(u64, usize)>> {
+        if self.zero_length_dcid {
+            return Err(Error::InvalidState);
+        }
+
+        let mut retired_path_ids = Vec::new();
+        // If an endpoint receives a NEW_CONNECTION_ID frame that repeats a
+        // previously issued connection ID with a different Stateless Reset
+        // Token field value or a different Sequence Number field value, or if a
+        // sequence number is used for different connection IDs, the endpoint
+        // MAY treat that receipt as a connection error of type
+        // PROTOCOL_VIOLATION.
+        if let Some(e) =
+            self.dcids.values().find(|e| e.cid == cid || e.seq == seq)
+        {
+            if e.cid != cid || e.seq != seq || e.reset_token != Some(reset_token)
+            {
+                return Err(Error::InvalidFrame);
+            }
+            // The identifier is already there, nothing to do.
+            return Ok(retired_path_ids);
+        }
+
+        // The value in the Retire Prior To field MUST be less than or equal to
+        // the value in the Sequence Number field. Receiving a value in the
+        // Retire Prior To field that is greater than that in the Sequence
+        // Number field MUST be treated as a connection error of type
+        // FRAME_ENCODING_ERROR.
+        if retire_prior_to > seq {
+            return Err(Error::InvalidFrame);
+        }
+
+        // An endpoint that receives a NEW_CONNECTION_ID frame with a sequence
+        // number smaller than the Retire Prior To field of a previously
+        // received NEW_CONNECTION_ID frame MUST send a corresponding
+        // RETIRE_CONNECTION_ID frame that retires the newly received connection
+        // ID, unless it has already done so for that sequence number.
+        if seq < self.largest_peer_retire_prior_to {
+            if !self.retire_dcids.contains(&seq) {
+                self.retire_dcids.push_back(seq);
+                return Ok(retired_path_ids);
+            }
+        }
+
+        // A receiver MUST ignore any Retire Prior To fields that do not
+        // increase the largest received Retire Prior To value.
+        if retire_prior_to > self.largest_peer_retire_prior_to {
+            let retired = &mut self.retire_dcids;
+            let events = &mut self.events;
+            self.dcids.retain(|seq, e| {
+                if *seq < retire_prior_to {
+                    retired.push_back(*seq);
+                    // We also need to notify the application.
+                    if let Some(evs) = events {
+                        evs.push_back(ConnectionIdEvent::RetiredDestination(
+                            *seq,
+                        ));
+                    }
+
+                    if let Some(pid) = e.path_id {
+                        retired_path_ids.push((*seq, pid));
+                    }
+
+                    return false;
+                }
+                true
+            });
+            self.largest_peer_retire_prior_to = retire_prior_to;
+        }
+
+        if seq > self.largest_destination_seq {
+            self.largest_destination_seq = seq;
+        }
+
+        self.dcids.insert(seq, ConnectionIdEntry {
+            cid: cid.clone(),
+            seq,
+            reset_token: Some(reset_token),
+            path_id: None,
+        });
+
+        // After processing a NEW_CONNECTION_ID frame and adding and retiring
+        // active connection IDs, if the number of active connection IDs exceeds
+        // the value advertised in its active_connection_id_limit transport
+        // parameter, an endpoint MUST close the connection with an error of type
+        // CONNECTION_ID_LIMIT_ERROR.
+        if self.dcids.len() > self.destination_conn_id_limit {
+            return Err(Error::IdLimit);
+        }
+
+        // Notifies the application.
+        if let Some(evs) = &mut self.events {
+            evs.push_back(ConnectionIdEvent::NewDestination(
+                seq,
+                cid,
+                reset_token,
+            ));
+        }
+
+        Ok(retired_path_ids)
+    }
+
+    /// Retires the Source Connection ID having the provided sequence number.
+    ///
+    /// In case the retired Connection ID is the same as the one used by the
+    /// packet requesting the retiring, or if the retired sequence number is
+    /// greater than any previously advertised sequence numbers, it returns an
+    /// [`InvalidState`].
+    ///
+    /// Returns the path ID that was associated to the retired CID, if any.
+    ///
+    /// [`InvalidState`]: enum.Error.html#InvalidState
+    pub fn retire_scid(
+        &mut self, seq: u64, pkt_dcid: &ConnectionId,
+    ) -> Result<Option<usize>> {
+        if seq >= self.next_scid_seq {
+            return Err(Error::InvalidState);
+        }
+
+        let pid = if let Some(e) = self.scids.remove(&seq) {
+            if e.cid == *pkt_dcid {
+                return Err(Error::InvalidState);
+            }
+            // Notifies the application.
+            if let Some(evs) = &mut self.events {
+                evs.push_back(ConnectionIdEvent::RetiredSource(e.cid));
+            }
+
+            // Retiring this SCID may increase the retire prior to.
+            let lowest_scid_seq = self.lowest_usable_scid_seq()?;
+            self.retire_prior_to = lowest_scid_seq;
+
+            e.path_id
+        } else {
+            None
+        };
+
+        Ok(pid)
+    }
+
+    /// Retires the Destination Connection ID having the provided sequence
+    /// number.
+    ///
+    /// If the caller tries to retire the last destination Connection ID, this
+    /// method triggers an [`OutOfIdentifiers`].
+    ///
+    /// If the caller tries to retire a non-existing Destination Connection
+    /// ID sequence number, this method returns an [`InvalidState`].
+    ///
+    /// Returns the path ID that was associated to the retired CID, if any.
+    ///
+    /// [`OutOfIdentifiers`]: enum.Error.html#OutOfIdentifiers
+    /// [`InvalidState`]: enum.Error.html#InvalidState
+    pub fn retire_dcid(&mut self, seq: u64) -> Result<Option<usize>> {
+        if self.zero_length_dcid {
+            return Err(Error::InvalidState);
+        }
+
+        if self.dcids.len() == 1 {
+            return Err(Error::OutOfIdentifiers);
+        }
+
+        let e = self.dcids.remove(&seq).ok_or(Error::InvalidState)?;
+
+        self.retire_dcids.push_back(seq);
+
+        Ok(e.path_id)
+    }
+
+    /// Updates the Destination Connection ID entry with the provided sequence
+    /// number to indicate that it is now linked to the provided path ID.
+    pub fn link_dcid_to_path_id(
+        &mut self, dcid_seq: u64, path_id: usize,
+    ) -> Result<()> {
+        let e = self.dcids.get_mut(&dcid_seq).ok_or(Error::InvalidState)?;
+        e.path_id = Some(path_id);
+        Ok(())
+    }
+
+    /// Gets the minimum Source Connection ID sequence number whose removal has
+    /// not been requested yet.
+    #[inline]
+    pub fn lowest_usable_scid_seq(&self) -> Result<u64> {
+        self.scids
+            .keys()
+            .filter_map(|x| {
+                if *x >= self.retire_prior_to {
+                    Some(*x)
+                } else {
+                    None
+                }
+            })
+            .min()
+            .ok_or(Error::InvalidState)
+    }
+
+    /// Gets the lowest Destination Connection ID sequence number that is not
+    /// associated to a path.
+    #[inline]
+    pub fn lowest_available_dcid_seq(&self) -> Option<u64> {
+        self.dcids
+            .iter()
+            .filter_map(
+                |(s, e)| if e.path_id.is_none() { Some(*s) } else { None },
+            )
+            .min()
+    }
+
+    /// Returns the oldest active source Connection ID on this connection.
+    #[inline]
+    pub fn oldest_scid(&self) -> Result<&ConnectionIdEntry> {
+        self.scids.values().next().ok_or(Error::InvalidState)
+    }
+
+    /// Returns the oldest active destinatino Connection ID on this connection.
+    #[inline]
+    pub fn oldest_dcid(&self) -> Result<&ConnectionIdEntry> {
+        self.dcids.values().next().ok_or(Error::InvalidState)
+    }
+
+    /// Adds or remove the destination Connection ID sequence number from the
+    /// retire destination Connection ID set.
+    #[inline]
+    pub fn mark_new_scids(&mut self, scid_seq: u64, new: bool) {
+        if new {
+            self.new_scids.push_back(scid_seq);
+        } else {
+            self.new_scids.retain(|s| *s != scid_seq);
+        }
+    }
+
+    /// Adds or remove the destination Connection ID sequence number from the
+    /// retire destination Connection ID set.
+    #[inline]
+    pub fn mark_retire_dcids(&mut self, dcid_seq: u64, retire: bool) {
+        if retire {
+            self.retire_dcids.push_back(dcid_seq);
+        } else {
+            self.retire_dcids.retain(|s| *s != dcid_seq);
+        }
+    }
+
+    /// Creates an iterator over source Connection IDs that need to send
+    /// NEW_CONNECTION_ID frames.
+    #[inline]
+    pub fn new_scids(&self) -> std::collections::vec_deque::Iter<u64> {
+        self.new_scids.iter()
+    }
+
+    /// Creates an iterator over destination Connection IDs that need to send
+    /// RETIRE_CONNECTION_ID frames.
+    #[inline]
+    pub fn retire_dcids(&self) -> std::collections::vec_deque::Iter<u64> {
+        self.retire_dcids.iter()
+    }
+
+    /// Returns true if there are new source Connection IDs to advertise.
+    #[inline]
+    pub fn has_new_scids(&self) -> bool {
+        !self.new_scids.is_empty()
+    }
+
+    /// Returns true if there are retired destination Connection IDs to\
+    /// advertise.
+    #[inline]
+    pub fn has_retire_dcids(&self) -> bool {
+        !self.retire_dcids.is_empty()
+    }
+
+    /// Returns whether zero-length source CIDs are used.
+    #[inline]
+    pub fn zero_length_scid(&self) -> bool {
+        self.zero_length_scid
+    }
+
+    /// Returns whether zero-length destination CIDs are used.
+    #[inline]
+    pub fn zero_length_dcid(&self) -> bool {
+        self.zero_length_dcid
+    }
+
+    /// Gets the first CID-related event to be notified to the application.
+    #[inline]
+    pub fn pop_event(&mut self) -> Option<ConnectionIdEvent> {
+        self.events.as_mut().and_then(|evs| evs.pop_front())
+    }
+
+    /// Gets the NEW_CONNECTION_ID frame related to the source connection ID
+    /// with sequence `seq_num`.
+    pub fn get_new_connection_id_frame_for(
+        &self, seq_num: u64,
+    ) -> Result<frame::Frame> {
+        let e = self.scids.get(&seq_num).ok_or(Error::InvalidState)?;
+        Ok(frame::Frame::NewConnectionId {
+            seq_num,
+            retire_prior_to: self.retire_prior_to,
+            conn_id: e.cid.to_vec(),
+            reset_token: e.reset_token.ok_or(Error::InvalidState)?.to_be_bytes(),
+        })
+    }
+
+    /// Returns the number of source Connection IDs that are active. This is
+    /// only meaningful if the host uses non-zero length Source Connection IDs.
+    #[inline]
+    pub fn active_source_cids(&self) -> usize {
+        self.scids.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::create_cid_and_reset_token;
+
+    impl ConnectionIdentifiers {
+        /// Returns the number of Source Connection IDs that have not been
+        /// assigned to a path yet.
+        ///
+        /// Note that this function is only meaningful if the host uses non-zero
+        /// length Source Connection IDs.
+        #[inline]
+        fn available_scids(&self) -> usize {
+            self.scids.values().filter(|e| e.path_id.is_none()).count()
+        }
+    }
+
+    #[test]
+    fn ids_new_scids() {
+        let mut ids = ConnectionIdentifiers::new(2, true);
+        ids.set_source_conn_id_limit(3);
+
+        let (scid, _) = create_cid_and_reset_token(16);
+        let (dcid, _) = create_cid_and_reset_token(16);
+
+        ids.set_initial_dcid(dcid, None, None);
+        ids.new_scid(scid, None, false, None, false).unwrap();
+
+        assert_eq!(ids.pop_event(), None);
+        assert_eq!(ids.available_scids(), 1);
+        assert_eq!(ids.has_new_scids(), false);
+        assert_eq!(ids.new_scids().collect::<Vec<&u64>>(), Vec::<&u64>::new());
+
+        let (scid2, rt2) = create_cid_and_reset_token(16);
+
+        assert_eq!(ids.new_scid(scid2, Some(rt2), true, None, false), Ok(1));
+        assert_eq!(ids.available_scids(), 2);
+        assert_eq!(ids.has_new_scids(), true);
+        assert_eq!(ids.new_scids().collect::<Vec<&u64>>(), vec![&1]);
+
+        let (scid3, rt3) = create_cid_and_reset_token(16);
+
+        assert_eq!(ids.new_scid(scid3, Some(rt3), true, None, false), Ok(2));
+        assert_eq!(ids.available_scids(), 3);
+        assert_eq!(ids.has_new_scids(), true);
+        assert_eq!(ids.new_scids().collect::<Vec<&u64>>(), vec![&1, &2]);
+
+        // If now we give another CID, it reports an error since it exceeds the
+        // limit of active CIDs.
+        let (scid4, rt4) = create_cid_and_reset_token(16);
+
+        assert_eq!(
+            ids.new_scid(scid4, Some(rt4), true, None, false),
+            Err(Error::IdLimit),
+        );
+        assert_eq!(ids.available_scids(), 3);
+        assert_eq!(ids.has_new_scids(), true);
+        assert_eq!(ids.new_scids().collect::<Vec<&u64>>(), vec![&1, &2]);
+        assert_eq!(ids.pop_event(), None);
+
+        // Assume we sent them.
+        ids.mark_new_scids(1, false);
+        ids.mark_new_scids(2, false);
+
+        assert_eq!(ids.available_scids(), 3);
+        assert_eq!(ids.has_new_scids(), false);
+        assert_eq!(ids.new_scids().collect::<Vec<&u64>>(), Vec::<&u64>::new());
+        assert_eq!(ids.pop_event(), None);
+    }
+
+    #[test]
+    fn new_dcid_event() {
+        let mut ids = ConnectionIdentifiers::new(2, true);
+
+        let (scid, _) = create_cid_and_reset_token(16);
+        let (dcid, _) = create_cid_and_reset_token(16);
+
+        ids.set_initial_dcid(dcid, None, None);
+        ids.new_scid(scid, None, false, None, false).unwrap();
+
+        assert_eq!(ids.pop_event(), None);
+
+        assert_eq!(ids.dcids.len(), 1);
+
+        let (dcid2, rt2) = create_cid_and_reset_token(16);
+
+        assert_eq!(
+            ids.new_dcid(dcid2.clone(), 1, rt2, 0),
+            Ok(Vec::<(u64, usize)>::new()),
+        );
+        assert_eq!(
+            ids.pop_event(),
+            Some(ConnectionIdEvent::NewDestination(1, dcid2, rt2))
+        );
+        assert_eq!(ids.pop_event(), None);
+        assert_eq!(ids.dcids.len(), 2);
+
+        // Now we assume that the client wants to advertise more source
+        // Connection IDs than the advertised limit. This is valid if it
+        // requests its peer to retire enough Connection IDs to fit within the
+        // limits.
+        let (dcid3, rt3) = create_cid_and_reset_token(16);
+        assert_eq!(
+            ids.new_dcid(dcid3.clone(), 2, rt3, 1),
+            Ok(Vec::<(u64, usize)>::new()),
+        );
+        assert_eq!(
+            ids.pop_event(),
+            Some(ConnectionIdEvent::RetiredDestination(0))
+        );
+        assert_eq!(
+            ids.pop_event(),
+            Some(ConnectionIdEvent::NewDestination(2, dcid3, rt3))
+        );
+        assert_eq!(ids.pop_event(), None);
+        assert_eq!(ids.dcids.len(), 2);
+        assert_eq!(ids.has_retire_dcids(), true);
+        assert_eq!(ids.retire_dcids().collect::<Vec::<&u64>>(), vec![&0]);
+
+        // Fake RETIRE_CONNECTION_ID sending.
+        ids.mark_retire_dcids(0, false);
+        assert_eq!(ids.has_retire_dcids(), false);
+        assert_eq!(
+            ids.retire_dcids().collect::<Vec::<&u64>>(),
+            Vec::<&u64>::new()
+        );
+
+        // Now tries to experience CID retirement. If the server tries to remove
+        // non-existing DCIDs, it fails.
+        assert_eq!(ids.retire_dcid(0), Err(Error::InvalidState));
+        assert_eq!(ids.retire_dcid(3), Err(Error::InvalidState));
+        assert_eq!(ids.has_retire_dcids(), false);
+        assert_eq!(ids.dcids.len(), 2);
+
+        // Now it removes DCID with sequence 1.
+        assert_eq!(ids.retire_dcid(1), Ok(None));
+        assert_eq!(ids.has_retire_dcids(), true);
+        assert_eq!(ids.retire_dcids().collect::<Vec::<&u64>>(), vec![&1]);
+        assert_eq!(ids.dcids.len(), 1);
+
+        // Fake RETIRE_CONNECTION_ID sending.
+        ids.mark_retire_dcids(1, false);
+        assert_eq!(ids.has_retire_dcids(), false);
+        assert_eq!(
+            ids.retire_dcids().collect::<Vec::<&u64>>(),
+            Vec::<&u64>::new()
+        );
+
+        // Trying to remove the last DCID triggers an error.
+        assert_eq!(ids.retire_dcid(2), Err(Error::OutOfIdentifiers));
+        assert_eq!(ids.has_retire_dcids(), false);
+        assert_eq!(ids.dcids.len(), 1);
+    }
+}

--- a/quiche/src/cid.rs
+++ b/quiche/src/cid.rs
@@ -316,11 +316,11 @@ impl ConnectionIdentifiers {
         // received NEW_CONNECTION_ID frame MUST send a corresponding
         // RETIRE_CONNECTION_ID frame that retires the newly received connection
         // ID, unless it has already done so for that sequence number.
-        if seq < self.largest_peer_retire_prior_to {
-            if !self.retire_dcids.contains(&seq) {
-                self.retire_dcids.push_back(seq);
-                return Ok(retired_path_ids);
-            }
+        if seq < self.largest_peer_retire_prior_to &&
+            !self.retire_dcids.contains(&seq)
+        {
+            self.retire_dcids.push_back(seq);
+            return Ok(retired_path_ids);
         }
 
         // A receiver MUST ignore any Retire Prior To fields that do not

--- a/quiche/src/cid.rs
+++ b/quiche/src/cid.rs
@@ -30,7 +30,6 @@ use crate::Result;
 use crate::frame;
 use crate::packet::ConnectionId;
 
-use std::collections::HashMap;
 use std::collections::VecDeque;
 
 /// A Connection Id-specific event.
@@ -48,7 +47,7 @@ pub enum ConnectionIdEvent {
 }
 
 /// A structure holding a `ConnectionId` and all its related metadata.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ConnectionIdEntry {
     /// The Connection ID.
     pub cid: ConnectionId<'static>,
@@ -60,51 +59,161 @@ pub struct ConnectionIdEntry {
     pub path_id: Option<usize>,
 }
 
-/// A simple no-op hasher for Connection ID sequence numbers.
-///
-/// The QUIC protocol and quiche library guarantees Connection ID sequence
-/// number uniqueness, so we can save effort by avoiding using a more
-/// complicated algorithm.
 #[derive(Default)]
-pub struct ConnectionIdSeqHasher {
-    id: u64,
+struct BoundedNonEmptyConnectionIdVecDeque {
+    /// The inner `VecDeque`.
+    inner: VecDeque<ConnectionIdEntry>,
+    /// The maximum number of elements that the `VecDeque` can have.
+    capacity: usize,
 }
 
-impl std::hash::Hasher for ConnectionIdSeqHasher {
-    #[inline]
-    fn finish(&self) -> u64 {
-        self.id
+impl BoundedNonEmptyConnectionIdVecDeque {
+    /// Creates a `VecDeque` with the provided `capacity` and inserts
+    /// `initial_entry` in it.
+    fn new(capacity: usize, initial_entry: ConnectionIdEntry) -> Self {
+        let capacity = std::cmp::max(capacity, 1);
+        let mut inner = VecDeque::with_capacity(capacity);
+        inner.push_back(initial_entry);
+        Self { inner, capacity }
     }
 
-    #[inline]
-    fn write_u64(&mut self, id: u64) {
-        self.id = id;
+    /// Updates the capacity of the inner `VecDeque` to `new_capacity`. Does
+    /// nothing if `new_capacity` is lower or equal to the current `capacity`.
+    fn resize(&mut self, new_capacity: usize) {
+        if new_capacity > self.capacity {
+            self.capacity = new_capacity;
+            let additional = new_capacity - self.inner.len();
+            self.inner.reserve_exact(additional);
+        }
     }
 
-    #[inline]
-    fn write(&mut self, _: &[u8]) {
-        // We need a default write() for the trait but Connection ID sequence
-        // number will always be a u64 so we just delegate to write_u64.
-        unimplemented!()
+    /// Returns the oldest inserted entry still present in the `VecDeque`.
+    fn get_oldest(&self) -> &ConnectionIdEntry {
+        self.inner.front().expect("vecdeque is empty")
+    }
+
+    /// Gets a immutable reference to the entry having the provided `seq`.
+    fn get(&self, seq: u64) -> Option<&ConnectionIdEntry> {
+        // We need to iterate over the whole map to find the key.
+        self.inner.iter().find(|e| e.seq == seq)
+    }
+
+    /// Gets a mutable reference to the entry having the provided `seq`.
+    fn get_mut(&mut self, seq: u64) -> Option<&mut ConnectionIdEntry> {
+        // We need to iterate over the whole map to find the key.
+        self.inner.iter_mut().find(|e| e.seq == seq)
+    }
+
+    /// Returns an iterator over the entries in the `VecDeque`.
+    fn iter(&self) -> impl Iterator<Item = &ConnectionIdEntry> {
+        self.inner.iter()
+    }
+
+    /// Returns the number of elements in the `VecDeque`.
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Inserts the provided entry in the `VecDeque`.
+    ///
+    /// This method ensures the unicity of the `seq` associated to an entry. If
+    /// an entry has the same `seq` than `e`, this method updates the entry in
+    /// the `VecDeque` and the number of stored elements remains unchanged.
+    ///
+    /// If inserting a new element would exceed the collection's capacity, this
+    /// method raises an [`IdLimit`].
+    ///
+    /// [`IdLimit`]: enum.Error.html#IdLimit
+    fn insert(&mut self, e: ConnectionIdEntry) -> Result<()> {
+        // Ensure we don't have duplicates.
+        match self.get_mut(e.seq) {
+            Some(oe) => *oe = e,
+            None => {
+                if self.inner.len() == self.capacity {
+                    return Err(Error::IdLimit);
+                }
+                self.inner.push_back(e);
+            },
+        };
+        Ok(())
+    }
+
+    /// Removes all the elements in the collection and inserts the provided one.
+    fn clear_and_insert(&mut self, e: ConnectionIdEntry) {
+        self.inner.clear();
+        self.inner.push_back(e);
+    }
+
+    /// Removes the element in the collection having the provided `seq`.
+    ///
+    /// If this method is called when there remains a single element in the
+    /// collection, this method raises an [`OutOfIdentifiers`].
+    ///
+    /// Returns `Some` if the element was in the collection and removed, or
+    /// `None` if it was not and nothing was modified.
+    ///
+    /// [`OutOfIdentifiers`]: enum.Error.html#OutOfIdentifiers
+    fn remove(&mut self, seq: u64) -> Result<Option<ConnectionIdEntry>> {
+        if self.inner.len() <= 1 {
+            return Err(Error::OutOfIdentifiers);
+        }
+
+        Ok(self
+            .inner
+            .iter()
+            .position(|e| e.seq == seq)
+            .and_then(|index| self.inner.remove(index)))
+    }
+
+    /// Removes all the elements in the collection whose `seq` is lower than the
+    /// provided one, and inserts `e` in the collection.
+    ///
+    /// For each removed element `re`, `f(re)` is called.
+    ///
+    /// If the inserted element has a `seq` lower than the one used to remove
+    /// elements, it raises an [`OutOfIdentifiers`].
+    ///
+    /// [`OutOfIdentifiers`]: enum.Error.html#OutOfIdentifiers
+    fn remove_lower_than_and_insert<F>(
+        &mut self, seq: u64, e: ConnectionIdEntry, mut f: F,
+    ) -> Result<()>
+    where
+        F: FnMut(&ConnectionIdEntry),
+    {
+        // The insert entry MUST have a sequence higher or equal to the ones
+        // being retired.
+        if e.seq < seq {
+            return Err(Error::OutOfIdentifiers);
+        }
+
+        // To avoid exceeding the capacity of the inner `VecDeque`, we first
+        // remove the elements and then insert the new one.
+        self.inner.retain(|e| {
+            if e.seq < seq {
+                f(e);
+                false
+            } else {
+                true
+            }
+        });
+
+        // Note that if no element has been retired and the `VecDeque` reaches
+        // its capacity limit, this will raise an `IdLimit`.
+        self.insert(e)
     }
 }
-
-type BuildConnectionIdSeqHasher =
-    std::hash::BuildHasherDefault<ConnectionIdSeqHasher>;
-
-type ConnectionIdSeqHashMap<V> = HashMap<u64, V, BuildConnectionIdSeqHasher>;
 
 #[derive(Default)]
 pub struct ConnectionIdentifiers {
     /// All the Destination Connection IDs provided by our peer.
-    dcids: ConnectionIdSeqHashMap<ConnectionIdEntry>,
+    dcids: BoundedNonEmptyConnectionIdVecDeque,
     /// All the Source Connection IDs we provide to our peer.
-    scids: ConnectionIdSeqHashMap<ConnectionIdEntry>,
+    scids: BoundedNonEmptyConnectionIdVecDeque,
 
     /// Source Connection IDs that should be announced to the peer.
-    new_scids: VecDeque<u64>,
+    advertise_new_scid_seqs: VecDeque<u64>,
     /// Retired Destination Connection IDs that should be announced to the peer.
-    retire_dcids: VecDeque<u64>,
+    retire_dcid_seqs: VecDeque<u64>,
 
     /// All Connection ID related events that should be notified to the
     /// application.
@@ -119,8 +228,6 @@ pub struct ConnectionIdentifiers {
     /// "Retire Prior To" value to advertise to the peer.
     retire_prior_to: u64,
 
-    /// The maximum number of destination Connection IDs we allow.
-    destination_conn_id_limit: usize,
     /// The maximum number of source Connection IDs our peer allows us.
     source_conn_id_limit: usize,
 
@@ -132,23 +239,54 @@ pub struct ConnectionIdentifiers {
 
 impl ConnectionIdentifiers {
     /// Creates a new `ConnectionIdentifiers` with the specified destination
-    /// connection ID limit.
+    /// connection ID limit and initial source Connection ID. The destination
+    /// Connection ID is set to the empty one.
     pub fn new(
         mut destination_conn_id_limit: usize, enable_events: bool,
+        initial_scid: ConnectionId, reset_token: Option<u128>,
     ) -> ConnectionIdentifiers {
         // It must be at least 2.
         if destination_conn_id_limit < 2 {
             destination_conn_id_limit = 2;
         }
+        // Initially, the limit of active source connection IDs is 2.
+        let source_conn_id_limit = 2;
         let events = if enable_events {
             Some(VecDeque::new())
         } else {
             None
         };
-        ConnectionIdentifiers {
+        // Record the zero-length SCID status.
+        let zero_length_scid = initial_scid.is_empty();
+        // We need to track up to (2 * source_conn_id_limit - 1) source
+        // Connection IDs when the host wants to force their renewal.
+        let scids = BoundedNonEmptyConnectionIdVecDeque::new(
+            2 * source_conn_id_limit - 1,
+            ConnectionIdEntry {
+                cid: initial_scid.into_owned(),
+                seq: 0,
+                reset_token,
+                path_id: Some(0),
+            },
+        );
+        let dcids = BoundedNonEmptyConnectionIdVecDeque::new(
             destination_conn_id_limit,
-            source_conn_id_limit: 2,
+            ConnectionIdEntry {
+                cid: ConnectionId::default(),
+                seq: 0,
+                reset_token: None,
+                path_id: Some(0),
+            },
+        );
+        // Because we already inserted the initial SCID.
+        let next_scid_seq = 1;
+        ConnectionIdentifiers {
+            source_conn_id_limit,
             events,
+            scids,
+            dcids,
+            zero_length_scid,
+            next_scid_seq,
             ..Default::default()
         }
     }
@@ -158,6 +296,9 @@ impl ConnectionIdentifiers {
         // It must be at least 2.
         if v >= 2 {
             self.source_conn_id_limit = v as usize;
+            // We need to track up to (2 * source_conn_id_limit - 1) source
+            // Connection IDs when the host wants to force their renewal.
+            self.scids.resize((2 * v - 1) as usize);
         }
     }
 
@@ -165,7 +306,7 @@ impl ConnectionIdentifiers {
     /// number.
     #[inline]
     pub fn get_scid(&self, seq_num: u64) -> Result<&ConnectionIdEntry> {
-        self.scids.get(&seq_num).ok_or(Error::InvalidState)
+        self.scids.get(seq_num).ok_or(Error::InvalidState)
     }
 
     /// Adds a new source identifier, and indicates whether it should be
@@ -204,14 +345,12 @@ impl ConnectionIdentifiers {
             return Err(Error::InvalidState);
         }
 
+        // Check whether the number of source Connection IDs does not exceed the
+        // limit. If the host agrees to retire old CIDs, it can store up to
+        // (2 * source_active_conn_id - 1) source CIDs. This limit is enforced
+        // when calling `self.scids.insert()`.
         if self.scids.len() >= self.source_conn_id_limit {
             if !retire_if_needed {
-                return Err(Error::IdLimit);
-            }
-
-            // Avoid buggy applications from driving the stack crazy.
-            let wrap_around_limit = 2 * self.source_conn_id_limit;
-            if self.scids.len() >= wrap_around_limit {
                 return Err(Error::IdLimit);
             }
 
@@ -225,28 +364,23 @@ impl ConnectionIdentifiers {
             return Err(Error::InvalidState);
         }
 
-        if seq == 0 {
-            // Record the zero-length SCID status.
-            self.zero_length_scid = cid.is_empty();
-        }
-
         // Check first that the SCID has not been inserted before.
-        if let Some((s, e)) = self.scids.iter().find(|(_, e)| e.cid == cid) {
+        if let Some(e) = self.scids.iter().find(|e| e.cid == cid) {
             if e.reset_token != reset_token {
                 return Err(Error::InvalidState);
             }
-            return Ok(*s);
+            return Ok(e.seq);
         }
 
-        self.scids.insert(seq, ConnectionIdEntry {
+        self.scids.insert(ConnectionIdEntry {
             cid,
             seq,
             reset_token,
             path_id,
-        });
+        })?;
         self.next_scid_seq += 1;
 
-        self.mark_new_scids(seq, advertise);
+        self.mark_advertise_new_scid_seq(seq, advertise);
 
         Ok(seq)
     }
@@ -256,10 +390,9 @@ impl ConnectionIdentifiers {
         &mut self, cid: ConnectionId<'static>, reset_token: Option<u128>,
         path_id: Option<usize>,
     ) {
-        self.dcids.clear();
         // Record the zero-length DCID status.
         self.zero_length_dcid = cid.is_empty();
-        self.dcids.insert(0, ConnectionIdEntry {
+        self.dcids.clear_and_insert(ConnectionIdEntry {
             cid,
             seq: 0,
             reset_token,
@@ -291,8 +424,7 @@ impl ConnectionIdentifiers {
         // sequence number is used for different connection IDs, the endpoint
         // MAY treat that receipt as a connection error of type
         // PROTOCOL_VIOLATION.
-        if let Some(e) =
-            self.dcids.values().find(|e| e.cid == cid || e.seq == seq)
+        if let Some(e) = self.dcids.iter().find(|e| e.cid == cid || e.seq == seq)
         {
             if e.cid != cid || e.seq != seq || e.reset_token != Some(reset_token)
             {
@@ -317,56 +449,54 @@ impl ConnectionIdentifiers {
         // RETIRE_CONNECTION_ID frame that retires the newly received connection
         // ID, unless it has already done so for that sequence number.
         if seq < self.largest_peer_retire_prior_to &&
-            !self.retire_dcids.contains(&seq)
+            !self.retire_dcid_seqs.contains(&seq)
         {
-            self.retire_dcids.push_back(seq);
+            self.retire_dcid_seqs.push_back(seq);
             return Ok(retired_path_ids);
-        }
-
-        // A receiver MUST ignore any Retire Prior To fields that do not
-        // increase the largest received Retire Prior To value.
-        if retire_prior_to > self.largest_peer_retire_prior_to {
-            let retired = &mut self.retire_dcids;
-            let events = &mut self.events;
-            self.dcids.retain(|seq, e| {
-                if *seq < retire_prior_to {
-                    retired.push_back(*seq);
-                    // We also need to notify the application.
-                    if let Some(evs) = events {
-                        evs.push_back(ConnectionIdEvent::RetiredDestination(
-                            *seq,
-                        ));
-                    }
-
-                    if let Some(pid) = e.path_id {
-                        retired_path_ids.push((*seq, pid));
-                    }
-
-                    return false;
-                }
-                true
-            });
-            self.largest_peer_retire_prior_to = retire_prior_to;
         }
 
         if seq > self.largest_destination_seq {
             self.largest_destination_seq = seq;
         }
 
-        self.dcids.insert(seq, ConnectionIdEntry {
+        let new_entry = ConnectionIdEntry {
             cid: cid.clone(),
             seq,
             reset_token: Some(reset_token),
             path_id: None,
-        });
+        };
 
+        // A receiver MUST ignore any Retire Prior To fields that do not
+        // increase the largest received Retire Prior To value.
+        //
         // After processing a NEW_CONNECTION_ID frame and adding and retiring
         // active connection IDs, if the number of active connection IDs exceeds
         // the value advertised in its active_connection_id_limit transport
         // parameter, an endpoint MUST close the connection with an error of type
         // CONNECTION_ID_LIMIT_ERROR.
-        if self.dcids.len() > self.destination_conn_id_limit {
-            return Err(Error::IdLimit);
+        if retire_prior_to > self.largest_peer_retire_prior_to {
+            let retired = &mut self.retire_dcid_seqs;
+            let events = &mut self.events;
+            self.dcids.remove_lower_than_and_insert(
+                retire_prior_to,
+                new_entry,
+                |e| {
+                    retired.push_back(e.seq);
+                    // We also need to notify the application.
+                    if let Some(evs) = events {
+                        evs.push_back(ConnectionIdEvent::RetiredDestination(
+                            e.seq,
+                        ));
+                    }
+
+                    if let Some(pid) = e.path_id {
+                        retired_path_ids.push((e.seq, pid));
+                    }
+                },
+            )?;
+            self.largest_peer_retire_prior_to = retire_prior_to;
+        } else {
+            self.dcids.insert(new_entry)?;
         }
 
         // Notifies the application.
@@ -398,7 +528,7 @@ impl ConnectionIdentifiers {
             return Err(Error::InvalidState);
         }
 
-        let pid = if let Some(e) = self.scids.remove(&seq) {
+        let pid = if let Some(e) = self.scids.remove(seq)? {
             if e.cid == *pkt_dcid {
                 return Err(Error::InvalidState);
             }
@@ -437,13 +567,9 @@ impl ConnectionIdentifiers {
             return Err(Error::InvalidState);
         }
 
-        if self.dcids.len() == 1 {
-            return Err(Error::OutOfIdentifiers);
-        }
+        let e = self.dcids.remove(seq)?.ok_or(Error::InvalidState)?;
 
-        let e = self.dcids.remove(&seq).ok_or(Error::InvalidState)?;
-
-        self.retire_dcids.push_back(seq);
+        self.retire_dcid_seqs.push_back(seq);
 
         Ok(e.path_id)
     }
@@ -453,7 +579,7 @@ impl ConnectionIdentifiers {
     pub fn link_dcid_to_path_id(
         &mut self, dcid_seq: u64, path_id: usize,
     ) -> Result<()> {
-        let e = self.dcids.get_mut(&dcid_seq).ok_or(Error::InvalidState)?;
+        let e = self.dcids.get_mut(dcid_seq).ok_or(Error::InvalidState)?;
         e.path_id = Some(path_id);
         Ok(())
     }
@@ -463,10 +589,10 @@ impl ConnectionIdentifiers {
     #[inline]
     pub fn lowest_usable_scid_seq(&self) -> Result<u64> {
         self.scids
-            .keys()
-            .filter_map(|x| {
-                if *x >= self.retire_prior_to {
-                    Some(*x)
+            .iter()
+            .filter_map(|e| {
+                if e.seq >= self.retire_prior_to {
+                    Some(e.seq)
                 } else {
                     None
                 }
@@ -481,71 +607,96 @@ impl ConnectionIdentifiers {
     pub fn lowest_available_dcid_seq(&self) -> Option<u64> {
         self.dcids
             .iter()
-            .filter_map(
-                |(s, e)| if e.path_id.is_none() { Some(*s) } else { None },
-            )
+            .filter_map(|e| {
+                if e.path_id.is_none() {
+                    Some(e.seq)
+                } else {
+                    None
+                }
+            })
             .min()
     }
 
-    /// Returns the oldest active source Connection ID on this connection.
+    /// Returns the oldest active source Connection ID of this connection.
     #[inline]
-    pub fn oldest_scid(&self) -> Result<&ConnectionIdEntry> {
-        self.scids.values().next().ok_or(Error::InvalidState)
+    pub fn oldest_scid(&self) -> &ConnectionIdEntry {
+        self.scids.get_oldest()
     }
 
-    /// Returns the oldest active destinatino Connection ID on this connection.
+    /// Returns the oldest known active destination Connection ID of this
+    /// connection.
+    ///
+    /// Note that due to e.g., reordering at reception side, the oldest known
+    /// active destination Connection ID is not necessarily the one having the
+    /// lowest sequence.
     #[inline]
-    pub fn oldest_dcid(&self) -> Result<&ConnectionIdEntry> {
-        self.dcids.values().next().ok_or(Error::InvalidState)
+    pub fn oldest_dcid(&self) -> &ConnectionIdEntry {
+        self.dcids.get_oldest()
     }
 
-    /// Adds or remove the destination Connection ID sequence number from the
-    /// retire destination Connection ID set.
-    #[inline]
-    pub fn mark_new_scids(&mut self, scid_seq: u64, new: bool) {
-        if new {
-            self.new_scids.push_back(scid_seq);
-        } else {
-            self.new_scids.retain(|s| *s != scid_seq);
-        }
-    }
-
-    /// Adds or remove the destination Connection ID sequence number from the
-    /// retire destination Connection ID set.
-    #[inline]
-    pub fn mark_retire_dcids(&mut self, dcid_seq: u64, retire: bool) {
-        if retire {
-            self.retire_dcids.push_back(dcid_seq);
-        } else {
-            self.retire_dcids.retain(|s| *s != dcid_seq);
-        }
-    }
-
-    /// Creates an iterator over source Connection IDs that need to send
+    /// Adds or remove the source Connection ID sequence number from the
+    /// source Connection ID set that need to be advertised to the peer through
     /// NEW_CONNECTION_ID frames.
     #[inline]
-    pub fn new_scids(&self) -> std::collections::vec_deque::Iter<u64> {
-        self.new_scids.iter()
+    pub fn mark_advertise_new_scid_seq(
+        &mut self, scid_seq: u64, advertise: bool,
+    ) {
+        if advertise {
+            self.advertise_new_scid_seqs.push_back(scid_seq);
+        } else if let Some(index) = self
+            .advertise_new_scid_seqs
+            .iter()
+            .position(|s| *s == scid_seq)
+        {
+            self.advertise_new_scid_seqs.remove(index);
+        }
     }
 
-    /// Creates an iterator over destination Connection IDs that need to send
-    /// RETIRE_CONNECTION_ID frames.
+    /// Adds or remove the destination Connection ID sequence number from the
+    /// retired destination Connection ID set that need to be advertised to the
+    /// peer through RETIRE_CONNECTION_ID frames.
     #[inline]
-    pub fn retire_dcids(&self) -> std::collections::vec_deque::Iter<u64> {
-        self.retire_dcids.iter()
+    pub fn mark_retire_dcid_seq(&mut self, dcid_seq: u64, retire: bool) {
+        if retire {
+            self.retire_dcid_seqs.push_back(dcid_seq);
+        } else if let Some(index) =
+            self.retire_dcid_seqs.iter().position(|s| *s == dcid_seq)
+        {
+            self.retire_dcid_seqs.remove(index);
+        }
+    }
+
+    /// Gets a source Connection ID's sequence number requiring advertising it
+    /// to the peer through NEW_CONNECTION_ID frame, if any.
+    ///
+    /// If `Some`, it always returns the same value until it has been removed
+    /// using `mark_advertise_new_scid_seq`.
+    #[inline]
+    pub fn next_advertise_new_scid_seq(&self) -> Option<u64> {
+        self.advertise_new_scid_seqs.front().copied()
+    }
+
+    /// Gets a destination Connection IDs's sequence number that need to send
+    /// RETIRE_CONNECTION_ID frames.
+    ///
+    /// If `Some`, it always returns the same value until it has been removed
+    /// using `mark_retire_dcid_seq`.
+    #[inline]
+    pub fn next_retire_dcid_seq(&self) -> Option<u64> {
+        self.retire_dcid_seqs.front().copied()
     }
 
     /// Returns true if there are new source Connection IDs to advertise.
     #[inline]
     pub fn has_new_scids(&self) -> bool {
-        !self.new_scids.is_empty()
+        !self.advertise_new_scid_seqs.is_empty()
     }
 
     /// Returns true if there are retired destination Connection IDs to\
     /// advertise.
     #[inline]
     pub fn has_retire_dcids(&self) -> bool {
-        !self.retire_dcids.is_empty()
+        !self.retire_dcid_seqs.is_empty()
     }
 
     /// Returns whether zero-length source CIDs are used.
@@ -571,7 +722,7 @@ impl ConnectionIdentifiers {
     pub fn get_new_connection_id_frame_for(
         &self, seq_num: u64,
     ) -> Result<frame::Frame> {
-        let e = self.scids.get(&seq_num).ok_or(Error::InvalidState)?;
+        let e = self.scids.get(seq_num).ok_or(Error::InvalidState)?;
         Ok(frame::Frame::NewConnectionId {
             seq_num,
             retire_prior_to: self.retire_prior_to,
@@ -601,39 +752,37 @@ mod tests {
         /// length Source Connection IDs.
         #[inline]
         fn available_scids(&self) -> usize {
-            self.scids.values().filter(|e| e.path_id.is_none()).count()
+            self.scids.iter().filter(|e| e.path_id.is_none()).count()
         }
     }
 
     #[test]
     fn ids_new_scids() {
-        let mut ids = ConnectionIdentifiers::new(2, true);
-        ids.set_source_conn_id_limit(3);
-
         let (scid, _) = create_cid_and_reset_token(16);
         let (dcid, _) = create_cid_and_reset_token(16);
 
+        let mut ids = ConnectionIdentifiers::new(2, true, scid, None);
+        ids.set_source_conn_id_limit(3);
         ids.set_initial_dcid(dcid, None, None);
-        ids.new_scid(scid, None, false, None, false).unwrap();
 
         assert_eq!(ids.pop_event(), None);
-        assert_eq!(ids.available_scids(), 1);
+        assert_eq!(ids.available_scids(), 0);
         assert_eq!(ids.has_new_scids(), false);
-        assert_eq!(ids.new_scids().collect::<Vec<&u64>>(), Vec::<&u64>::new());
+        assert_eq!(ids.next_advertise_new_scid_seq(), None);
 
         let (scid2, rt2) = create_cid_and_reset_token(16);
 
         assert_eq!(ids.new_scid(scid2, Some(rt2), true, None, false), Ok(1));
-        assert_eq!(ids.available_scids(), 2);
+        assert_eq!(ids.available_scids(), 1);
         assert_eq!(ids.has_new_scids(), true);
-        assert_eq!(ids.new_scids().collect::<Vec<&u64>>(), vec![&1]);
+        assert_eq!(ids.next_advertise_new_scid_seq(), Some(1));
 
         let (scid3, rt3) = create_cid_and_reset_token(16);
 
         assert_eq!(ids.new_scid(scid3, Some(rt3), true, None, false), Ok(2));
-        assert_eq!(ids.available_scids(), 3);
+        assert_eq!(ids.available_scids(), 2);
         assert_eq!(ids.has_new_scids(), true);
-        assert_eq!(ids.new_scids().collect::<Vec<&u64>>(), vec![&1, &2]);
+        assert_eq!(ids.next_advertise_new_scid_seq(), Some(1));
 
         // If now we give another CID, it reports an error since it exceeds the
         // limit of active CIDs.
@@ -643,30 +792,34 @@ mod tests {
             ids.new_scid(scid4, Some(rt4), true, None, false),
             Err(Error::IdLimit),
         );
-        assert_eq!(ids.available_scids(), 3);
+        assert_eq!(ids.available_scids(), 2);
         assert_eq!(ids.has_new_scids(), true);
-        assert_eq!(ids.new_scids().collect::<Vec<&u64>>(), vec![&1, &2]);
+        assert_eq!(ids.next_advertise_new_scid_seq(), Some(1));
         assert_eq!(ids.pop_event(), None);
 
-        // Assume we sent them.
-        ids.mark_new_scids(1, false);
-        ids.mark_new_scids(2, false);
+        // Assume we sent one of them.
+        ids.mark_advertise_new_scid_seq(1, false);
+        assert_eq!(ids.available_scids(), 2);
+        assert_eq!(ids.has_new_scids(), true);
+        assert_eq!(ids.next_advertise_new_scid_seq(), Some(2));
+        assert_eq!(ids.pop_event(), None);
 
-        assert_eq!(ids.available_scids(), 3);
+        // Send the other.
+        ids.mark_advertise_new_scid_seq(2, false);
+
+        assert_eq!(ids.available_scids(), 2);
         assert_eq!(ids.has_new_scids(), false);
-        assert_eq!(ids.new_scids().collect::<Vec<&u64>>(), Vec::<&u64>::new());
+        assert_eq!(ids.next_advertise_new_scid_seq(), None);
         assert_eq!(ids.pop_event(), None);
     }
 
     #[test]
     fn new_dcid_event() {
-        let mut ids = ConnectionIdentifiers::new(2, true);
-
         let (scid, _) = create_cid_and_reset_token(16);
         let (dcid, _) = create_cid_and_reset_token(16);
 
+        let mut ids = ConnectionIdentifiers::new(2, true, scid, None);
         ids.set_initial_dcid(dcid, None, None);
-        ids.new_scid(scid, None, false, None, false).unwrap();
 
         assert_eq!(ids.pop_event(), None);
 
@@ -705,15 +858,12 @@ mod tests {
         assert_eq!(ids.pop_event(), None);
         assert_eq!(ids.dcids.len(), 2);
         assert_eq!(ids.has_retire_dcids(), true);
-        assert_eq!(ids.retire_dcids().collect::<Vec::<&u64>>(), vec![&0]);
+        assert_eq!(ids.next_retire_dcid_seq(), Some(0));
 
         // Fake RETIRE_CONNECTION_ID sending.
-        ids.mark_retire_dcids(0, false);
+        ids.mark_retire_dcid_seq(0, false);
         assert_eq!(ids.has_retire_dcids(), false);
-        assert_eq!(
-            ids.retire_dcids().collect::<Vec::<&u64>>(),
-            Vec::<&u64>::new()
-        );
+        assert_eq!(ids.next_retire_dcid_seq(), None);
 
         // Now tries to experience CID retirement. If the server tries to remove
         // non-existing DCIDs, it fails.
@@ -725,16 +875,13 @@ mod tests {
         // Now it removes DCID with sequence 1.
         assert_eq!(ids.retire_dcid(1), Ok(None));
         assert_eq!(ids.has_retire_dcids(), true);
-        assert_eq!(ids.retire_dcids().collect::<Vec::<&u64>>(), vec![&1]);
+        assert_eq!(ids.next_retire_dcid_seq(), Some(1));
         assert_eq!(ids.dcids.len(), 1);
 
         // Fake RETIRE_CONNECTION_ID sending.
-        ids.mark_retire_dcids(1, false);
+        ids.mark_retire_dcid_seq(1, false);
         assert_eq!(ids.has_retire_dcids(), false);
-        assert_eq!(
-            ids.retire_dcids().collect::<Vec::<&u64>>(),
-            Vec::<&u64>::new()
-        );
+        assert_eq!(ids.next_retire_dcid_seq(), None);
 
         // Trying to remove the last DCID triggers an error.
         assert_eq!(ids.retire_dcid(2), Err(Error::OutOfIdentifiers));

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -952,30 +952,22 @@ pub extern fn quiche_conn_trace_id(
 #[no_mangle]
 pub extern fn quiche_conn_source_id(
     conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
-) -> c_int {
-    let conn_id = match conn.source_id() {
-        Ok(cid) => cid,
-        Err(e) => return e.to_c() as c_int,
-    };
+) {
+    let conn_id = conn.source_id();
     let id = conn_id.as_ref();
     *out = id.as_ptr();
     *out_len = id.len();
-    0
 }
 
 #[no_mangle]
 pub extern fn quiche_conn_destination_id(
     conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
-) -> c_int {
-    let conn_id = match conn.destination_id() {
-        Ok(cid) => cid,
-        Err(e) => return e.to_c() as c_int,
-    };
+) {
+    let conn_id = conn.destination_id();
     let id = conn_id.as_ref();
 
     *out = id.as_ptr();
     *out_len = id.len();
-    0
 }
 
 #[no_mangle]

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -1100,12 +1100,21 @@ impl std::fmt::Debug for Frame {
                 write!(f, "STREAMS_BLOCKED type=uni limit={}", limit)?;
             },
 
-            Frame::NewConnectionId { .. } => {
-                write!(f, "NEW_CONNECTION_ID (TODO)")?;
+            Frame::NewConnectionId {
+                seq_num,
+                retire_prior_to,
+                conn_id,
+                reset_token,
+            } => {
+                write!(
+                    f,
+                    "NEW_CONNECTION_ID seq_num={} retire_prior_to={} conn_id={:02x?} reset_token={:02x?}",
+                    seq_num, retire_prior_to, conn_id, reset_token,
+                )?;
             },
 
-            Frame::RetireConnectionId { .. } => {
-                write!(f, "RETIRE_CONNECTION_ID (TODO)")?;
+            Frame::RetireConnectionId { seq_num } => {
+                write!(f, "RETIRE_CONNECTION_ID seq_num={}", seq_num)?;
             },
 
             Frame::PathChallenge { data } => {


### PR DESCRIPTION
The main features that this commit introduces are the following.

Monitoring of QUIC events

This commit introduces a new public Connection method called
`poll()`, acting similarly to the `poll()` method in the h3 module.
This enables the application to handle various newly introduced
events, currently only specific to Connection IDs.

Support for Connection ID changes

The connection is no more bound to a single SCID-DCID pair and can
now advertise and use other Connection IDs through
NEW_CONNECTION_ID and RETIRE_CONNECTION_ID frames. From an API
viewpoint, a host can indicate in its QUIC config the maximum
number of active connection IDs it can support
(`set_active_connection_id_limit()`). Then, it can actively provide
Connection IDs to its peer (`new_source_cid()`) and retire
peer-provided Connection IDs (`retire_destination_cid()`). Passive
operations (like receiving a new Destination Connection ID or
retiring a source Connection ID) are monitored through the `poll()`
method. Connection IDs are handled by a dedicated structure,
`ConnectionIdentifiers`, located in the newly introduced `cid`
module.

Retro-compatibility notes

The provided features were designed to minimise breaking changes to
the application. Still, taking advantages of all the features
brought by this commit requires the application to listen to events
returned by `poll()`. By default, the generation of these events is
disabled to avoid allocating memory for events that will never be
read. An application wanting to handle such events needs to
explicitly request them by calling the `enable_events()` method of
the `Config` structure.