### PR TITLE
Add a new API for setting application protocols from a slice of byte strings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.56 as build
+FROM rust:1.57 as build
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ is disabled by default), by passing ``--features ffi`` to ``cargo``.
 Building
 --------
 
-quiche requires Rust 1.56 or later to build. The latest stable Rust release can
+quiche requires Rust 1.57 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -402,13 +402,12 @@ fn main() {
                 // we need the value and if something fails at this stage, there
                 // is not much anyone can do to recover.
                 let app_proto = client.conn.application_proto();
-                let app_proto = &std::str::from_utf8(app_proto).unwrap();
 
-                if alpns::HTTP_09.contains(app_proto) {
+                if alpns::HTTP_09.contains(&app_proto) {
                     client.http_conn = Some(Box::new(Http09Conn::default()));
 
                     client.app_proto_selected = true;
-                } else if alpns::HTTP_3.contains(app_proto) {
+                } else if alpns::HTTP_3.contains(&app_proto) {
                     let dgram_sender = if conn_args.dgrams_enabled {
                         Some(Http3DgramSender::new(
                             conn_args.dgram_count,
@@ -426,7 +425,7 @@ fn main() {
                     ));
 
                     client.app_proto_selected = true;
-                } else if alpns::SIDUCK.contains(app_proto) {
+                } else if alpns::SIDUCK.contains(&app_proto) {
                     client.siduck_conn = Some(SiDuckConn::new(
                         conn_args.dgram_count,
                         conn_args.dgram_data.clone(),

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -362,9 +362,8 @@ pub fn connect(
             // is not much anyone can do to recover.
 
             let app_proto = conn.application_proto();
-            let app_proto = &std::str::from_utf8(app_proto).unwrap();
 
-            if alpns::HTTP_09.contains(app_proto) {
+            if alpns::HTTP_09.contains(&app_proto) {
                 http_conn = Some(Http09Conn::with_urls(
                     &args.urls,
                     args.reqs_cardinal,
@@ -372,7 +371,7 @@ pub fn connect(
                 ));
 
                 app_proto_selected = true;
-            } else if alpns::HTTP_3.contains(app_proto) {
+            } else if alpns::HTTP_3.contains(&app_proto) {
                 let dgram_sender = if conn_args.dgrams_enabled {
                     Some(Http3DgramSender::new(
                         conn_args.dgram_count,
@@ -396,7 +395,7 @@ pub fn connect(
                 ));
 
                 app_proto_selected = true;
-            } else if alpns::SIDUCK.contains(app_proto) {
+            } else if alpns::SIDUCK.contains(&app_proto) {
                 siduck_conn = Some(SiDuckConn::new(
                     conn_args.dgram_count,
                     conn_args.dgram_data.clone(),

--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -60,21 +60,10 @@ const H3_MESSAGE_ERROR: u64 = 0x10E;
 ///
 /// This module contains constants and functions for working with ALPN.
 pub mod alpns {
-    pub const HTTP_09: [&str; 5] =
-        ["hq-interop", "hq-29", "hq-28", "hq-27", "http/0.9"];
-    pub const HTTP_3: [&str; 4] = ["h3", "h3-29", "h3-28", "h3-27"];
-    pub const SIDUCK: [&str; 2] = ["siduck", "siduck-00"];
-
-    pub fn length_prefixed(alpns: &[&str]) -> Vec<u8> {
-        let mut out = Vec::new();
-
-        for s in alpns {
-            out.push(s.len() as u8);
-            out.extend_from_slice(s.as_bytes());
-        }
-
-        out
-    }
+    pub const HTTP_09: [&[u8]; 5] =
+        [b"hq-interop", b"hq-29", b"hq-28", b"hq-27", b"http/0.9"];
+    pub const HTTP_3: [&[u8]; 4] = [b"h3", b"h3-29", b"h3-28", b"h3-27"];
+    pub const SIDUCK: [&[u8]; 2] = [b"siduck", b"siduck-00"];
 }
 
 pub struct PartialRequest {

--- a/fuzz/src/packet_recv_client.rs
+++ b/fuzz/src/packet_recv_client.rs
@@ -14,7 +14,7 @@ lazy_static! {
     static ref CONFIG: Mutex<quiche::Config> = {
         let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
         config
-            .set_application_protos(b"\x05hq-23\x08http/0.9")
+            .set_application_protos(&[b"hq-23", b"http/0.9"])
             .unwrap();
         config.set_initial_max_data(30);
         config.set_initial_max_stream_data_bidi_local(15);

--- a/fuzz/src/packet_recv_server.rs
+++ b/fuzz/src/packet_recv_server.rs
@@ -21,7 +21,7 @@ lazy_static! {
         config.load_cert_chain_from_pem_file(&crt_path).unwrap();
         config.load_priv_key_from_pem_file(&key_path).unwrap();
         config
-            .set_application_protos(b"\x05hq-23\x08http/0.9")
+            .set_application_protos(&[b"hq-23", b"http/0.9"])
             .unwrap();
         config.set_initial_max_data(30);
         config.set_initial_max_stream_data_bidi_local(15);

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["quic", "http3"]
 categories = ["network-programming"]
 license = "BSD-2-Clause"
-rust-version = "1.56"
+rust-version = "1.57"
 include = [
     "/*.md",
     "/*.toml",

--- a/quiche/examples/client.rs
+++ b/quiche/examples/client.rs
@@ -81,9 +81,13 @@ fn main() {
     config.verify_peer(false);
 
     config
-        .set_application_protos(
-            b"\x0ahq-interop\x05hq-29\x05hq-28\x05hq-27\x08http/0.9",
-        )
+        .set_application_protos(&[
+            b"hq-interop",
+            b"hq-29",
+            b"hq-28",
+            b"hq-27",
+            b"http/0.9",
+        ])
         .unwrap();
 
     config.set_max_idle_timeout(5000);

--- a/quiche/examples/server.rs
+++ b/quiche/examples/server.rs
@@ -85,9 +85,13 @@ fn main() {
         .unwrap();
 
     config
-        .set_application_protos(
-            b"\x0ahq-interop\x05hq-29\x05hq-28\x05hq-27\x08http/0.9",
-        )
+        .set_application_protos(&[
+            b"hq-interop",
+            b"hq-29",
+            b"hq-28",
+            b"hq-27",
+            b"http/0.9",
+        ])
         .unwrap();
 
     config.set_max_idle_timeout(5000);

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -196,12 +196,14 @@ pub extern fn quiche_config_enable_early_data(config: &mut Config) {
 }
 
 #[no_mangle]
+/// Corresponds to the `Config::set_application_protos_wire_format` Rust
+/// function.
 pub extern fn quiche_config_set_application_protos(
     config: &mut Config, protos: *const u8, protos_len: size_t,
 ) -> c_int {
     let protos = unsafe { slice::from_raw_parts(protos, protos_len) };
 
-    match config.set_application_protos(protos) {
+    match config.set_application_protos_wire_format(protos) {
         Ok(_) => 0,
 
         Err(e) => e.to_c() as c_int,

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -319,7 +319,7 @@ use qlog::events::EventType;
 ///
 /// [`Config::set_application_protos()`]:
 /// ../struct.Config.html#method.set_application_protos
-pub const APPLICATION_PROTOCOL: &[u8] = b"\x02h3\x05h3-29\x05h3-28\x05h3-27";
+pub const APPLICATION_PROTOCOL: &[&[u8]] = &[b"h3", b"h3-29", b"h3-28", b"h3-27"];
 
 // The offset used when converting HTTP/3 urgency to quiche urgency.
 const PRIORITY_URGENCY_OFFSET: u8 = 124;
@@ -2666,7 +2666,7 @@ pub mod testing {
             let mut config = crate::Config::new(crate::PROTOCOL_VERSION)?;
             config.load_cert_chain_from_pem_file("examples/cert.crt")?;
             config.load_priv_key_from_pem_file("examples/cert.key")?;
-            config.set_application_protos(b"\x02h3")?;
+            config.set_application_protos(&[b"h3"])?;
             config.set_initial_max_data(1500);
             config.set_initial_max_stream_data_bidi_local(150);
             config.set_initial_max_stream_data_bidi_remote(150);
@@ -4409,7 +4409,7 @@ mod tests {
         config
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
-        config.set_application_protos(b"\x02h3").unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
         config.set_initial_max_data(1500);
         config.set_initial_max_stream_data_bidi_local(150);
         config.set_initial_max_stream_data_bidi_remote(150);
@@ -4546,7 +4546,7 @@ mod tests {
         config
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
-        config.set_application_protos(b"\x02h3").unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
         config.set_initial_max_data(70);
         config.set_initial_max_stream_data_bidi_local(150);
         config.set_initial_max_stream_data_bidi_remote(150);
@@ -4592,7 +4592,7 @@ mod tests {
         config
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
-        config.set_application_protos(b"\x02h3").unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
         config.set_initial_max_data(70);
         config.set_initial_max_stream_data_bidi_local(150);
         config.set_initial_max_stream_data_bidi_remote(150);
@@ -4702,7 +4702,7 @@ mod tests {
         config
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
-        config.set_application_protos(b"\x02h3").unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
         config.set_initial_max_data(69);
         config.set_initial_max_stream_data_bidi_local(150);
         config.set_initial_max_stream_data_bidi_remote(150);
@@ -4750,7 +4750,7 @@ mod tests {
         config
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
-        config.set_application_protos(b"\x02h3").unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
         config.set_initial_max_data(70);
         config.set_initial_max_stream_data_bidi_local(150);
         config.set_initial_max_stream_data_bidi_remote(150);
@@ -4795,7 +4795,7 @@ mod tests {
         config
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
-        config.set_application_protos(b"\x02h3").unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
         config.set_initial_max_data(70);
         config.set_initial_max_stream_data_bidi_local(150);
         config.set_initial_max_stream_data_bidi_remote(150);
@@ -4845,7 +4845,7 @@ mod tests {
         config
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
-        config.set_application_protos(b"\x02h3").unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
         config.set_initial_max_data(70);
         config.set_initial_max_stream_data_bidi_local(150);
         config.set_initial_max_stream_data_bidi_remote(150);
@@ -5007,7 +5007,7 @@ mod tests {
         config
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
-        config.set_application_protos(b"\x02h3").unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
         config.set_initial_max_data(1500);
         config.set_initial_max_stream_data_bidi_local(150);
         config.set_initial_max_stream_data_bidi_remote(150);
@@ -5055,7 +5055,7 @@ mod tests {
         config
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
-        config.set_application_protos(b"\x02h3").unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
         config.set_initial_max_data(1500);
         config.set_initial_max_stream_data_bidi_local(150);
         config.set_initial_max_stream_data_bidi_remote(150);
@@ -5147,7 +5147,7 @@ mod tests {
         config
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
-        config.set_application_protos(b"\x02h3").unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
         config.set_initial_max_data(1500);
         config.set_initial_max_stream_data_bidi_local(150);
         config.set_initial_max_stream_data_bidi_remote(150);
@@ -5499,7 +5499,7 @@ mod tests {
         config
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
-        config.set_application_protos(b"\x02h3").unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
         config.set_initial_max_data(1500);
         config.set_initial_max_stream_data_bidi_local(150);
         config.set_initial_max_stream_data_bidi_remote(150);

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -294,12 +294,12 @@ impl Context {
         }
     }
 
-    pub fn set_alpn(&mut self, v: &[Vec<u8>]) -> Result<()> {
+    pub fn set_alpn(&mut self, v: &[&[u8]]) -> Result<()> {
         let mut protos: Vec<u8> = Vec::new();
 
         for proto in v {
             protos.push(proto.len() as u8);
-            protos.append(&mut proto.clone());
+            protos.extend_from_slice(proto);
         }
 
         // Configure ALPN for servers.


### PR DESCRIPTION
This avoids requiring clients to do tedious and error-prone length calculations manually.
As a bonus, it avoids some unnecessary copies in quiche itself.

- Relax the lifetime constraints on `Octets`
- Rename `set_application_protos` to `set_application_protos_wire_format`
- Add a new `set_application_protos` function that takes a slice of byte strings
- Change `set_alpn` to take a slice of slices instead of a slice of `Vec`
- Changes apps to use the new API