### PR TITLE
recovery: update delivery_rate on all packets

### DIFF
--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -267,6 +267,9 @@ impl Recovery {
         self.largest_sent_pkt[epoch] =
             cmp::max(self.largest_sent_pkt[epoch], pkt_num);
 
+        self.delivery_rate
+            .on_packet_sent(&mut pkt, self.bytes_in_flight, now);
+
         if in_flight {
             if ack_eliciting {
                 self.time_of_last_sent_ack_eliciting_pkt[epoch] = Some(now);
@@ -276,12 +279,6 @@ impl Recovery {
 
             self.update_app_limited(
                 (self.bytes_in_flight + sent_bytes) < self.congestion_window,
-            );
-
-            self.delivery_rate.on_packet_sent(
-                &mut pkt,
-                self.bytes_in_flight,
-                now,
             );
 
             self.on_packet_sent_cc(sent_bytes, now);


### PR DESCRIPTION
Currently `delivery_rate.on_packet_sent()` is called
only packets with in-flight data, which makes non
in-flight packets not updated with some metadata such
as `delivered`, etc. They have zero payload, but
need to be included in the rate estimation and
app_limited updates. Otherwise there can be unsync
between `Rate.last_sent_packet` and `Rate.latest_acked`
(`last_sent_packet` doesn't include non-ack-eliciting
packets but `latest_acked` does), which can mess up
`Rate.end_of_app_limited` tracking.