### PR TITLE
ci: disable mingw32 test

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -165,7 +165,15 @@ jobs:
         with:
           args: install nasm
 
+      - name: Run cargo build
+        if: matrix.target == 'x86_64-pc-windows-gnu'
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target=${{ matrix.target }} --verbose --all-targets --features=ffi,qlog
+
       - name: Run cargo test
+        if: matrix.target != 'x86_64-pc-windows-gnu'
         uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
Looks like mingw32 test executable crashes outside the
tests occasionally. Since windows tests are covered by
msvc builds, mingw32 is switched to build only, not
running test to prevent CI flakiness.