### PR TITLE
Bump minimum rust version to 1.56

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.54 as build
+FROM rust:1.56 as build
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ is disabled by default), by passing ``--features ffi`` to ``cargo``.
 Building
 --------
 
-quiche requires Rust 1.54 or later to build. The latest stable Rust release can
+quiche requires Rust 1.56 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched


### PR DESCRIPTION
rust_decimal need `edition2021`.