### PR TITLE
h3: tweak impl Debug for headers to quote fields and escape embedded quotes

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -240,6 +240,17 @@ fn dump_json(reqs: &[Http3Request], output_sink: &mut dyn FnMut(String)) {
     output_sink(out);
 }
 
+pub fn hdrs_to_strings(hdrs: &[quiche::h3::Header]) -> Vec<(String, String)> {
+    hdrs.iter()
+        .map(|h| {
+            let name = String::from_utf8_lossy(h.name()).to_string();
+            let value = String::from_utf8_lossy(h.value()).to_string();
+
+            (name, value)
+        })
+        .collect()
+}
+
 /// Generate a new pair of Source Connection ID and reset token.
 pub fn generate_cid_and_reset_token<T: SecureRandom>(
     rng: &T,
@@ -1348,7 +1359,8 @@ impl HttpConn for Http3Conn {
                 Ok((stream_id, quiche::h3::Event::Headers { list, .. })) => {
                     debug!(
                         "got response headers {:?} on stream id {}",
-                        &list, stream_id
+                        hdrs_to_strings(&list),
+                        stream_id
                     );
 
                     let req = self
@@ -1523,7 +1535,7 @@ impl HttpConn for Http3Conn {
                     info!(
                         "{} got request {:?} on stream id {}",
                         conn.trace_id(),
-                        &list,
+                        hdrs_to_strings(&list),
                         stream_id
                     );
 

--- a/quiche/examples/http3-client.rs
+++ b/quiche/examples/http3-client.rs
@@ -345,13 +345,13 @@ fn hex_dump(buf: &[u8]) -> String {
     vec.join("")
 }
 
-fn hdrs_to_strings(hdrs: &[quiche::h3::Header]) -> Vec<(String, String)> {
+pub fn hdrs_to_strings(hdrs: &[quiche::h3::Header]) -> Vec<(String, String)> {
     hdrs.iter()
         .map(|h| {
-            (
-                String::from_utf8(h.name().into()).unwrap(),
-                String::from_utf8(h.value().into()).unwrap(),
-            )
+            let name = String::from_utf8_lossy(h.name()).to_string();
+            let value = String::from_utf8_lossy(h.value()).to_string();
+
+            (name, value)
         })
         .collect()
 }

--- a/quiche/examples/http3-server.rs
+++ b/quiche/examples/http3-server.rs
@@ -670,13 +670,13 @@ fn handle_writable(client: &mut Client, stream_id: u64) {
     }
 }
 
-fn hdrs_to_strings(hdrs: &[quiche::h3::Header]) -> Vec<(String, String)> {
+pub fn hdrs_to_strings(hdrs: &[quiche::h3::Header]) -> Vec<(String, String)> {
     hdrs.iter()
         .map(|h| {
-            (
-                String::from_utf8(h.name().into()).unwrap(),
-                String::from_utf8(h.value().into()).unwrap(),
-            )
+            let name = String::from_utf8_lossy(h.name()).to_string();
+            let value = String::from_utf8_lossy(h.value()).to_string();
+
+            (name, value)
         })
         .collect()
 }

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -291,6 +291,7 @@ use std::collections::VecDeque;
 #[cfg(feature = "sfv")]
 use std::convert::TryFrom;
 use std::fmt;
+use std::fmt::Write;
 
 #[cfg(feature = "qlog")]
 use qlog::events::h3::H3FrameCreated;
@@ -568,16 +569,18 @@ pub struct Header(Vec<u8>, Vec<u8>);
 
 fn try_print_as_readable(hdr: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
     match std::str::from_utf8(hdr) {
-        Ok(s) => f.write_str(s),
+        Ok(s) => f.write_str(&s.escape_default().to_string()),
         Err(_) => write!(f, "{:?}", hdr),
     }
 }
 
 impl fmt::Debug for Header {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_char('"')?;
         try_print_as_readable(&self.0, f)?;
         f.write_str(": ")?;
-        try_print_as_readable(&self.1, f)
+        try_print_as_readable(&self.1, f)?;
+        f.write_char('"')
     }
 }
 

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -439,13 +439,13 @@ pub fn run(
     Ok(())
 }
 
-fn hdrs_to_strings(hdrs: &[quiche::h3::Header]) -> Vec<(String, String)> {
+pub fn hdrs_to_strings(hdrs: &[quiche::h3::Header]) -> Vec<(String, String)> {
     hdrs.iter()
         .map(|h| {
-            (
-                String::from_utf8(h.name().into()).unwrap(),
-                String::from_utf8(h.value().into()).unwrap(),
-            )
+            let name = String::from_utf8_lossy(h.name()).to_string();
+            let value = String::from_utf8_lossy(h.value()).to_string();
+
+            (name, value)
         })
         .collect()
 }


### PR DESCRIPTION
Tweaks the debug format slightly so that they can be human-readable and a bit more grepable when values contain comma or quote.

Restores quiche-apps to something closer to the previous format, for legacy consumers

Previous:
```
got response headers [:status: 200, date: Mon, 11 Jul 2022 17:41:05 GMT, content-type: text/html, cf-cache-status: MISS, cf-apo-via: origin,miss, expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct", priority: u=3,i=?0, strict-transport-security: max-age=15552000; preload, lucas: pardue, server: cloudflare, cf-ray: 729353f2dab47545-LHR, alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400] on stream id 0
```

Now:

```
got response headers [(":status", "200"), ("date", "Tue, 12 Jul 2022 14:23:36 GMT"), ("content-type", "text/html"), ("cf-cache-status", "MISS"), ("cf-apo-via", "origin,miss"), ("expect-ct", "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""), ("priority", "u=3,i=?0"), ("strict-transport-security", "max-age=15552000; preload"), ("lucas", "pardue"), ("server", "cloudflare"), ("cf-ray", "729a700daaad0075-LHR"), ("alt-svc", "h3=\":443\"; ma=86400, h3-29=\":443\"; ma=86400")] on stream id 0
```
