### PR TITLE
ci: fixing MinGW cross build, adding to CI

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -135,7 +135,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        target: ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]
+        target: ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-gnu"]
     # Only run on "pull_request" event for external PRs. This is to avoid
     # duplicate builds for PRs created from internal branches.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
@@ -152,6 +152,13 @@ jobs:
           toolchain: ${{ env.TOOLCHAIN }}
           target: ${{ matrix.target }}
           override: true
+
+      - name: Set up MinGW
+        if: matrix.target == 'x86_64-pc-windows-gnu'
+        uses: egor-tensin/setup-mingw@v2
+        with:
+          platform: x64
+          cc: 1
 
       - name: Install dependencies
         uses: crazy-max/ghaction-chocolatey@v1


### PR DESCRIPTION
- Read target_env from CARGO_TARGET_ vars.
- Override _WIN32_WINNT for building in MinGW.
- Fix linking order (-lssl -lcrypto) for MinGW linker.
- Add Windows + MinGW (x86_64-pc-windows-gnu)
  to github workflow (MinGW + 32bit is still broken).