### PR TITLE
apps: fix rounding down max_send_burst

### DIFF
--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -456,10 +456,9 @@ fn main() {
         // packets to be sent.
         continue_write = false;
         for client in clients.values_mut() {
-            let max_send_burst = client
-                .conn
-                .send_quantum()
-                .min(MAX_BUF_SIZE / MAX_DATAGRAM_SIZE * MAX_DATAGRAM_SIZE);
+            let max_send_burst = client.conn.send_quantum().min(MAX_BUF_SIZE) /
+                MAX_DATAGRAM_SIZE *
+                MAX_DATAGRAM_SIZE;
 
             loop {
                 let (write, send_info) = match client.conn.send(&mut out) {


### PR DESCRIPTION
Currently when send_quantum() is smaller than the maximum
buffer size, it can make a small leftover because it's not
rounded down to the maximum datagram size. Now it takes the
mininum of max buffer size or send_quantum() first
and rounds down by the maximum datagram size.