### PR TITLE
Connection migration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ a new connection, while [`accept()`] is for servers:
 
 ```rust
 // Client connection.
-let conn = quiche::connect(Some(&server_name), &scid, &mut config)?;
+let conn = quiche::connect(Some(&server_name), &scid, local, peer, &mut config)?;
 
 // Server connection.
-let conn = quiche::accept(&scid, None, &mut config)?;
+let conn = quiche::accept(&scid, None, local, peer, &mut config)?;
 ```
 
 ### Handling incoming packets
@@ -93,10 +93,12 @@ Using the connection's [`recv()`] method the application can process
 incoming packets that belong to that connection from the network:
 
 ```rust
+let to = socket.local_addr().unwrap();
+
 loop {
     let (read, from) = socket.recv_from(&mut buf).unwrap();
 
-    let recv_info = quiche::RecvInfo { from };
+    let recv_info = quiche::RecvInfo { from, to };
 
     let read = match conn.recv(&mut buf[..read], recv_info) {
         Ok(v) => v,

--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -48,6 +48,8 @@ pub struct CommonArgs {
     pub dgrams_enabled: bool,
     pub dgram_count: u64,
     pub dgram_data: String,
+    pub max_active_cids: u64,
+    pub enable_active_migration: bool,
 }
 
 /// Creates a new `CommonArgs` structure using the provided [`Docopt`].
@@ -68,6 +70,8 @@ pub struct CommonArgs {
 /// --dgram-proto PROTO         DATAGRAM application protocol.
 /// --dgram-count COUNT         Number of DATAGRAMs to send.
 /// --dgram-data DATA           DATAGRAM data to send.
+/// --max-active-cids NUM       Maximum number of active Connection IDs.
+/// --enable-active-migration   Enable active connection migration.
 ///
 /// [`Docopt`]: https://docs.rs/docopt/1.1.0/docopt/
 impl Args for CommonArgs {
@@ -143,6 +147,11 @@ impl Args for CommonArgs {
 
         let disable_hystart = args.get_bool("--disable-hystart");
 
+        let max_active_cids = args.get_str("--max-active-cids");
+        let max_active_cids = max_active_cids.parse::<u64>().unwrap();
+
+        let enable_active_migration = args.get_bool("--enable-active-migration");
+
         CommonArgs {
             alpns,
             max_data,
@@ -160,6 +169,8 @@ impl Args for CommonArgs {
             dgrams_enabled,
             dgram_count,
             dgram_data,
+            max_active_cids,
+            enable_active_migration,
         }
     }
 }
@@ -183,6 +194,8 @@ impl Default for CommonArgs {
             dgrams_enabled: false,
             dgram_count: 0,
             dgram_data: "quack".to_string(),
+            max_active_cids: 2,
+            enable_active_migration: false,
         }
     }
 }
@@ -216,6 +229,9 @@ Options:
   --no-grease              Don't send GREASE.
   --cc-algorithm NAME      Specify which congestion control algorithm to use [default: cubic].
   --disable-hystart        Disable HyStart++.
+  --max-active-cids NUM    The maximum number of active Connection IDs we can support [default: 2].
+  --enable-active-migration   Enable active connection migration.
+  --perform-migration      Perform connection migration on another source port.
   -H --header HEADER ...   Add a request header.
   -n --requests REQUESTS   Send the given number of identical requests [default: 1].
   --session-file PATH      File used to cache a TLS session for resumption.
@@ -237,6 +253,7 @@ pub struct ClientArgs {
     pub connect_to: Option<String>,
     pub session_file: Option<String>,
     pub source_port: u16,
+    pub perform_migration: bool,
 }
 
 impl Args for ClientArgs {
@@ -303,6 +320,8 @@ impl Args for ClientArgs {
         let source_port = args.get_str("--source-port");
         let source_port = source_port.parse::<u16>().unwrap();
 
+        let perform_migration = args.get_bool("--perform-migration");
+
         ClientArgs {
             version,
             dump_response_path,
@@ -316,6 +335,7 @@ impl Args for ClientArgs {
             connect_to,
             session_file,
             source_port,
+            perform_migration,
         }
     }
 }
@@ -335,6 +355,7 @@ impl Default for ClientArgs {
             connect_to: None,
             session_file: None,
             source_port: 0,
+            perform_migration: false,
         }
     }
 }
@@ -367,6 +388,8 @@ Options:
   --dgram-data DATA           Data to send for certain types of DATAGRAM application protocol [default: brrr].
   --cc-algorithm NAME         Specify which congestion control algorithm to use [default: cubic].
   --disable-hystart           Disable HyStart++.
+  --max-active-cids NUM       The maximum number of active Connection IDs we can support [default: 2].
+  --enable-active-migration   Enable active connection migration.
   -h --help                   Show this screen.
 ";
 

--- a/fuzz/src/packet_recv_client.rs
+++ b/fuzz/src/packet_recv_client.rs
@@ -33,18 +33,20 @@ static SCID: quiche::ConnectionId<'static> =
 
 fuzz_target!(|data: &[u8]| {
     let from: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+    let to: SocketAddr = "127.0.0.1:4321".parse().unwrap();
 
     let mut buf = data.to_vec();
 
     let mut conn = quiche::connect(
         Some("quic.tech"),
         &SCID,
+        to.clone(),
         from.clone(),
         &mut CONFIG.lock().unwrap(),
     )
     .unwrap();
 
-    let info = quiche::RecvInfo { from };
+    let info = quiche::RecvInfo { from, to };
 
     conn.recv(&mut buf, info).ok();
 });

--- a/fuzz/src/packet_recv_server.rs
+++ b/fuzz/src/packet_recv_server.rs
@@ -39,13 +39,15 @@ static SCID: quiche::ConnectionId<'static> =
 
 fuzz_target!(|data: &[u8]| {
     let from: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+    let to: SocketAddr = "127.0.0.1:4321".parse().unwrap();
 
     let mut buf = data.to_vec();
 
     let mut conn =
-        quiche::accept(&SCID, None, from, &mut CONFIG.lock().unwrap()).unwrap();
+        quiche::accept(&SCID, None, to, from, &mut CONFIG.lock().unwrap())
+            .unwrap();
 
-    let info = quiche::RecvInfo { from };
+    let info = quiche::RecvInfo { from, to };
 
     conn.recv(&mut buf, info).ok();
 });

--- a/nginx/nginx-1.16.patch
+++ b/nginx/nginx-1.16.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Initial QUIC and HTTP/3 implementation using quiche
  auto/options                            |    9 +
  src/core/ngx_connection.h               |    7 +
  src/core/ngx_core.h                     |    3 +
- src/event/ngx_event_quic.c              |  620 +++++++
+ src/event/ngx_event_quic.c              |  625 +++++++
  src/event/ngx_event_quic.h              |   49 +
  src/event/ngx_event_udp.c               |    8 +
  src/http/modules/ngx_http_ssl_module.c  |   13 +-
@@ -343,7 +343,7 @@ new file mode 100644
 index 000000000..591a809e0
 --- /dev/null
 +++ b/src/event/ngx_event_quic.c
-@@ -0,0 +1,620 @@
+@@ -0,0 +1,625 @@
 +
 +/*
 + * Copyright (C) Cloudflare, Inc.
@@ -519,6 +519,7 @@ index 000000000..591a809e0
 +#endif
 +
 +    conn = quiche_conn_new_with_tls(scid, sizeof(scid), NULL, 0,
++                                    c->local_sockaddr, c->local_socklen,
 +                                    c->sockaddr, c->socklen, quic->config,
 +                                    c->ssl->connection, true);
 +    if (conn == NULL) {
@@ -552,6 +553,8 @@ index 000000000..591a809e0
 +    quiche_recv_info recv_info = {
 +        c->sockaddr,
 +        c->socklen,
++        c->local_sockaddr,
++        c->local_socklen,
 +    };
 +
 +    /* Process the client's Initial packet, which was saved into c->buffer by
@@ -614,6 +617,8 @@ index 000000000..591a809e0
 +        quiche_recv_info recv_info = {
 +            c->sockaddr,
 +            c->socklen,
++            c->local_sockaddr,
++            c->local_socklen,
 +        };
 +
 +        ssize_t done = quiche_conn_recv(c->quic->conn, buf, n, &recv_info);

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -58,6 +58,7 @@ log = { version = "0.4", features = ["std"] }
 libc = "0.2"
 libm = "0.2"
 ring = "0.16"
+slab = "0.4.5"
 lazy_static = "1"
 octets = { version = "0.2", path = "../octets" }
 boring = { version = "2.0.0", optional = true }

--- a/quiche/examples/client.rs
+++ b/quiche/examples/client.rs
@@ -102,9 +102,13 @@ fn main() {
 
     let scid = quiche::ConnectionId::from_ref(&scid);
 
+    // Get local address.
+    let local_addr = socket.local_addr().unwrap();
+
     // Create a QUIC connection and initiate handshake.
     let mut conn =
-        quiche::connect(url.domain(), &scid, peer_addr, &mut config).unwrap();
+        quiche::connect(url.domain(), &scid, local_addr, peer_addr, &mut config)
+            .unwrap();
 
     info!(
         "connecting to {:} from {:} with scid {}",
@@ -163,7 +167,10 @@ fn main() {
 
             debug!("got {} bytes", len);
 
-            let recv_info = quiche::RecvInfo { from };
+            let recv_info = quiche::RecvInfo {
+                to: socket.local_addr().unwrap(),
+                from,
+            };
 
             // Process potentially coalesced packets.
             let read = match conn.recv(&mut buf[..len], recv_info) {

--- a/quiche/examples/http3-client.c
+++ b/quiche/examples/http3-client.c
@@ -53,6 +53,9 @@ struct conn_io {
 
     int sock;
 
+    struct sockaddr_storage local_addr;
+    socklen_t local_addr_len;
+
     quiche_conn *conn;
 
     quiche_h3_conn *http3;
@@ -144,8 +147,10 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
 
         quiche_recv_info recv_info = {
             (struct sockaddr *) &peer_addr,
-
             peer_addr_len,
+
+            (struct sockaddr *) &conn_io->local_addr,
+            conn_io->local_addr_len,
         };
 
         ssize_t done = quiche_conn_recv(conn_io->conn, buf, read, &recv_info);
@@ -338,7 +343,7 @@ static void timeout_cb(EV_P_ ev_timer *w, int revents) {
         quiche_conn_stats(conn_io->conn, &stats);
 
         fprintf(stderr, "connection closed, recv=%zu sent=%zu lost=%zu rtt=%" PRIu64 "ns\n",
-                stats.recv, stats.sent, stats.lost, stats.rtt);
+                stats.recv, stats.sent, stats.lost, stats.paths[0].rtt);
 
         ev_break(EV_A_ EVBREAK_ONE);
         return;
@@ -414,17 +419,27 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    quiche_conn *conn = quiche_connect(host, (const uint8_t*) scid, sizeof(scid),
+    struct conn_io *conn_io = malloc(sizeof(*conn_io));
+    if (conn_io == NULL) {
+        fprintf(stderr, "failed to allocate connection IO\n");
+        return -1;
+    }
+
+    conn_io->local_addr_len = sizeof(conn_io->local_addr);
+    if (getsockname(sock, (struct sockaddr *)&conn_io->local_addr,
+                    &conn_io->local_addr_len) != 0)
+    {
+        perror("failed to get local address of socket");
+        return -1;
+    };
+
+    quiche_conn *conn = quiche_connect(host, (const uint8_t *) scid, sizeof(scid),
+                                       (struct sockaddr *) &conn_io->local_addr,
+                                       conn_io->local_addr_len,
                                        peer->ai_addr, peer->ai_addrlen, config);
 
     if (conn == NULL) {
         fprintf(stderr, "failed to create connection\n");
-        return -1;
-    }
-
-    struct conn_io *conn_io = malloc(sizeof(*conn_io));
-    if (conn_io == NULL) {
-        fprintf(stderr, "failed to allocate connection IO\n");
         return -1;
     }
 

--- a/quiche/examples/http3-client.rs
+++ b/quiche/examples/http3-client.rs
@@ -103,9 +103,13 @@ fn main() {
 
     let scid = quiche::ConnectionId::from_ref(&scid);
 
+    // Get local address.
+    let local_addr = socket.local_addr().unwrap();
+
     // Create a QUIC connection and initiate handshake.
     let mut conn =
-        quiche::connect(url.domain(), &scid, peer_addr, &mut config).unwrap();
+        quiche::connect(url.domain(), &scid, local_addr, peer_addr, &mut config)
+            .unwrap();
 
     info!(
         "connecting to {:} from {:} with scid {}",
@@ -186,7 +190,10 @@ fn main() {
 
             debug!("got {} bytes", len);
 
-            let recv_info = quiche::RecvInfo { from };
+            let recv_info = quiche::RecvInfo {
+                to: local_addr,
+                from,
+            };
 
             // Process potentially coalesced packets.
             let read = match conn.recv(&mut buf[..len], recv_info) {

--- a/quiche/examples/http3-server.rs
+++ b/quiche/examples/http3-server.rs
@@ -114,6 +114,8 @@ fn main() {
 
     let mut clients = ClientMap::new();
 
+    let local_addr = socket.local_addr().unwrap();
+
     loop {
         // Find the shorter timeout from all the active connections.
         //
@@ -261,9 +263,14 @@ fn main() {
 
                 debug!("New connection: dcid={:?} scid={:?}", hdr.dcid, scid);
 
-                let conn =
-                    quiche::accept(&scid, odcid.as_ref(), from, &mut config)
-                        .unwrap();
+                let conn = quiche::accept(
+                    &scid,
+                    odcid.as_ref(),
+                    local_addr,
+                    from,
+                    &mut config,
+                )
+                .unwrap();
 
                 let client = Client {
                     conn,
@@ -282,7 +289,10 @@ fn main() {
                 }
             };
 
-            let recv_info = quiche::RecvInfo { from };
+            let recv_info = quiche::RecvInfo {
+                to: socket.local_addr().unwrap(),
+                from,
+            };
 
             // Process potentially coalesced packets.
             let read = match client.conn.recv(pkt_buf, recv_info) {

--- a/quiche/examples/server.c
+++ b/quiche/examples/server.c
@@ -55,6 +55,9 @@
 struct connections {
     int sock;
 
+    struct sockaddr *local_addr;
+    socklen_t local_addr_len;
+
     struct conn_io *h;
 };
 
@@ -175,8 +178,11 @@ static uint8_t *gen_cid(uint8_t *cid, size_t cid_len) {
 
 static struct conn_io *create_conn(uint8_t *scid, size_t scid_len,
                                    uint8_t *odcid, size_t odcid_len,
+                                   struct sockaddr *local_addr,
+                                   socklen_t local_addr_len,
                                    struct sockaddr_storage *peer_addr,
-                                   socklen_t peer_addr_len) {
+                                   socklen_t peer_addr_len)
+{
     struct conn_io *conn_io = calloc(1, sizeof(*conn_io));
     if (conn_io == NULL) {
         fprintf(stderr, "failed to allocate connection IO\n");
@@ -191,6 +197,8 @@ static struct conn_io *create_conn(uint8_t *scid, size_t scid_len,
 
     quiche_conn *conn = quiche_accept(conn_io->cid, LOCAL_CONN_ID_LEN,
                                       odcid, odcid_len,
+                                      local_addr,
+                                      local_addr_len,
                                       (struct sockaddr *) peer_addr,
                                       peer_addr_len,
                                       config);
@@ -336,6 +344,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
             }
 
             conn_io = create_conn(dcid, dcid_len, odcid, odcid_len,
+                                  conns->local_addr, conns->local_addr_len,
                                   &peer_addr, peer_addr_len);
 
             if (conn_io == NULL) {
@@ -344,9 +353,11 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
         }
 
         quiche_recv_info recv_info = {
-            (struct sockaddr *) &peer_addr,
-
+            (struct sockaddr *)&peer_addr,
             peer_addr_len,
+
+            conns->local_addr,
+            conns->local_addr_len,
         };
 
         ssize_t done = quiche_conn_recv(conn_io->conn, buf, read, &recv_info);
@@ -393,7 +404,7 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
 
             quiche_conn_stats(conn_io->conn, &stats);
             fprintf(stderr, "connection closed, recv=%zu sent=%zu lost=%zu rtt=%" PRIu64 "ns cwnd=%zu\n",
-                    stats.recv, stats.sent, stats.lost, stats.rtt, stats.cwnd);
+                    stats.recv, stats.sent, stats.lost, stats.paths[0].rtt, stats.paths[0].cwnd);
 
             HASH_DELETE(hh, conns->h, conn_io);
 
@@ -417,7 +428,7 @@ static void timeout_cb(EV_P_ ev_timer *w, int revents) {
 
         quiche_conn_stats(conn_io->conn, &stats);
         fprintf(stderr, "connection closed, recv=%zu sent=%zu lost=%zu rtt=%" PRIu64 "ns cwnd=%zu\n",
-                stats.recv, stats.sent, stats.lost, stats.rtt, stats.cwnd);
+                stats.recv, stats.sent, stats.lost, stats.paths[0].rtt, stats.paths[0].cwnd);
 
         HASH_DELETE(hh, conns->h, conn_io);
 
@@ -487,6 +498,8 @@ int main(int argc, char *argv[]) {
     struct connections c;
     c.sock = sock;
     c.h = NULL;
+    c.local_addr = local->ai_addr;
+    c.local_addr_len = local->ai_addrlen;
 
     conns = &c;
 

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -222,6 +222,12 @@ void quiche_config_set_max_connection_window(quiche_config *config, uint64_t v);
 // Sets the maximum stream window.
 void quiche_config_set_max_stream_window(quiche_config *config, uint64_t v);
 
+// Sets the limit of active connection IDs.
+void quiche_config_set_active_connection_id_limit(quiche_config *config, uint64_t v);
+
+// Sets the initial stateless reset token.
+void quiche_config_set_stateless_reset_token(quiche_config *config, const uint8_t *v);
+
 // Frees the config object.
 void quiche_config_free(quiche_config *config);
 
@@ -239,13 +245,15 @@ typedef struct Connection quiche_conn;
 // Creates a new server-side connection.
 quiche_conn *quiche_accept(const uint8_t *scid, size_t scid_len,
                            const uint8_t *odcid, size_t odcid_len,
-                           const struct sockaddr *from, size_t from_len,
+                           const struct sockaddr *local, size_t local_len,
+                           const struct sockaddr *peer, size_t peer_len,
                            quiche_config *config);
 
 // Creates a new client-side connection.
 quiche_conn *quiche_connect(const char *server_name,
                             const uint8_t *scid, size_t scid_len,
-                            const struct sockaddr *to, size_t to_len,
+                            const struct sockaddr *local, size_t local_len,
+                            const struct sockaddr *peer, size_t peer_len,
                             quiche_config *config);
 
 // Writes a version negotiation packet.
@@ -265,6 +273,7 @@ bool quiche_version_is_supported(uint32_t version);
 
 quiche_conn *quiche_conn_new_with_tls(const uint8_t *scid, size_t scid_len,
                                       const uint8_t *odcid, size_t odcid_len,
+                                      const struct sockaddr *local, size_t local_len,
                                       const struct sockaddr *peer, size_t peer_len,
                                       quiche_config *config, void *ssl,
                                       bool is_server);
@@ -287,8 +296,13 @@ void quiche_conn_set_qlog_fd(quiche_conn *conn, int fd, const char *log_title,
 int quiche_conn_set_session(quiche_conn *conn, const uint8_t *buf, size_t buf_len);
 
 typedef struct {
+    // The remote address the packet was received from.
     struct sockaddr *from;
     socklen_t from_len;
+
+    // The local address the packet was received on.
+    struct sockaddr *to;
+    socklen_t to_len;
 } quiche_recv_info;
 
 // Processes QUIC packets received from the peer.
@@ -296,7 +310,11 @@ ssize_t quiche_conn_recv(quiche_conn *conn, uint8_t *buf, size_t buf_len,
                          const quiche_recv_info *info);
 
 typedef struct {
-    // The address the packet should be sent to.
+    // The local address the packet should be sent from.
+    struct sockaddr_storage from;
+    socklen_t from_len;
+
+    // The remote address the packet should be sent to.
     struct sockaddr_storage to;
     socklen_t to_len;
 
@@ -446,6 +464,58 @@ bool quiche_stream_iter_next(quiche_stream_iter *iter, uint64_t *stream_id);
 void quiche_stream_iter_free(quiche_stream_iter *iter);
 
 typedef struct {
+    // The local address used by this path.
+    struct sockaddr_storage local_addr;
+    socklen_t local_addr_len;
+
+    // The peer address seen by this path.
+    struct sockaddr_storage peer_addr;
+    socklen_t peer_addr_len;
+
+    // The validation state of the path.
+    ssize_t validation_state;
+
+    // Whether this path is active.
+    bool active;
+
+    // The number of QUIC packets received on this path.
+    size_t recv;
+
+    // The number of QUIC packets sent on this path.
+    size_t sent;
+
+    // The number of QUIC packets that were lost on this path.
+    size_t lost;
+
+    // The number of sent QUIC packets with retranmitted data on this path.
+    size_t retrans;
+
+    // The estimated round-trip time of the path (in nanoseconds).
+    uint64_t rtt;
+
+    // The size of the path's congestion window in bytes.
+    size_t cwnd;
+
+    // The number of sent bytes on this path.
+    uint64_t sent_bytes;
+
+    // The number of recevied bytes on this path.
+    uint64_t recv_bytes;
+
+    // The number of bytes lost on this path.
+    uint64_t lost_bytes;
+
+    // The number of stream bytes retransmitted on this path.
+    uint64_t stream_retrans_bytes;
+
+    // The current PMTU for the path.
+    size_t pmtu;
+
+    // The most recent data delivery rate estimate in bytes/s.
+    uint64_t delivery_rate;
+} quiche_path_stats;
+
+typedef struct {
     // The number of QUIC packets received on this connection.
     size_t recv;
 
@@ -458,12 +528,6 @@ typedef struct {
     // The number of sent QUIC packets with retranmitted data.
     size_t retrans;
 
-    // The estimated round-trip time of the connection (in nanoseconds).
-    uint64_t rtt;
-
-    // The size of the connection's congestion window in bytes.
-    size_t cwnd;
-
     // The number of sent bytes.
     uint64_t sent_bytes;
 
@@ -475,12 +539,6 @@ typedef struct {
 
     // The number of stream bytes retransmitted.
     uint64_t stream_retrans_bytes;
-
-    // The current PMTU for the connection.
-    size_t pmtu;
-
-    // The most recent data delivery rate estimate in bytes/s.
-    uint64_t delivery_rate;
 
     // The maximum idle timeout.
     uint64_t peer_max_idle_timeout;
@@ -520,6 +578,12 @@ typedef struct {
 
     // DATAGRAM frame extension parameter, if any.
     ssize_t peer_max_datagram_frame_size;
+
+    // The stats of the connection's paths.
+    quiche_path_stats paths[8];
+
+    // The number of stats of the connection's paths.
+    size_t paths_len;
 } quiche_stats;
 
 // Collects and returns statistics about the connection.

--- a/quiche/src/cid.rs
+++ b/quiche/src/cid.rs
@@ -1,0 +1,963 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::Error;
+use crate::Result;
+
+use crate::frame;
+use crate::packet::ConnectionId;
+
+use std::collections::VecDeque;
+
+/// A structure holding a `ConnectionId` and all its related metadata.
+#[derive(Debug, Default)]
+pub struct ConnectionIdEntry {
+    /// The Connection ID.
+    pub cid: ConnectionId<'static>,
+
+    /// Its associated sequence number.
+    pub seq: u64,
+
+    /// Its associated reset token. Initial CIDs may not have any reset token.
+    pub reset_token: Option<u128>,
+
+    /// The path identifier using this CID, if any.
+    pub path_id: Option<usize>,
+}
+
+#[derive(Default)]
+struct BoundedNonEmptyConnectionIdVecDeque {
+    /// The inner `VecDeque`.
+    inner: VecDeque<ConnectionIdEntry>,
+
+    /// The maximum number of elements that the `VecDeque` can have.
+    capacity: usize,
+}
+
+impl BoundedNonEmptyConnectionIdVecDeque {
+    /// Creates a `VecDeque` with the provided `capacity` and inserts
+    /// `initial_entry` in it.
+    fn new(capacity: usize, initial_entry: ConnectionIdEntry) -> Self {
+        let capacity = std::cmp::max(capacity, 1);
+        let mut inner = VecDeque::with_capacity(capacity);
+        inner.push_back(initial_entry);
+        Self { inner, capacity }
+    }
+
+    /// Updates the capacity of the inner `VecDeque` to `new_capacity`. Does
+    /// nothing if `new_capacity` is lower or equal to the current `capacity`.
+    fn resize(&mut self, new_capacity: usize) {
+        if new_capacity > self.capacity {
+            self.capacity = new_capacity;
+            let additional = new_capacity - self.inner.len();
+            self.inner.reserve_exact(additional);
+        }
+    }
+
+    /// Returns the oldest inserted entry still present in the `VecDeque`.
+    fn get_oldest(&self) -> &ConnectionIdEntry {
+        self.inner.front().expect("vecdeque is empty")
+    }
+
+    /// Gets a immutable reference to the entry having the provided `seq`.
+    fn get(&self, seq: u64) -> Option<&ConnectionIdEntry> {
+        // We need to iterate over the whole map to find the key.
+        self.inner.iter().find(|e| e.seq == seq)
+    }
+
+    /// Gets a mutable reference to the entry having the provided `seq`.
+    fn get_mut(&mut self, seq: u64) -> Option<&mut ConnectionIdEntry> {
+        // We need to iterate over the whole map to find the key.
+        self.inner.iter_mut().find(|e| e.seq == seq)
+    }
+
+    /// Returns an iterator over the entries in the `VecDeque`.
+    fn iter(&self) -> impl Iterator<Item = &ConnectionIdEntry> {
+        self.inner.iter()
+    }
+
+    /// Returns the number of elements in the `VecDeque`.
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Inserts the provided entry in the `VecDeque`.
+    ///
+    /// This method ensures the unicity of the `seq` associated to an entry. If
+    /// an entry has the same `seq` than `e`, this method updates the entry in
+    /// the `VecDeque` and the number of stored elements remains unchanged.
+    ///
+    /// If inserting a new element would exceed the collection's capacity, this
+    /// method raises an [`IdLimit`].
+    ///
+    /// [`IdLimit`]: enum.Error.html#IdLimit
+    fn insert(&mut self, e: ConnectionIdEntry) -> Result<()> {
+        // Ensure we don't have duplicates.
+        match self.get_mut(e.seq) {
+            Some(oe) => *oe = e,
+            None => {
+                if self.inner.len() == self.capacity {
+                    return Err(Error::IdLimit);
+                }
+                self.inner.push_back(e);
+            },
+        };
+        Ok(())
+    }
+
+    /// Removes all the elements in the collection and inserts the provided one.
+    fn clear_and_insert(&mut self, e: ConnectionIdEntry) {
+        self.inner.clear();
+        self.inner.push_back(e);
+    }
+
+    /// Removes the element in the collection having the provided `seq`.
+    ///
+    /// If this method is called when there remains a single element in the
+    /// collection, this method raises an [`OutOfIdentifiers`].
+    ///
+    /// Returns `Some` if the element was in the collection and removed, or
+    /// `None` if it was not and nothing was modified.
+    ///
+    /// [`OutOfIdentifiers`]: enum.Error.html#OutOfIdentifiers
+    fn remove(&mut self, seq: u64) -> Result<Option<ConnectionIdEntry>> {
+        if self.inner.len() <= 1 {
+            return Err(Error::OutOfIdentifiers);
+        }
+
+        Ok(self
+            .inner
+            .iter()
+            .position(|e| e.seq == seq)
+            .and_then(|index| self.inner.remove(index)))
+    }
+
+    /// Removes all the elements in the collection whose `seq` is lower than the
+    /// provided one, and inserts `e` in the collection.
+    ///
+    /// For each removed element `re`, `f(re)` is called.
+    ///
+    /// If the inserted element has a `seq` lower than the one used to remove
+    /// elements, it raises an [`OutOfIdentifiers`].
+    ///
+    /// [`OutOfIdentifiers`]: enum.Error.html#OutOfIdentifiers
+    fn remove_lower_than_and_insert<F>(
+        &mut self, seq: u64, e: ConnectionIdEntry, mut f: F,
+    ) -> Result<()>
+    where
+        F: FnMut(&ConnectionIdEntry),
+    {
+        // The insert entry MUST have a sequence higher or equal to the ones
+        // being retired.
+        if e.seq < seq {
+            return Err(Error::OutOfIdentifiers);
+        }
+
+        // To avoid exceeding the capacity of the inner `VecDeque`, we first
+        // remove the elements and then insert the new one.
+        self.inner.retain(|e| {
+            if e.seq < seq {
+                f(e);
+                false
+            } else {
+                true
+            }
+        });
+
+        // Note that if no element has been retired and the `VecDeque` reaches
+        // its capacity limit, this will raise an `IdLimit`.
+        self.insert(e)
+    }
+}
+
+/// An iterator over QUIC Connection IDs.
+pub struct ConnectionIdIter {
+    cids: VecDeque<ConnectionId<'static>>,
+}
+
+impl Iterator for ConnectionIdIter {
+    type Item = ConnectionId<'static>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.cids.pop_front()
+    }
+}
+
+impl ExactSizeIterator for ConnectionIdIter {
+    #[inline]
+    fn len(&self) -> usize {
+        self.cids.len()
+    }
+}
+
+#[derive(Default)]
+pub struct ConnectionIdentifiers {
+    /// All the Destination Connection IDs provided by our peer.
+    dcids: BoundedNonEmptyConnectionIdVecDeque,
+
+    /// All the Source Connection IDs we provide to our peer.
+    scids: BoundedNonEmptyConnectionIdVecDeque,
+
+    /// Source Connection IDs that should be announced to the peer.
+    advertise_new_scid_seqs: VecDeque<u64>,
+
+    /// Retired Destination Connection IDs that should be announced to the peer.
+    retire_dcid_seqs: VecDeque<u64>,
+
+    /// Retired Source Connection IDs that should be notified to the
+    /// application.
+    retired_scids: VecDeque<ConnectionId<'static>>,
+
+    /// Largest "Retire Prior To" we received from the peer.
+    largest_peer_retire_prior_to: u64,
+
+    /// Largest sequence number we received from the peer.
+    largest_destination_seq: u64,
+
+    /// Next sequence number to use.
+    next_scid_seq: u64,
+
+    /// "Retire Prior To" value to advertise to the peer.
+    retire_prior_to: u64,
+
+    /// The maximum number of source Connection IDs our peer allows us.
+    source_conn_id_limit: usize,
+
+    /// Does the host use zero-length source Connection ID.
+    zero_length_scid: bool,
+
+    /// Does the host use zero-length destination Connection ID.
+    zero_length_dcid: bool,
+}
+
+impl ConnectionIdentifiers {
+    /// Creates a new `ConnectionIdentifiers` with the specified destination
+    /// connection ID limit and initial source Connection ID. The destination
+    /// Connection ID is set to the empty one.
+    pub fn new(
+        mut destination_conn_id_limit: usize, initial_scid: &ConnectionId,
+        initial_path_id: usize, reset_token: Option<u128>,
+    ) -> ConnectionIdentifiers {
+        // It must be at least 2.
+        if destination_conn_id_limit < 2 {
+            destination_conn_id_limit = 2;
+        }
+
+        // Initially, the limit of active source connection IDs is 2.
+        let source_conn_id_limit = 2;
+
+        // Record the zero-length SCID status.
+        let zero_length_scid = initial_scid.is_empty();
+
+        let initial_scid =
+            ConnectionId::from_ref(initial_scid.as_ref()).into_owned();
+
+        // We need to track up to (2 * source_conn_id_limit - 1) source
+        // Connection IDs when the host wants to force their renewal.
+        let scids = BoundedNonEmptyConnectionIdVecDeque::new(
+            2 * source_conn_id_limit - 1,
+            ConnectionIdEntry {
+                cid: initial_scid,
+                seq: 0,
+                reset_token,
+                path_id: Some(initial_path_id),
+            },
+        );
+
+        let dcids = BoundedNonEmptyConnectionIdVecDeque::new(
+            destination_conn_id_limit,
+            ConnectionIdEntry {
+                cid: ConnectionId::default(),
+                seq: 0,
+                reset_token: None,
+                path_id: Some(initial_path_id),
+            },
+        );
+
+        // Because we already inserted the initial SCID.
+        let next_scid_seq = 1;
+        ConnectionIdentifiers {
+            scids,
+            dcids,
+            retired_scids: VecDeque::new(),
+            next_scid_seq,
+            source_conn_id_limit,
+            zero_length_scid,
+            ..Default::default()
+        }
+    }
+
+    /// Sets the maximum number of source connection IDs our peer allows us.
+    pub fn set_source_conn_id_limit(&mut self, v: u64) {
+        // It must be at least 2.
+        if v >= 2 {
+            self.source_conn_id_limit = v as usize;
+            // We need to track up to (2 * source_conn_id_limit - 1) source
+            // Connection IDs when the host wants to force their renewal.
+            self.scids.resize((2 * v - 1) as usize);
+        }
+    }
+
+    /// Gets the destination Connection ID associated with the provided sequence
+    /// number.
+    #[inline]
+    pub fn get_dcid(&self, seq_num: u64) -> Result<&ConnectionIdEntry> {
+        self.dcids.get(seq_num).ok_or(Error::InvalidState)
+    }
+
+    /// Gets the source Connection ID associated with the provided sequence
+    /// number.
+    #[inline]
+    pub fn get_scid(&self, seq_num: u64) -> Result<&ConnectionIdEntry> {
+        self.scids.get(seq_num).ok_or(Error::InvalidState)
+    }
+
+    /// Adds a new source identifier, and indicates whether it should be
+    /// advertised through a `NEW_CONNECTION_ID` frame or not.
+    ///
+    /// At any time, the peer cannot have more Destination Connection IDs than
+    /// the maximum number of active Connection IDs it negotiated. In such case
+    /// (i.e., when [`active_source_cids()`] - `peer_active_conn_id_limit` = 0,
+    /// if the caller agrees to request the removal of previous connection IDs,
+    /// it sets the `retire_if_needed` parameter. Otherwhise, an [`IdLimit`] is
+    /// returned.
+    ///
+    /// Note that setting `retire_if_needed` does not prevent this function from
+    /// returning an [`IdLimit`] in the case the caller wants to retire still
+    /// unannounced Connection IDs.
+    ///
+    /// When setting the initial Source Connection ID, the `reset_token` may be
+    /// `None`. However, other Source CIDs must have an associated
+    /// `reset_token`. Providing `None` as the `reset_token` for non-initial
+    /// SCIDs raises an [`InvalidState`].
+    ///
+    /// In the case the provided `cid` is already present, it does not add it.
+    /// If the provided `reset_token` differs from the one already registered,
+    /// returns an `InvalidState`.
+    ///
+    /// Returns the sequence number associated to that new source identifier.
+    ///
+    /// [`active_source_cids()`]:  struct.ConnectionIdentifiers.html#method.active_source_cids
+    /// [`InvalidState`]: enum.Error.html#InvalidState
+    /// [`IdLimit`]: enum.Error.html#IdLimit
+    pub fn new_scid(
+        &mut self, cid: ConnectionId<'static>, reset_token: Option<u128>,
+        advertise: bool, path_id: Option<usize>, retire_if_needed: bool,
+    ) -> Result<u64> {
+        if self.zero_length_scid {
+            return Err(Error::InvalidState);
+        }
+
+        // Check whether the number of source Connection IDs does not exceed the
+        // limit. If the host agrees to retire old CIDs, it can store up to
+        // (2 * source_active_conn_id - 1) source CIDs. This limit is enforced
+        // when calling `self.scids.insert()`.
+        if self.scids.len() >= self.source_conn_id_limit {
+            if !retire_if_needed {
+                return Err(Error::IdLimit);
+            }
+
+            // We need to retire the lowest one.
+            self.retire_prior_to = self.lowest_usable_scid_seq()? + 1;
+        }
+
+        let seq = self.next_scid_seq;
+
+        if reset_token.is_none() && seq != 0 {
+            return Err(Error::InvalidState);
+        }
+
+        // Check first that the SCID has not been inserted before.
+        if let Some(e) = self.scids.iter().find(|e| e.cid == cid) {
+            if e.reset_token != reset_token {
+                return Err(Error::InvalidState);
+            }
+            return Ok(e.seq);
+        }
+
+        self.scids.insert(ConnectionIdEntry {
+            cid,
+            seq,
+            reset_token,
+            path_id,
+        })?;
+        self.next_scid_seq += 1;
+
+        self.mark_advertise_new_scid_seq(seq, advertise);
+
+        Ok(seq)
+    }
+
+    /// Sets the initial destination identifier.
+    pub fn set_initial_dcid(
+        &mut self, cid: ConnectionId<'static>, reset_token: Option<u128>,
+        path_id: Option<usize>,
+    ) {
+        // Record the zero-length DCID status.
+        self.zero_length_dcid = cid.is_empty();
+        self.dcids.clear_and_insert(ConnectionIdEntry {
+            cid,
+            seq: 0,
+            reset_token,
+            path_id,
+        });
+    }
+
+    /// Adds a new Destination Connection ID (originating from a
+    /// NEW_CONNECTION_ID frame) and process all its related metadata.
+    ///
+    /// Returns an error if the provided Connection ID or its metadata are
+    /// invalid.
+    ///
+    /// Returns a list of tuples (DCID sequence number, Path ID), containing the
+    /// sequence number of retired DCIDs that were linked to their respective
+    /// Path ID.
+    pub fn new_dcid(
+        &mut self, cid: ConnectionId<'static>, seq: u64, reset_token: u128,
+        retire_prior_to: u64,
+    ) -> Result<Vec<(u64, usize)>> {
+        if self.zero_length_dcid {
+            return Err(Error::InvalidState);
+        }
+
+        let mut retired_path_ids = Vec::new();
+        // If an endpoint receives a NEW_CONNECTION_ID frame that repeats a
+        // previously issued connection ID with a different Stateless Reset
+        // Token field value or a different Sequence Number field value, or if a
+        // sequence number is used for different connection IDs, the endpoint
+        // MAY treat that receipt as a connection error of type
+        // PROTOCOL_VIOLATION.
+        if let Some(e) = self.dcids.iter().find(|e| e.cid == cid || e.seq == seq)
+        {
+            if e.cid != cid || e.seq != seq || e.reset_token != Some(reset_token)
+            {
+                return Err(Error::InvalidFrame);
+            }
+            // The identifier is already there, nothing to do.
+            return Ok(retired_path_ids);
+        }
+
+        // The value in the Retire Prior To field MUST be less than or equal to
+        // the value in the Sequence Number field. Receiving a value in the
+        // Retire Prior To field that is greater than that in the Sequence
+        // Number field MUST be treated as a connection error of type
+        // FRAME_ENCODING_ERROR.
+        if retire_prior_to > seq {
+            return Err(Error::InvalidFrame);
+        }
+
+        // An endpoint that receives a NEW_CONNECTION_ID frame with a sequence
+        // number smaller than the Retire Prior To field of a previously
+        // received NEW_CONNECTION_ID frame MUST send a corresponding
+        // RETIRE_CONNECTION_ID frame that retires the newly received connection
+        // ID, unless it has already done so for that sequence number.
+        if seq < self.largest_peer_retire_prior_to &&
+            !self.retire_dcid_seqs.contains(&seq)
+        {
+            self.retire_dcid_seqs.push_back(seq);
+            return Ok(retired_path_ids);
+        }
+
+        if seq > self.largest_destination_seq {
+            self.largest_destination_seq = seq;
+        }
+
+        let new_entry = ConnectionIdEntry {
+            cid: cid.clone(),
+            seq,
+            reset_token: Some(reset_token),
+            path_id: None,
+        };
+
+        // A receiver MUST ignore any Retire Prior To fields that do not
+        // increase the largest received Retire Prior To value.
+        //
+        // After processing a NEW_CONNECTION_ID frame and adding and retiring
+        // active connection IDs, if the number of active connection IDs exceeds
+        // the value advertised in its active_connection_id_limit transport
+        // parameter, an endpoint MUST close the connection with an error of type
+        // CONNECTION_ID_LIMIT_ERROR.
+        if retire_prior_to > self.largest_peer_retire_prior_to {
+            let retired = &mut self.retire_dcid_seqs;
+            self.dcids.remove_lower_than_and_insert(
+                retire_prior_to,
+                new_entry,
+                |e| {
+                    retired.push_back(e.seq);
+
+                    if let Some(pid) = e.path_id {
+                        retired_path_ids.push((e.seq, pid));
+                    }
+                },
+            )?;
+            self.largest_peer_retire_prior_to = retire_prior_to;
+        } else {
+            self.dcids.insert(new_entry)?;
+        }
+
+        Ok(retired_path_ids)
+    }
+
+    /// Retires the Source Connection ID having the provided sequence number.
+    ///
+    /// In case the retired Connection ID is the same as the one used by the
+    /// packet requesting the retiring, or if the retired sequence number is
+    /// greater than any previously advertised sequence numbers, it returns an
+    /// [`InvalidState`].
+    ///
+    /// Returns the path ID that was associated to the retired CID, if any.
+    ///
+    /// [`InvalidState`]: enum.Error.html#InvalidState
+    pub fn retire_scid(
+        &mut self, seq: u64, pkt_dcid: &ConnectionId,
+    ) -> Result<Option<usize>> {
+        if seq >= self.next_scid_seq {
+            return Err(Error::InvalidState);
+        }
+
+        let pid = if let Some(e) = self.scids.remove(seq)? {
+            if e.cid == *pkt_dcid {
+                return Err(Error::InvalidState);
+            }
+
+            // Notifies the application.
+            self.retired_scids.push_back(e.cid);
+
+            // Retiring this SCID may increase the retire prior to.
+            let lowest_scid_seq = self.lowest_usable_scid_seq()?;
+            self.retire_prior_to = lowest_scid_seq;
+
+            e.path_id
+        } else {
+            None
+        };
+
+        Ok(pid)
+    }
+
+    /// Retires the Destination Connection ID having the provided sequence
+    /// number.
+    ///
+    /// If the caller tries to retire the last destination Connection ID, this
+    /// method triggers an [`OutOfIdentifiers`].
+    ///
+    /// If the caller tries to retire a non-existing Destination Connection
+    /// ID sequence number, this method returns an [`InvalidState`].
+    ///
+    /// Returns the path ID that was associated to the retired CID, if any.
+    ///
+    /// [`OutOfIdentifiers`]: enum.Error.html#OutOfIdentifiers
+    /// [`InvalidState`]: enum.Error.html#InvalidState
+    pub fn retire_dcid(&mut self, seq: u64) -> Result<Option<usize>> {
+        if self.zero_length_dcid {
+            return Err(Error::InvalidState);
+        }
+
+        let e = self.dcids.remove(seq)?.ok_or(Error::InvalidState)?;
+
+        self.retire_dcid_seqs.push_back(seq);
+
+        Ok(e.path_id)
+    }
+
+    /// Updates the Source Connection ID entry with the provided sequence number
+    /// to indicate that it is now linked to the provided path ID.
+    pub fn link_scid_to_path_id(
+        &mut self, dcid_seq: u64, path_id: usize,
+    ) -> Result<()> {
+        let e = self.scids.get_mut(dcid_seq).ok_or(Error::InvalidState)?;
+        e.path_id = Some(path_id);
+        Ok(())
+    }
+
+    /// Updates the Destination Connection ID entry with the provided sequence
+    /// number to indicate that it is now linked to the provided path ID.
+    pub fn link_dcid_to_path_id(
+        &mut self, dcid_seq: u64, path_id: usize,
+    ) -> Result<()> {
+        let e = self.dcids.get_mut(dcid_seq).ok_or(Error::InvalidState)?;
+        e.path_id = Some(path_id);
+        Ok(())
+    }
+
+    /// Gets the minimum Source Connection ID sequence number whose removal has
+    /// not been requested yet.
+    #[inline]
+    pub fn lowest_usable_scid_seq(&self) -> Result<u64> {
+        self.scids
+            .iter()
+            .filter_map(|e| {
+                if e.seq >= self.retire_prior_to {
+                    Some(e.seq)
+                } else {
+                    None
+                }
+            })
+            .min()
+            .ok_or(Error::InvalidState)
+    }
+
+    /// Gets the lowest Destination Connection ID sequence number that is not
+    /// associated to a path.
+    #[inline]
+    pub fn lowest_available_dcid_seq(&self) -> Option<u64> {
+        self.dcids
+            .iter()
+            .filter_map(|e| {
+                if e.path_id.is_none() {
+                    Some(e.seq)
+                } else {
+                    None
+                }
+            })
+            .min()
+    }
+
+    /// Finds the sequence number of the Source Connection ID having the
+    /// provided value and the identifier of the path using it, if any.
+    #[inline]
+    pub fn find_scid_seq(
+        &self, scid: &ConnectionId,
+    ) -> Option<(u64, Option<usize>)> {
+        self.scids.iter().find_map(|e| {
+            if e.cid == *scid {
+                Some((e.seq, e.path_id))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Returns the number of Source Connection IDs that have not been
+    /// assigned to a path yet.
+    ///
+    /// Note that this function is only meaningful if the host uses non-zero
+    /// length Source Connection IDs.
+    #[inline]
+    pub fn available_scids(&self) -> usize {
+        self.scids.iter().filter(|e| e.path_id.is_none()).count()
+    }
+
+    /// Returns the number of Destination Connectino IDs that have not been
+    /// assigned to a path yet.
+    ///
+    /// Note that this function returns 0 if the host uses zero length
+    /// Destination Connection IDs.
+    #[inline]
+    pub fn available_dcids(&self) -> usize {
+        if self.zero_length_dcid() {
+            return 0;
+        }
+        self.dcids.iter().filter(|e| e.path_id.is_none()).count()
+    }
+
+    /// Returns the oldest active source Connection ID of this connection.
+    #[inline]
+    pub fn oldest_scid(&self) -> &ConnectionIdEntry {
+        self.scids.get_oldest()
+    }
+
+    /// Returns the oldest known active destination Connection ID of this
+    /// connection.
+    ///
+    /// Note that due to e.g., reordering at reception side, the oldest known
+    /// active destination Connection ID is not necessarily the one having the
+    /// lowest sequence.
+    #[inline]
+    pub fn oldest_dcid(&self) -> &ConnectionIdEntry {
+        self.dcids.get_oldest()
+    }
+
+    /// Adds or remove the source Connection ID sequence number from the
+    /// source Connection ID set that need to be advertised to the peer through
+    /// NEW_CONNECTION_ID frames.
+    #[inline]
+    pub fn mark_advertise_new_scid_seq(
+        &mut self, scid_seq: u64, advertise: bool,
+    ) {
+        if advertise {
+            self.advertise_new_scid_seqs.push_back(scid_seq);
+        } else if let Some(index) = self
+            .advertise_new_scid_seqs
+            .iter()
+            .position(|s| *s == scid_seq)
+        {
+            self.advertise_new_scid_seqs.remove(index);
+        }
+    }
+
+    /// Adds or remove the destination Connection ID sequence number from the
+    /// retired destination Connection ID set that need to be advertised to the
+    /// peer through RETIRE_CONNECTION_ID frames.
+    #[inline]
+    pub fn mark_retire_dcid_seq(&mut self, dcid_seq: u64, retire: bool) {
+        if retire {
+            self.retire_dcid_seqs.push_back(dcid_seq);
+        } else if let Some(index) =
+            self.retire_dcid_seqs.iter().position(|s| *s == dcid_seq)
+        {
+            self.retire_dcid_seqs.remove(index);
+        }
+    }
+
+    /// Gets a source Connection ID's sequence number requiring advertising it
+    /// to the peer through NEW_CONNECTION_ID frame, if any.
+    ///
+    /// If `Some`, it always returns the same value until it has been removed
+    /// using `mark_advertise_new_scid_seq`.
+    #[inline]
+    pub fn next_advertise_new_scid_seq(&self) -> Option<u64> {
+        self.advertise_new_scid_seqs.front().copied()
+    }
+
+    /// Gets a destination Connection IDs's sequence number that need to send
+    /// RETIRE_CONNECTION_ID frames.
+    ///
+    /// If `Some`, it always returns the same value until it has been removed
+    /// using `mark_retire_dcid_seq`.
+    #[inline]
+    pub fn next_retire_dcid_seq(&self) -> Option<u64> {
+        self.retire_dcid_seqs.front().copied()
+    }
+
+    /// Returns true if there are new source Connection IDs to advertise.
+    #[inline]
+    pub fn has_new_scids(&self) -> bool {
+        !self.advertise_new_scid_seqs.is_empty()
+    }
+
+    /// Returns true if there are retired destination Connection IDs to\
+    /// advertise.
+    #[inline]
+    pub fn has_retire_dcids(&self) -> bool {
+        !self.retire_dcid_seqs.is_empty()
+    }
+
+    /// Returns whether zero-length source CIDs are used.
+    #[inline]
+    pub fn zero_length_scid(&self) -> bool {
+        self.zero_length_scid
+    }
+
+    /// Returns whether zero-length destination CIDs are used.
+    #[inline]
+    pub fn zero_length_dcid(&self) -> bool {
+        self.zero_length_dcid
+    }
+
+    /// Gets the NEW_CONNECTION_ID frame related to the source connection ID
+    /// with sequence `seq_num`.
+    pub fn get_new_connection_id_frame_for(
+        &self, seq_num: u64,
+    ) -> Result<frame::Frame> {
+        let e = self.scids.get(seq_num).ok_or(Error::InvalidState)?;
+        Ok(frame::Frame::NewConnectionId {
+            seq_num,
+            retire_prior_to: self.retire_prior_to,
+            conn_id: e.cid.to_vec(),
+            reset_token: e.reset_token.ok_or(Error::InvalidState)?.to_be_bytes(),
+        })
+    }
+
+    /// Returns the number of source Connection IDs that are active. This is
+    /// only meaningful if the host uses non-zero length Source Connection IDs.
+    #[inline]
+    pub fn active_source_cids(&self) -> usize {
+        self.scids.len()
+    }
+
+    pub fn pop_retired_scid(&mut self) -> Option<ConnectionId<'static>> {
+        self.retired_scids.pop_front()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::create_cid_and_reset_token;
+
+    #[test]
+    fn ids_new_scids() {
+        let (scid, _) = create_cid_and_reset_token(16);
+        let (dcid, _) = create_cid_and_reset_token(16);
+
+        let mut ids = ConnectionIdentifiers::new(2, &scid, 0, None);
+        ids.set_source_conn_id_limit(3);
+        ids.set_initial_dcid(dcid, None, Some(0));
+
+        assert_eq!(ids.available_dcids(), 0);
+        assert_eq!(ids.available_scids(), 0);
+        assert_eq!(ids.has_new_scids(), false);
+        assert_eq!(ids.next_advertise_new_scid_seq(), None);
+
+        let (scid2, rt2) = create_cid_and_reset_token(16);
+
+        assert_eq!(ids.new_scid(scid2, Some(rt2), true, None, false), Ok(1));
+        assert_eq!(ids.available_dcids(), 0);
+        assert_eq!(ids.available_scids(), 1);
+        assert_eq!(ids.has_new_scids(), true);
+        assert_eq!(ids.next_advertise_new_scid_seq(), Some(1));
+
+        let (scid3, rt3) = create_cid_and_reset_token(16);
+
+        assert_eq!(ids.new_scid(scid3, Some(rt3), true, None, false), Ok(2));
+        assert_eq!(ids.available_dcids(), 0);
+        assert_eq!(ids.available_scids(), 2);
+        assert_eq!(ids.has_new_scids(), true);
+        assert_eq!(ids.next_advertise_new_scid_seq(), Some(1));
+
+        // If now we give another CID, it reports an error since it exceeds the
+        // limit of active CIDs.
+        let (scid4, rt4) = create_cid_and_reset_token(16);
+
+        assert_eq!(
+            ids.new_scid(scid4, Some(rt4), true, None, false),
+            Err(Error::IdLimit),
+        );
+        assert_eq!(ids.available_dcids(), 0);
+        assert_eq!(ids.available_scids(), 2);
+        assert_eq!(ids.has_new_scids(), true);
+        assert_eq!(ids.next_advertise_new_scid_seq(), Some(1));
+
+        // Assume we sent one of them.
+        ids.mark_advertise_new_scid_seq(1, false);
+        assert_eq!(ids.available_dcids(), 0);
+        assert_eq!(ids.available_scids(), 2);
+        assert_eq!(ids.has_new_scids(), true);
+        assert_eq!(ids.next_advertise_new_scid_seq(), Some(2));
+
+        // Send the other.
+        ids.mark_advertise_new_scid_seq(2, false);
+
+        assert_eq!(ids.available_dcids(), 0);
+        assert_eq!(ids.available_scids(), 2);
+        assert_eq!(ids.has_new_scids(), false);
+        assert_eq!(ids.next_advertise_new_scid_seq(), None);
+    }
+
+    #[test]
+    fn new_dcid_event() {
+        let (scid, _) = create_cid_and_reset_token(16);
+        let (dcid, _) = create_cid_and_reset_token(16);
+
+        let mut ids = ConnectionIdentifiers::new(2, &scid, 0, None);
+        ids.set_initial_dcid(dcid, None, Some(0));
+
+        assert_eq!(ids.available_dcids(), 0);
+        assert_eq!(ids.dcids.len(), 1);
+
+        let (dcid2, rt2) = create_cid_and_reset_token(16);
+
+        assert_eq!(
+            ids.new_dcid(dcid2.clone(), 1, rt2, 0),
+            Ok(Vec::<(u64, usize)>::new()),
+        );
+        assert_eq!(ids.available_dcids(), 1);
+        assert_eq!(ids.dcids.len(), 2);
+
+        // Now we assume that the client wants to advertise more source
+        // Connection IDs than the advertised limit. This is valid if it
+        // requests its peer to retire enough Connection IDs to fit within the
+        // limits.
+        let (dcid3, rt3) = create_cid_and_reset_token(16);
+        assert_eq!(ids.new_dcid(dcid3.clone(), 2, rt3, 1), Ok(vec![(0, 0)]));
+        // The CID module does not handle path replacing. Fake it now.
+        ids.link_dcid_to_path_id(1, 0).unwrap();
+        assert_eq!(ids.available_dcids(), 1);
+        assert_eq!(ids.dcids.len(), 2);
+        assert_eq!(ids.has_retire_dcids(), true);
+        assert_eq!(ids.next_retire_dcid_seq(), Some(0));
+
+        // Fake RETIRE_CONNECTION_ID sending.
+        ids.mark_retire_dcid_seq(0, false);
+        assert_eq!(ids.has_retire_dcids(), false);
+        assert_eq!(ids.next_retire_dcid_seq(), None);
+
+        // Now tries to experience CID retirement. If the server tries to remove
+        // non-existing DCIDs, it fails.
+        assert_eq!(ids.retire_dcid(0), Err(Error::InvalidState));
+        assert_eq!(ids.retire_dcid(3), Err(Error::InvalidState));
+        assert_eq!(ids.has_retire_dcids(), false);
+        assert_eq!(ids.dcids.len(), 2);
+
+        // Now it removes DCID with sequence 1.
+        assert_eq!(ids.retire_dcid(1), Ok(Some(0)));
+        // The CID module does not handle path replacing. Fake it now.
+        ids.link_dcid_to_path_id(2, 0).unwrap();
+        assert_eq!(ids.available_dcids(), 0);
+        assert_eq!(ids.has_retire_dcids(), true);
+        assert_eq!(ids.next_retire_dcid_seq(), Some(1));
+        assert_eq!(ids.dcids.len(), 1);
+
+        // Fake RETIRE_CONNECTION_ID sending.
+        ids.mark_retire_dcid_seq(1, false);
+        assert_eq!(ids.has_retire_dcids(), false);
+        assert_eq!(ids.next_retire_dcid_seq(), None);
+
+        // Trying to remove the last DCID triggers an error.
+        assert_eq!(ids.retire_dcid(2), Err(Error::OutOfIdentifiers));
+        assert_eq!(ids.available_dcids(), 0);
+        assert_eq!(ids.has_retire_dcids(), false);
+        assert_eq!(ids.dcids.len(), 1);
+    }
+
+    #[test]
+    fn retire_scids() {
+        let (scid, _) = create_cid_and_reset_token(16);
+        let (dcid, _) = create_cid_and_reset_token(16);
+
+        let mut ids = ConnectionIdentifiers::new(3, &scid, 0, None);
+        ids.set_initial_dcid(dcid, None, Some(0));
+        ids.set_source_conn_id_limit(3);
+
+        let (scid2, rt2) = create_cid_and_reset_token(16);
+        let (scid3, rt3) = create_cid_and_reset_token(16);
+
+        assert_eq!(
+            ids.new_scid(scid2.clone(), Some(rt2), true, None, false),
+            Ok(1),
+        );
+        assert_eq!(ids.scids.len(), 2);
+        assert_eq!(
+            ids.new_scid(scid3.clone(), Some(rt3), true, None, false),
+            Ok(2),
+        );
+        assert_eq!(ids.scids.len(), 3);
+
+        assert_eq!(ids.pop_retired_scid(), None);
+
+        assert_eq!(ids.retire_scid(0, &scid2), Ok(Some(0)));
+
+        assert_eq!(ids.pop_retired_scid(), Some(scid));
+        assert_eq!(ids.pop_retired_scid(), None);
+
+        assert_eq!(ids.retire_scid(1, &scid3), Ok(None));
+
+        assert_eq!(ids.pop_retired_scid(), Some(scid2));
+        assert_eq!(ids.pop_retired_scid(), None);
+    }
+}

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -798,6 +798,16 @@ impl Frame {
         )
     }
 
+    pub fn probing(&self) -> bool {
+        matches!(
+            self,
+            Frame::Padding { .. } |
+                Frame::NewConnectionId { .. } |
+                Frame::PathChallenge { .. } |
+                Frame::PathResponse { .. }
+        )
+    }
+
     #[cfg(feature = "qlog")]
     pub fn to_qlog(&self) -> QuicFrame {
         match self {
@@ -1108,12 +1118,21 @@ impl std::fmt::Debug for Frame {
                 write!(f, "STREAMS_BLOCKED type=uni limit={}", limit)?;
             },
 
-            Frame::NewConnectionId { .. } => {
-                write!(f, "NEW_CONNECTION_ID (TODO)")?;
+            Frame::NewConnectionId {
+                seq_num,
+                retire_prior_to,
+                conn_id,
+                reset_token,
+            } => {
+                write!(
+                    f,
+                    "NEW_CONNECTION_ID seq_num={} retire_prior_to={} conn_id={:02x?} reset_token={:02x?}",
+                    seq_num, retire_prior_to, conn_id, reset_token,
+                )?;
             },
 
-            Frame::RetireConnectionId { .. } => {
-                write!(f, "RETIRE_CONNECTION_ID (TODO)")?;
+            Frame::RetireConnectionId { seq_num } => {
+                write!(f, "RETIRE_CONNECTION_ID seq_num={}", seq_num)?;
             },
 
             Frame::PathChallenge { data } => {

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -60,8 +60,9 @@
 //! ```no_run
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
 //! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
-//! # let from = "127.0.0.1:1234".parse().unwrap();
-//! # let mut conn = quiche::accept(&scid, None, from, &mut config).unwrap();
+//! # let peer = "127.0.0.1:1234".parse().unwrap();
+//! # let local = "127.0.0.1:4321".parse().unwrap();
+//! # let mut conn = quiche::accept(&scid, None, local, peer, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! let h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
 //! # Ok::<(), quiche::h3::Error>(())
@@ -76,8 +77,9 @@
 //! ```no_run
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
 //! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
-//! # let to = "127.0.0.1:1234".parse().unwrap();
-//! # let mut conn = quiche::connect(None, &scid, to, &mut config).unwrap();
+//! # let peer = "127.0.0.1:1234".parse().unwrap();
+//! # let local = "127.0.0.1:4321".parse().unwrap();
+//! # let mut conn = quiche::connect(None, &scid, local, peer, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
 //! let req = vec![
@@ -98,8 +100,9 @@
 //! ```no_run
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
 //! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
-//! # let to = "127.0.0.1:1234".parse().unwrap();
-//! # let mut conn = quiche::connect(None, &scid, to, &mut config).unwrap();
+//! # let peer = "127.0.0.1:1234".parse().unwrap();
+//! # let local = "127.0.0.1:4321".parse().unwrap();
+//! # let mut conn = quiche::connect(None, &scid, local, peer, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
 //! let req = vec![
@@ -129,8 +132,9 @@
 //!
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
 //! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
-//! # let from = "127.0.0.1:1234".parse().unwrap();
-//! # let mut conn = quiche::accept(&scid, None, from, &mut config).unwrap();
+//! # let peer = "127.0.0.1:1234".parse().unwrap();
+//! # let local = "127.0.0.1:1234".parse().unwrap();
+//! # let mut conn = quiche::accept(&scid, None, local, peer, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
 //! loop {
@@ -197,8 +201,9 @@
 //!
 //! # let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
 //! # let scid = quiche::ConnectionId::from_ref(&[0xba; 16]);
-//! # let to = "127.0.0.1:1234".parse().unwrap();
-//! # let mut conn = quiche::connect(None, &scid, to, &mut config).unwrap();
+//! # let peer = "127.0.0.1:1234".parse().unwrap();
+//! # let local = "127.0.0.1:1234".parse().unwrap();
+//! # let mut conn = quiche::connect(None, &scid, local, peer, &mut config).unwrap();
 //! # let h3_config = quiche::h3::Config::new()?;
 //! # let mut h3_conn = quiche::h3::Connection::with_transport(&mut conn, &h3_config)?;
 //! loop {

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -819,6 +819,8 @@ pub struct PktNumSpace {
 
     pub largest_rx_pkt_time: time::Instant,
 
+    pub largest_rx_non_probing_pkt_num: u64,
+
     pub next_pkt_num: u64,
 
     pub recv_pkt_need_ack: ranges::RangeSet,
@@ -842,6 +844,8 @@ impl PktNumSpace {
             largest_rx_pkt_num: 0,
 
             largest_rx_pkt_time: time::Instant::now(),
+
+            largest_rx_non_probing_pkt_num: 0,
 
             next_pkt_num: 0,
 

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -1,0 +1,1056 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::time;
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::net::SocketAddr;
+
+use slab::Slab;
+
+use crate::Error;
+use crate::Result;
+
+use crate::recovery;
+use crate::recovery::HandshakeStatus;
+
+/// The different states of the path validation.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PathState {
+    /// The path failed its validation.
+    Failed,
+
+    /// The path exists, but no path validation has been performed.
+    Unknown,
+
+    /// The path is under validation.
+    Validating,
+
+    /// The remote address has been validated, but not the path MTU.
+    ValidatingMTU,
+
+    /// The path has been validated.
+    Validated,
+}
+
+impl PathState {
+    #[cfg(feature = "ffi")]
+    pub fn to_c(self) -> libc::ssize_t {
+        match self {
+            PathState::Failed => -1,
+            PathState::Unknown => 0,
+            PathState::Validating => 1,
+            PathState::ValidatingMTU => 2,
+            PathState::Validated => 3,
+        }
+    }
+}
+
+/// A path-specific event.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PathEvent {
+    /// A new network path (local address, peer address) has been seen on a
+    /// received packet. Note that this event is only triggered for servers, as
+    /// the client is responsible from initiating new paths. The application may
+    /// then probe this new path, if desired.
+    New(SocketAddr, SocketAddr),
+
+    /// The related network path between local `SocketAddr` and peer
+    /// `SocketAddr` has been validated.
+    Validated(SocketAddr, SocketAddr),
+
+    /// The related network path between local `SocketAddr` and peer
+    /// `SocketAddr` failed to be validated. This network path will not be used
+    /// anymore, unless the application requests probing this path again.
+    FailedValidation(SocketAddr, SocketAddr),
+
+    /// The related network path between local `SocketAddr` and peer
+    /// `SocketAddr` has been closed and is now unusable on this connection.
+    Closed(SocketAddr, SocketAddr),
+
+    /// The stack observes that the Source Connection ID with the given sequence
+    /// number, initialy used by the peer over the first pair of `SocketAddr`s,
+    /// is now reused over the second pair of `SocketAddr`s.
+    ReusedSourceConnectionId(
+        u64,
+        (SocketAddr, SocketAddr),
+        (SocketAddr, SocketAddr),
+    ),
+
+    /// The connection observed that the peer migrated over the network path
+    /// denoted by the pair of `SocketAddr`, i.e., non-probing packets have been
+    /// received on this network path. This is a server side only event.
+    ///
+    /// Note that this event is only raised if the path has been validated.
+    PeerMigrated(SocketAddr, SocketAddr),
+}
+
+/// A network path on which QUIC packets can be sent.
+#[derive(Debug)]
+pub struct Path {
+    /// The local address.
+    local_addr: SocketAddr,
+
+    /// The remote address.
+    peer_addr: SocketAddr,
+
+    /// Source CID sequence number used over that path.
+    pub active_scid_seq: Option<u64>,
+
+    /// Destination CID sequence number used over that path.
+    pub active_dcid_seq: Option<u64>,
+
+    /// The current validation state of the path.
+    state: PathState,
+
+    /// Is this path used to send non-probing packets.
+    active: bool,
+
+    /// Loss recovery and congestion control state.
+    pub recovery: recovery::Recovery,
+
+    /// Pending challenge data with the size of the packet containing them and
+    /// when they were sent.
+    in_flight_challenges: VecDeque<([u8; 8], usize, time::Instant)>,
+
+    /// The maximum challenge size that got acknowledged.
+    max_challenge_size: usize,
+
+    /// Number of consecutive (spaced by at least 1 RTT) probing packets lost.
+    probing_lost: usize,
+
+    /// Last instant when a probing packet got lost.
+    last_probe_lost_time: Option<time::Instant>,
+
+    /// Received challenge data.
+    received_challenges: VecDeque<[u8; 8]>,
+
+    /// Number of packets sent on this path.
+    pub sent_count: usize,
+
+    /// Number of packets received on this path.
+    pub recv_count: usize,
+
+    /// Total number of packets sent with data retransmitted from this path.
+    pub retrans_count: usize,
+
+    /// Total number of sent bytes over this path.
+    pub sent_bytes: u64,
+
+    /// Total number of bytes received over this path.
+    pub recv_bytes: u64,
+
+    /// Total number of bytes retransmitted from this path.
+    /// This counts only STREAM and CRYPTO data.
+    pub stream_retrans_bytes: u64,
+
+    /// Total number of bytes the server can send before the peer's address
+    /// is verified.
+    pub max_send_bytes: usize,
+
+    /// Whether the peer's address has been verified.
+    pub verified_peer_address: bool,
+
+    /// Whether the peer has verified our address.
+    pub peer_verified_local_address: bool,
+
+    /// Does it requires sending PATH_CHALLENGE?
+    challenge_requested: bool,
+
+    /// Whether the failure of this path was notified.
+    failure_notified: bool,
+
+    /// Whether the connection tries to migrate to this path, but it still needs
+    /// to be validated.
+    migrating: bool,
+}
+
+impl Path {
+    /// Create a new Path instance with the provided addresses, the remaining of
+    /// the fields being set to their default value.
+    pub fn new(
+        local_addr: SocketAddr, peer_addr: SocketAddr,
+        recovery_config: &recovery::RecoveryConfig, is_initial: bool,
+    ) -> Self {
+        let (state, active_scid_seq, active_dcid_seq) = if is_initial {
+            (PathState::Validated, Some(0), Some(0))
+        } else {
+            (PathState::Unknown, None, None)
+        };
+
+        Self {
+            local_addr,
+            peer_addr,
+            active_scid_seq,
+            active_dcid_seq,
+            state,
+            active: false,
+            recovery: recovery::Recovery::new_with_config(recovery_config),
+            in_flight_challenges: VecDeque::new(),
+            max_challenge_size: 0,
+            probing_lost: 0,
+            last_probe_lost_time: None,
+            received_challenges: VecDeque::new(),
+            sent_count: 0,
+            recv_count: 0,
+            retrans_count: 0,
+            sent_bytes: 0,
+            recv_bytes: 0,
+            stream_retrans_bytes: 0,
+            max_send_bytes: 0,
+            verified_peer_address: false,
+            peer_verified_local_address: false,
+            challenge_requested: false,
+            failure_notified: false,
+            migrating: false,
+        }
+    }
+
+    /// Returns the local address on which this path operates.
+    #[inline]
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Returns the peer address on which this path operates.
+    #[inline]
+    pub fn peer_addr(&self) -> SocketAddr {
+        self.peer_addr
+    }
+
+    /// Returns whether the path is working (i.e., not failed).
+    #[inline]
+    fn working(&self) -> bool {
+        self.state > PathState::Failed
+    }
+
+    /// Returns whether the path is active.
+    #[inline]
+    pub fn active(&self) -> bool {
+        self.active && self.working() && self.active_dcid_seq.is_some()
+    }
+
+    /// Returns whether the path can be used to send non-probing packets.
+    #[inline]
+    pub fn usable(&self) -> bool {
+        self.active() ||
+            (self.state == PathState::Validated &&
+                self.active_dcid_seq.is_some())
+    }
+
+    /// Returns whether the path is unused.
+    #[inline]
+    fn unused(&self) -> bool {
+        // FIXME: we should check that there is nothing in the sent queue.
+        !self.active() && self.active_dcid_seq.is_none()
+    }
+
+    /// Returns whether the path requires sending a probing packet.
+    #[inline]
+    pub fn probing_required(&self) -> bool {
+        !self.received_challenges.is_empty() || self.validation_requested()
+    }
+
+    /// Promotes the path to the provided state only if the new state is greater
+    /// than the current one.
+    fn promote_to(&mut self, state: PathState) {
+        if self.state < state {
+            self.state = state;
+        }
+    }
+
+    /// Returns whether the path is validated.
+    #[inline]
+    pub fn validated(&self) -> bool {
+        self.state == PathState::Validated
+    }
+
+    /// Returns whether this path failed its validation.
+    #[inline]
+    fn validation_failed(&self) -> bool {
+        self.state == PathState::Failed
+    }
+
+    // Returns whether this path is under path validation process.
+    #[inline]
+    pub fn under_validation(&self) -> bool {
+        matches!(self.state, PathState::Validating | PathState::ValidatingMTU)
+    }
+
+    /// Requests path validation.
+    #[inline]
+    pub fn request_validation(&mut self) {
+        self.challenge_requested = true;
+    }
+
+    /// Returns whether a validation is requested.
+    #[inline]
+    pub fn validation_requested(&self) -> bool {
+        self.challenge_requested
+    }
+
+    pub fn on_challenge_sent(&mut self) {
+        self.promote_to(PathState::Validating);
+        self.challenge_requested = false;
+    }
+
+    pub fn on_challenge_received(&mut self, data: [u8; 8]) {
+        self.received_challenges.push_back(data);
+        self.peer_verified_local_address = true;
+    }
+
+    pub fn has_pending_challenge(&self, data: [u8; 8]) -> bool {
+        self.in_flight_challenges.iter().any(|(d, ..)| *d == data)
+    }
+
+    /// Returns whether the path is now validated.
+    pub fn on_response_received(&mut self, data: [u8; 8]) -> bool {
+        self.verified_peer_address = true;
+        self.probing_lost = 0;
+
+        let mut challenge_size = 0;
+        self.in_flight_challenges.retain(|(d, s, _)| {
+            if *d == data {
+                challenge_size = *s;
+                false
+            } else {
+                true
+            }
+        });
+
+        // The 4-tuple is reachable, but we didn't check Path MTU yet.
+        self.promote_to(PathState::ValidatingMTU);
+
+        self.max_challenge_size =
+            std::cmp::max(self.max_challenge_size, challenge_size);
+
+        if self.state == PathState::ValidatingMTU {
+            if self.max_challenge_size >= crate::MIN_CLIENT_INITIAL_LEN {
+                // Path MTU is sufficient for QUIC traffic.
+                self.promote_to(PathState::Validated);
+                return true;
+            }
+
+            // If the MTU was not validated, probe again.
+            self.request_validation();
+        }
+
+        false
+    }
+
+    fn on_failed_validation(&mut self) {
+        self.state = PathState::Failed;
+        self.active = false;
+    }
+
+    #[inline]
+    pub fn pop_received_challenge(&mut self) -> Option<[u8; 8]> {
+        self.received_challenges.pop_front()
+    }
+
+    pub fn on_loss_detection_timeout(
+        &mut self, handshake_status: HandshakeStatus, now: time::Instant,
+        is_server: bool, trace_id: &str,
+    ) -> (usize, usize) {
+        let (lost_packets, lost_bytes) = self.recovery.on_loss_detection_timeout(
+            handshake_status,
+            now,
+            trace_id,
+        );
+
+        let mut lost_probe_time = None;
+        self.in_flight_challenges.retain(|(_, _, sent_time)| {
+            if *sent_time <= now {
+                if lost_probe_time.is_none() {
+                    lost_probe_time = Some(*sent_time);
+                }
+                false
+            } else {
+                true
+            }
+        });
+
+        // If we lost probing packets, check if the path failed
+        // validation.
+        if let Some(lost_probe_time) = lost_probe_time {
+            self.last_probe_lost_time = match self.last_probe_lost_time {
+                Some(last) => {
+                    // Count a loss if at least 1-RTT happenned.
+                    if lost_probe_time - last >= self.recovery.rtt() {
+                        self.probing_lost += 1;
+                        Some(lost_probe_time)
+                    } else {
+                        Some(last)
+                    }
+                },
+                None => {
+                    self.probing_lost += 1;
+                    Some(lost_probe_time)
+                },
+            };
+            // As a server, if requesting a challenge is not
+            // possible due to the amplification attack, declare the
+            // validation as failed.
+            if self.probing_lost >= crate::MAX_PROBING_TIMEOUTS ||
+                (is_server && self.max_send_bytes < crate::MIN_PROBING_SIZE)
+            {
+                self.on_failed_validation();
+            } else {
+                self.request_validation();
+            }
+        }
+
+        (lost_packets, lost_bytes)
+    }
+
+    pub fn stats(&self) -> PathStats {
+        PathStats {
+            local_addr: self.local_addr,
+            peer_addr: self.peer_addr,
+            validation_state: self.state,
+            active: self.active,
+            recv: self.recv_count,
+            sent: self.sent_count,
+            lost: self.recovery.lost_count,
+            retrans: self.retrans_count,
+            rtt: self.recovery.rtt(),
+            cwnd: self.recovery.cwnd(),
+            sent_bytes: self.sent_bytes,
+            recv_bytes: self.recv_bytes,
+            lost_bytes: self.recovery.bytes_lost,
+            stream_retrans_bytes: self.stream_retrans_bytes,
+            pmtu: self.recovery.max_datagram_size(),
+            delivery_rate: self.recovery.delivery_rate(),
+        }
+    }
+}
+
+/// An iterator over SocketAddr.
+#[derive(Default)]
+pub struct SocketAddrIter {
+    pub(crate) sockaddrs: Vec<SocketAddr>,
+}
+
+impl Iterator for SocketAddrIter {
+    type Item = SocketAddr;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.sockaddrs.pop()
+    }
+}
+
+impl ExactSizeIterator for SocketAddrIter {
+    #[inline]
+    fn len(&self) -> usize {
+        self.sockaddrs.len()
+    }
+}
+
+/// All path-related information.
+pub struct PathMap {
+    /// The paths of the connection. Each of them has an internal identifier
+    /// that is used by `addrs_to_paths` and `ConnectionEntry`.
+    paths: Slab<Path>,
+
+    /// The mapping from the (local `SocketAddr`, peer `SocketAddr`) to the
+    /// `Path` structure identifier.
+    addrs_to_paths: HashMap<(SocketAddr, SocketAddr), usize>,
+
+    /// Path-specific events to be notified to the application.
+    events: VecDeque<PathEvent>,
+
+    /// Whether this manager serves a connection as a server.
+    is_server: bool,
+}
+
+impl PathMap {
+    /// Creates a new `PathMap` with the initial provided `path` and a
+    /// capacity limit.
+    pub fn new(
+        mut initial_path: Path, max_concurrent_paths: usize, is_server: bool,
+    ) -> Self {
+        let mut paths = Slab::with_capacity(max_concurrent_paths);
+        let mut addrs_to_paths = HashMap::new();
+
+        let local_addr = initial_path.local_addr;
+        let peer_addr = initial_path.peer_addr;
+
+        // As it is the first path, it is active by default.
+        initial_path.active = true;
+
+        let active_path_id = paths.insert(initial_path);
+        addrs_to_paths.insert((local_addr, peer_addr), active_path_id);
+
+        Self {
+            paths,
+            addrs_to_paths,
+            events: VecDeque::new(),
+            is_server,
+        }
+    }
+
+    /// Gets an immutable reference to the path identified by `path_id`. If the
+    /// provided `path_id` does not identify any current `Path`, returns an
+    /// [`InvalidState`].
+    ///
+    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    #[inline]
+    pub fn get(&self, path_id: usize) -> Result<&Path> {
+        self.paths.get(path_id).ok_or(Error::InvalidState)
+    }
+
+    /// Gets a mutable reference to the path identified by `path_id`. If the
+    /// provided `path_id` does not identify any current `Path`, returns an
+    /// [`InvalidState`].
+    ///
+    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    #[inline]
+    pub fn get_mut(&mut self, path_id: usize) -> Result<&mut Path> {
+        self.paths.get_mut(path_id).ok_or(Error::InvalidState)
+    }
+
+    #[inline]
+    /// Gets an immutable reference to the active path with the value of the
+    /// lowest identifier. If there is no active path, returns `None`.
+    pub fn get_active_with_pid(&self) -> Option<(usize, &Path)> {
+        self.paths.iter().find(|(_, p)| p.active())
+    }
+
+    /// Gets an immutable reference to the active path with the lowest
+    /// identifier. If there is no active path, returns an [`InvalidState`].
+    ///
+    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    #[inline]
+    pub fn get_active(&self) -> Result<&Path> {
+        self.get_active_with_pid()
+            .map(|(_, p)| p)
+            .ok_or(Error::InvalidState)
+    }
+
+    /// Gets the lowest active path identifier. If there is no active path,
+    /// returns an [`InvalidState`].
+    ///
+    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    #[inline]
+    pub fn get_active_path_id(&self) -> Result<usize> {
+        self.get_active_with_pid()
+            .map(|(pid, _)| pid)
+            .ok_or(Error::InvalidState)
+    }
+
+    /// Gets an mutable reference to the active path with the lowest identifier.
+    /// If there is no active path, returns an [`InvalidState`].
+    ///
+    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    #[inline]
+    pub fn get_active_mut(&mut self) -> Result<&mut Path> {
+        self.paths
+            .iter_mut()
+            .map(|(_, p)| p)
+            .find(|p| p.active())
+            .ok_or(Error::InvalidState)
+    }
+
+    /// Returns an iterator over all existing paths.
+    #[inline]
+    pub fn iter(&self) -> slab::Iter<Path> {
+        self.paths.iter()
+    }
+
+    /// Returns a mutable iterator over all existing paths.
+    #[inline]
+    pub fn iter_mut(&mut self) -> slab::IterMut<Path> {
+        self.paths.iter_mut()
+    }
+
+    /// Returns the `Path` identifier related to the provided `addrs`.
+    #[inline]
+    pub fn path_id_from_addrs(
+        &self, addrs: &(SocketAddr, SocketAddr),
+    ) -> Option<usize> {
+        self.addrs_to_paths.get(addrs).copied()
+    }
+
+    /// Checks if creating a new path will not exceed the current `self.paths`
+    /// capacity. If yes, this method tries to remove one unused path. If it
+    /// fails to do so, returns [`Done`].
+    ///
+    /// [`Done`]: enum.Error.html#variant.Done
+    fn make_room_for_new_path(&mut self) -> Result<()> {
+        if self.paths.len() < self.paths.capacity() {
+            return Ok(());
+        }
+
+        let (pid_to_remove, _) = self
+            .paths
+            .iter()
+            .find(|(_, p)| p.unused())
+            .ok_or(Error::Done)?;
+
+        let path = self.paths.remove(pid_to_remove);
+        self.addrs_to_paths
+            .remove(&(path.local_addr, path.peer_addr));
+
+        self.notify_event(PathEvent::Closed(path.local_addr, path.peer_addr));
+
+        Ok(())
+    }
+
+    /// Records the provided `Path` and returns its assigned identifier.
+    ///
+    /// On success, this method takes care of creating a notification to the
+    /// serving application, if it serves a server-side connection.
+    ///
+    /// If there are already `max_concurrent_paths` currently recorded, this
+    /// method tries to remove an unused `Path` first. If it fails to do so,
+    /// it returns [`Done`].
+    ///
+    /// [`Done`]: enum.Error.html#variant.Done
+    pub fn insert_path(&mut self, path: Path, is_server: bool) -> Result<usize> {
+        self.make_room_for_new_path()?;
+
+        let local_addr = path.local_addr;
+        let peer_addr = path.peer_addr;
+
+        let pid = self.paths.insert(path);
+        self.addrs_to_paths.insert((local_addr, peer_addr), pid);
+
+        // Notifies the application if we are in server mode.
+        if is_server {
+            self.notify_event(PathEvent::New(local_addr, peer_addr));
+        }
+
+        Ok(pid)
+    }
+
+    /// Notifies a path event to the application served by the connection.
+    pub fn notify_event(&mut self, ev: PathEvent) {
+        self.events.push_back(ev);
+    }
+
+    /// Gets the first path event to be notified to the application.
+    pub fn pop_event(&mut self) -> Option<PathEvent> {
+        self.events.pop_front()
+    }
+
+    /// Notifies all failed validations to the application.
+    pub fn notify_failed_validations(&mut self) {
+        let validation_failed = self
+            .paths
+            .iter_mut()
+            .filter(|(_, p)| p.validation_failed() && !p.failure_notified);
+
+        for (_, p) in validation_failed {
+            self.events.push_back(PathEvent::FailedValidation(
+                p.local_addr,
+                p.peer_addr,
+            ));
+
+            p.failure_notified = true;
+        }
+    }
+
+    /// Finds a path candidate to be active and returns its identifier.
+    pub fn find_candidate_path(&self) -> Option<usize> {
+        // TODO: also consider unvalidated paths if there are no more validated.
+        self.paths
+            .iter()
+            .find(|(_, p)| p.usable())
+            .map(|(pid, _)| pid)
+    }
+
+    /// Handles the sending of PATH_CHALLENGE.
+    pub fn on_challenge_sent(
+        &mut self, path_id: usize, data: [u8; 8], pkt_size: usize,
+        sent_time: time::Instant,
+    ) -> Result<()> {
+        let path = self.get_mut(path_id)?;
+
+        path.on_challenge_sent();
+        path.in_flight_challenges
+            .push_back((data, pkt_size, sent_time));
+
+        Ok(())
+    }
+
+    /// Handles incoming PATH_RESPONSE data.
+    pub fn on_response_received(&mut self, data: [u8; 8]) -> Result<()> {
+        let active_pid = self.get_active_path_id()?;
+
+        let challenge_pending =
+            self.iter_mut().find(|(_, p)| p.has_pending_challenge(data));
+
+        if let Some((pid, p)) = challenge_pending {
+            if p.on_response_received(data) {
+                let local_addr = p.local_addr;
+                let peer_addr = p.peer_addr;
+                let was_migrating = p.migrating;
+
+                p.migrating = false;
+
+                // Notifies the application.
+                self.notify_event(PathEvent::Validated(local_addr, peer_addr));
+
+                // If this path was the candidate for migration, notifies the
+                // application.
+                if pid == active_pid && was_migrating {
+                    self.notify_event(PathEvent::PeerMigrated(
+                        local_addr, peer_addr,
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Sets the path with identifier 'path_id' to be active.
+    ///
+    /// There can be exactly one active path on which non-probing packets can be
+    /// sent. If another path is marked as active, it will be superseeded by the
+    /// one having `path_id` as identifier.
+    ///
+    /// A server should always ensure that the active path is validated. If it
+    /// is already the case, it notifies the application that the connection
+    /// migrated. Otherwise, it triggers a path validation and defers the
+    /// notification once it is actually validated.
+    pub fn set_active_path(&mut self, path_id: usize) -> Result<()> {
+        let is_server = self.is_server;
+
+        if let Ok(old_active_path) = self.get_active_mut() {
+            old_active_path.active = false;
+        }
+
+        let new_active_path = self.get_mut(path_id)?;
+        new_active_path.active = true;
+
+        if is_server {
+            if new_active_path.validated() {
+                let local_addr = new_active_path.local_addr();
+                let peer_addr = new_active_path.peer_addr();
+
+                self.notify_event(PathEvent::PeerMigrated(local_addr, peer_addr));
+            } else {
+                new_active_path.migrating = true;
+
+                // Requests path validation if needed.
+                if !new_active_path.under_validation() {
+                    new_active_path.request_validation();
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handles potential connection migration.
+    pub fn on_peer_migrated(
+        &mut self, new_pid: usize, disable_dcid_reuse: bool,
+    ) -> Result<()> {
+        let active_path_id = self.get_active_path_id()?;
+
+        if active_path_id == new_pid {
+            return Ok(());
+        }
+
+        self.set_active_path(new_pid)?;
+
+        let no_spare_dcid = self.get_mut(new_pid)?.active_dcid_seq.is_none();
+
+        if no_spare_dcid && !disable_dcid_reuse {
+            self.get_mut(new_pid)?.active_dcid_seq =
+                self.get_mut(active_path_id)?.active_dcid_seq;
+        }
+
+        Ok(())
+    }
+}
+
+/// Statistics about the path of a connection.
+///
+/// It is part of the `Stats` structure returned by the [`stats()`] method.
+///
+/// [`stats()`]: struct.Connection.html#method.stats
+#[derive(Clone)]
+pub struct PathStats {
+    /// The local address of the path.
+    pub local_addr: SocketAddr,
+
+    /// The peer address of the path.
+    pub peer_addr: SocketAddr,
+
+    /// The path validation state.
+    pub validation_state: PathState,
+
+    /// Whether the path is marked as active.
+    pub active: bool,
+
+    /// The number of QUIC packets received.
+    pub recv: usize,
+
+    /// The number of QUIC packets sent.
+    pub sent: usize,
+
+    /// The number of QUIC packets that were lost.
+    pub lost: usize,
+
+    /// The number of sent QUIC packets with retransmitted data.
+    pub retrans: usize,
+
+    /// The estimated round-trip time of the connection.
+    pub rtt: time::Duration,
+
+    /// The size of the connection's congestion window in bytes.
+    pub cwnd: usize,
+
+    /// The number of sent bytes.
+    pub sent_bytes: u64,
+
+    /// The number of received bytes.
+    pub recv_bytes: u64,
+
+    /// The number of bytes lost.
+    pub lost_bytes: u64,
+
+    /// The number of stream bytes retransmitted.
+    pub stream_retrans_bytes: u64,
+
+    /// The current PMTU for the connection.
+    pub pmtu: usize,
+
+    /// The most recent data delivery rate estimate in bytes/s.
+    ///
+    /// Note that this value could be inaccurate if the application does not
+    /// respect pacing hints (see [`SendInfo.at`] and [Pacing] for more
+    /// details).
+    ///
+    /// [`SendInfo.at`]: struct.SendInfo.html#structfield.at
+    /// [Pacing]: index.html#pacing
+    pub delivery_rate: u64,
+}
+
+impl std::fmt::Debug for PathStats {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "local_addr={:?} peer_addr={:?} ",
+            self.local_addr, self.peer_addr,
+        )?;
+        write!(
+            f,
+            "validation_state={:?} active={} ",
+            self.validation_state, self.active,
+        )?;
+        write!(
+            f,
+            "recv={} sent={} lost={} retrans={} rtt={:?} cwnd={}",
+            self.recv, self.sent, self.lost, self.retrans, self.rtt, self.cwnd,
+        )?;
+
+        write!(
+            f,
+            " sent_bytes={} recv_bytes={} lost_bytes={}",
+            self.sent_bytes, self.recv_bytes, self.lost_bytes,
+        )?;
+
+        write!(
+            f,
+            " stream_retrans_bytes={} pmtu={} delivery_rate={}",
+            self.stream_retrans_bytes, self.pmtu, self.delivery_rate,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rand;
+    use crate::MIN_CLIENT_INITIAL_LEN;
+
+    use crate::recovery::RecoveryConfig;
+    use crate::Config;
+
+    use super::*;
+
+    #[test]
+    fn path_validation_limited_mtu() {
+        let client_addr = "127.0.0.1:1234".parse().unwrap();
+        let client_addr_2 = "127.0.0.1:5678".parse().unwrap();
+        let server_addr = "127.0.0.1:4321".parse().unwrap();
+
+        let config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        let recovery_config = RecoveryConfig::from_config(&config);
+
+        let path = Path::new(client_addr, server_addr, &recovery_config, true);
+        let mut path_mgr = PathMap::new(path, 2, false);
+
+        let probed_path =
+            Path::new(client_addr_2, server_addr, &recovery_config, false);
+        path_mgr.insert_path(probed_path, false).unwrap();
+
+        let pid = path_mgr
+            .path_id_from_addrs(&(client_addr_2, server_addr))
+            .unwrap();
+        path_mgr.get_mut(pid).unwrap().request_validation();
+        assert_eq!(path_mgr.get_mut(pid).unwrap().validation_requested(), true);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().probing_required(), true);
+
+        // Fake sending of PathChallenge in a packet of MIN_CLIENT_INITIAL_LEN - 1
+        // bytes.
+        let data = rand::rand_u64().to_be_bytes();
+        path_mgr
+            .on_challenge_sent(
+                pid,
+                data,
+                MIN_CLIENT_INITIAL_LEN - 1,
+                time::Instant::now(),
+            )
+            .unwrap();
+
+        assert_eq!(path_mgr.get_mut(pid).unwrap().validation_requested(), false);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().probing_required(), false);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().under_validation(), true);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().validated(), false);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().state, PathState::Validating);
+        assert_eq!(path_mgr.pop_event(), None);
+
+        // Receives the response. The path is reachable, but the MTU is not
+        // validated yet.
+        path_mgr.on_response_received(data).unwrap();
+
+        assert_eq!(path_mgr.get_mut(pid).unwrap().validation_requested(), true);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().probing_required(), true);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().under_validation(), true);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().validated(), false);
+        assert_eq!(
+            path_mgr.get_mut(pid).unwrap().state,
+            PathState::ValidatingMTU
+        );
+        assert_eq!(path_mgr.pop_event(), None);
+
+        // Fake sending of PathChallenge in a packet of MIN_CLIENT_INITIAL_LEN
+        // bytes.
+        let data = rand::rand_u64().to_be_bytes();
+        path_mgr
+            .on_challenge_sent(
+                pid,
+                data,
+                MIN_CLIENT_INITIAL_LEN,
+                time::Instant::now(),
+            )
+            .unwrap();
+
+        path_mgr.on_response_received(data).unwrap();
+
+        assert_eq!(path_mgr.get_mut(pid).unwrap().validation_requested(), false);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().probing_required(), false);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().under_validation(), false);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().validated(), true);
+        assert_eq!(path_mgr.get_mut(pid).unwrap().state, PathState::Validated);
+        assert_eq!(
+            path_mgr.pop_event(),
+            Some(PathEvent::Validated(client_addr_2, server_addr))
+        );
+    }
+
+    #[test]
+    fn multiple_probes() {
+        let client_addr = "127.0.0.1:1234".parse().unwrap();
+        let server_addr = "127.0.0.1:4321".parse().unwrap();
+
+        let config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        let recovery_config = RecoveryConfig::from_config(&config);
+
+        let path = Path::new(client_addr, server_addr, &recovery_config, true);
+        let mut client_path_mgr = PathMap::new(path, 2, false);
+        let mut server_path =
+            Path::new(server_addr, client_addr, &recovery_config, false);
+
+        let client_pid = client_path_mgr
+            .path_id_from_addrs(&(client_addr, server_addr))
+            .unwrap();
+
+        // First probe.
+        let data = rand::rand_u64().to_be_bytes();
+        client_path_mgr
+            .on_challenge_sent(
+                client_pid,
+                data,
+                MIN_CLIENT_INITIAL_LEN,
+                time::Instant::now(),
+            )
+            .unwrap();
+
+        // Second probe.
+        let data_2 = rand::rand_u64().to_be_bytes();
+        client_path_mgr
+            .on_challenge_sent(
+                client_pid,
+                data_2,
+                MIN_CLIENT_INITIAL_LEN,
+                time::Instant::now(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            client_path_mgr
+                .get(client_pid)
+                .unwrap()
+                .in_flight_challenges
+                .len(),
+            2
+        );
+
+        // If we receive multiple challenges, we can store them.
+        server_path.on_challenge_received(data);
+        assert_eq!(server_path.received_challenges.len(), 1);
+        server_path.on_challenge_received(data_2);
+        assert_eq!(server_path.received_challenges.len(), 2);
+
+        // Response for first probe.
+        client_path_mgr.on_response_received(data).unwrap();
+        assert_eq!(
+            client_path_mgr
+                .get(client_pid)
+                .unwrap()
+                .in_flight_challenges
+                .len(),
+            1
+        );
+
+        // Response for second probe.
+        client_path_mgr.on_response_received(data_2).unwrap();
+        assert_eq!(
+            client_path_mgr
+                .get(client_pid)
+                .unwrap()
+                .in_flight_challenges
+                .len(),
+            0
+        );
+    }
+}

--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -46,6 +46,7 @@ use crate::recovery::Recovery;
 
 pub static CUBIC: CongestionControlOps = CongestionControlOps {
     on_init,
+    reset,
     on_packet_sent,
     on_packets_acked,
     congestion_event,
@@ -146,6 +147,10 @@ impl State {
 }
 
 fn on_init(_r: &mut Recovery) {}
+
+fn reset(r: &mut Recovery) {
+    r.cubic_state = State::default();
+}
 
 fn collapse_cwnd(r: &mut Recovery) {
     let cubic = &mut r.cubic_state;

--- a/quiche/src/recovery/delivery_rate.rs
+++ b/quiche/src/recovery/delivery_rate.rs
@@ -359,7 +359,7 @@ mod tests {
                 now,
                 "",
             ),
-            Ok(()),
+            Ok((0, 0)),
         );
 
         assert_eq!(r.app_limited(), true);

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -40,6 +40,7 @@ use crate::recovery::Recovery;
 
 pub static RENO: CongestionControlOps = CongestionControlOps {
     on_init,
+    reset,
     on_packet_sent,
     on_packets_acked,
     congestion_event,
@@ -51,6 +52,8 @@ pub static RENO: CongestionControlOps = CongestionControlOps {
 };
 
 pub fn on_init(_r: &mut Recovery) {}
+
+pub fn reset(_r: &mut Recovery) {}
 
 pub fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
     r.bytes_in_flight += sent_bytes;

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -119,8 +119,11 @@ pub fn run(
     // Create a QUIC connection and initiate handshake.
     let url = &test.endpoint();
 
+    let local_addr = socket.local_addr().unwrap();
+
     let mut conn =
-        quiche::connect(url.domain(), &scid, peer_addr, &mut config).unwrap();
+        quiche::connect(url.domain(), &scid, local_addr, peer_addr, &mut config)
+            .unwrap();
 
     if let Some(session_file) = &session_file {
         if let Ok(session) = std::fs::read(session_file) {
@@ -182,7 +185,10 @@ pub fn run(
 
             debug!("got {} bytes", len);
 
-            let recv_info = quiche::RecvInfo { from };
+            let recv_info = quiche::RecvInfo {
+                from,
+                to: local_addr,
+            };
 
             // Process potentially coalesced packets.
             let read = match conn.recv(&mut buf[..len], recv_info) {


### PR DESCRIPTION
This PR provides provides connection migration support to quiche. It is composed of 3 incremental parts (the current 3 commits), starting from CID handling support, then path validation and finally connection migration. See the commit messages for further details about the changes introduced by each of them.

Note that while most of the changes are additive, there are a few breaking API changes introduced by the path validation support. Namely,

- `RecvInfo` now contains the `to` field, indicating the local host address on which the packet was received.
- `SendInfo` now contains the `from` field, indicating from which local host address the packet should be sent.
- Both `connect` and `accept` now takes an owned `ConnectionId` for the source CID and an additional `SocketAddr` parameter corresponding to the (initial) local host address that is used by the connection.