### PR TITLE
enable 'ws2def' and 'ws2ipdef' features for winapi 

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -65,7 +65,7 @@ qlog = { version = "0.6", path = "../qlog", optional = true }
 sfv = { version = "0.9", optional = true }
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "0.3", features = ["wincrypt"] }
+winapi = { version = "0.3", features = ["wincrypt", "ws2def", "ws2ipdef"] }
 
 [dev-dependencies]
 mio = { version = "0.8", features = ["net", "os-poll"] }


### PR DESCRIPTION
Not sure how it ever worked, but apparently we need to enable this.