### PR TITLE
cc: BBRv2 congestion control module

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -219,6 +219,7 @@ enum quiche_cc_algorithm {
     QUICHE_CC_RENO = 0,
     QUICHE_CC_CUBIC = 1,
     QUICHE_CC_BBR = 2,
+    QUICHE_CC_BBR2 = 3,
 };
 
 // Sets the congestion control algorithm used.

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4270,6 +4270,8 @@ impl Connection {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data,
         };
 

--- a/quiche/src/recovery/bbr/mod.rs
+++ b/quiche/src/recovery/bbr/mod.rs
@@ -323,13 +323,13 @@ fn on_packets_acked(
 }
 
 fn congestion_event(
-    r: &mut Recovery, lost_bytes: usize, time_sent: Instant,
+    r: &mut Recovery, lost_bytes: usize, largest_lost_pkt: &Sent,
     _epoch: packet::Epoch, now: Instant,
 ) {
     r.bbr_state.newly_lost_bytes = lost_bytes;
 
     // Upon entering Fast Recovery.
-    if !r.in_congestion_recovery(time_sent) {
+    if !r.in_congestion_recovery(largest_lost_pkt.time_sent) {
         // Upon entering Fast Recovery.
         bbr_enter_recovery(r, now);
     }

--- a/quiche/src/recovery/bbr/mod.rs
+++ b/quiche/src/recovery/bbr/mod.rs
@@ -429,6 +429,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 has_data: false,
             };
 
@@ -497,6 +499,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 has_data: false,
             };
 
@@ -564,6 +568,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 has_data: false,
             };
 
@@ -613,6 +619,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 has_data: false,
             };
 
@@ -683,6 +691,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 has_data: false,
             };
 
@@ -752,6 +762,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 has_data: false,
             };
 
@@ -804,6 +816,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 

--- a/quiche/src/recovery/bbr2/init.rs
+++ b/quiche/src/recovery/bbr2/init.rs
@@ -1,0 +1,90 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::*;
+use crate::recovery::Recovery;
+
+use std::time::Instant;
+
+// BBR2 Functions at Initialization.
+//
+
+// 4.2.1.  Initialization
+pub fn bbr2_init(r: &mut Recovery) {
+    let rtt = r.rtt();
+    let now = Instant::now();
+
+    let bbr = &mut r.bbr2_state;
+    bbr.min_rtt = rtt;
+    bbr.min_rtt_stamp = now;
+    bbr.probe_rtt_done_stamp = None;
+    bbr.probe_rtt_round_done = false;
+    bbr.prior_cwnd = 0;
+    bbr.idle_restart = false;
+    bbr.extra_acked_interval_start = now;
+    bbr.extra_acked_delivered = 0;
+    bbr.bw_lo = u64::MAX;
+    bbr.bw_hi = u64::MAX;
+    bbr.inflight_lo = usize::MAX;
+    bbr.inflight_hi = usize::MAX;
+    bbr.probe_up_cnt = usize::MAX;
+
+    r.send_quantum = r.max_datagram_size;
+
+    per_loss::bbr2_reset_congestion_signals(r);
+    per_loss::bbr2_reset_lower_bounds(r);
+    bbr2_init_round_counting(r);
+    bbr2_init_full_pipe(r);
+    pacing::bbr2_init_pacing_rate(r);
+    bbr2_enter_startup(r);
+}
+
+// 4.5.1.  BBR.round_count: Tracking Packet-Timed Round Trips
+fn bbr2_init_round_counting(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    bbr.next_round_delivered = 0;
+    bbr.round_start = false;
+    bbr.round_count = 0;
+}
+
+// 4.3.1.1.  Startup Dynamics
+pub fn bbr2_enter_startup(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    bbr.state = BBR2StateMachine::Startup;
+    bbr.pacing_gain = STARTUP_PACING_GAIN;
+    bbr.cwnd_gain = STARTUP_CWND_GAIN;
+}
+
+// 4.3.1.2.  Exiting Startup Based on Bandwidth Plateau
+fn bbr2_init_full_pipe(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    bbr.filled_pipe = false;
+    bbr.full_bw = 0;
+    bbr.full_bw_count = 0;
+}

--- a/quiche/src/recovery/bbr2/mod.rs
+++ b/quiche/src/recovery/bbr2/mod.rs
@@ -1,0 +1,666 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! BBR v2 Congestion Control
+//!
+//! This implementation is based on the following draft:
+//! <https://tools.ietf.org/html/draft-cardwell-iccrg-bbr-congestion-control-02>
+
+use crate::minmax::Minmax;
+use crate::packet;
+use crate::recovery::*;
+
+use std::time::Duration;
+use std::time::Instant;
+
+pub static BBR2: CongestionControlOps = CongestionControlOps {
+    on_init,
+    reset,
+    on_packet_sent,
+    on_packets_acked,
+    congestion_event,
+    collapse_cwnd,
+    checkpoint,
+    rollback,
+    has_custom_pacing,
+    debug_fmt,
+};
+
+/// The static discount factor of 1% used to scale BBR.bw to produce
+/// BBR.pacing_rate.
+const PACING_MARGIN_PERCENT: f64 = 0.01;
+
+/// A constant specifying the minimum gain value
+/// for calculating the pacing rate that will allow the sending rate to
+/// double each round (4*ln(2) ~= 2.77) [BBRStartupPacingGain]; used in
+/// Startup mode for BBR.pacing_gain.
+const STARTUP_PACING_GAIN: f64 = 2.77;
+
+/// A constant specifying the minimum gain value for
+/// calculating the cwnd that will allow the sending rate to double each
+/// round (2.0); used in Startup mode for BBR.cwnd_gain.
+const STARTUP_CWND_GAIN: f64 = 2.0;
+
+/// The maximum tolerated per-round-trip packet loss rate
+/// when probing for bandwidth (the default is 2%).
+const LOSS_THRESH: f64 = 0.02;
+
+/// The default multiplicative decrease to make upon each round
+/// trip during which the connection detects packet loss (the value is
+/// 0.7).
+const BETA: f64 = 0.7;
+
+/// The multiplicative factor to apply to BBR.inflight_hi
+/// when attempting to leave free headroom in the path (e.g. free space
+/// in the bottleneck buffer or free time slots in the bottleneck link)
+/// that can be used by cross traffic (the value is 0.85).
+const HEADROOM: f64 = 0.85;
+
+/// The minimal cwnd value BBR targets, to allow
+/// pipelining with TCP endpoints that follow an "ACK every other packet"
+/// delayed-ACK policy: 4 * SMSS.
+const MIN_PIPE_CWND_PKTS: usize = 4;
+
+/// The filter window length for BBR.MaxBwFilter = 2 (representing up to 2
+/// ProbeBW cycles, the current cycle and the previous full cycle).
+const MAX_BW_FILTER_LEN: Duration = Duration::from_secs(2);
+
+/// The window length of the BBR.ExtraACKedFilter max filter window: 10 (in
+/// units of packet-timed round trips).
+const EXTRA_ACKED_FILTER_LEN: Duration = Duration::from_secs(10);
+
+/// A constant specifying the length of the BBR.min_rtt min filter window,
+/// MinRTTFilterLen is 10 secs.
+const MIN_RTT_FILTER_LEN: Duration = Duration::from_secs(10);
+
+/// A constant specifying the gain value for calculating the cwnd during
+/// ProbeRTT: 0.5 (meaning that ProbeRTT attempts to reduce in-flight data to
+/// 50% of the estimated BDP).
+const PROBE_RTT_CWND_GAIN: f64 = 0.5;
+
+/// A constant specifying the minimum duration for which ProbeRTT state holds
+/// inflight to BBRMinPipeCwnd or fewer packets: 200 ms.
+const PROBE_RTT_DURATION: Duration = Duration::from_millis(200);
+
+/// ProbeRTTInterval: A constant specifying the minimum time interval between
+/// ProbeRTT states: 5 secs.
+const PROBE_RTT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Threshold for checking a full bandwidth growth during Startup.
+const MAX_BW_GROWTH_THRESHOLD: f64 = 1.25;
+
+/// BBR2 Internal State Machine.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+enum BBR2StateMachine {
+    Startup,
+    Drain,
+    ProbeBWDOWN,
+    ProbeBWCRUISE,
+    ProbeBWREFILL,
+    ProbeBWUP,
+    ProbeRTT,
+}
+
+/// BBR2 Ack Phases.
+#[derive(Debug, PartialEq, Eq)]
+enum BBR2AckPhase {
+    Init,
+    ProbeFeedback,
+    ProbeStarting,
+    ProbeStopping,
+    Refilling,
+}
+
+/// BBR2 Specific State Variables.
+pub struct State {
+    // 2.3.  Per-ACK Rate Sample State
+    // It's stored in rate sample but we keep in BBR state here.
+
+    // The volume of data that was estimated to be in
+    // flight at the time of the transmission of the packet that has just
+    // been ACKed.
+    tx_in_flight: usize,
+
+    // The volume of data that was declared lost between the
+    // transmission and acknowledgement of the packet that has just been
+    // ACKed.
+    lost: usize,
+
+    // The volume of data cumulatively or selectively acknowledged upon the ACK
+    // that was just received.  (This quantity is referred to as "DeliveredData"
+    // in [RFC6937].)
+    newly_acked_bytes: usize,
+
+    // The volume of data newly marked lost upon the ACK that was just received.
+    newly_lost_bytes: usize,
+
+    // 2.4.  Output Control Parameters
+    // The current pacing rate for a BBR2 flow, which controls inter-packet
+    // spacing.
+    pacing_rate: u64,
+
+    // 2.5.  Pacing State and Parameters
+    // The dynamic gain factor used to scale BBR.bw to
+    // produce BBR.pacing_rate.
+    pacing_gain: f64,
+
+    // 2.6.  cwnd State and Parameters
+    // The dynamic gain factor used to scale the estimated BDP to produce a
+    // congestion window (cwnd).
+    cwnd_gain: f64,
+
+    // A boolean indicating whether BBR is currently using packet conservation
+    // dynamics to bound cwnd.
+    packet_conservation: bool,
+
+    // 2.7.  General Algorithm State
+    // The current state of a BBR2 flow in the BBR2 state machine.
+    state: BBR2StateMachine,
+
+    // Count of packet-timed round trips elapsed so far.
+    round_count: u64,
+
+    // A boolean that BBR2 sets to true once per packet-timed round trip,
+    // on ACKs that advance BBR2.round_count.
+    round_start: bool,
+
+    // packet.delivered value denoting the end of a packet-timed round trip.
+    next_round_delivered: usize,
+
+    // A boolean that is true if and only if a connection is restarting after
+    // being idle.
+    idle_restart: bool,
+
+    // 2.9.1.  Data Rate Network Path Model Parameters
+    // The windowed maximum recent bandwidth sample - obtained using the BBR
+    // delivery rate sampling algorithm
+    // [draft-cheng-iccrg-delivery-rate-estimation] - measured during the current
+    // or previous bandwidth probing cycle (or during Startup, if the flow is
+    // still in that state).  (Part of the long-term model.)
+    max_bw: u64,
+
+    // The long-term maximum sending bandwidth that the algorithm estimates will
+    // produce acceptable queue pressure, based on signals in the current or
+    // previous bandwidth probing cycle, as measured by loss.  (Part of the
+    // long-term model.)
+    bw_hi: u64,
+
+    // The short-term maximum sending bandwidth that the algorithm estimates is
+    // safe for matching the current network path delivery rate, based on any
+    // loss signals in the current bandwidth probing cycle.  This is generally
+    // lower than max_bw or bw_hi (thus the name).  (Part of the short-term
+    // model.)
+    bw_lo: u64,
+
+    // The maximum sending bandwidth that the algorithm estimates is appropriate
+    // for matching the current network path delivery rate, given all available
+    // signals in the model, at any time scale.  It is the min() of max_bw,
+    // bw_hi, and bw_lo.
+    bw: u64,
+
+    // 2.9.2.  Data Volume Network Path Model Parameters
+    // The windowed minimum round-trip time sample measured over the last
+    // MinRTTFilterLen = 10 seconds.  This attempts to estimate the two-way
+    // propagation delay of the network path when all connections sharing a
+    // bottleneck are using BBR, but also allows BBR to estimate the value
+    // required for a bdp estimate that allows full throughput if there are
+    // legacy loss-based Reno or CUBIC flows sharing the bottleneck.
+    min_rtt: Duration,
+
+    // The estimate of the network path's BDP (Bandwidth-Delay Product), computed
+    // as: BBR.bdp = BBR.bw * BBR.min_rtt.
+    bdp: usize,
+
+    // A volume of data that is the estimate of the recent degree of aggregation
+    // in the network path.
+    extra_acked: usize,
+
+    // The estimate of the minimum volume of data necessary to achieve full
+    // throughput when using sender (TSO/GSO) and receiver (LRO, GRO) host
+    // offload mechanisms.
+    offload_budget: usize,
+
+    // The estimate of the volume of in-flight data required to fully utilize the
+    // bottleneck bandwidth available to the flow, based on the BDP estimate
+    // (BBR.bdp), the aggregation estimate (BBR.extra_acked), the offload budget
+    // (BBR.offload_budget), and BBRMinPipeCwnd.
+    max_inflight: usize,
+
+    // Analogous to BBR.bw_hi, the long-term maximum volume of in-flight data
+    // that the algorithm estimates will produce acceptable queue pressure, based
+    // on signals in the current or previous bandwidth probing cycle, as measured
+    // by loss.  That is, if a flow is probing for bandwidth, and observes that
+    // sending a particular volume of in-flight data causes a loss rate higher
+    // than the loss rate objective, it sets inflight_hi to that volume of data.
+    // (Part of the long-term model.)
+    inflight_hi: usize,
+
+    // Analogous to BBR.bw_lo, the short-term maximum volume of in-flight data
+    // that the algorithm estimates is safe for matching the current network path
+    // delivery process, based on any loss signals in the current bandwidth
+    // probing cycle.  This is generally lower than max_inflight or inflight_hi
+    // (thus the name).  (Part of the short-term model.)
+    inflight_lo: usize,
+
+    // 2.10.  State for Responding to Congestion
+    // a 1-round-trip max of delivered bandwidth (rs.delivery_rate).
+    bw_latest: u64,
+
+    // a 1-round-trip max of delivered volume of data (rs.delivered).
+    inflight_latest: usize,
+
+    // 2.11.  Estimating BBR.max_bw
+    // The filter for tracking the maximum recent rs.delivery_rate sample, for
+    // estimating BBR.max_bw.
+    max_bw_filter: Minmax<u64>,
+
+    // The virtual time used by the BBR.max_bw filter window.  Note that
+    // BBR.cycle_count only needs to be tracked with a single bit, since the
+    // BBR.MaxBwFilter only needs to track samples from two time slots: the
+    // previous ProbeBW cycle and the current ProbeBW cycle.
+    cycle_count: u64,
+
+    // 2.12.  Estimating BBR.extra_acked
+    // the start of the time interval for estimating the excess amount of data
+    // acknowledged due to aggregation effects.
+    extra_acked_interval_start: Instant,
+
+    // the volume of data marked as delivered since
+    // BBR.extra_acked_interval_start.
+    extra_acked_delivered: usize,
+
+    // BBR.ExtraACKedFilter: the max filter tracking the recent maximum degree of
+    // aggregation in the path.
+    extra_acked_filter: Minmax<usize>,
+
+    // 2.13.  Startup Parameters and State
+    // A boolean that records whether BBR estimates that it has ever fully
+    // utilized its available bandwidth ("filled the pipe").
+    filled_pipe: bool,
+
+    // A recent baseline BBR.max_bw to estimate if BBR has "filled the pipe" in
+    // Startup.
+    full_bw: u64,
+
+    // The number of non-app-limited round trips without large increases in
+    // BBR.full_bw.
+    full_bw_count: usize,
+
+    // 2.14.1.  Parameters for Estimating BBR.min_rtt
+    // The wall clock time at which the current BBR.min_rtt sample was obtained.
+    min_rtt_stamp: Instant,
+
+    // 2.14.2.  Parameters for Scheduling ProbeRTT
+    // The minimum RTT sample recorded in the last ProbeRTTInterval.
+    probe_rtt_min_delay: Duration,
+
+    // The wall clock time at which the current BBR.probe_rtt_min_delay sample
+    // was obtained.
+    probe_rtt_min_stamp: Instant,
+
+    // A boolean recording whether the BBR.probe_rtt_min_delay has expired and is
+    // due for a refresh with an application idle period or a transition into
+    // ProbeRTT state.
+    probe_rtt_expired: bool,
+
+    // Others
+    // A state indicating we are in the recovery.
+    in_recovery: bool,
+
+    // Start time of the connection.
+    start_time: Instant,
+
+    // Saved cwnd before loss recovery.
+    prior_cwnd: usize,
+
+    // Whether we have a bandwidth probe samples.
+    bw_probe_samples: bool,
+
+    // Others
+    probe_up_cnt: usize,
+
+    prior_bytes_in_flight: usize,
+
+    probe_rtt_done_stamp: Option<Instant>,
+
+    probe_rtt_round_done: bool,
+
+    bw_probe_wait: Duration,
+
+    rounds_since_probe: usize,
+
+    cycle_stamp: Instant,
+
+    ack_phase: BBR2AckPhase,
+
+    bw_probe_up_rounds: usize,
+
+    bw_probe_up_acks: usize,
+
+    loss_round_start: bool,
+
+    loss_round_delivered: usize,
+
+    loss_in_round: bool,
+}
+
+impl State {
+    pub fn new() -> Self {
+        let now = Instant::now();
+
+        State {
+            tx_in_flight: 0,
+
+            lost: 0,
+
+            newly_acked_bytes: 0,
+
+            newly_lost_bytes: 0,
+
+            pacing_rate: 0,
+
+            pacing_gain: 0.0,
+
+            cwnd_gain: 0.0,
+
+            packet_conservation: false,
+
+            state: BBR2StateMachine::Startup,
+
+            round_count: 0,
+
+            round_start: false,
+
+            next_round_delivered: 0,
+
+            idle_restart: false,
+
+            max_bw: 0,
+
+            bw_hi: 0,
+
+            bw_lo: 0,
+
+            bw: 0,
+
+            min_rtt: Duration::MAX,
+
+            bdp: 0,
+
+            extra_acked: 0,
+
+            offload_budget: 0,
+
+            max_inflight: 0,
+
+            inflight_hi: 0,
+
+            inflight_lo: 0,
+
+            bw_latest: 0,
+
+            inflight_latest: 0,
+
+            max_bw_filter: Minmax::new(0),
+
+            cycle_count: 0,
+
+            extra_acked_interval_start: now,
+
+            extra_acked_delivered: 0,
+
+            extra_acked_filter: Minmax::new(0),
+
+            filled_pipe: false,
+
+            full_bw: 0,
+
+            full_bw_count: 0,
+
+            min_rtt_stamp: now,
+
+            probe_rtt_min_delay: Duration::MAX,
+
+            probe_rtt_min_stamp: now,
+
+            probe_rtt_expired: false,
+
+            in_recovery: false,
+
+            start_time: now,
+
+            prior_cwnd: 0,
+
+            bw_probe_samples: false,
+
+            probe_up_cnt: 0,
+
+            prior_bytes_in_flight: 0,
+
+            probe_rtt_done_stamp: None,
+
+            probe_rtt_round_done: false,
+
+            bw_probe_wait: Duration::ZERO,
+
+            rounds_since_probe: 0,
+
+            cycle_stamp: now,
+
+            ack_phase: BBR2AckPhase::Init,
+
+            bw_probe_up_rounds: 0,
+
+            bw_probe_up_acks: 0,
+
+            loss_round_start: false,
+
+            loss_round_delivered: 0,
+
+            loss_in_round: false,
+        }
+    }
+}
+
+// When entering the recovery episode.
+fn bbr2_enter_recovery(r: &mut Recovery, now: Instant) {
+    r.bbr2_state.prior_cwnd = per_ack::bbr2_save_cwnd(r);
+
+    r.congestion_window = r.bytes_in_flight +
+        r.bbr2_state.newly_acked_bytes.max(r.max_datagram_size);
+    r.congestion_recovery_start_time = Some(now);
+
+    r.bbr2_state.packet_conservation = true;
+    r.bbr2_state.in_recovery = true;
+
+    // Start round now.
+    r.bbr2_state.next_round_delivered = r.delivery_rate.delivered();
+}
+
+// When exiting the recovery episode.
+fn bbr2_exit_recovery(r: &mut Recovery) {
+    r.congestion_recovery_start_time = None;
+
+    r.bbr2_state.packet_conservation = false;
+    r.bbr2_state.in_recovery = false;
+
+    per_ack::bbr2_restore_cwnd(r);
+}
+
+// Congestion Control Hooks.
+//
+fn on_init(r: &mut Recovery) {
+    init::bbr2_init(r);
+}
+
+fn reset(r: &mut Recovery) {
+    r.bbr2_state = State::new();
+
+    init::bbr2_init(r);
+}
+
+fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, now: Instant) {
+    r.bytes_in_flight += sent_bytes;
+
+    per_transmit::bbr2_on_transmit(r, now);
+}
+
+fn on_packets_acked(
+    r: &mut Recovery, packets: &mut Vec<Acked>, _epoch: packet::Epoch,
+    now: Instant,
+) {
+    r.bbr2_state.newly_acked_bytes =
+        packets.drain(..).fold(0, |acked_bytes, p| {
+            r.bbr2_state.prior_bytes_in_flight = r.bytes_in_flight;
+
+            per_ack::bbr2_update_model_and_state(r, &p, now);
+
+            r.bytes_in_flight = r.bytes_in_flight.saturating_sub(p.size);
+
+            acked_bytes + p.size
+        });
+
+    if let Some(pkt) = packets.last() {
+        if !r.in_congestion_recovery(pkt.time_sent) {
+            // Upon exiting loss recovery.
+            bbr2_exit_recovery(r);
+        }
+    }
+
+    per_ack::bbr2_update_control_parameters(r, now);
+
+    r.bbr2_state.newly_lost_bytes = 0;
+}
+
+fn congestion_event(
+    r: &mut Recovery, lost_bytes: usize, largest_lost_pkt: &Sent,
+    _epoch: packet::Epoch, now: Instant,
+) {
+    r.bbr2_state.newly_lost_bytes = lost_bytes;
+
+    per_loss::bbr2_update_on_loss(r, largest_lost_pkt, now);
+
+    // Upon entering Fast Recovery.
+    if !r.in_congestion_recovery(largest_lost_pkt.time_sent) {
+        // Upon entering Fast Recovery.
+        bbr2_enter_recovery(r, now);
+    }
+}
+
+fn collapse_cwnd(r: &mut Recovery) {
+    // BBROnEnterRTO()
+    r.bbr2_state.prior_cwnd = per_ack::bbr2_save_cwnd(r);
+
+    r.congestion_window = r.bytes_in_flight + r.max_datagram_size;
+}
+
+fn checkpoint(_r: &mut Recovery) {}
+
+fn rollback(_r: &mut Recovery) -> bool {
+    false
+}
+
+fn has_custom_pacing() -> bool {
+    true
+}
+
+// rate -> kbit/sec. if inf, return -1
+fn rate_kbps(rate: u64) -> isize {
+    if rate == u64::MAX {
+        -1
+    } else {
+        (rate * 8 / 1000) as isize
+    }
+}
+
+fn debug_fmt(r: &Recovery, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    let bbr = &r.bbr2_state;
+
+    write!(f, "bbr2={{ ")?;
+    write!(
+        f,
+        "state={:?} in_recovery={} ack_phase={:?} filled_pipe={} ",
+        bbr.state, bbr.in_recovery, bbr.ack_phase, bbr.filled_pipe
+    )?;
+    write!(
+        f,
+        "send_quantum={} extra_acked={} min_rtt={:?} round_start={} ",
+        r.send_quantum, bbr.extra_acked, bbr.min_rtt, bbr.round_start
+    )?;
+    write!(
+        f,
+        "max_bw={}kbps bw_lo={}kbps bw={}kbps bw_hi={}kbps ",
+        rate_kbps(bbr.max_bw),
+        rate_kbps(bbr.bw_lo),
+        rate_kbps(bbr.bw),
+        rate_kbps(bbr.bw_hi)
+    )?;
+    write!(
+        f,
+        "inflight_lo={} inflight_hi={} ",
+        bbr.inflight_lo, bbr.inflight_hi
+    )?;
+    write!(
+        f,
+        "probe_up_cnt={} bw_probe_samples={} ",
+        bbr.probe_up_cnt, bbr.bw_probe_samples
+    )?;
+    write!(f, "}}")
+}
+
+// TODO: write more tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::recovery;
+
+    #[test]
+    fn bbr_init() {
+        let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        cfg.set_cc_algorithm(recovery::CongestionControlAlgorithm::BBR2);
+
+        let mut r = Recovery::new(&cfg);
+
+        // on_init() is called in Connection::new(), so it need to be
+        // called manually here.
+        r.on_init();
+
+        assert_eq!(
+            r.cwnd(),
+            r.max_datagram_size * r.initial_congestion_window_packets
+        );
+        assert_eq!(r.bytes_in_flight, 0);
+
+        assert_eq!(r.bbr2_state.state, BBR2StateMachine::Startup);
+    }
+}
+
+mod init;
+mod pacing;
+mod per_ack;
+mod per_loss;
+mod per_transmit;

--- a/quiche/src/recovery/bbr2/pacing.rs
+++ b/quiche/src/recovery/bbr2/pacing.rs
@@ -1,0 +1,63 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::*;
+
+use std::time::Duration;
+
+use crate::recovery::Recovery;
+
+// BBR2 Transmit Packet Pacing Functions
+//
+
+// 4.6.2.  Pacing Rate: BBR.pacing_rate
+pub fn bbr2_init_pacing_rate(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    let srtt = r
+        .smoothed_rtt
+        .unwrap_or_else(|| Duration::from_millis(1))
+        .as_secs_f64();
+
+    // At init, cwnd is initcwnd.
+    let nominal_bandwidth = r.congestion_window as f64 / srtt;
+
+    bbr.pacing_rate = (STARTUP_PACING_GAIN * nominal_bandwidth) as u64;
+}
+
+pub fn bbr2_set_pacing_rate_with_gain(r: &mut Recovery, pacing_gain: f64) {
+    let rate = (pacing_gain *
+        r.bbr2_state.bw as f64 *
+        (1.0 - PACING_MARGIN_PERCENT)) as u64;
+
+    if r.bbr2_state.filled_pipe || rate > r.bbr2_state.pacing_rate {
+        r.bbr2_state.pacing_rate = rate;
+    }
+}
+
+pub fn bbr2_set_pacing_rate(r: &mut Recovery) {
+    bbr2_set_pacing_rate_with_gain(r, r.bbr2_state.pacing_gain);
+}

--- a/quiche/src/recovery/bbr2/per_ack.rs
+++ b/quiche/src/recovery/bbr2/per_ack.rs
@@ -1,0 +1,743 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::*;
+use crate::rand;
+use crate::recovery;
+
+use std::cmp;
+use std::time::Instant;
+
+/// 1.2Mbps in bytes/sec
+const PACING_RATE_1_2MBPS: u64 = 1200 * 1000 / 8;
+
+/// The minimal cwnd value BBR2 tries to target, in bytes
+#[inline]
+fn bbr2_min_pipe_cwnd(r: &mut Recovery) -> usize {
+    MIN_PIPE_CWND_PKTS * r.max_datagram_size
+}
+
+// BBR2 Functions when ACK is received.
+//
+pub fn bbr2_update_model_and_state(
+    r: &mut Recovery, packet: &Acked, now: Instant,
+) {
+    per_loss::bbr2_update_latest_delivery_signals(r);
+    per_loss::bbr2_update_congestion_signals(r, packet);
+    bbr2_update_ack_aggregation(r, packet, now);
+    bbr2_check_startup_done(r);
+    bbr2_check_drain(r, now);
+    bbr2_update_probe_bw_cycle_phase(r, now);
+    bbr2_update_min_rtt(r, now);
+    bbr2_check_probe_rtt(r, now);
+    per_loss::bbr2_advance_latest_delivery_signals(r);
+    per_loss::bbr2_bound_bw_for_model(r);
+}
+
+pub fn bbr2_update_control_parameters(r: &mut Recovery, now: Instant) {
+    pacing::bbr2_set_pacing_rate(r);
+    bbr2_set_send_quantum(r);
+
+    // Set outgoing packet pacing rate
+    // It is called here because send_quantum may be updated too.
+    r.set_pacing_rate(r.bbr2_state.pacing_rate, now);
+
+    bbr2_set_cwnd(r);
+}
+
+// BBR2 Functions while processing ACKs.
+//
+
+// 4.3.1.1.  Startup Dynamics
+fn bbr2_check_startup_done(r: &mut Recovery) {
+    bbr2_check_startup_full_bandwidth(r);
+    bbr2_check_startup_high_loss(r);
+
+    if r.bbr2_state.state == BBR2StateMachine::Startup && r.bbr2_state.filled_pipe
+    {
+        bbr2_enter_drain(r);
+    }
+}
+
+// 4.3.1.2.  Exiting Startup Based on Bandwidth Plateau
+fn bbr2_check_startup_full_bandwidth(r: &mut Recovery) {
+    if r.bbr2_state.filled_pipe ||
+        !r.bbr2_state.round_start ||
+        r.delivery_rate.sample_is_app_limited()
+    {
+        // No need to check for a full pipe now.
+        return;
+    }
+
+    // Still growing?
+    if r.bbr2_state.max_bw >=
+        (r.bbr2_state.full_bw as f64 * MAX_BW_GROWTH_THRESHOLD) as u64
+    {
+        // Record new baseline level
+        r.bbr2_state.full_bw = r.bbr2_state.max_bw;
+        r.bbr2_state.full_bw_count = 0;
+        return;
+    }
+
+    // Another round w/o much growth
+    r.bbr2_state.full_bw_count += 1;
+
+    if r.bbr2_state.full_bw_count >= 3 {
+        r.bbr2_state.filled_pipe = true;
+    }
+}
+
+// 4.3.1.3.  Exiting Startup Based on Packet Loss
+fn bbr2_check_startup_high_loss(_r: &mut Recovery) {
+    // TODO: this is not implemented (not in the draft)
+}
+
+// 4.3.2.  Drain
+fn bbr2_enter_drain(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    bbr.state = BBR2StateMachine::Drain;
+
+    // pace slowly
+    bbr.pacing_gain = 1.0 / STARTUP_CWND_GAIN;
+
+    // maintain cwnd
+    bbr.cwnd_gain = STARTUP_CWND_GAIN;
+}
+
+fn bbr2_check_drain(r: &mut Recovery, now: Instant) {
+    if r.bbr2_state.state == BBR2StateMachine::Drain &&
+        r.bytes_in_flight <= bbr2_inflight(r, r.bbr2_state.bw, 1.0)
+    {
+        // BBR estimates the queue was drained
+        bbr2_enter_probe_bw(r, now);
+    }
+}
+
+// 4.3.3.  ProbeBW
+// 4.3.3.5.3.  Design Considerations for Choosing Constant Parameters
+fn bbr2_check_time_to_probe_bw(r: &mut Recovery, now: Instant) -> bool {
+    // Is it time to transition from DOWN or CRUISE to REFILL?
+    if bbr2_has_elapsed_in_phase(r, r.bbr2_state.bw_probe_wait, now) ||
+        bbr2_is_reno_coexistence_probe_time(r)
+    {
+        bbr2_start_probe_bw_refill(r);
+
+        return true;
+    }
+
+    false
+}
+
+// Randomized decision about how long to wait until
+// probing for bandwidth, using round count and wall clock.
+fn bbr2_pick_probe_wait(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    // Decide random round-trip bound for wait
+    bbr.rounds_since_probe = rand::rand_u8() as usize % 2;
+
+    // Decide the random wall clock bound for wait
+    bbr.bw_probe_wait = Duration::from_secs_f64(
+        2.0 + rand::rand_u64_uniform(1000000) as f64 / 1000000.0,
+    );
+}
+
+fn bbr2_is_reno_coexistence_probe_time(r: &mut Recovery) -> bool {
+    let reno_rounds = bbr2_target_inflight(r);
+    let rounds = reno_rounds.min(63);
+
+    r.bbr2_state.rounds_since_probe >= rounds
+}
+
+// How much data do we want in flight?
+// Our estimated BDP, unless congestion cut cwnd.
+pub fn bbr2_target_inflight(r: &mut Recovery) -> usize {
+    r.bbr2_state.bdp.min(r.congestion_window)
+}
+
+// 4.3.3.6.  ProbeBW Algorithm Details
+fn bbr2_enter_probe_bw(r: &mut Recovery, now: Instant) {
+    bbr2_start_probe_bw_down(r, now);
+}
+
+pub fn bbr2_start_probe_bw_down(r: &mut Recovery, now: Instant) {
+    per_loss::bbr2_reset_congestion_signals(r);
+
+    // not growing inflight_hi
+    r.bbr2_state.probe_up_cnt = usize::MAX;
+
+    bbr2_pick_probe_wait(r);
+
+    // start wall clock
+    r.bbr2_state.cycle_stamp = now;
+    r.bbr2_state.ack_phase = BBR2AckPhase::ProbeStopping;
+
+    bbr2_start_round(r);
+
+    r.bbr2_state.state = BBR2StateMachine::ProbeBWDOWN;
+}
+
+fn bbr2_start_probe_bw_cruise(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    bbr.state = BBR2StateMachine::ProbeBWCRUISE;
+}
+
+fn bbr2_start_probe_bw_refill(r: &mut Recovery) {
+    per_loss::bbr2_reset_lower_bounds(r);
+
+    r.bbr2_state.bw_probe_up_rounds = 0;
+    r.bbr2_state.bw_probe_up_acks = 0;
+    r.bbr2_state.ack_phase = BBR2AckPhase::Refilling;
+
+    bbr2_start_round(r);
+
+    r.bbr2_state.state = BBR2StateMachine::ProbeBWREFILL;
+}
+
+fn bbr2_start_probe_bw_up(r: &mut Recovery, now: Instant) {
+    r.bbr2_state.ack_phase = BBR2AckPhase::ProbeStarting;
+
+    bbr2_start_round(r);
+
+    // Start wall clock.
+    r.bbr2_state.cycle_stamp = now;
+    r.bbr2_state.state = BBR2StateMachine::ProbeBWUP;
+
+    bbr2_raise_inflight_hi_slope(r);
+}
+
+// The core state machine logic for ProbeBW
+fn bbr2_update_probe_bw_cycle_phase(r: &mut Recovery, now: Instant) {
+    if !r.bbr2_state.filled_pipe {
+        // only handling steady-state behavior here
+        return;
+    }
+
+    bbr2_adapt_upper_bounds(r, now);
+
+    if !bbr2_is_in_a_probe_bw_state(r) {
+        // only handling ProbeBW states here
+        return;
+    }
+
+    match r.bbr2_state.state {
+        BBR2StateMachine::ProbeBWDOWN => {
+            if bbr2_check_time_to_probe_bw(r, now) {
+                // Already decided state transition.
+                return;
+            }
+
+            if bbr2_check_time_to_cruise(r) {
+                bbr2_start_probe_bw_cruise(r);
+            }
+        },
+
+        BBR2StateMachine::ProbeBWCRUISE => {
+            bbr2_check_time_to_probe_bw(r, now);
+        },
+
+        BBR2StateMachine::ProbeBWREFILL => {
+            // After one round of REFILL, start UP.
+            if r.bbr2_state.round_start {
+                r.bbr2_state.bw_probe_samples = true;
+
+                bbr2_start_probe_bw_up(r, now);
+            }
+        },
+
+        BBR2StateMachine::ProbeBWUP => {
+            if bbr2_has_elapsed_in_phase(r, r.bbr2_state.min_rtt, now) &&
+                r.bytes_in_flight > bbr2_inflight(r, r.bbr2_state.max_bw, 1.25)
+            {
+                bbr2_start_probe_bw_down(r, now);
+            }
+        },
+
+        _ => (),
+    }
+}
+
+pub fn bbr2_is_in_a_probe_bw_state(r: &mut Recovery) -> bool {
+    let state = r.bbr2_state.state;
+
+    state == BBR2StateMachine::ProbeBWDOWN ||
+        state == BBR2StateMachine::ProbeBWCRUISE ||
+        state == BBR2StateMachine::ProbeBWREFILL ||
+        state == BBR2StateMachine::ProbeBWUP
+}
+
+fn bbr2_check_time_to_cruise(r: &mut Recovery) -> bool {
+    if r.bytes_in_flight > bbr2_inflight_with_headroom(r) {
+        // Not enough headroom.
+        return false;
+    }
+
+    if r.bytes_in_flight <= bbr2_inflight(r, r.bbr2_state.max_bw, 1.0) {
+        // inflight <= estimated BDP
+        return true;
+    }
+
+    false
+}
+
+fn bbr2_has_elapsed_in_phase(
+    r: &mut Recovery, interval: Duration, now: Instant,
+) -> bool {
+    now > r.bbr2_state.cycle_stamp + interval
+}
+
+// Return a volume of data that tries to leave free
+// headroom in the bottleneck buffer or link for
+// other flows, for fairness convergence and lower
+// RTTs and loss
+fn bbr2_inflight_with_headroom(r: &mut Recovery) -> usize {
+    let bbr = &mut r.bbr2_state;
+
+    if bbr.inflight_hi == usize::MAX {
+        return usize::MAX;
+    }
+
+    let headroom = ((HEADROOM * bbr.inflight_hi as f64) as usize).max(1);
+
+    bbr.inflight_hi
+        .saturating_sub(headroom)
+        .max(bbr2_min_pipe_cwnd(r))
+}
+
+// Raise inflight_hi slope if appropriate.
+fn bbr2_raise_inflight_hi_slope(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    let growth_this_round = (1 << bbr.bw_probe_up_rounds) * r.max_datagram_size;
+
+    bbr.bw_probe_up_rounds = (bbr.bw_probe_up_rounds + 1).min(30);
+    bbr.probe_up_cnt = (r.congestion_window / growth_this_round).max(1);
+}
+
+// Increase inflight_hi if appropriate.
+fn bbr2_probe_inflight_hi_upward(r: &mut Recovery) {
+    if r.app_limited() || r.congestion_window < r.bbr2_state.inflight_hi {
+        // Not fully using inflight_hi, so don't grow it.
+        return;
+    }
+
+    let bbr = &mut r.bbr2_state;
+
+    // bw_probe_up_acks is a packet count.
+    bbr.bw_probe_up_acks += 1;
+
+    if bbr.bw_probe_up_acks >= bbr.probe_up_cnt {
+        let delta = bbr.bw_probe_up_acks / bbr.probe_up_cnt;
+
+        bbr.bw_probe_up_acks -= delta * bbr.probe_up_cnt;
+
+        bbr.inflight_hi += delta * r.max_datagram_size;
+    }
+
+    if bbr.round_start {
+        bbr2_raise_inflight_hi_slope(r);
+    }
+}
+
+// Track ACK state and update bbr.max_bw window and
+// bbr.inflight_hi and bbr.bw_hi.
+fn bbr2_adapt_upper_bounds(r: &mut Recovery, now: Instant) {
+    if r.bbr2_state.ack_phase == BBR2AckPhase::ProbeStarting &&
+        r.bbr2_state.round_start
+    {
+        // Starting to get bw probing samples.
+        r.bbr2_state.ack_phase = BBR2AckPhase::ProbeFeedback;
+    }
+
+    if r.bbr2_state.ack_phase == BBR2AckPhase::ProbeStopping &&
+        r.bbr2_state.round_start
+    {
+        r.bbr2_state.bw_probe_samples = false;
+        r.bbr2_state.ack_phase = BBR2AckPhase::Init;
+
+        // End of samples from bw probing phase.
+        if bbr2_is_in_a_probe_bw_state(r) &&
+            !r.delivery_rate.sample_is_app_limited()
+        {
+            bbr2_advance_max_bw_filter(r);
+        }
+    }
+
+    if !per_loss::bbr2_check_inflight_too_high(r, now) {
+        // Loss rate is safe. Adjust upper bounds upward.
+        if r.bbr2_state.inflight_hi == usize::MAX ||
+            r.bbr2_state.bw_hi == u64::MAX
+        {
+            // No upper bounds to raise.
+            return;
+        }
+
+        if r.bbr2_state.tx_in_flight > r.bbr2_state.inflight_hi {
+            r.bbr2_state.inflight_hi = r.bbr2_state.tx_in_flight;
+        }
+
+        // TODO: what's rs.bw???
+        if r.delivery_rate() > r.bbr2_state.bw_hi {
+            r.bbr2_state.bw_hi = r.delivery_rate();
+        }
+
+        if r.bbr2_state.state == BBR2StateMachine::ProbeBWUP {
+            bbr2_probe_inflight_hi_upward(r);
+        }
+    }
+}
+
+// 4.3.4. ProbeRTT
+// 4.3.4.4.  ProbeRTT Logic
+fn bbr2_update_min_rtt(r: &mut Recovery, now: Instant) {
+    let bbr = &mut r.bbr2_state;
+
+    bbr.probe_rtt_expired = now > bbr.probe_rtt_min_stamp + PROBE_RTT_INTERVAL;
+
+    let rs_rtt = r.delivery_rate.sample_rtt();
+
+    if !rs_rtt.is_zero() &&
+        (rs_rtt < bbr.probe_rtt_min_delay || bbr.probe_rtt_expired)
+    {
+        bbr.probe_rtt_min_delay = rs_rtt;
+        bbr.probe_rtt_min_stamp = now;
+    }
+
+    let min_rtt_expired = now > bbr.min_rtt_stamp + MIN_RTT_FILTER_LEN;
+
+    if bbr.probe_rtt_min_delay < bbr.min_rtt || min_rtt_expired {
+        bbr.min_rtt = bbr.probe_rtt_min_delay;
+        bbr.min_rtt_stamp = bbr.probe_rtt_min_stamp;
+    }
+}
+
+fn bbr2_check_probe_rtt(r: &mut Recovery, now: Instant) {
+    if r.bbr2_state.state != BBR2StateMachine::ProbeRTT &&
+        r.bbr2_state.probe_rtt_expired &&
+        !r.bbr2_state.idle_restart
+    {
+        bbr2_enter_probe_rtt(r);
+
+        r.bbr2_state.prior_cwnd = per_ack::bbr2_save_cwnd(r);
+        r.bbr2_state.probe_rtt_done_stamp = None;
+        r.bbr2_state.ack_phase = BBR2AckPhase::ProbeStopping;
+
+        bbr2_start_round(r);
+    }
+
+    if r.bbr2_state.state == BBR2StateMachine::ProbeRTT {
+        bbr2_handle_probe_rtt(r, now);
+    }
+
+    if r.delivery_rate.sample_delivered() > 0 {
+        r.bbr2_state.idle_restart = false;
+    }
+}
+
+fn bbr2_enter_probe_rtt(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    bbr.state = BBR2StateMachine::ProbeRTT;
+    bbr.pacing_gain = 1.0;
+    bbr.cwnd_gain = PROBE_RTT_CWND_GAIN;
+}
+
+fn bbr2_handle_probe_rtt(r: &mut Recovery, now: Instant) {
+    // Ignore low rate samples during ProbeRTT.
+    r.delivery_rate.update_app_limited(true);
+
+    if r.bbr2_state.probe_rtt_done_stamp.is_some() {
+        if r.bbr2_state.round_start {
+            r.bbr2_state.probe_rtt_round_done = true;
+        }
+
+        if r.bbr2_state.probe_rtt_round_done {
+            bbr2_check_probe_rtt_done(r, now);
+        }
+    } else if r.bytes_in_flight <= bbr2_probe_rtt_cwnd(r) {
+        // Wait for at least ProbeRTTDuration to elapse.
+        r.bbr2_state.probe_rtt_done_stamp = Some(now + PROBE_RTT_DURATION);
+
+        // Wait for at lease one round to elapse.
+        r.bbr2_state.probe_rtt_round_done = false;
+
+        bbr2_start_round(r);
+    }
+}
+
+pub fn bbr2_check_probe_rtt_done(r: &mut Recovery, now: Instant) {
+    let bbr = &mut r.bbr2_state;
+
+    if let Some(probe_rtt_done_stamp) = bbr.probe_rtt_done_stamp {
+        if now > probe_rtt_done_stamp {
+            // Schedule next ProbeRTT.
+            bbr.probe_rtt_min_stamp = now;
+
+            bbr2_restore_cwnd(r);
+            bbr2_exit_probe_rtt(r, now);
+        }
+    }
+}
+
+// 4.3.4.5.  Exiting ProbeRTT
+fn bbr2_exit_probe_rtt(r: &mut Recovery, now: Instant) {
+    per_loss::bbr2_reset_lower_bounds(r);
+
+    if r.bbr2_state.filled_pipe {
+        bbr2_start_probe_bw_down(r, now);
+        bbr2_start_probe_bw_cruise(r);
+    } else {
+        init::bbr2_enter_startup(r);
+    }
+}
+
+// 4.5.1.  BBR.round_count: Tracking Packet-Timed Round Trips
+fn bbr2_update_round(r: &mut Recovery, packet: &Acked) {
+    if packet.delivered >= r.bbr2_state.next_round_delivered {
+        bbr2_start_round(r);
+
+        r.bbr2_state.round_count += 1;
+        r.bbr2_state.rounds_since_probe += 1;
+        r.bbr2_state.round_start = true;
+    } else {
+        r.bbr2_state.round_start = false;
+    }
+}
+
+fn bbr2_start_round(r: &mut Recovery) {
+    r.bbr2_state.next_round_delivered = r.delivery_rate.delivered();
+}
+
+// 4.5.2.4.  Updating the BBR.max_bw Max Filter
+pub fn bbr2_update_max_bw(r: &mut Recovery, packet: &Acked) {
+    bbr2_update_round(r, packet);
+
+    if r.delivery_rate() >= r.bbr2_state.max_bw ||
+        !r.delivery_rate.sample_is_app_limited()
+    {
+        r.bbr2_state.max_bw = r.bbr2_state.max_bw_filter.running_max(
+            MAX_BW_FILTER_LEN,
+            r.bbr2_state.start_time +
+                Duration::from_secs(r.bbr2_state.cycle_count),
+            r.delivery_rate(),
+        );
+    }
+}
+
+// 4.5.2.5.  Tracking Time for the BBR.max_bw Max Filter
+fn bbr2_advance_max_bw_filter(r: &mut Recovery) {
+    r.bbr2_state.cycle_count += 1;
+}
+
+// 4.5.4.  BBR.offload_budget
+fn bbr2_update_offload_budget(r: &mut Recovery) {
+    r.bbr2_state.offload_budget = 3 * r.send_quantum;
+}
+
+// 4.5.5.  BBR.extra_acked
+fn bbr2_update_ack_aggregation(r: &mut Recovery, packet: &Acked, now: Instant) {
+    let bbr = &mut r.bbr2_state;
+
+    // Find excess ACKed beyond expected amount over this interval.
+    let interval = now - bbr.extra_acked_interval_start;
+    let mut expected_delivered =
+        (bbr.bw as f64 * interval.as_secs_f64()) as usize;
+
+    // Reset interval if ACK rate is below expected rate.
+    if bbr.extra_acked_delivered <= expected_delivered {
+        bbr.extra_acked_delivered = 0;
+        bbr.extra_acked_interval_start = now;
+        expected_delivered = 0;
+    }
+
+    bbr.extra_acked_delivered += packet.size;
+
+    let extra = bbr.extra_acked_delivered.saturating_sub(expected_delivered);
+    let extra = extra.min(r.congestion_window);
+
+    bbr.extra_acked = bbr.extra_acked_filter.running_max(
+        EXTRA_ACKED_FILTER_LEN,
+        bbr.start_time + Duration::from_secs(bbr.round_count),
+        extra,
+    );
+}
+
+// 4.6.3.  Send Quantum: BBR.send_quantum
+fn bbr2_set_send_quantum(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    let rate = bbr.pacing_rate;
+    let floor = if rate < PACING_RATE_1_2MBPS {
+        r.max_datagram_size
+    } else {
+        2 * r.max_datagram_size
+    };
+
+    r.send_quantum = cmp::min((rate / 1000_u64) as usize, 64 * 1024);
+    r.send_quantum = r.send_quantum.max(floor);
+}
+
+// 4.6.4.1.  Initial cwnd
+// 4.6.4.2.  Computing BBR.max_inflight
+fn bbr2_bdp_multiple(r: &mut Recovery, bw: u64, gain: f64) -> usize {
+    let bbr = &mut r.bbr2_state;
+
+    if bbr.min_rtt == Duration::MAX {
+        // No valid RTT samples yet.
+        return r.max_datagram_size * r.initial_congestion_window_packets;
+    }
+
+    bbr.bdp = (bw as f64 * bbr.min_rtt.as_secs_f64()) as usize;
+
+    (gain * bbr.bdp as f64) as usize
+}
+
+fn bbr2_quantization_budget(r: &mut Recovery, inflight: usize) -> usize {
+    bbr2_update_offload_budget(r);
+
+    let inflight = inflight.max(r.bbr2_state.offload_budget);
+    let inflight = inflight.max(bbr2_min_pipe_cwnd(r));
+
+    // TODO: cycle_idx is unused
+    if r.bbr2_state.state == BBR2StateMachine::ProbeBWUP {
+        return inflight + 2 * r.max_datagram_size;
+    }
+
+    inflight
+}
+
+fn bbr2_inflight(r: &mut Recovery, bw: u64, gain: f64) -> usize {
+    let inflight = bbr2_bdp_multiple(r, bw, gain);
+
+    bbr2_quantization_budget(r, inflight)
+}
+
+fn bbr2_update_max_inflight(r: &mut Recovery) {
+    // TODO: not implemented (not in the draft)
+    // bbr2_update_aggregation_budget(r);
+
+    let inflight = bbr2_bdp_multiple(r, r.bbr2_state.bw, r.bbr2_state.cwnd_gain);
+    let inflight = inflight + r.bbr2_state.extra_acked;
+
+    r.bbr2_state.max_inflight = bbr2_quantization_budget(r, inflight);
+}
+
+// 4.6.4.4.  Modulating cwnd in Loss Recovery
+pub fn bbr2_save_cwnd(r: &mut Recovery) -> usize {
+    if !r.bbr2_state.in_recovery &&
+        r.bbr2_state.state != BBR2StateMachine::ProbeRTT
+    {
+        r.congestion_window
+    } else {
+        r.congestion_window.max(r.bbr2_state.prior_cwnd)
+    }
+}
+
+pub fn bbr2_restore_cwnd(r: &mut Recovery) {
+    r.congestion_window = r.congestion_window.max(r.bbr2_state.prior_cwnd);
+}
+
+fn bbr2_modulate_cwnd_for_recovery(r: &mut Recovery) {
+    let acked_bytes = r.bbr2_state.newly_acked_bytes;
+    let lost_bytes = r.bbr2_state.newly_lost_bytes;
+
+    if lost_bytes > 0 {
+        // QUIC mininum cwnd is 2 x MSS.
+        r.congestion_window = r
+            .congestion_window
+            .saturating_sub(lost_bytes)
+            .max(r.max_datagram_size * recovery::MINIMUM_WINDOW_PACKETS);
+    }
+
+    if r.bbr2_state.packet_conservation {
+        r.congestion_window =
+            r.congestion_window.max(r.bytes_in_flight + acked_bytes);
+    }
+}
+
+// 4.6.4.5.  Modulating cwnd in ProbeRTT
+fn bbr2_probe_rtt_cwnd(r: &mut Recovery) -> usize {
+    let probe_rtt_cwnd =
+        bbr2_bdp_multiple(r, r.bbr2_state.bw, PROBE_RTT_CWND_GAIN);
+
+    probe_rtt_cwnd.max(bbr2_min_pipe_cwnd(r))
+}
+
+fn bbr2_bound_cwnd_for_probe_rtt(r: &mut Recovery) {
+    if r.bbr2_state.state == BBR2StateMachine::ProbeRTT {
+        r.congestion_window = r.congestion_window.min(bbr2_probe_rtt_cwnd(r));
+    }
+}
+
+// 4.6.4.6.  Core cwnd Adjustment Mechanism
+fn bbr2_set_cwnd(r: &mut Recovery) {
+    let acked_bytes = r.bbr2_state.newly_acked_bytes;
+
+    bbr2_update_max_inflight(r);
+    bbr2_modulate_cwnd_for_recovery(r);
+
+    if !r.bbr2_state.packet_conservation {
+        if r.bbr2_state.filled_pipe {
+            r.congestion_window = cmp::min(
+                r.congestion_window + acked_bytes,
+                r.bbr2_state.max_inflight,
+            )
+        } else if r.congestion_window < r.bbr2_state.max_inflight ||
+            r.delivery_rate.delivered() <
+                r.max_datagram_size * r.initial_congestion_window_packets
+        {
+            r.congestion_window += acked_bytes;
+        }
+
+        r.congestion_window = r.congestion_window.max(bbr2_min_pipe_cwnd(r))
+    }
+
+    bbr2_bound_cwnd_for_probe_rtt(r);
+    bbr2_bound_cwnd_for_model(r);
+}
+
+// 4.6.4.7.  Bounding cwnd Based on Recent Congestion
+fn bbr2_bound_cwnd_for_model(r: &mut Recovery) {
+    let mut cap = usize::MAX;
+
+    if bbr2_is_in_a_probe_bw_state(r) &&
+        r.bbr2_state.state != BBR2StateMachine::ProbeBWCRUISE
+    {
+        cap = r.bbr2_state.inflight_hi;
+    } else if r.bbr2_state.state == BBR2StateMachine::ProbeRTT ||
+        r.bbr2_state.state == BBR2StateMachine::ProbeBWCRUISE
+    {
+        cap = bbr2_inflight_with_headroom(r);
+    }
+
+    // Apply inflight_lo (possibly infinite).
+    cap = cap.min(r.bbr2_state.inflight_lo);
+    cap = cap.max(bbr2_min_pipe_cwnd(r));
+
+    r.congestion_window = r.congestion_window.min(cap);
+}

--- a/quiche/src/recovery/bbr2/per_loss.rs
+++ b/quiche/src/recovery/bbr2/per_loss.rs
@@ -1,0 +1,207 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::*;
+use crate::recovery::Recovery;
+
+// BBR2 Functions on every packet loss event.
+//
+// 4.2.4.  Per-Loss Steps
+pub fn bbr2_update_on_loss(r: &mut Recovery, packet: &Sent, now: Instant) {
+    bbr2_handle_lost_packet(r, packet, now);
+}
+
+// 4.5.6.  Updating the Model Upon Packet Loss
+// 4.5.6.2.  Probing for Bandwidth In ProbeBW
+pub fn bbr2_check_inflight_too_high(r: &mut Recovery, now: Instant) -> bool {
+    if bbr2_is_inflight_too_high(r) {
+        if r.bbr2_state.bw_probe_samples {
+            bbr2_handle_inflight_too_high(r, now);
+        }
+
+        // inflight too high.
+        return true;
+    }
+
+    // inflight not too high.
+    false
+}
+
+fn bbr2_is_inflight_too_high(r: &mut Recovery) -> bool {
+    r.bbr2_state.lost > (r.bbr2_state.tx_in_flight as f64 * LOSS_THRESH) as usize
+}
+
+fn bbr2_handle_inflight_too_high(r: &mut Recovery, now: Instant) {
+    // Only react once per bw probe.
+    r.bbr2_state.bw_probe_samples = false;
+
+    if !r.delivery_rate.sample_is_app_limited() {
+        r.bbr2_state.inflight_hi = r
+            .bbr2_state
+            .tx_in_flight
+            .max((per_ack::bbr2_target_inflight(r) as f64 * BETA) as usize);
+    }
+
+    if r.bbr2_state.state == BBR2StateMachine::ProbeBWUP {
+        per_ack::bbr2_start_probe_bw_down(r, now);
+    }
+}
+
+fn bbr2_handle_lost_packet(r: &mut Recovery, packet: &Sent, now: Instant) {
+    if !r.bbr2_state.bw_probe_samples {
+        return;
+    }
+
+    r.bbr2_state.tx_in_flight = packet.tx_in_flight;
+    r.bbr2_state.lost = (r.bytes_lost - packet.lost) as usize;
+
+    r.delivery_rate_update_app_limited(packet.is_app_limited);
+
+    if bbr2_is_inflight_too_high(r) {
+        r.bbr2_state.tx_in_flight = bbr2_inflight_hi_from_lost_packet(r, packet);
+
+        bbr2_handle_inflight_too_high(r, now);
+    }
+}
+
+fn bbr2_inflight_hi_from_lost_packet(r: &mut Recovery, packet: &Sent) -> usize {
+    let size = packet.size;
+    let inflight_prev = r.bbr2_state.tx_in_flight - size;
+    let lost_prev = r.bbr2_state.lost - size;
+    let lost_prefix = (LOSS_THRESH * inflight_prev as f64 - lost_prev as f64) /
+        (1.0 - LOSS_THRESH);
+
+    inflight_prev + lost_prefix as usize
+}
+
+// 4.5.6.3.  When not Probing for Bandwidth
+pub fn bbr2_update_latest_delivery_signals(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    // Near start of ACK processing.
+    bbr.loss_round_start = false;
+    bbr.bw_latest = bbr.bw_latest.max(r.delivery_rate.sample_delivery_rate());
+    bbr.inflight_latest =
+        bbr.inflight_latest.max(r.delivery_rate.sample_delivered());
+
+    if r.delivery_rate.sample_prior_delivered() >= bbr.loss_round_delivered {
+        bbr.loss_round_delivered = r.delivery_rate.delivered();
+        bbr.loss_round_start = true;
+    }
+}
+
+pub fn bbr2_advance_latest_delivery_signals(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    // Near end of ACK processing.
+    if bbr.loss_round_start {
+        bbr.bw_latest = r.delivery_rate.sample_delivery_rate();
+        bbr.inflight_latest = r.delivery_rate.sample_delivered();
+    }
+}
+
+pub fn bbr2_reset_congestion_signals(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    bbr.loss_in_round = false;
+    bbr.bw_latest = 0;
+    bbr.inflight_latest = 0;
+}
+
+pub fn bbr2_update_congestion_signals(r: &mut Recovery, packet: &Acked) {
+    // Update congestion state on every ACK.
+    per_ack::bbr2_update_max_bw(r, packet);
+
+    if r.bbr2_state.lost > 0 {
+        r.bbr2_state.loss_in_round = true;
+    }
+
+    if !r.bbr2_state.loss_round_start {
+        // Wait until end of round trip.
+        return;
+    }
+
+    bbr2_adapt_lower_bounds_from_congestion(r);
+
+    r.bbr2_state.loss_in_round = false;
+}
+
+fn bbr2_adapt_lower_bounds_from_congestion(r: &mut Recovery) {
+    // Once per round-trip respond to congestion.
+    if bbr2_is_probing_bw(r) {
+        return;
+    }
+
+    if r.bbr2_state.loss_in_round {
+        bbr2_init_lower_bounds(r);
+        bbr2_loss_lower_bounds(r);
+    }
+}
+
+fn bbr2_init_lower_bounds(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    // Handle the first congestion episode in this cycle.
+    if bbr.bw_lo == u64::MAX {
+        bbr.bw_lo = bbr.max_bw;
+    }
+
+    if bbr.inflight_lo == usize::MAX {
+        bbr.inflight_lo = r.congestion_window;
+    }
+}
+
+fn bbr2_loss_lower_bounds(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    // Adjust model once per round based on loss.
+    bbr.bw_lo = bbr.bw_latest.max((bbr.bw_lo as f64 * BETA) as u64);
+    bbr.inflight_lo = bbr
+        .inflight_latest
+        .max((bbr.inflight_lo as f64 * BETA) as usize);
+}
+
+pub fn bbr2_reset_lower_bounds(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    bbr.bw_lo = u64::MAX;
+    bbr.inflight_lo = usize::MAX;
+}
+
+pub fn bbr2_bound_bw_for_model(r: &mut Recovery) {
+    let bbr = &mut r.bbr2_state;
+
+    bbr.bw = bbr.max_bw.min(bbr.bw_lo.min(bbr.bw_hi));
+}
+
+// This function is not defined in the draft but used.
+fn bbr2_is_probing_bw(r: &mut Recovery) -> bool {
+    let state = r.bbr2_state.state;
+
+    state == BBR2StateMachine::Startup ||
+        state == BBR2StateMachine::ProbeBWREFILL ||
+        state == BBR2StateMachine::ProbeBWUP
+}

--- a/quiche/src/recovery/bbr2/per_transmit.rs
+++ b/quiche/src/recovery/bbr2/per_transmit.rs
@@ -1,0 +1,51 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::*;
+use crate::recovery::Recovery;
+
+use std::time::Instant;
+
+// BBR2 Functions when trasmitting packets.
+//
+// 4.2.2.  Per-Transmit Steps
+pub fn bbr2_on_transmit(r: &mut Recovery, now: Instant) {
+    bbr2_handle_restart_from_idle(r, now);
+}
+
+// 4.4.3.  Logic
+fn bbr2_handle_restart_from_idle(r: &mut Recovery, now: Instant) {
+    if r.bytes_in_flight == 0 && r.delivery_rate.app_limited() {
+        r.bbr2_state.idle_restart = true;
+        r.bbr2_state.extra_acked_interval_start = now;
+
+        if per_ack::bbr2_is_in_a_probe_bw_state(r) {
+            pacing::bbr2_set_pacing_rate_with_gain(r, 1.0);
+        } else if r.bbr2_state.state == BBR2StateMachine::ProbeRTT {
+            per_ack::bbr2_check_probe_rtt_done(r, now);
+        }
+    }
+}

--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -487,6 +487,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -505,6 +507,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             rtt: Duration::ZERO,
         }];
 
@@ -535,6 +539,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -554,6 +560,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             },
             Acked {
@@ -564,6 +572,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             },
             Acked {
@@ -574,6 +584,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             },
         ];
@@ -607,6 +619,8 @@ mod tests {
             first_sent_time: now,
             is_app_limited: false,
             has_data: false,
+            tx_in_flight: 0,
+            lost: 0,
         };
 
         r.congestion_event(
@@ -649,6 +663,8 @@ mod tests {
             first_sent_time: now,
             is_app_limited: false,
             has_data: false,
+            tx_in_flight: 0,
+            lost: 0,
         };
 
         // Trigger congestion event to update ssthresh
@@ -685,6 +701,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             }];
 
@@ -721,6 +739,8 @@ mod tests {
             first_sent_time: now,
             is_app_limited: false,
             has_data: false,
+            tx_in_flight: 0,
+            lost: 0,
         };
 
         r.congestion_event(
@@ -746,6 +766,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             rtt: Duration::ZERO,
         }];
 
@@ -781,6 +803,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -812,6 +836,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             }];
 
@@ -849,6 +875,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             }];
 
@@ -889,6 +917,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             }];
 
@@ -929,6 +959,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -960,6 +992,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             }];
 
@@ -997,6 +1031,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             }];
 
@@ -1035,6 +1071,8 @@ mod tests {
                     delivered_time: now,
                     first_sent_time: now,
                     is_app_limited: false,
+                    tx_in_flight: 0,
+                    lost: 0,
                     rtt: Duration::ZERO,
                 }];
 
@@ -1076,6 +1114,8 @@ mod tests {
             first_sent_time: now,
             is_app_limited: false,
             has_data: false,
+            tx_in_flight: 0,
+            lost: 0,
         };
 
         r.congestion_event(
@@ -1100,6 +1140,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             rtt: Duration::ZERO,
         }];
 
@@ -1133,6 +1175,8 @@ mod tests {
             first_sent_time: now,
             is_app_limited: false,
             has_data: false,
+            tx_in_flight: 0,
+            lost: 0,
         };
 
         let prev_cwnd = r.cwnd();
@@ -1158,6 +1202,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             rtt: Duration::ZERO,
         }];
 
@@ -1204,6 +1250,8 @@ mod tests {
             first_sent_time: now,
             is_app_limited: false,
             has_data: false,
+            tx_in_flight: 0,
+            lost: 0,
         };
 
         r.congestion_event(
@@ -1238,6 +1286,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             }];
 
@@ -1266,6 +1316,8 @@ mod tests {
             first_sent_time: now,
             is_app_limited: false,
             has_data: false,
+            tx_in_flight: 0,
+            lost: 0,
         };
 
         r.congestion_event(

--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -43,6 +43,7 @@ use crate::recovery::reno;
 use crate::recovery::Acked;
 use crate::recovery::CongestionControlOps;
 use crate::recovery::Recovery;
+use crate::recovery::Sent;
 
 pub static CUBIC: CongestionControlOps = CongestionControlOps {
     on_init,
@@ -348,9 +349,10 @@ fn on_packet_acked(
 }
 
 fn congestion_event(
-    r: &mut Recovery, _lost_bytes: usize, time_sent: Instant,
+    r: &mut Recovery, _lost_bytes: usize, largest_lost_pkt: &Sent,
     epoch: packet::Epoch, now: Instant,
 ) {
+    let time_sent = largest_lost_pkt.time_sent;
     let in_congestion_recovery = r.in_congestion_recovery(time_sent);
 
     // Start a new congestion event if packet was sent after the
@@ -591,9 +593,25 @@ mod tests {
         let now = Instant::now();
         let prev_cwnd = r.cwnd();
 
+        let p = recovery::Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: r.max_datagram_size,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            has_data: false,
+        };
+
         r.congestion_event(
             r.max_datagram_size,
-            now,
+            &p,
             packet::Epoch::Application,
             now,
         );
@@ -617,10 +635,26 @@ mod tests {
             r.on_packet_sent_cc(r.max_datagram_size, now);
         }
 
+        let p = recovery::Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: r.max_datagram_size,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            has_data: false,
+        };
+
         // Trigger congestion event to update ssthresh
         r.congestion_event(
             r.max_datagram_size,
-            now,
+            &p,
             packet::Epoch::Application,
             now,
         );
@@ -673,9 +707,25 @@ mod tests {
         r.on_packet_sent_cc(30000, now);
 
         // Trigger congestion event to update ssthresh
+        let p = recovery::Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: r.max_datagram_size,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            has_data: false,
+        };
+
         r.congestion_event(
             r.max_datagram_size,
-            now,
+            &p,
             packet::Epoch::Application,
             now,
         );
@@ -1012,9 +1062,25 @@ mod tests {
         }
 
         // Trigger congestion event to update ssthresh
+        let p = recovery::Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: r.max_datagram_size,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            has_data: false,
+        };
+
         r.congestion_event(
             r.max_datagram_size,
-            now,
+            &p,
             packet::Epoch::Application,
             now,
         );
@@ -1053,10 +1119,26 @@ mod tests {
         let now = now + rtt;
 
         // Trigger another congestion event.
+        let p = recovery::Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: r.max_datagram_size,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            has_data: false,
+        };
+
         let prev_cwnd = r.cwnd();
         r.congestion_event(
             r.max_datagram_size,
-            now,
+            &p,
             packet::Epoch::Application,
             now,
         );
@@ -1108,9 +1190,25 @@ mod tests {
         }
 
         // Trigger congestion event to update ssthresh
+        let p = recovery::Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: r.max_datagram_size,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            has_data: false,
+        };
+
         r.congestion_event(
             r.max_datagram_size,
-            now,
+            &p,
             packet::Epoch::Application,
             now,
         );
@@ -1154,9 +1252,25 @@ mod tests {
         // Fast convergence: now there is 2nd congestion event and
         // cwnd is not fully recovered to w_max, w_max will be
         // further reduced.
+        let p = recovery::Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: r.max_datagram_size,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            has_data: false,
+        };
+
         r.congestion_event(
             r.max_datagram_size,
-            now,
+            &p,
             packet::Epoch::Application,
             now,
         );

--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -607,7 +607,7 @@ mod tests {
 
         let p = recovery::Sent {
             pkt_num: 0,
-            frames: vec![],
+            frames: smallvec![],
             time_sent: now,
             time_acked: None,
             time_lost: None,
@@ -651,7 +651,7 @@ mod tests {
 
         let p = recovery::Sent {
             pkt_num: 0,
-            frames: vec![],
+            frames: smallvec![],
             time_sent: now,
             time_acked: None,
             time_lost: None,
@@ -727,7 +727,7 @@ mod tests {
         // Trigger congestion event to update ssthresh
         let p = recovery::Sent {
             pkt_num: 0,
-            frames: vec![],
+            frames: smallvec![],
             time_sent: now,
             time_acked: None,
             time_lost: None,
@@ -1102,7 +1102,7 @@ mod tests {
         // Trigger congestion event to update ssthresh
         let p = recovery::Sent {
             pkt_num: 0,
-            frames: vec![],
+            frames: smallvec![],
             time_sent: now,
             time_acked: None,
             time_lost: None,
@@ -1163,7 +1163,7 @@ mod tests {
         // Trigger another congestion event.
         let p = recovery::Sent {
             pkt_num: 0,
-            frames: vec![],
+            frames: smallvec![],
             time_sent: now,
             time_acked: None,
             time_lost: None,
@@ -1238,7 +1238,7 @@ mod tests {
         // Trigger congestion event to update ssthresh
         let p = recovery::Sent {
             pkt_num: 0,
-            frames: vec![],
+            frames: smallvec![],
             time_sent: now,
             time_acked: None,
             time_lost: None,
@@ -1304,7 +1304,7 @@ mod tests {
         // further reduced.
         let p = recovery::Sent {
             pkt_num: 0,
-            frames: vec![],
+            frames: smallvec![],
             time_sent: now,
             time_acked: None,
             time_lost: None,

--- a/quiche/src/recovery/delivery_rate.rs
+++ b/quiche/src/recovery/delivery_rate.rs
@@ -175,6 +175,14 @@ impl Rate {
     pub fn sample_is_app_limited(&self) -> bool {
         self.rate_sample.is_app_limited
     }
+
+    pub fn sample_delivered(&self) -> usize {
+        self.rate_sample.delivered
+    }
+
+    pub fn sample_prior_delivered(&self) -> usize {
+        self.rate_sample.prior_delivered
+    }
 }
 
 #[derive(Default, Debug)]

--- a/quiche/src/recovery/delivery_rate.rs
+++ b/quiche/src/recovery/delivery_rate.rs
@@ -79,7 +79,9 @@ impl Default for Rate {
 }
 
 impl Rate {
-    pub fn on_packet_sent(&mut self, pkt: &mut Sent, bytes_in_flight: usize) {
+    pub fn on_packet_sent(
+        &mut self, pkt: &mut Sent, bytes_in_flight: usize, bytes_lost: u64,
+    ) {
         // No packets in flight.
         if bytes_in_flight == 0 {
             self.first_sent_time = pkt.time_sent;
@@ -90,6 +92,8 @@ impl Rate {
         pkt.delivered_time = self.delivered_time;
         pkt.delivered = self.delivered;
         pkt.is_app_limited = self.app_limited();
+        pkt.tx_in_flight = bytes_in_flight;
+        pkt.lost = bytes_lost;
 
         self.last_sent_packet = pkt.pkt_num;
     }
@@ -238,6 +242,8 @@ mod tests {
                 first_sent_time: now,
                 is_app_limited: false,
                 has_data: false,
+                tx_in_flight: 0,
+                lost: 0,
             };
 
             r.on_packet_sent(
@@ -263,6 +269,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now.checked_sub(rtt).unwrap(),
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
             };
 
             r.delivery_rate.update_rate_sample(&acked, now);
@@ -302,6 +310,8 @@ mod tests {
                 first_sent_time: now,
                 is_app_limited: false,
                 has_data: false,
+                tx_in_flight: 0,
+                lost: 0,
             };
 
             r.on_packet_sent(
@@ -341,6 +351,8 @@ mod tests {
                 first_sent_time: now,
                 is_app_limited: false,
                 has_data: false,
+                tx_in_flight: 0,
+                lost: 0,
             };
 
             r.on_packet_sent(

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -383,8 +383,11 @@ impl Recovery {
         pkt.time_sent = self.get_packet_send_time();
 
         // bytes_in_flight is already updated. Use previous value.
-        self.delivery_rate
-            .on_packet_sent(&mut pkt, self.bytes_in_flight - sent_bytes);
+        self.delivery_rate.on_packet_sent(
+            &mut pkt,
+            self.bytes_in_flight - sent_bytes,
+            self.bytes_lost,
+        );
 
         self.sent[epoch].push_back(pkt);
 
@@ -548,6 +551,10 @@ impl Recovery {
                     first_sent_time: unacked.first_sent_time,
 
                     is_app_limited: unacked.is_app_limited,
+
+                    tx_in_flight: unacked.tx_in_flight,
+
+                    lost: unacked.lost,
                 });
 
                 trace!("{} packet newly acked {}", trace_id, unacked.pkt_num);
@@ -1251,6 +1258,10 @@ pub struct Sent {
 
     pub is_app_limited: bool,
 
+    pub tx_in_flight: usize,
+
+    pub lost: u64,
+
     pub has_data: bool,
 }
 
@@ -1263,6 +1274,8 @@ impl std::fmt::Debug for Sent {
         write!(f, "delivered_time={:?} ", self.delivered_time)?;
         write!(f, "first_sent_time={:?} ", self.first_sent_time)?;
         write!(f, "is_app_limited={} ", self.is_app_limited)?;
+        write!(f, "tx_in_flight={} ", self.tx_in_flight)?;
+        write!(f, "lost={} ", self.lost)?;
         write!(f, "has_data={} ", self.has_data)?;
 
         Ok(())
@@ -1286,6 +1299,10 @@ pub struct Acked {
     pub first_sent_time: Instant,
 
     pub is_app_limited: bool,
+
+    pub tx_in_flight: usize,
+
+    pub lost: u64,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1488,6 +1505,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1514,6 +1533,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1540,6 +1561,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1566,6 +1589,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1625,6 +1650,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1651,6 +1678,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1723,6 +1752,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1749,6 +1780,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1775,6 +1808,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1801,6 +1836,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1884,6 +1921,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1910,6 +1949,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1936,6 +1977,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -1962,6 +2005,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -2058,6 +2103,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -2116,6 +2163,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -2147,6 +2196,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -163,6 +163,9 @@ pub struct Recovery {
     // BBR state.
     bbr_state: bbr::State,
 
+    // BBRv2 state.
+    bbr2_state: bbr2::State,
+
     /// How many non-ack-eliciting packets have been sent.
     outstanding_non_ack_eliciting: usize,
 
@@ -290,6 +293,8 @@ impl Recovery {
             qlog_metrics: QlogMetrics::default(),
 
             bbr_state: bbr::State::new(),
+
+            bbr2_state: bbr2::State::new(),
 
             outstanding_non_ack_eliciting: 0,
 
@@ -1121,6 +1126,8 @@ pub enum CongestionControlAlgorithm {
     CUBIC = 1,
     /// BBR congestion control algorithm. `bbr` in a string form.
     BBR   = 2,
+    /// BBRv2 congestion control algorithm. `bbr2` in a string form.
+    BBR2  = 3,
 }
 
 impl FromStr for CongestionControlAlgorithm {
@@ -1134,6 +1141,7 @@ impl FromStr for CongestionControlAlgorithm {
             "reno" => Ok(CongestionControlAlgorithm::Reno),
             "cubic" => Ok(CongestionControlAlgorithm::CUBIC),
             "bbr" => Ok(CongestionControlAlgorithm::BBR),
+            "bbr2" => Ok(CongestionControlAlgorithm::BBR2),
 
             _ => Err(crate::Error::CongestionControl),
         }
@@ -1180,6 +1188,7 @@ impl From<CongestionControlAlgorithm> for &'static CongestionControlOps {
             CongestionControlAlgorithm::Reno => &reno::RENO,
             CongestionControlAlgorithm::CUBIC => &cubic::CUBIC,
             CongestionControlAlgorithm::BBR => &bbr::BBR,
+            CongestionControlAlgorithm::BBR2 => &bbr2::BBR2,
         }
     }
 }
@@ -2226,6 +2235,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -2254,6 +2265,7 @@ mod tests {
 }
 
 mod bbr;
+mod bbr2;
 mod cubic;
 mod delivery_rate;
 mod hystart;

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -340,7 +340,7 @@ mod tests {
 
         let p = recovery::Sent {
             pkt_num: 0,
-            frames: vec![],
+            frames: smallvec![],
             time_sent: now,
             time_acked: None,
             time_lost: None,
@@ -381,7 +381,7 @@ mod tests {
 
         let p = recovery::Sent {
             pkt_num: 0,
-            frames: vec![],
+            frames: smallvec![],
             time_sent: now,
             time_acked: None,
             time_lost: None,

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -37,6 +37,7 @@ use crate::recovery;
 use crate::recovery::Acked;
 use crate::recovery::CongestionControlOps;
 use crate::recovery::Recovery;
+use crate::recovery::Sent;
 
 pub static RENO: CongestionControlOps = CongestionControlOps {
     on_init,
@@ -108,11 +109,13 @@ fn on_packet_acked(
 }
 
 fn congestion_event(
-    r: &mut Recovery, _lost_bytes: usize, time_sent: Instant,
+    r: &mut Recovery, _lost_bytes: usize, largest_lost_pkt: &Sent,
     epoch: packet::Epoch, now: Instant,
 ) {
     // Start a new congestion event if packet was sent after the
     // start of the previous congestion recovery period.
+    let time_sent = largest_lost_pkt.time_sent;
+
     if !r.in_congestion_recovery(time_sent) {
         r.congestion_recovery_start_time = Some(now);
 
@@ -323,9 +326,25 @@ mod tests {
 
         let now = Instant::now();
 
+        let p = recovery::Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: r.max_datagram_size,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: std::time::Instant::now(),
+            first_sent_time: std::time::Instant::now(),
+            is_app_limited: false,
+            has_data: false,
+        };
+
         r.congestion_event(
             r.max_datagram_size,
-            now,
+            &p,
             packet::Epoch::Application,
             now,
         );
@@ -346,10 +365,26 @@ mod tests {
         // Fill up bytes_in_flight to avoid app_limited=true
         r.on_packet_sent_cc(20000, now);
 
+        let p = recovery::Sent {
+            pkt_num: 0,
+            frames: vec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: r.max_datagram_size,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: std::time::Instant::now(),
+            first_sent_time: std::time::Instant::now(),
+            is_app_limited: false,
+            has_data: false,
+        };
+
         // Trigger congestion event to update ssthresh
         r.congestion_event(
             r.max_datagram_size,
-            now,
+            &p,
             packet::Epoch::Application,
             now,
         );

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -217,6 +217,8 @@ mod tests {
             delivered_time: std::time::Instant::now(),
             first_sent_time: std::time::Instant::now(),
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -235,6 +237,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             rtt: Duration::ZERO,
         }];
 
@@ -266,6 +270,8 @@ mod tests {
             delivered_time: std::time::Instant::now(),
             first_sent_time: std::time::Instant::now(),
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             has_data: false,
         };
 
@@ -285,6 +291,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             },
             Acked {
@@ -295,6 +303,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             },
             Acked {
@@ -305,6 +315,8 @@ mod tests {
                 delivered_time: now,
                 first_sent_time: now,
                 is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
                 rtt: Duration::ZERO,
             },
         ];
@@ -340,6 +352,8 @@ mod tests {
             first_sent_time: std::time::Instant::now(),
             is_app_limited: false,
             has_data: false,
+            tx_in_flight: 0,
+            lost: 0,
         };
 
         r.congestion_event(
@@ -379,6 +393,8 @@ mod tests {
             first_sent_time: std::time::Instant::now(),
             is_app_limited: false,
             has_data: false,
+            tx_in_flight: 0,
+            lost: 0,
         };
 
         // Trigger congestion event to update ssthresh
@@ -406,6 +422,8 @@ mod tests {
             delivered_time: now,
             first_sent_time: now,
             is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
             rtt: Duration::ZERO,
         }];
 


### PR DESCRIPTION
This PR is implementing BBR v2 congestion control algorithm specified in [draft-cardwell-iccrg-bbr-congestion-control-02](https://datatracker.ietf.org/doc/html/draft-cardwell-iccrg-bbr-congestion-control-02), based on #1180.

Mostly as-is translation of the draft, might be buggy and not well tested. Also it need some additional change on the recovery and rate estimatino module included in this PR.

If you look for more stable bbr, see #1180 first.

- [ ] more test under various network conditions
- [ ] write unit tests
- [ ] split recovery module changes into a separate PRs.