### PR TITLE
dgram: don't allocate full queue upfront

### DIFF
--- a/quiche/src/dgram.rs
+++ b/quiche/src/dgram.rs
@@ -29,6 +29,8 @@ use crate::Result;
 
 use std::collections::VecDeque;
 
+const DGRAM_QUEUE_DEFAULT_LEN: usize = 256;
+
 /// Keeps track of DATAGRAM frames.
 #[derive(Default)]
 pub struct DatagramQueue {
@@ -40,7 +42,9 @@ pub struct DatagramQueue {
 impl DatagramQueue {
     pub fn new(queue_max_len: usize) -> Self {
         DatagramQueue {
-            queue: VecDeque::with_capacity(queue_max_len),
+            queue: VecDeque::with_capacity(
+                DGRAM_QUEUE_DEFAULT_LEN.min(queue_max_len),
+            ),
             queue_bytes_size: 0,
             queue_max_len,
         }


### PR DESCRIPTION
Instead of allocating the max queue size upfront, allocate a smaller
size and allow the queue to grow to the maximum limit.