### PR TITLE
apps: fix single_char_pattern clippy warning

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -50,6 +50,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: --features=ffi,qlog -- -D warnings
+
+      - name: Run cargo clippy on examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
           args: --examples --features=ffi,qlog -- -D warnings
 
       - name: Run cargo doc

--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -185,9 +185,7 @@ fn dump_json(reqs: &[Http3Request], output_sink: &mut dyn FnMut(String)) {
             writeln!(
                 out,
                 "          \"value\": \"{}\"",
-                std::str::from_utf8(h.value())
-                    .unwrap()
-                    .replace("\"", "\\\"")
+                std::str::from_utf8(h.value()).unwrap().replace('"', "\\\"")
             )
             .unwrap();
 
@@ -214,9 +212,7 @@ fn dump_json(reqs: &[Http3Request], output_sink: &mut dyn FnMut(String)) {
             writeln!(
                 out,
                 "          \"value\": \"{}\"",
-                std::str::from_utf8(h.value())
-                    .unwrap()
-                    .replace("\"", "\\\"")
+                std::str::from_utf8(h.value()).unwrap().replace('"', "\\\"")
             )
             .unwrap();
 


### PR DESCRIPTION
This also adds a commit to fix clippy in CI, as it was run only on the quiche package in the workspace (not apps, qlog, ...) because of the `--examples` option.