### PR TITLE
apps: allow apps to be compiled without sfv feature

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -33,6 +33,7 @@ use std::io::prelude::*;
 
 use std::collections::HashMap;
 
+#[cfg(feature = "sfv")]
 use std::convert::TryFrom;
 
 use std::fmt::Write as _;
@@ -1147,10 +1148,14 @@ impl Http3Conn {
                 .push(quiche::h3::Header::new(b"priority", priority.as_slice()));
         }
 
+        #[cfg(feature = "sfv")]
         let priority = match quiche::h3::Priority::try_from(priority.as_slice()) {
             Ok(v) => v,
-            Err(_) => Default::default(),
+            Err(_) => quiche::h3::Priority::default(),
         };
+
+        #[cfg(not(feature = "sfv"))]
+        let priority = quiche::h3::Priority::default();
 
         Ok((headers, body, priority))
     }


### PR DESCRIPTION
When we externalized the Priority field value parsing out of quiche,
we provided an optional utility function behind the the `sfv` feature.

In the apps, only the quiche-server requires the `sfv` feature. And we
started by assuming this is a default features. Unfortunately, if trying
to build the quiche-apps crate with `--no-default-features`,
quiche-server will then fail. This is especially annoying because people
have a good reason to build a slimmed-down quiche-client without all the
extra feautres.

This change modifies the quiche-server related code so that is can build
without the `sfv` feature. In this case, any Priority headers or
PRIORITY_UPDATE fields cannot be parsed. Instead, the default priority
is assumed.
