### PR TITLE
Use mio v0.8 in examples

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -66,7 +66,7 @@ qlog = { version = "0.6", path = "../qlog", optional = true }
 winapi = { version = "0.3", features = ["wincrypt"] }
 
 [dev-dependencies]
-mio = "0.6"
+mio = { version = "0.8", features = ["net", "os-poll"] }
 url = "1"
 
 [lib]

--- a/quiche/examples/http3-client.rs
+++ b/quiche/examples/http3-client.rs
@@ -52,7 +52,7 @@ fn main() {
     let url = url::Url::parse(&args.next().unwrap()).unwrap();
 
     // Setup the event loop.
-    let poll = mio::Poll::new().unwrap();
+    let mut poll = mio::Poll::new().unwrap();
     let mut events = mio::Events::with_capacity(1024);
 
     // Resolve server address.
@@ -69,15 +69,12 @@ fn main() {
     // Create the UDP socket backing the QUIC connection, and register it with
     // the event loop.
     let socket = std::net::UdpSocket::bind(bind_addr).unwrap();
+    socket.set_nonblocking(true).unwrap();
 
-    let socket = mio::net::UdpSocket::from_socket(socket).unwrap();
-    poll.register(
-        &socket,
-        mio::Token(0),
-        mio::Ready::readable(),
-        mio::PollOpt::edge(),
-    )
-    .unwrap();
+    let mut socket = mio::net::UdpSocket::from_std(socket);
+    poll.registry()
+        .register(&mut socket, mio::Token(0), mio::Interest::READABLE)
+        .unwrap();
 
     // Create the configuration for the QUIC connection.
     let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
@@ -121,7 +118,7 @@ fn main() {
 
     let (write, send_info) = conn.send(&mut out).expect("initial send failed");
 
-    while let Err(e) = socket.send_to(&out[..write], &send_info.to) {
+    while let Err(e) = socket.send_to(&out[..write], send_info.to) {
         if e.kind() == std::io::ErrorKind::WouldBlock {
             debug!("send() would block");
             continue;
@@ -316,7 +313,7 @@ fn main() {
                 },
             };
 
-            if let Err(e) = socket.send_to(&out[..write], &send_info.to) {
+            if let Err(e) = socket.send_to(&out[..write], send_info.to) {
                 if e.kind() == std::io::ErrorKind::WouldBlock {
                     debug!("send() would block");
                     break;

--- a/quiche/examples/server.rs
+++ b/quiche/examples/server.rs
@@ -64,20 +64,17 @@ fn main() {
     }
 
     // Setup the event loop.
-    let poll = mio::Poll::new().unwrap();
+    let mut poll = mio::Poll::new().unwrap();
     let mut events = mio::Events::with_capacity(1024);
 
     // Create the UDP listening socket, and register it with the event loop.
     let socket = net::UdpSocket::bind("127.0.0.1:4433").unwrap();
+    socket.set_nonblocking(true).unwrap();
 
-    let socket = mio::net::UdpSocket::from_socket(socket).unwrap();
-    poll.register(
-        &socket,
-        mio::Token(0),
-        mio::Ready::readable(),
-        mio::PollOpt::edge(),
-    )
-    .unwrap();
+    let mut socket = mio::net::UdpSocket::from_std(socket);
+    poll.registry()
+        .register(&mut socket, mio::Token(0), mio::Interest::READABLE)
+        .unwrap();
 
     // Create the configuration for the QUIC connections.
     let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
@@ -192,7 +189,7 @@ fn main() {
 
                     let out = &out[..len];
 
-                    if let Err(e) = socket.send_to(out, &from) {
+                    if let Err(e) = socket.send_to(out, from) {
                         if e.kind() == std::io::ErrorKind::WouldBlock {
                             debug!("send() would block");
                             break;
@@ -229,7 +226,7 @@ fn main() {
 
                     let out = &out[..len];
 
-                    if let Err(e) = socket.send_to(out, &from) {
+                    if let Err(e) = socket.send_to(out, from) {
                         if e.kind() == std::io::ErrorKind::WouldBlock {
                             debug!("send() would block");
                             break;
@@ -348,7 +345,7 @@ fn main() {
                     },
                 };
 
-                if let Err(e) = socket.send_to(&out[..write], &send_info.to) {
+                if let Err(e) = socket.send_to(&out[..write], send_info.to) {
                     if e.kind() == std::io::ErrorKind::WouldBlock {
                         debug!("send() would block");
                         break;


### PR DESCRIPTION
This PR updates the version of `mio` used in the examples from v0.6 to v0.8 (latest minor version).

After this change, I've confirmed that the `http3-server` and` http3-client` examples work as before:

```console
$ cd quiche/
$ mkdir examples/root/
$ echo 'Hello World!' > examples/root/hello

// Server
$ cargo run --example http3-server

// Client (another shell)
$ cargo run --example http3-client https://127.0.0.1:4433/hello
Hello World!
```

Closes https://github.com/cloudflare/quiche/issues/1196