### PR TITLE
h3: remove dgram API in order to add support for RFC version

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -26,6 +26,7 @@ env_logger = "0.6"
 mio = { version = "0.8", features = ["net", "os-poll"] }
 url = "1"
 log = "0.4"
+octets = { version = "0.2", path = "../octets" }
 ring = "0.16"
 quiche = { path = "../quiche" }
 libc = "0.2"

--- a/nginx/nginx-1.16.patch
+++ b/nginx/nginx-1.16.patch
@@ -2264,7 +2264,7 @@ new file mode 100644
 index 000000000..d7c4fbf1d
 --- /dev/null
 +++ b/src/http/v3/ngx_http_v3.c
-@@ -0,0 +1,2273 @@
+@@ -0,0 +1,2270 @@
 +
 +/*
 + * Copyright (C) Cloudflare, Inc.
@@ -2746,9 +2746,6 @@ index 000000000..d7c4fbf1d
 +            }
 +
 +            case QUICHE_H3_EVENT_PRIORITY_UPDATE:
-+                break;
-+
-+            case QUICHE_H3_EVENT_DATAGRAM:
 +                break;
 +
 +            case QUICHE_H3_EVENT_GOAWAY:

--- a/quiche/examples/http3-client.c
+++ b/quiche/examples/http3-client.c
@@ -313,9 +313,6 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                 case QUICHE_H3_EVENT_PRIORITY_UPDATE:
                     break;
 
-                case QUICHE_H3_EVENT_DATAGRAM:
-                    break;
-
                 case QUICHE_H3_EVENT_GOAWAY: {
                     fprintf(stderr, "got GOAWAY\n");
                     break;

--- a/quiche/examples/http3-client.rs
+++ b/quiche/examples/http3-client.rs
@@ -280,8 +280,6 @@ fn main() {
                         conn.close(true, 0x100, b"kthxbye").unwrap();
                     },
 
-                    Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
-
                     Ok((_, quiche::h3::Event::PriorityUpdate)) => unreachable!(),
 
                     Ok((goaway_id, quiche::h3::Event::GoAway)) => {

--- a/quiche/examples/http3-server.c
+++ b/quiche/examples/http3-server.c
@@ -459,9 +459,6 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
                     case QUICHE_H3_EVENT_PRIORITY_UPDATE:
                         break;
 
-                    case QUICHE_H3_EVENT_DATAGRAM:
-                        break;
-
                     case QUICHE_H3_EVENT_GOAWAY: {
                         fprintf(stderr, "got GOAWAY\n");
                         break;

--- a/quiche/examples/http3-server.rs
+++ b/quiche/examples/http3-server.rs
@@ -367,8 +367,6 @@ fn main() {
 
                         Ok((_stream_id, quiche::h3::Event::Reset { .. })) => (),
 
-                        Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
-
                         Ok((
                             _prioritized_element_id,
                             quiche::h3::Event::PriorityUpdate,

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -659,6 +659,15 @@ ssize_t quiche_conn_send_ack_eliciting_on_path(quiche_conn *conn,
 // Frees the connection object.
 void quiche_conn_free(quiche_conn *conn);
 
+// Writes an unsigned variable-length integer in network byte-order into
+// the provided buffer.
+int quiche_put_varint(uint8_t *buf, size_t buf_len,
+                      uint64_t val);
+
+// Reads an unsigned variable-length integer in network byte-order from
+// the provided buffer and returns the wire length.
+ssize_t quiche_get_varint(const uint8_t *buf, size_t buf_len,
+                          uint64_t val);
 
 // HTTP/3 API
 //
@@ -827,7 +836,6 @@ enum quiche_h3_event_type {
     QUICHE_H3_EVENT_HEADERS,
     QUICHE_H3_EVENT_DATA,
     QUICHE_H3_EVENT_FINISHED,
-    QUICHE_H3_EVENT_DATAGRAM,
     QUICHE_H3_EVENT_GOAWAY,
     QUICHE_H3_EVENT_RESET,
     QUICHE_H3_EVENT_PRIORITY_UPDATE,
@@ -939,15 +947,6 @@ int quiche_h3_take_last_priority_update(quiche_h3_conn *conn,
 // Returns whether the peer enabled HTTP/3 DATAGRAM frame support.
 bool quiche_h3_dgram_enabled_by_peer(quiche_h3_conn *conn,
                                      quiche_conn *quic_conn);
-
-// Writes data to the DATAGRAM send queue.
-ssize_t quiche_h3_send_dgram(quiche_h3_conn *conn, quiche_conn *quic_conn,
-                            uint64_t flow_id, uint8_t *data, size_t data_len);
-
-// Reads data from the DATAGRAM receive queue.
-ssize_t quiche_h3_recv_dgram(quiche_h3_conn *conn, quiche_conn *quic_conn,
-                            uint64_t *flow_id, size_t *flow_id_len,
-                            uint8_t *out, size_t out_len);
 
 // Frees the HTTP/3 connection object.
 void quiche_h3_conn_free(quiche_h3_conn *conn);

--- a/quiche/src/h3/ffi.rs
+++ b/quiche/src/h3/ffi.rs
@@ -143,8 +143,6 @@ pub extern fn quiche_h3_event_type(ev: &h3::Event) -> u32 {
 
         h3::Event::Finished { .. } => 2,
 
-        h3::Event::Datagram { .. } => 3,
-
         h3::Event::GoAway { .. } => 4,
 
         h3::Event::Reset { .. } => 5,
@@ -363,46 +361,6 @@ pub extern fn quiche_h3_dgram_enabled_by_peer(
     conn: &h3::Connection, quic_conn: &Connection,
 ) -> bool {
     conn.dgram_enabled_by_peer(quic_conn)
-}
-
-#[no_mangle]
-pub extern fn quiche_h3_send_dgram(
-    conn: &mut h3::Connection, quic_conn: &mut Connection, flow_id: u64,
-    data: *const u8, data_len: size_t,
-) -> c_int {
-    if data_len > <ssize_t>::max_value() as usize {
-        panic!("The provided buffer is too large");
-    }
-
-    let data = unsafe { slice::from_raw_parts(data, data_len) };
-
-    match conn.send_dgram(quic_conn, flow_id, data) {
-        Ok(_) => 0,
-
-        Err(e) => e.to_c() as c_int,
-    }
-}
-
-#[no_mangle]
-pub extern fn quiche_h3_recv_dgram(
-    conn: &mut h3::Connection, quic_conn: &mut Connection, flow_id: *mut u64,
-    flow_id_len: *mut usize, out: *mut u8, out_len: size_t,
-) -> ssize_t {
-    if out_len > <ssize_t>::max_value() as usize {
-        panic!("The provided buffer is too large");
-    }
-
-    let out = unsafe { slice::from_raw_parts_mut(out, out_len) };
-
-    match conn.recv_dgram(quic_conn, out) {
-        Ok((len, id, id_len)) => {
-            unsafe { *flow_id = id };
-            unsafe { *flow_id_len = id_len };
-            len as ssize_t
-        },
-
-        Err(e) => e.to_c(),
-    }
 }
 
 #[no_mangle]

--- a/quiche/src/h3/frame.rs
+++ b/quiche/src/h3/frame.rs
@@ -242,7 +242,7 @@ impl Frame {
 
                 if let Some(val) = h3_datagram {
                     b.put_varint(SETTINGS_H3_DATAGRAM_00)?;
-                    b.put_varint(*val as u64)?;
+                    b.put_varint(*val)?;
                     b.put_varint(SETTINGS_H3_DATAGRAM)?;
                     b.put_varint(*val)?;
                 }

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -172,8 +172,6 @@
 //!             // Peer reset the stream, handle it.
 //!         },
 //!
-//!         Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
-//!
 //!         Ok((_flow_id, quiche::h3::Event::PriorityUpdate)) => (),
 //!
 //!         Ok((goaway_id, quiche::h3::Event::GoAway)) => {
@@ -234,8 +232,6 @@
 //!         Ok((stream_id, quiche::h3::Event::Reset(err))) => {
 //!             // Peer reset the stream, handle it.
 //!         },
-//!
-//!         Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
 //!
 //!         Ok((_prioritized_element_id, quiche::h3::Event::PriorityUpdate)) => (),
 //!
@@ -685,19 +681,6 @@ pub enum Event {
     /// The associated data represents the error code sent by the peer.
     Reset(u64),
 
-    /// DATAGRAM was received.
-    ///
-    /// This indicates that the application can use the [`recv_dgram()`] method
-    /// to retrieve the HTTP/3 DATAGRAM.
-    ///
-    /// Note that [`recv_dgram()`] will need to be called repeatedly until the
-    /// [`Done`] value is returned, as the event will not be re-armed until all
-    /// buffered DATAGRAMs with the same flow ID are read.
-    ///
-    /// [`recv_dgram()`]: struct.Connection.html#method.recv_dgram
-    /// [`Done`]: enum.Error.html#variant.Done
-    Datagram,
-
     /// PRIORITY_UPDATE was received.
     ///
     /// This indicates that the application can use the
@@ -858,8 +841,6 @@ pub struct Connection {
 
     local_goaway_id: Option<u64>,
     peer_goaway_id: Option<u64>,
-
-    dgram_event_triggered: bool,
 }
 
 impl Connection {
@@ -920,8 +901,6 @@ impl Connection {
 
             local_goaway_id: None,
             peer_goaway_id: None,
-
-            dgram_event_triggered: false,
         })
     }
 
@@ -1338,83 +1317,6 @@ impl Connection {
         self.peer_settings.connect_protocol_enabled == Some(1)
     }
 
-    /// Sends an HTTP/3 DATAGRAM with the specified flow ID.
-    pub fn send_dgram(
-        &mut self, conn: &mut super::Connection, flow_id: u64, buf: &[u8],
-    ) -> Result<()> {
-        let len = octets::varint_len(flow_id) + buf.len();
-        let mut d = vec![0; len];
-        let mut b = octets::OctetsMut::with_slice(&mut d);
-
-        b.put_varint(flow_id)?;
-        b.put_bytes(buf)?;
-
-        conn.dgram_send_vec(d)?;
-
-        Ok(())
-    }
-
-    /// Reads a DATAGRAM into the provided buffer.
-    ///
-    /// Applications should call this method whenever the [`poll()`] method
-    /// returns a [`Datagram`] event.
-    ///
-    /// On success the DATAGRAM data is returned, with length and Flow ID and
-    /// length of the Flow ID.
-    ///
-    /// [`Done`] is returned if there is no data to read.
-    ///
-    /// [`BufferTooShort`] is returned if the provided buffer is too small for
-    /// the data.
-    ///
-    /// [`poll()`]: struct.Connection.html#method.poll
-    /// [`Datagram`]: enum.Event.html#variant.Datagram
-    /// [`Done`]: enum.Error.html#variant.Done
-    /// [`BufferTooShort`]: enum.Error.html#variant.BufferTooShort
-    pub fn recv_dgram(
-        &mut self, conn: &mut super::Connection, buf: &mut [u8],
-    ) -> Result<(usize, u64, usize)> {
-        let len = conn.dgram_recv(buf).map_err(|err| {
-            if matches!(err, super::Error::Done) {
-                self.dgram_event_triggered = false;
-            }
-            err
-        })?;
-        let mut b = octets::Octets::with_slice(buf);
-        let flow_id = b.get_varint()?;
-        Ok((len, flow_id, b.off()))
-    }
-
-    /// Returns the maximum HTTP/3 DATAGRAM payload that can be sent.
-    pub fn dgram_max_writable_len(
-        &self, conn: &super::Connection, flow_id: u64,
-    ) -> Option<usize> {
-        let flow_id_len = octets::varint_len(flow_id);
-        match conn.dgram_max_writable_len() {
-            None => None,
-            Some(len) => len.checked_sub(flow_id_len),
-        }
-    }
-
-    // A helper function for determining if there is a DATAGRAM event.
-    fn process_dgrams(
-        &mut self, conn: &mut super::Connection,
-    ) -> Result<(u64, Event)> {
-        if conn.dgram_recv_queue_len() > 0 {
-            if self.dgram_event_triggered {
-                return Err(Error::Done);
-            }
-
-            self.dgram_event_triggered = true;
-
-            return Ok((0, Event::Datagram));
-        }
-
-        self.dgram_event_triggered = false;
-
-        Err(Error::Done)
-    }
-
     /// Reads request or response body data into the provided buffer.
     ///
     /// Applications should call this method whenever the [`poll()`] method
@@ -1625,9 +1527,6 @@ impl Connection {
     /// which is used in methods [`recv_body()`], [`send_response()`] or
     /// [`send_body()`].
     ///
-    /// The event [`Datagram`] returns a dummy value of `0`, this should be
-    /// ignored by the application.
-    ///
     /// The event [`GoAway`] returns an ID that depends on the connection role.
     /// A client receives the largest processed stream ID. A server receives the
     /// the largest permitted push ID.
@@ -1644,7 +1543,6 @@ impl Connection {
     /// [`Headers`]: enum.Event.html#variant.Headers
     /// [`Data`]: enum.Event.html#variant.Data
     /// [`Finished`]: enum.Event.html#variant.Finished
-    /// [`Datagram`]: enum.Event.html#variant.Datagram
     /// [`GoAway`]: enum.Event.html#variant.GoAWay
     /// [`PriorityUpdate`]: enum.Event.html#variant.PriorityUpdate
     /// [`recv_body()`]: struct.Connection.html#method.recv_body
@@ -1696,15 +1594,6 @@ impl Connection {
         if let Some(finished) = self.finished_streams.pop_front() {
             return Ok((finished, Event::Finished));
         }
-
-        // Process queued DATAGRAMs if the poll threshold allows it.
-        match self.process_dgrams(conn) {
-            Ok(v) => return Ok(v),
-
-            Err(Error::Done) => (),
-
-            Err(e) => return Err(e),
-        };
 
         // Process HTTP/3 data from readable streams.
         for s in conn.readable() {
@@ -3073,9 +2962,14 @@ pub mod testing {
         /// On success it returns the data.
         pub fn send_dgram_client(&mut self, flow_id: u64) -> Result<Vec<u8>> {
             let bytes = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            let len = octets::varint_len(flow_id) + bytes.len();
+            let mut d = vec![0; len];
+            let mut b = octets::OctetsMut::with_slice(&mut d);
 
-            self.client
-                .send_dgram(&mut self.pipe.client, flow_id, &bytes)?;
+            b.put_varint(flow_id)?;
+            b.put_bytes(&bytes)?;
+
+            self.pipe.client.dgram_send(&d)?;
 
             self.advance().ok();
 
@@ -3089,7 +2983,11 @@ pub mod testing {
         pub fn recv_dgram_client(
             &mut self, buf: &mut [u8],
         ) -> Result<(usize, u64, usize)> {
-            self.client.recv_dgram(&mut self.pipe.client, buf)
+            let len = self.pipe.client.dgram_recv(buf)?;
+            let mut b = octets::Octets::with_slice(buf);
+            let flow_id = b.get_varint()?;
+
+            Ok((len, flow_id, b.off()))
         }
 
         /// Send an HTTP/3 DATAGRAM with default data from the server
@@ -3097,9 +2995,14 @@ pub mod testing {
         /// On success it returns the data.
         pub fn send_dgram_server(&mut self, flow_id: u64) -> Result<Vec<u8>> {
             let bytes = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            let len = octets::varint_len(flow_id) + bytes.len();
+            let mut d = vec![0; len];
+            let mut b = octets::OctetsMut::with_slice(&mut d);
 
-            self.server
-                .send_dgram(&mut self.pipe.server, flow_id, &bytes)?;
+            b.put_varint(flow_id)?;
+            b.put_bytes(&bytes)?;
+
+            self.pipe.server.dgram_send(&d)?;
 
             self.advance().ok();
 
@@ -3113,7 +3016,11 @@ pub mod testing {
         pub fn recv_dgram_server(
             &mut self, buf: &mut [u8],
         ) -> Result<(usize, u64, usize)> {
-            self.server.recv_dgram(&mut self.pipe.server, buf)
+            let len = self.pipe.server.dgram_recv(buf)?;
+            let mut b = octets::Octets::with_slice(buf);
+            let flow_id = b.get_varint()?;
+
+            Ok((len, flow_id, b.off()))
         }
 
         /// Sends a single HTTP/3 frame from the server.
@@ -5576,12 +5483,11 @@ mod tests {
 
         s.send_dgram_client(0).unwrap();
 
-        assert_eq!(s.poll_server(), Ok((0, Event::Datagram)));
-        assert_eq!(s.recv_dgram_server(&mut buf), Ok(result));
         assert_eq!(s.poll_server(), Err(Error::Done));
+        assert_eq!(s.recv_dgram_server(&mut buf), Ok(result));
 
         s.send_dgram_server(0).unwrap();
-        assert_eq!(s.poll_client(), Ok((0, Event::Datagram)));
+        assert_eq!(s.poll_client(), Err(Error::Done));
         assert_eq!(s.recv_dgram_client(&mut buf), Ok(result));
     }
 
@@ -5599,30 +5505,21 @@ mod tests {
         s.send_dgram_client(0).unwrap();
         s.send_dgram_client(0).unwrap();
 
-        assert_eq!(s.poll_server(), Ok((0, Event::Datagram)));
-        assert_eq!(s.recv_dgram_server(&mut buf), Ok(result));
         assert_eq!(s.poll_server(), Err(Error::Done));
         assert_eq!(s.recv_dgram_server(&mut buf), Ok(result));
-        assert_eq!(s.poll_server(), Err(Error::Done));
         assert_eq!(s.recv_dgram_server(&mut buf), Ok(result));
-        assert_eq!(s.poll_server(), Err(Error::Done));
+        assert_eq!(s.recv_dgram_server(&mut buf), Ok(result));
         assert_eq!(s.recv_dgram_server(&mut buf), Err(Error::Done));
-        assert_eq!(s.poll_server(), Err(Error::Done));
 
         s.send_dgram_server(0).unwrap();
         s.send_dgram_server(0).unwrap();
         s.send_dgram_server(0).unwrap();
 
-        assert_eq!(s.poll_client(), Ok((0, Event::Datagram)));
-        assert_eq!(s.poll_server(), Err(Error::Done));
-        assert_eq!(s.recv_dgram_client(&mut buf), Ok(result));
         assert_eq!(s.poll_client(), Err(Error::Done));
         assert_eq!(s.recv_dgram_client(&mut buf), Ok(result));
-        assert_eq!(s.poll_client(), Err(Error::Done));
         assert_eq!(s.recv_dgram_client(&mut buf), Ok(result));
-        assert_eq!(s.poll_client(), Err(Error::Done));
+        assert_eq!(s.recv_dgram_client(&mut buf), Ok(result));
         assert_eq!(s.recv_dgram_client(&mut buf), Err(Error::Done));
-        assert_eq!(s.poll_client(), Err(Error::Done));
     }
 
     #[test]
@@ -5642,22 +5539,17 @@ mod tests {
         s.send_dgram_client(0).unwrap();
         s.send_dgram_client(0).unwrap();
 
-        // Only 3 independent DATAGRAM events will fire.
-        assert_eq!(s.poll_server(), Ok((0, Event::Datagram)));
-        assert_eq!(s.recv_dgram_server(&mut buf), Ok(result));
+        // Only 3 independent DATAGRAMs to read events will fire.
         assert_eq!(s.poll_server(), Err(Error::Done));
         assert_eq!(s.recv_dgram_server(&mut buf), Ok(result));
-        assert_eq!(s.poll_server(), Err(Error::Done));
         assert_eq!(s.recv_dgram_server(&mut buf), Ok(result));
-        assert_eq!(s.poll_server(), Err(Error::Done));
+        assert_eq!(s.recv_dgram_server(&mut buf), Ok(result));
         assert_eq!(s.recv_dgram_server(&mut buf), Err(Error::Done));
-        assert_eq!(s.poll_server(), Err(Error::Done));
     }
 
     #[test]
-    /// Send a single DATAGRAM and request. Ensure that poll continuously cycles
-    /// between the two types if the data is not read.
-    fn poll_yield_cycling() {
+    /// Send a single DATAGRAM and request.
+    fn poll_datagram_cycling_no_read() {
         let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
         config
             .load_cert_chain_from_pem_file("examples/cert.crt")
@@ -5691,9 +5583,6 @@ mod tests {
 
         s.send_dgram_client(0).unwrap();
 
-        // Now let's test the poll counts and yielding.
-        assert_eq!(s.poll_server(), Ok((0, Event::Datagram)));
-
         assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
         assert_eq!(s.poll_server(), Ok((stream, Event::Data)));
 
@@ -5701,9 +5590,8 @@ mod tests {
     }
 
     #[test]
-    /// Send a single DATAGRAM and request. Ensure that poll
-    /// yield cycles and cleanly exits if data is read.
-    fn poll_yield_single_read() {
+    /// Send a single DATAGRAM and request.
+    fn poll_datagram_single_read() {
         let mut buf = [0; 65535];
 
         let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
@@ -5744,9 +5632,6 @@ mod tests {
 
         s.send_dgram_client(0).unwrap();
 
-        // Now let's test the poll counts and yielding.
-        assert_eq!(s.poll_server(), Ok((0, Event::Datagram)));
-
         assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
         assert_eq!(s.poll_server(), Ok((stream, Event::Data)));
 
@@ -5774,9 +5659,6 @@ mod tests {
 
         s.send_dgram_server(0).unwrap();
 
-        // Now let's test the poll counts and yielding.
-        assert_eq!(s.poll_client(), Ok((0, Event::Datagram)));
-
         assert_eq!(s.poll_client(), Ok((stream, ev_headers)));
         assert_eq!(s.poll_client(), Ok((stream, Event::Data)));
 
@@ -5793,9 +5675,8 @@ mod tests {
     }
 
     #[test]
-    /// Send a multiple DATAGRAMs and requests. Ensure that poll
-    /// yield cycles and cleanly exits if data is read.
-    fn poll_yield_multi_read() {
+    /// Send multiple DATAGRAMs and requests.
+    fn poll_datagram_multi_read() {
         let mut buf = [0; 65535];
 
         let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
@@ -5845,9 +5726,6 @@ mod tests {
         s.send_dgram_client(2).unwrap();
         s.send_dgram_client(2).unwrap();
         s.send_dgram_client(2).unwrap();
-
-        // Now let's test the poll counts and yielding.
-        assert_eq!(s.poll_server(), Ok((0, Event::Datagram)));
 
         assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
         assert_eq!(s.poll_server(), Ok((stream, Event::Data)));
@@ -5905,8 +5783,6 @@ mod tests {
         s.send_dgram_server(2).unwrap();
         s.send_dgram_server(2).unwrap();
         s.send_dgram_server(2).unwrap();
-
-        assert_eq!(s.poll_client(), Ok((0, Event::Datagram)));
 
         assert_eq!(s.poll_client(), Ok((stream, ev_headers)));
         assert_eq!(s.poll_client(), Ok((stream, Event::Data)));
@@ -6192,8 +6068,6 @@ mod tests {
         s.send_dgram_client(2).unwrap();
         s.send_dgram_client(2).unwrap();
 
-        assert_eq!(s.poll_server(), Ok((0, Event::Datagram)));
-
         assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
         assert_eq!(s.poll_server(), Ok((stream, Event::Data)));
 
@@ -6214,7 +6088,6 @@ mod tests {
         s.send_dgram_client(0).unwrap();
         s.send_dgram_client(2).unwrap();
 
-        assert_eq!(s.poll_server(), Ok((0, Event::Datagram)));
         assert_eq!(s.poll_server(), Err(Error::Done));
 
         assert_eq!(s.recv_dgram_server(&mut buf), Ok(flow_0_result));

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -360,8 +360,6 @@ pub fn run(
                         }
                     },
 
-                    Ok((_flow_id, quiche::h3::Event::Datagram)) => (),
-
                     Ok((_, quiche::h3::Event::PriorityUpdate)) => (),
 
                     Ok((_goaway_id, quiche::h3::Event::GoAway)) => (),


### PR DESCRIPTION
h3: add HTTP/3 datagram RFC version
    
    With this change, we add support for advertising the HTTP/3 datagram SETTING
    value (0x33) defined in draft 11 and RFC-to-be when an h3 Connection is
    configured to have datagrams enabled.
    
    The format of the the HTTP/3 datagrams are pretty much structurally identical,
    so there is not much meaningful difference between versions. Applications that
    rely on HTTP/3 datagrams, such as to use CONNECT-UDP, would apply their own
    semantics to these datagrams and can manage that themselves. Therefore, this
    change doesn't provide fine grain control over versions.

h3: remove HTTP/3 datagram API
    
    An HTTP/3 datagram is a series of fields carried in a QUIC DATAGRAM frame
    payload. In draft 00, draft 11 and what will be the RFC there is a single field,
    which is a variable-length integer.
    
    Previously, the h3 module provided support functions that were a thin shim over
    quiche's transport-layer datagram methods, which helped with the variable-length
    encoding of the first field in the HTTP/3 datagram. However, in the meantime we
    spun out the Octets crate, which allows applications to easily handle varints
    themselves. Furthermore, changes in specifications like CONNECT-UDP mean that
    applications are probably required to do additional processing of varint fields
    that might exist after the first field. At this stage, the h3 datagram API
    provides minimal utility and in the worst case is confusing for applications
    that would use it for different purposes.
    
    This change removes quiche::h3::send_dgram() and quiche::h3::recv_dgram()
    functions. Instead applications are now responsible for serialization /
    deserialization of HTTP/3 datagrams, with the recommendation being that they use
    the Octets crate. This is demonstrated by related changes to the apps.
    
    Since the Octets crate does not provide a C API itself, helper function have
    been added to quiche's C API to support varint handling.

