### PR TITLE
recovery: time_sent can be in the future

### DIFF
--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -304,7 +304,7 @@ fn on_packet_acked(
             }
         }
 
-        let t = now - ca_start_time;
+        let t = now.saturating_duration_since(ca_start_time);
 
         // target = w_cubic(t + rtt)
         let target = r.cubic_state.w_cubic(t + r.min_rtt, r.max_datagram_size);

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -422,7 +422,12 @@ impl Recovery {
 
                     // Calculate new time reordering threshold.
                     let loss_delay = max_rtt.mul_f64(self.time_thresh);
-                    if now.duration_since(unacked.time_sent) > loss_delay {
+
+                    // unacked.time_sent can be in the future due to
+                    // pacing.
+                    if now.saturating_duration_since(unacked.time_sent) >
+                        loss_delay
+                    {
                         // TODO: do time threshold update
                         self.time_thresh = 5_f64 / 4_f64;
                     }


### PR DESCRIPTION
Due to pacing calcuation pkt.time_sent can be a future
time. For such case the time difference need to be zero.