### PR TITLE
qlog: release 0.7

### DIFF
--- a/qlog/Cargo.toml
+++ b/qlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qlog"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Lucas Pardue <lucaspardue.24.7@gmail.com>"]
 edition = "2018"
 description = "qlog data model for QUIC and HTTP/3"

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -61,7 +61,7 @@ lazy_static = "1"
 octets = { version = "0.1", path = "../octets" }
 boring = { version = "2.0.0", optional = true }
 foreign-types-shared = { version = "0.3.0", optional = true }
-qlog = { version = "0.6", path = "../qlog", optional = true }
+qlog = { version = "0.7", path = "../qlog", optional = true }
 sfv = { version = "0.9", optional = true }
 
 [target."cfg(windows)".dependencies]


### PR DESCRIPTION
Changes include:

* Align qlog data model with draft-ietf-quic-qlog-quic-events-01 and
  draft-ietf-quic-qlog-h3-events-01
* Make all qlog streamer serializer event writes atomic. QUIC packet
  events no longer lock the serializer.
* New method `add_event_data_now()` added to the streaming serializer.
