### PR TITLE
ffi: fix conversions between SocketAddr and strust sockaddr

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -67,7 +67,7 @@ qlog = { version = "0.7", path = "../qlog", optional = true }
 sfv = { version = "0.9", optional = true }
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "0.3", features = ["wincrypt", "ws2def", "ws2ipdef"] }
+winapi = { version = "0.3", features = ["wincrypt", "ws2def", "ws2ipdef", "ws2tcpip"] }
 
 [dev-dependencies]
 mio = { version = "0.8", features = ["net", "os-poll"] }


### PR DESCRIPTION
Due to https://github.com/rust-lang/rust/pull/78802 we can't simply copy
the binary representation of `SocketAddr` into `struct sockaddr*` and
vice versa, so implement proper conversions.