### PR TITLE
add support for configuring and communicating preferred address

### DIFF
--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -627,6 +627,24 @@ pub struct Token {
     pub details: Option<String>,
 }
 
+impl Token {
+    pub fn new(
+        ty: Option<TokenType>,
+        length: Option<u32>,
+        stateless_reset_token: Option<Vec<u8>>,
+        details: Option<String>
+    ) -> Self {
+        Token {
+            ty,
+            length,
+            data: HexSlice::maybe_string(
+                stateless_reset_token.as_ref(),
+            ),
+            details,
+        }
+    }
+}
+
 pub struct HexSlice<'a>(&'a [u8]);
 
 impl<'a> HexSlice<'a> {

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -629,17 +629,13 @@ pub struct Token {
 
 impl Token {
     pub fn new(
-        ty: Option<TokenType>,
-        length: Option<u32>,
-        stateless_reset_token: Option<Vec<u8>>,
-        details: Option<String>
+        ty: Option<TokenType>, length: Option<u32>,
+        stateless_reset_token: Option<Vec<u8>>, details: Option<String>,
     ) -> Self {
         Token {
             ty,
             length,
-            data: HexSlice::maybe_string(
-                stateless_reset_token.as_ref(),
-            ),
+            data: HexSlice::maybe_string(stateless_reset_token.as_ref()),
             details,
         }
     }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1136,7 +1136,7 @@ impl Config {
         connection_id: &ConnectionId,
         stateless_reset_token: Vec<u8>
     ) -> Result<()> {
-        if addr_str_v6.is_none() && addr_str_v4.is_none() {
+        if (addr_str_v6.is_none() && addr_str_v4.is_none()) || connection_id.is_empty() {
             return Err(Error::TlsFail);
         }
 
@@ -5908,6 +5908,12 @@ impl Connection {
         // Record the max_active_conn_id parameter advertised by the peer.
         self.ids
             .set_source_conn_id_limit(peer_params.active_conn_id_limit);
+
+        if let Some(preferred_address) = &peer_params.preferred_address_params {
+            if preferred_address.connection_id.len() == 0 {
+                return Err(Error::InvalidTransportParam);
+            }
+        }
 
         self.peer_transport_params = peer_params;
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -5803,6 +5803,12 @@ impl Connection {
     fn encode_transport_params(&mut self) -> Result<()> {
         let mut raw_params = [0; 189];
 
+        // A server that chooses a zero-length connection ID MUST NOT provide a preferred address.
+        if self.ids.zero_length_scid()
+            && self.local_transport_params.preferred_address_params.is_some() {
+            self.local_transport_params.preferred_address_params.take();
+        }
+
         let raw_params = TransportParams::encode(
             &self.local_transport_params,
             self.is_server,
@@ -8235,6 +8241,59 @@ mod tests {
 
         assert_eq!(pipe.server.server_preferred_address_v4(), None);
         assert_eq!(pipe.server.server_preferred_address_v6(), None);
+    }
+
+    #[test]
+    fn server_preferred_address_with_zero_len_cid() {
+        let preferred_addr_v4 = SocketAddrV4::from_str("0.0.0.1:8080").unwrap();
+        let preferred_addr_v6 = SocketAddrV6::from_str("[::1]:8080").unwrap();
+        let stateless_reset_token = vec![0xba; 16];
+        // Given a zero length cid.
+        let connection_id = &ConnectionId::from_vec(Vec::new());
+
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config.load_cert_chain_from_pem_file("examples/cert.crt").unwrap();
+        config.load_priv_key_from_pem_file("examples/cert.key").unwrap();
+        config.set_application_protos(&[b"proto1", b"proto2"]).unwrap();
+        config.set_initial_max_data(30);
+        config.set_initial_max_stream_data_bidi_local(15);
+        config.set_initial_max_stream_data_bidi_remote(15);
+        config.set_initial_max_stream_data_uni(10);
+        config.set_initial_max_streams_bidi(3);
+        config.set_initial_max_streams_uni(3);
+        config.set_max_idle_timeout(180_000);
+        config.verify_peer(false);
+        config.set_ack_delay_exponent(8);
+
+        // Zero-length connection ID must not be included in this transport param.
+        assert_eq!(
+            config.set_preferred_address(
+                Some(preferred_addr_v4.to_string()),
+                Some(preferred_addr_v6.to_string()),
+                &connection_id,
+                stateless_reset_token.clone()
+            ),
+            Err(Error::TlsFail)
+        );
+
+        let connection_id = &ConnectionId::from_vec(vec![0; MAX_CONN_ID_LEN]);
+        config.set_preferred_address(
+            Some(preferred_addr_v4.to_string()),
+            Some(preferred_addr_v6.to_string()),
+            &connection_id,
+            stateless_reset_token.clone()
+        ).unwrap();
+
+        // Server chooses a zero-length connection ID.
+        let mut pipe = testing::Pipe::with_config_and_scid_lengths(
+            &mut config, MAX_CONN_ID_LEN, 0
+        ).unwrap();
+
+        assert_eq!(pipe.handshake(), Ok(()));
+
+        // Preferred address will not be included.
+        assert_eq!(pipe.client.server_preferred_address_v4(), None);
+        assert_eq!(pipe.client.server_preferred_address_v6(), None);
     }
 
     #[test]

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1128,7 +1128,7 @@ impl Config {
         self.disable_dcid_reuse = v;
     }
 
-    // TODO: add docs
+    /// Set the server's preferred address.
     pub fn set_preferred_address(
         &mut self,
         addr_str_v4: Option<String>,
@@ -5784,7 +5784,7 @@ impl Connection {
         }
     }
 
-    // TODO: add docs
+    /// Returns the server's preferred address for V4.
     pub fn server_preferred_address_v4(&self) -> Option<(SocketAddrV4, ConnectionId, Vec<u8>)> {
         match self.peer_transport_params.preferred_address_params.as_ref() {
             Some(params) => params.address_v4(),
@@ -5792,7 +5792,7 @@ impl Connection {
         }
     }
 
-    // TODO: add docs
+    /// Returns the server's preferred address for V6.
     pub fn server_preferred_address_v6(&self) -> Option<(SocketAddrV6, ConnectionId, Vec<u8>)> {
         match self.peer_transport_params.preferred_address_params.as_ref() {
             Some(params) => params.address_v6(),
@@ -5916,6 +5916,7 @@ impl Connection {
             .set_source_conn_id_limit(peer_params.active_conn_id_limit);
 
         if let Some(preferred_address) = &peer_params.preferred_address_params {
+            // Zero-length connection ID must not be sent.
             if preferred_address.connection_id.len() == 0 {
                 return Err(Error::InvalidTransportParam);
             }
@@ -7542,7 +7543,6 @@ impl TransportParams {
     }
 }
 
-// TODO: add docs
 #[derive(Clone, Debug, PartialEq)]
 struct PreferredAddressParams<'a> {
     addr_v4: Option<SocketAddrV4>,

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -369,7 +369,11 @@ use std::cmp;
 use std::convert::TryInto;
 use std::time;
 
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
+use std::net::SocketAddr;
+use std::net::SocketAddrV4;
+use std::net::SocketAddrV6;
 
 use std::str::FromStr;
 
@@ -1130,32 +1134,20 @@ impl Config {
 
     /// Set the server's preferred address.
     pub fn set_preferred_address(
-        &mut self,
-        addr_str_v4: Option<String>,
-        addr_str_v6: Option<String>,
-        connection_id: &ConnectionId,
-        stateless_reset_token: Vec<u8>
+        &mut self, v4: Option<SocketAddrV4>, v6: Option<SocketAddrV6>,
+        connection_id: &ConnectionId, stateless_reset_token: Vec<u8>,
     ) -> Result<()> {
-        if (addr_str_v6.is_none() && addr_str_v4.is_none()) || connection_id.is_empty() {
+        if (v4.is_none() && v6.is_none()) || connection_id.is_empty() {
             return Err(Error::TlsFail);
         }
 
-        let mut addr_v4 = None;
-        if addr_str_v4.is_some() {
-            addr_v4 = Some(SocketAddrV4::from_str(addr_str_v4.unwrap().as_str()).map_err(|_| Error::TlsFail)?);
-        }
-
-        let mut addr_v6 = None;
-        if addr_str_v6.is_some() {
-            addr_v6 = Some(SocketAddrV6::from_str(addr_str_v6.unwrap().as_str()).map_err(|_| Error::TlsFail)?);
-        }
-
-        self.local_transport_params.preferred_address_params = Some(PreferredAddressParams::new(
-            addr_v4,
-            addr_v6,
-            connection_id.to_vec().into(),
-            stateless_reset_token
-        ));
+        self.local_transport_params.preferred_address_params =
+            Some(PreferredAddressParams::new(
+                v4,
+                v6,
+                connection_id.to_vec().into(),
+                stateless_reset_token,
+            ));
 
         Ok(())
     }
@@ -5785,7 +5777,9 @@ impl Connection {
     }
 
     /// Returns the server's preferred address for V4.
-    pub fn server_preferred_address_v4(&self) -> Option<(SocketAddrV4, ConnectionId, Vec<u8>)> {
+    pub fn server_preferred_address_v4(
+        &self,
+    ) -> Option<(SocketAddrV4, ConnectionId, Vec<u8>)> {
         match self.peer_transport_params.preferred_address_params.as_ref() {
             Some(params) => params.address_v4(),
             None => None,
@@ -5793,7 +5787,9 @@ impl Connection {
     }
 
     /// Returns the server's preferred address for V6.
-    pub fn server_preferred_address_v6(&self) -> Option<(SocketAddrV6, ConnectionId, Vec<u8>)> {
+    pub fn server_preferred_address_v6(
+        &self,
+    ) -> Option<(SocketAddrV6, ConnectionId, Vec<u8>)> {
         match self.peer_transport_params.preferred_address_params.as_ref() {
             Some(params) => params.address_v6(),
             None => None,
@@ -5803,9 +5799,13 @@ impl Connection {
     fn encode_transport_params(&mut self) -> Result<()> {
         let mut raw_params = [0; 189];
 
-        // A server that chooses a zero-length connection ID MUST NOT provide a preferred address.
-        if self.ids.zero_length_scid()
-            && self.local_transport_params.preferred_address_params.is_some() {
+        // A server that chooses a zero-length connection ID MUST NOT provide a
+        // preferred address.
+        if self.ids.zero_length_scid() &&
+            self.local_transport_params
+                .preferred_address_params
+                .is_some()
+        {
             self.local_transport_params.preferred_address_params.take();
         }
 
@@ -7249,7 +7249,8 @@ impl TransportParams {
                         return Err(Error::InvalidTransportParam);
                     }
 
-                    tp.preferred_address_params = Some(PreferredAddressParams::decode(&mut val)?);
+                    tp.preferred_address_params =
+                        Some(PreferredAddressParams::decode(&mut val)?);
                 },
 
                 0x000e => {
@@ -7409,16 +7410,17 @@ impl TransportParams {
         }
 
         if is_server {
-           if let Some(pa) = &tp.preferred_address_params {
-               let mut param_buf = [0; 61];
-               let pref_addr_params = PreferredAddressParams::encode(pa, &mut param_buf)?;
-               TransportParams::encode_param(
-                   &mut b,
-                   0x000d,
-                   pref_addr_params.len()
-               )?;
-               b.put_bytes(pref_addr_params)?;
-           }
+            if let Some(pa) = &tp.preferred_address_params {
+                let mut param_buf = [0; 61];
+                let pref_addr_params =
+                    PreferredAddressParams::encode(pa, &mut param_buf)?;
+                TransportParams::encode_param(
+                    &mut b,
+                    0x000d,
+                    pref_addr_params.len(),
+                )?;
+                b.put_bytes(pref_addr_params)?;
+            }
         }
 
         if tp.active_conn_id_limit != 2 {
@@ -7478,7 +7480,7 @@ impl TransportParams {
                     Some(qlog::TokenType::StatelessReset),
                     None,
                     Some(params.stateless_reset_token.clone()),
-                    None
+                    None,
                 );
 
                 Some(qlog::events::quic::PreferredAddress {
@@ -7501,8 +7503,8 @@ impl TransportParams {
                     connection_id: "".to_string(),
                     stateless_reset_token,
                 })
-            }
-            None => None
+            },
+            None => None,
         };
 
         EventData::TransportParametersSet(
@@ -7553,10 +7555,8 @@ struct PreferredAddressParams<'a> {
 
 impl<'a> PreferredAddressParams<'a> {
     fn new(
-        addr_v4: Option<SocketAddrV4>,
-        addr_v6: Option<SocketAddrV6>,
-        connection_id: ConnectionId<'a>,
-        stateless_reset_token: Vec<u8>
+        addr_v4: Option<SocketAddrV4>, addr_v6: Option<SocketAddrV6>,
+        connection_id: ConnectionId<'a>, stateless_reset_token: Vec<u8>,
     ) -> Self {
         PreferredAddressParams {
             addr_v4,
@@ -7565,7 +7565,7 @@ impl<'a> PreferredAddressParams<'a> {
             stateless_reset_token,
         }
     }
-    
+
     fn decode(b: &mut octets::Octets) -> Result<Self> {
         let mut addr_v4 = None;
         let ip_v4 = b.get_u32()?;
@@ -7580,7 +7580,8 @@ impl<'a> PreferredAddressParams<'a> {
         }
 
         let mut addr_v6 = None;
-        let ip_v6_b = <[u8; 16]>::try_from(b.get_bytes(16)?.slice(16)?).map_err(|_| Error::TlsFail)?;
+        let ip_v6_b = <[u8; 16]>::try_from(b.get_bytes(16)?.slice(16)?)
+            .map_err(|_| Error::TlsFail)?;
         let ip_v6 = Ipv6Addr::from(ip_v6_b);
         let port_v6 = b.get_u16()?;
 
@@ -7599,10 +7600,17 @@ impl<'a> PreferredAddressParams<'a> {
         let cid = b.get_bytes_with_varint_length()?.to_vec().into();
         let stateless_reset_token = b.get_bytes(16)?.to_vec();
 
-        Ok(PreferredAddressParams::new(addr_v4, addr_v6, cid, stateless_reset_token))
+        Ok(PreferredAddressParams::new(
+            addr_v4,
+            addr_v6,
+            cid,
+            stateless_reset_token,
+        ))
     }
 
-    fn encode<'o>(pa: &PreferredAddressParams, out: &'o mut [u8]) -> Result<&'o mut [u8]>  {
+    fn encode<'o>(
+        pa: &PreferredAddressParams, out: &'o mut [u8],
+    ) -> Result<&'o mut [u8]> {
         let mut b = octets::OctetsMut::with_slice(out);
 
         let (ip_v4, port_v4) = match pa.addr_v4 {
@@ -7631,17 +7639,23 @@ impl<'a> PreferredAddressParams<'a> {
     }
 
     fn address_v4(&self) -> Option<(SocketAddrV4, ConnectionId, Vec<u8>)> {
-        match self.addr_v4 {
-            Some(addr) => Some((addr, self.connection_id.clone(), self.stateless_reset_token.clone())),
-            None => None,
-        }
+        self.addr_v4.map(|addr| {
+            (
+                addr,
+                self.connection_id.clone(),
+                self.stateless_reset_token.clone(),
+            )
+        })
     }
 
     fn address_v6(&self) -> Option<(SocketAddrV6, ConnectionId, Vec<u8>)> {
-        match self.addr_v6 {
-            Some(addr) => Some((addr, self.connection_id.clone(), self.stateless_reset_token.clone())),
-            None => None,
-        }
+        self.addr_v6.map(|addr| {
+            (
+                addr,
+                self.connection_id.clone(),
+                self.stateless_reset_token.clone(),
+            )
+        })
     }
 }
 
@@ -8116,7 +8130,7 @@ mod tests {
                 Some(SocketAddrV4::from_str("0.0.0.1:12345").unwrap()),
                 Some(SocketAddrV6::from_str("[::1]:12345").unwrap()),
                 ConnectionId::from_vec(vec![0; MAX_CONN_ID_LEN]),
-                vec![0xba; 16]
+                vec![0xba; 16],
             )),
         };
 
@@ -8204,9 +8218,15 @@ mod tests {
         let stateless_reset_token = vec![0xba; 16];
 
         let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
-        config.load_cert_chain_from_pem_file("examples/cert.crt").unwrap();
-        config.load_priv_key_from_pem_file("examples/cert.key").unwrap();
-        config.set_application_protos(&[b"proto1", b"proto2"]).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config
+            .set_application_protos(&[b"proto1", b"proto2"])
+            .unwrap();
         config.set_initial_max_data(30);
         config.set_initial_max_stream_data_bidi_local(15);
         config.set_initial_max_stream_data_bidi_remote(15);
@@ -8216,12 +8236,14 @@ mod tests {
         config.set_max_idle_timeout(180_000);
         config.verify_peer(false);
         config.set_ack_delay_exponent(8);
-        config.set_preferred_address(
-            Some(preferred_addr_v4.to_string()),
-            Some(preferred_addr_v6.to_string()),
-            &connection_id,
-            stateless_reset_token.clone()
-        ).unwrap();
+        config
+            .set_preferred_address(
+                Some(preferred_addr_v4),
+                Some(preferred_addr_v6),
+                &connection_id,
+                stateless_reset_token.clone(),
+            )
+            .unwrap();
 
         let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
 
@@ -8232,11 +8254,19 @@ mod tests {
 
         assert_eq!(
             pipe.client.server_preferred_address_v4(),
-            Some((preferred_addr_v4, connection_id.clone(), stateless_reset_token.clone()))
+            Some((
+                preferred_addr_v4,
+                connection_id.clone(),
+                stateless_reset_token.clone()
+            ))
         );
         assert_eq!(
             pipe.client.server_preferred_address_v6(),
-            Some((preferred_addr_v6, connection_id.clone(), stateless_reset_token.clone()))
+            Some((
+                preferred_addr_v6,
+                connection_id.clone(),
+                stateless_reset_token.clone()
+            ))
         );
 
         assert_eq!(pipe.server.server_preferred_address_v4(), None);
@@ -8252,9 +8282,15 @@ mod tests {
         let connection_id = &ConnectionId::from_vec(Vec::new());
 
         let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
-        config.load_cert_chain_from_pem_file("examples/cert.crt").unwrap();
-        config.load_priv_key_from_pem_file("examples/cert.key").unwrap();
-        config.set_application_protos(&[b"proto1", b"proto2"]).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config
+            .set_application_protos(&[b"proto1", b"proto2"])
+            .unwrap();
         config.set_initial_max_data(30);
         config.set_initial_max_stream_data_bidi_local(15);
         config.set_initial_max_stream_data_bidi_remote(15);
@@ -8268,8 +8304,8 @@ mod tests {
         // Zero-length connection ID must not be included in this transport param.
         assert_eq!(
             config.set_preferred_address(
-                Some(preferred_addr_v4.to_string()),
-                Some(preferred_addr_v6.to_string()),
+                Some(preferred_addr_v4),
+                Some(preferred_addr_v6),
                 &connection_id,
                 stateless_reset_token.clone()
             ),
@@ -8277,17 +8313,22 @@ mod tests {
         );
 
         let connection_id = &ConnectionId::from_vec(vec![0; MAX_CONN_ID_LEN]);
-        config.set_preferred_address(
-            Some(preferred_addr_v4.to_string()),
-            Some(preferred_addr_v6.to_string()),
-            &connection_id,
-            stateless_reset_token.clone()
-        ).unwrap();
+        config
+            .set_preferred_address(
+                Some(preferred_addr_v4),
+                Some(preferred_addr_v6),
+                &connection_id,
+                stateless_reset_token.clone(),
+            )
+            .unwrap();
 
         // Server chooses a zero-length connection ID.
         let mut pipe = testing::Pipe::with_config_and_scid_lengths(
-            &mut config, MAX_CONN_ID_LEN, 0
-        ).unwrap();
+            &mut config,
+            MAX_CONN_ID_LEN,
+            0,
+        )
+        .unwrap();
 
         assert_eq!(pipe.handshake(), Ok(()));
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1135,7 +1135,7 @@ impl Config {
     /// Set the server's preferred address.
     pub fn set_preferred_address(
         &mut self, v4: Option<SocketAddrV4>, v6: Option<SocketAddrV6>,
-        connection_id: &ConnectionId, stateless_reset_token: Vec<u8>,
+        connection_id: &ConnectionId, stateless_reset_token: u128,
     ) -> Result<()> {
         if (v4.is_none() && v6.is_none()) || connection_id.is_empty() {
             return Err(Error::TlsFail);
@@ -5776,20 +5776,22 @@ impl Connection {
         }
     }
 
-    /// Returns the server's preferred address for V4.
+    /// Returns the server's preferred address which is a tuple with a
+    /// V4 socket address, a connection ID and a stateless reset token.
     pub fn server_preferred_address_v4(
         &self,
-    ) -> Option<(SocketAddrV4, ConnectionId, Vec<u8>)> {
+    ) -> Option<(SocketAddrV4, ConnectionId, u128)> {
         match self.peer_transport_params.preferred_address_params.as_ref() {
             Some(params) => params.address_v4(),
             None => None,
         }
     }
 
-    /// Returns the server's preferred address for V6.
+    /// Returns the server's preferred address which is a tuple with a
+    /// V6 socket address, a connection ID and a stateless reset token.
     pub fn server_preferred_address_v6(
         &self,
-    ) -> Option<(SocketAddrV6, ConnectionId, Vec<u8>)> {
+    ) -> Option<(SocketAddrV6, ConnectionId, u128)> {
         match self.peer_transport_params.preferred_address_params.as_ref() {
             Some(params) => params.address_v6(),
             None => None,
@@ -5917,7 +5919,7 @@ impl Connection {
 
         if let Some(preferred_address) = &peer_params.preferred_address_params {
             // Zero-length connection ID must not be sent.
-            if preferred_address.connection_id.len() == 0 {
+            if preferred_address.connection_id.is_empty() {
                 return Err(Error::InvalidTransportParam);
             }
         }
@@ -7479,7 +7481,7 @@ impl TransportParams {
                 let stateless_reset_token = qlog::Token::new(
                     Some(qlog::TokenType::StatelessReset),
                     None,
-                    Some(params.stateless_reset_token.clone()),
+                    Some(params.stateless_reset_token.to_be_bytes().to_vec()),
                     None,
                 );
 
@@ -7550,13 +7552,13 @@ struct PreferredAddressParams<'a> {
     addr_v4: Option<SocketAddrV4>,
     addr_v6: Option<SocketAddrV6>,
     connection_id: ConnectionId<'a>,
-    stateless_reset_token: Vec<u8>,
+    stateless_reset_token: u128,
 }
 
 impl<'a> PreferredAddressParams<'a> {
     fn new(
         addr_v4: Option<SocketAddrV4>, addr_v6: Option<SocketAddrV6>,
-        connection_id: ConnectionId<'a>, stateless_reset_token: Vec<u8>,
+        connection_id: ConnectionId<'a>, stateless_reset_token: u128,
     ) -> Self {
         PreferredAddressParams {
             addr_v4,
@@ -7598,7 +7600,12 @@ impl<'a> PreferredAddressParams<'a> {
         }
 
         let cid = b.get_bytes_with_varint_length()?.to_vec().into();
-        let stateless_reset_token = b.get_bytes(16)?.to_vec();
+        let stateless_reset_token = u128::from_be_bytes(
+            b.get_bytes(16)?
+                .to_vec()
+                .try_into()
+                .map_err(|_| Error::BufferTooShort)?,
+        );
 
         Ok(PreferredAddressParams::new(
             addr_v4,
@@ -7632,29 +7639,21 @@ impl<'a> PreferredAddressParams<'a> {
         b.put_varint(pa.connection_id.len() as u64)?;
         b.put_bytes(&pa.connection_id)?;
 
-        b.put_bytes(&pa.stateless_reset_token)?;
+        b.put_bytes(&pa.stateless_reset_token.to_be_bytes())?;
 
         let len = b.off();
         Ok(&mut out[..len])
     }
 
-    fn address_v4(&self) -> Option<(SocketAddrV4, ConnectionId, Vec<u8>)> {
+    fn address_v4(&self) -> Option<(SocketAddrV4, ConnectionId, u128)> {
         self.addr_v4.map(|addr| {
-            (
-                addr,
-                self.connection_id.clone(),
-                self.stateless_reset_token.clone(),
-            )
+            (addr, self.connection_id.clone(), self.stateless_reset_token)
         })
     }
 
-    fn address_v6(&self) -> Option<(SocketAddrV6, ConnectionId, Vec<u8>)> {
+    fn address_v6(&self) -> Option<(SocketAddrV6, ConnectionId, u128)> {
         self.addr_v6.map(|addr| {
-            (
-                addr,
-                self.connection_id.clone(),
-                self.stateless_reset_token.clone(),
-            )
+            (addr, self.connection_id.clone(), self.stateless_reset_token)
         })
     }
 }
@@ -8130,7 +8129,7 @@ mod tests {
                 Some(SocketAddrV4::from_str("0.0.0.1:12345").unwrap()),
                 Some(SocketAddrV6::from_str("[::1]:12345").unwrap()),
                 ConnectionId::from_vec(vec![0; MAX_CONN_ID_LEN]),
-                vec![0xba; 16],
+                u128::from_be_bytes([0xba; 16]),
             )),
         };
 
@@ -8215,7 +8214,7 @@ mod tests {
         let preferred_addr_v4 = SocketAddrV4::from_str("0.0.0.1:8080").unwrap();
         let preferred_addr_v6 = SocketAddrV6::from_str("[::1]:8080").unwrap();
         let connection_id = &ConnectionId::from_vec(vec![0; MAX_CONN_ID_LEN]);
-        let stateless_reset_token = vec![0xba; 16];
+        let stateless_reset_token = u128::from_be_bytes([0xba; 16]);
 
         let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
         config
@@ -8257,7 +8256,7 @@ mod tests {
             Some((
                 preferred_addr_v4,
                 connection_id.clone(),
-                stateless_reset_token.clone()
+                stateless_reset_token
             ))
         );
         assert_eq!(
@@ -8265,7 +8264,7 @@ mod tests {
             Some((
                 preferred_addr_v6,
                 connection_id.clone(),
-                stateless_reset_token.clone()
+                stateless_reset_token
             ))
         );
 
@@ -8277,7 +8276,7 @@ mod tests {
     fn server_preferred_address_with_zero_len_cid() {
         let preferred_addr_v4 = SocketAddrV4::from_str("0.0.0.1:8080").unwrap();
         let preferred_addr_v6 = SocketAddrV6::from_str("[::1]:8080").unwrap();
-        let stateless_reset_token = vec![0xba; 16];
+        let stateless_reset_token = u128::from_be_bytes([0xba; 16]);
         // Given a zero length cid.
         let connection_id = &ConnectionId::from_vec(Vec::new());
 
@@ -8307,7 +8306,7 @@ mod tests {
                 Some(preferred_addr_v4),
                 Some(preferred_addr_v6),
                 &connection_id,
-                stateless_reset_token.clone()
+                stateless_reset_token,
             ),
             Err(Error::TlsFail)
         );
@@ -8318,7 +8317,7 @@ mod tests {
                 Some(preferred_addr_v4),
                 Some(preferred_addr_v6),
                 &connection_id,
-                stateless_reset_token.clone(),
+                stateless_reset_token,
             )
             .unwrap();
 


### PR DESCRIPTION
Hello,
I have a wip PR for review for issue #828. This change allows users to configure the server's preferred address via Config. After the handshake, the preferred addresses can be accessed via the Connection.

- [X] implement encoding and decoding of params (`PreferredAddressParams`)
- [X] allow users to configure preferred address params via`Config`
- [X] allow clients to access the server's preferred address after the handshake
- [X] add/update unit tests 
- [x] update `TransportParams.to_qlog`
- [X] ~allow clients to update the `Connection`'s peer address with the preferred address~ #1223 

I will add docs once I get some feedback about these changes.
