### PR TITLE
Add support for `--trust-origin-ca-pem`

### DIFF
--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -232,6 +232,7 @@ Options:
   -n --requests REQUESTS   Send the given number of identical requests [default: 1].
   --session-file PATH      File used to cache a TLS session for resumption.
   --source-port PORT       Source port to use when connecting to the server [default: 0].
+  --trust-origin-ca-pem <file>  Path to the pem file of the origin's CA, if not publicly trusted.
   -h --help                Show this screen.
 ";
 
@@ -250,6 +251,7 @@ pub struct ClientArgs {
     pub session_file: Option<String>,
     pub source_port: u16,
     pub perform_migration: bool,
+    pub trust_origin_ca_pem: Option<String>,
 }
 
 impl Args for ClientArgs {
@@ -318,6 +320,13 @@ impl Args for ClientArgs {
 
         let perform_migration = args.get_bool("--perform-migration");
 
+        let trust_origin_ca_pem = args.get_str("--trust-origin-ca-pem");
+        let trust_origin_ca_pem = if !trust_origin_ca_pem.is_empty() {
+            Some(trust_origin_ca_pem.to_string())
+        } else {
+            None
+        };
+
         ClientArgs {
             version,
             dump_response_path,
@@ -332,6 +341,7 @@ impl Args for ClientArgs {
             session_file,
             source_port,
             perform_migration,
+            trust_origin_ca_pem,
         }
     }
 }
@@ -352,6 +362,7 @@ impl Default for ClientArgs {
             session_file: None,
             source_port: 0,
             perform_migration: false,
+            trust_origin_ca_pem: None,
         }
     }
 }

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -101,8 +101,18 @@ pub fn connect(
     // Create the configuration for the QUIC connection.
     let mut config = quiche::Config::new(args.version).unwrap();
 
-    config.verify_peer(!args.no_verify);
+    if let Some(ref trust_origin_ca_pem) = args.trust_origin_ca_pem {
+        config
+            .load_verify_locations_from_file(trust_origin_ca_pem)
+            .map_err(|e| {
+                ClientError::Other(format!(
+                    "error loading origin CA file : {}",
+                    e
+                ))
+            })?;
+    }
 
+    config.verify_peer(!args.no_verify);
     config.set_application_protos(&conn_args.alpns).unwrap();
 
     config.set_max_idle_timeout(conn_args.idle_timeout);

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -1022,7 +1022,10 @@ extern fn new_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int {
 fn map_result(bssl_result: c_int) -> Result<()> {
     match bssl_result {
         1 => Ok(()),
-        _ => Err(Error::TlsFail),
+        _ => {
+            log_ssl_error();
+            Err(Error::TlsFail)
+        },
     }
 }
 


### PR DESCRIPTION
This allows testing local servers, not just production servers with a public CA certificate.