### PR TITLE
only store &mut Connection in SSL ex_data when necessary

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -88,7 +88,7 @@ pub struct PartialResponse {
 }
 
 pub struct Client {
-    pub conn: std::pin::Pin<Box<quiche::Connection>>,
+    pub conn: quiche::Connection,
 
     pub http_conn: Option<Box<dyn HttpConn>>,
 
@@ -267,14 +267,14 @@ pub trait HttpConn {
     fn report_incomplete(&self, start: &std::time::Instant) -> bool;
 
     fn handle_requests(
-        &mut self, conn: &mut std::pin::Pin<Box<quiche::Connection>>,
+        &mut self, conn: &mut quiche::Connection,
         partial_requests: &mut HashMap<u64, PartialRequest>,
         partial_responses: &mut HashMap<u64, PartialResponse>, root: &str,
         index: &str, buf: &mut [u8],
     ) -> quiche::h3::Result<()>;
 
     fn handle_writable(
-        &mut self, conn: &mut std::pin::Pin<Box<quiche::Connection>>,
+        &mut self, conn: &mut quiche::Connection,
         partial_responses: &mut HashMap<u64, PartialResponse>, stream_id: u64,
     );
 }
@@ -638,7 +638,7 @@ impl HttpConn for Http09Conn {
     }
 
     fn handle_requests(
-        &mut self, conn: &mut std::pin::Pin<Box<quiche::Connection>>,
+        &mut self, conn: &mut quiche::Connection,
         partial_requests: &mut HashMap<u64, PartialRequest>,
         partial_responses: &mut HashMap<u64, PartialResponse>, root: &str,
         index: &str, buf: &mut [u8],
@@ -746,7 +746,7 @@ impl HttpConn for Http09Conn {
     }
 
     fn handle_writable(
-        &mut self, conn: &mut std::pin::Pin<Box<quiche::Connection>>,
+        &mut self, conn: &mut quiche::Connection,
         partial_responses: &mut HashMap<u64, PartialResponse>, stream_id: u64,
     ) {
         trace!("{} stream {} is writable", conn.trace_id(), stream_id);
@@ -1438,7 +1438,7 @@ impl HttpConn for Http3Conn {
     }
 
     fn handle_requests(
-        &mut self, conn: &mut std::pin::Pin<Box<quiche::Connection>>,
+        &mut self, conn: &mut quiche::Connection,
         _partial_requests: &mut HashMap<u64, PartialRequest>,
         partial_responses: &mut HashMap<u64, PartialResponse>, root: &str,
         index: &str, buf: &mut [u8],
@@ -1632,7 +1632,7 @@ impl HttpConn for Http3Conn {
     }
 
     fn handle_writable(
-        &mut self, conn: &mut std::pin::Pin<Box<quiche::Connection>>,
+        &mut self, conn: &mut quiche::Connection,
         partial_responses: &mut HashMap<u64, PartialResponse>, stream_id: u64,
     ) {
         debug!("{} stream {} is writable", conn.trace_id(), stream_id);

--- a/quiche/examples/http3-server.rs
+++ b/quiche/examples/http3-server.rs
@@ -46,7 +46,7 @@ struct PartialResponse {
 }
 
 struct Client {
-    conn: std::pin::Pin<Box<quiche::Connection>>,
+    conn: quiche::Connection,
 
     http3_conn: Option<quiche::h3::Connection>,
 

--- a/quiche/examples/server.rs
+++ b/quiche/examples/server.rs
@@ -42,7 +42,7 @@ struct PartialResponse {
 }
 
 struct Client {
-    conn: std::pin::Pin<Box<quiche::Connection>>,
+    conn: quiche::Connection,
 
     partial_responses: HashMap<u64, PartialResponse>,
 }

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -417,7 +417,7 @@ pub extern fn quiche_accept(
     let from = std_addr_from_c(from, from_len);
 
     match accept(&scid, odcid.as_ref(), from, config) {
-        Ok(c) => Box::into_raw(Pin::into_inner(c)),
+        Ok(c) => Box::into_raw(Box::new(c)),
 
         Err(_) => ptr::null_mut(),
     }
@@ -440,7 +440,7 @@ pub extern fn quiche_connect(
     let to = std_addr_from_c(to, to_len);
 
     match connect(server_name, &scid, to, config) {
-        Ok(c) => Box::into_raw(Pin::into_inner(c)),
+        Ok(c) => Box::into_raw(Box::new(c)),
 
         Err(_) => ptr::null_mut(),
     }
@@ -525,7 +525,7 @@ pub extern fn quiche_conn_new_with_tls(
         tls,
         is_server,
     ) {
-        Ok(c) => Box::into_raw(Pin::into_inner(c)),
+        Ok(c) => Box::into_raw(Box::new(c)),
 
         Err(_) => ptr::null_mut(),
     }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -359,7 +359,6 @@ use std::time;
 
 use std::net::SocketAddr;
 
-use std::pin::Pin;
 use std::str::FromStr;
 
 use std::collections::VecDeque;
@@ -1246,7 +1245,7 @@ pub struct Connection {
 pub fn accept(
     scid: &ConnectionId, odcid: Option<&ConnectionId>, from: SocketAddr,
     config: &mut Config,
-) -> Result<Pin<Box<Connection>>> {
+) -> Result<Connection> {
     let conn = Connection::new(scid, odcid, from, config, true)?;
 
     Ok(conn)
@@ -1272,7 +1271,7 @@ pub fn accept(
 pub fn connect(
     server_name: Option<&str>, scid: &ConnectionId, to: SocketAddr,
     config: &mut Config,
-) -> Result<Pin<Box<Connection>>> {
+) -> Result<Connection> {
     let mut conn = Connection::new(scid, None, to, config, false)?;
 
     if let Some(server_name) = server_name {
@@ -1484,7 +1483,7 @@ impl Connection {
     fn new(
         scid: &ConnectionId, odcid: Option<&ConnectionId>, peer: SocketAddr,
         config: &mut Config, is_server: bool,
-    ) -> Result<Pin<Box<Connection>>> {
+    ) -> Result<Connection> {
         let tls = config.tls_ctx.new_handshake()?;
         Connection::with_tls(scid, odcid, peer, config, tls, is_server)
     }
@@ -1492,13 +1491,13 @@ impl Connection {
     fn with_tls(
         scid: &ConnectionId, odcid: Option<&ConnectionId>, peer: SocketAddr,
         config: &mut Config, tls: tls::Handshake, is_server: bool,
-    ) -> Result<Pin<Box<Connection>>> {
+    ) -> Result<Connection> {
         let max_rx_data = config.local_transport_params.initial_max_data;
 
         let scid_as_hex: Vec<String> =
             scid.iter().map(|b| format!("{:02x}", b)).collect();
 
-        let mut conn = Box::pin(Connection {
+        let mut conn = Connection {
             version: config.version,
 
             dcid: ConnectionId::default(),
@@ -1625,7 +1624,7 @@ impl Connection {
             ),
 
             emit_dgram: true,
-        });
+        };
 
         if let Some(odcid) = odcid {
             conn.local_transport_params
@@ -1640,8 +1639,7 @@ impl Connection {
         conn.local_transport_params.initial_source_connection_id =
             Some(scid.to_vec().into());
 
-        let conn_ptr = &conn as &Connection as *const Connection;
-        conn.handshake.init(conn_ptr, is_server)?;
+        conn.handshake.init(is_server)?;
 
         conn.handshake
             .use_legacy_codepoint(config.version != PROTOCOL_VERSION_V1);
@@ -4860,12 +4858,13 @@ impl Connection {
     ///
     /// If the connection is already established, it does nothing.
     fn do_handshake(&mut self) -> Result<()> {
-        if self.handshake_completed {
-            // Handshake is already complete, nothing more to do.
-            return Ok(());
+        let conn_ptr = self as &mut Connection as *mut Connection;
+
+        if self.is_established() {
+            return self.handshake.process_post_handshake(conn_ptr);
         }
 
-        match self.handshake.do_handshake() {
+        match self.handshake.do_handshake(conn_ptr) {
             Ok(_) => (),
 
             Err(Error::Done) => {
@@ -5177,11 +5176,7 @@ impl Connection {
                     self.handshake.provide_data(level, recv_buf)?;
                 }
 
-                if self.is_established() {
-                    self.handshake.process_post_handshake()?;
-                } else {
-                    self.do_handshake()?;
-                }
+                self.do_handshake()?;
             },
 
             frame::Frame::CryptoHeader { .. } => unreachable!(),
@@ -6116,8 +6111,8 @@ pub mod testing {
     use super::*;
 
     pub struct Pipe {
-        pub client: Pin<Box<Connection>>,
-        pub server: Pin<Box<Connection>>,
+        pub client: Connection,
+        pub server: Connection,
     }
 
     impl Pipe {


### PR DESCRIPTION
We currently need to access the quiche connection state during the TLS
handshake inside BoringSSL's various callbacks, and to do this, when a
Connection structure in created, we store a pointer to it in the SSL
state using the "ex data" API.

This however has the disadvantage that the pointer to the Connection
structure needs to be stable for the whole duration of the connection,
which means that Connection is wrapped in `Pin<Box<...>>` to avoid
applications accidentally moving the structure (thus invalidating the
pointer stored in ex_data).

But we don't actually need the ex data pointer during the whole
connection, in fact, we only need it when calling specific BoringSSL
APIs (e.g. `SSL_do_handshake()`) that in turn call the callbacks
registered by quiche, which means that we can actually set the ex data
pointer just before calling those APIs, and clear it immediately after.

This removes the needs to pin the Connection structure, as it can't be
moved while we hold a mutable reference it (due to being inside one of
quiche's methods), and simplifies the API a bit (as applications don't
need the `Pin<Box<...>>` wrapper anymore).

Fixes #1210.