### PR TITLE
fix clippy lints

### DIFF
--- a/octets/src/lib.rs
+++ b/octets/src/lib.rs
@@ -37,7 +37,7 @@ pub type Result<T> = std::result::Result<T, BufferTooShortError>;
 /// An error indicating that the provided [`OctetsMut`] is not big enough.
 ///
 /// [`OctetsMut`]: struct.OctetsMut.html
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BufferTooShortError;
 
 impl std::fmt::Display for BufferTooShortError {
@@ -118,7 +118,7 @@ macro_rules! put_u {
 /// Additionally, an offset (initially set to the start of the buffer) is
 /// incremented as bytes are read from / written to the buffer, to allow for
 /// sequential operations.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Octets<'a> {
     buf: &'a [u8],
     off: usize,
@@ -320,7 +320,7 @@ impl<'a> AsRef<[u8]> for Octets<'a> {
 /// A zero-copy mutable byte buffer.
 ///
 /// Like `Octets` but mutable.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct OctetsMut<'a> {
     buf: &'a mut [u8],
     off: usize,

--- a/qlog/src/events/connectivity.rs
+++ b/qlog/src/events/connectivity.rs
@@ -31,14 +31,14 @@ use super::ApplicationErrorCode;
 use super::Bytes;
 use super::ConnectionErrorCode;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum TransportOwner {
     Local,
     Remote,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectionState {
     Attempted,
@@ -52,7 +52,7 @@ pub enum ConnectionState {
     Closed,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectivityEventType {
     ServerListening,
@@ -63,7 +63,7 @@ pub enum ConnectivityEventType {
     ConnectionStateUpdated,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectionClosedTrigger {
     Clean,
@@ -76,7 +76,7 @@ pub enum ConnectionClosedTrigger {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct ServerListening {
     pub ip_v4: Option<String>, // human-readable or bytes
     pub ip_v6: Option<String>, // human-readable or bytes
@@ -87,7 +87,7 @@ pub struct ServerListening {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct ConnectionStarted {
     pub ip_version: Option<String>, // "v4" or "v6"
     pub src_ip: String,             // human-readable or bytes
@@ -102,7 +102,7 @@ pub struct ConnectionStarted {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct ConnectionClosed {
     pub owner: Option<TransportOwner>,
 
@@ -116,7 +116,7 @@ pub struct ConnectionClosed {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct ConnectionIdUpdated {
     pub owner: Option<TransportOwner>,
 
@@ -125,13 +125,13 @@ pub struct ConnectionIdUpdated {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct SpinBitUpdated {
     pub state: bool,
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct ConnectionStateUpdated {
     pub old: Option<ConnectionState>,
     pub new: ConnectionState,

--- a/qlog/src/events/h3.rs
+++ b/qlog/src/events/h3.rs
@@ -30,14 +30,14 @@ use serde::Serialize;
 use super::RawInfo;
 use crate::Bytes;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum H3Owner {
     Local,
     Remote,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum H3StreamType {
     Data,
@@ -49,21 +49,21 @@ pub enum H3StreamType {
     Unknown,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum H3PushDecision {
     Claimed,
     Abandoned,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum H3PriorityTargetStreamType {
     Request,
     Push,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Http3EventType {
     ParametersSet,
@@ -74,7 +74,7 @@ pub enum Http3EventType {
     PushResolved,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ApplicationError {
     HttpNoError,
@@ -97,19 +97,19 @@ pub enum ApplicationError {
     Unknown,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct HttpHeader {
     pub name: String,
     pub value: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct Setting {
     pub name: String,
     pub value: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Http3FrameTypeName {
     Data,
@@ -125,7 +125,7 @@ pub enum Http3FrameTypeName {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(tag = "frame_type")]
 #[serde(rename_all = "snake_case")]
 // Strictly, the qlog spec says that all these frame types have a frame_type
@@ -180,7 +180,7 @@ pub enum Http3Frame {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct H3ParametersSet {
     pub owner: Option<H3Owner>,
 
@@ -193,7 +193,7 @@ pub struct H3ParametersSet {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct H3ParametersRestored {
     pub max_header_list_size: Option<u64>,
     pub max_table_capacity: Option<u64>,
@@ -201,7 +201,7 @@ pub struct H3ParametersRestored {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct H3StreamTypeSet {
     pub stream_id: u64,
     pub owner: Option<H3Owner>,
@@ -213,7 +213,7 @@ pub struct H3StreamTypeSet {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct H3FrameCreated {
     pub stream_id: u64,
     pub length: Option<u64>,
@@ -223,7 +223,7 @@ pub struct H3FrameCreated {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct H3FrameParsed {
     pub stream_id: u64,
     pub length: Option<u64>,
@@ -233,7 +233,7 @@ pub struct H3FrameParsed {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct H3PushResolved {
     push_id: Option<u64>,
     stream_id: Option<u64>,

--- a/qlog/src/events/mod.rs
+++ b/qlog/src/events/mod.rs
@@ -35,7 +35,7 @@ use connectivity::ConnectivityEventType;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(untagged)]
 pub enum EventType {
     ConnectivityEventType(ConnectivityEventType),
@@ -61,7 +61,7 @@ impl Default for EventType {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum TimeFormat {
     Absolute,
     Delta,
@@ -438,7 +438,7 @@ impl From<&EventData> for EventType {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum DataRecipient {
     User,
@@ -448,7 +448,7 @@ pub enum DataRecipient {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct RawInfo {
     pub length: Option<u64>,
     pub payload_length: Option<u64>,
@@ -649,7 +649,7 @@ impl EventData {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum GenericEventType {
     ConnectionError,
@@ -661,7 +661,7 @@ pub enum GenericEventType {
     Marker,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(untagged)]
 pub enum ConnectionErrorCode {
     TransportError(TransportError),
@@ -669,7 +669,7 @@ pub enum ConnectionErrorCode {
     Value(u64),
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(untagged)]
 pub enum ApplicationErrorCode {
     ApplicationError(ApplicationError),
@@ -677,7 +677,7 @@ pub enum ApplicationErrorCode {
 }
 
 // TODO
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum CryptoError {
     Prefix,

--- a/qlog/src/events/qpack.rs
+++ b/qlog/src/events/qpack.rs
@@ -30,7 +30,7 @@ use serde::Serialize;
 use super::h3::HttpHeader;
 use super::Bytes;
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum QpackEventType {
     StateUpdated,
@@ -42,42 +42,42 @@ pub enum QpackEventType {
     InstructionParsed,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum QpackOwner {
     Local,
     Remote,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum QpackStreamState {
     Blocked,
     Unblocked,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum QpackUpdateType {
     Added,
     Evicted,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct QpackDynamicTableEntry {
     pub index: u64,
     pub name: Option<String>,
     pub value: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct QpackHeaderBlockPrefix {
     pub required_insert_count: u64,
     pub sign_bit: bool,
     pub delta_base: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum QpackInstructionTypeName {
     SetDynamicTableCapacityInstruction,
@@ -89,14 +89,14 @@ pub enum QpackInstructionTypeName {
     InsertCountIncrementInstruction,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum QpackTableType {
     Static,
     Dynamic,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum QPackInstruction {
     SetDynamicTableCapacityInstruction {
         instruction_type: QpackInstructionTypeName,
@@ -153,7 +153,7 @@ pub enum QPackInstruction {
     },
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum QpackHeaderBlockRepresentationTypeName {
     IndexedHeaderField,
@@ -161,7 +161,7 @@ pub enum QpackHeaderBlockRepresentationTypeName {
     LiteralHeaderFieldWithoutName,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum QpackHeaderBlockRepresentation {
     IndexedHeaderField {
         header_field_type: QpackHeaderBlockRepresentationTypeName,
@@ -206,7 +206,7 @@ pub enum QpackHeaderBlockRepresentation {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct QpackStateUpdated {
     pub owner: Option<QpackOwner>,
 
@@ -218,7 +218,7 @@ pub struct QpackStateUpdated {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct QpackStreamStateUpdated {
     pub stream_id: u64,
 
@@ -226,7 +226,7 @@ pub struct QpackStreamStateUpdated {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct QpackDynamicTableUpdated {
     pub update_type: QpackUpdateType,
 
@@ -234,7 +234,7 @@ pub struct QpackDynamicTableUpdated {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct QpackHeadersEncoded {
     pub stream_id: Option<u64>,
 
@@ -248,7 +248,7 @@ pub struct QpackHeadersEncoded {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct QpackHeadersDecoded {
     pub stream_id: Option<u64>,
 
@@ -262,7 +262,7 @@ pub struct QpackHeadersDecoded {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct QpackInstructionCreated {
     pub instruction: QPackInstruction,
 
@@ -271,7 +271,7 @@ pub struct QpackInstructionCreated {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct QpackInstructionParsed {
     pub instruction: QPackInstruction,
 

--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -34,7 +34,7 @@ use super::RawInfo;
 use super::Token;
 use crate::HexSlice;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum PacketType {
     Initial,
@@ -51,7 +51,7 @@ pub enum PacketType {
     Unknown,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum PacketNumberSpace {
     Initial,
@@ -60,7 +60,7 @@ pub enum PacketNumberSpace {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct PacketHeader {
     pub packet_type: PacketType,
     pub packet_number: u64,
@@ -155,21 +155,21 @@ impl PacketHeader {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum StreamType {
     Bidirectional,
     Unidirectional,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum StreamSide {
     Sending,
     Receiving,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum StreamState {
     // bidirectional stream states, draft-23 3.4.
@@ -199,14 +199,14 @@ pub enum StreamState {
     Destroyed,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorSpace {
     TransportError,
     ApplicationError,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum TransportError {
     NoError,
@@ -226,7 +226,7 @@ pub enum TransportError {
     Unknown,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum TransportEventType {
     VersionInformation,
@@ -252,7 +252,7 @@ pub enum TransportEventType {
     DataMoved,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum PacketSentTrigger {
     RetransmitReordered,
@@ -262,13 +262,13 @@ pub enum PacketSentTrigger {
     CcBandwidthProbe,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum PacketReceivedTrigger {
     KeysUnavailable,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum PacketDroppedTrigger {
     KeysUnavailable,
@@ -285,21 +285,21 @@ pub enum PacketDroppedTrigger {
     InvalidInitial,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum PacketBufferedTrigger {
     Backpressure,
     KeysUnavailable,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum SecurityEventType {
     KeyUpdated,
     KeyRetired,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum RecoveryEventType {
     ParametersSet,
@@ -310,14 +310,14 @@ pub enum RecoveryEventType {
     MarkedForRetransmit,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum CongestionStateUpdatedTrigger {
     PersistentCongestion,
     Ecn,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum PacketLostTrigger {
     ReorderingThreshold,
@@ -325,7 +325,7 @@ pub enum PacketLostTrigger {
     PtoExpired,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum LossTimerEventType {
     Set,
@@ -333,21 +333,21 @@ pub enum LossTimerEventType {
     Cancelled,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum TimerType {
     Ack,
     Pto,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(untagged)]
 pub enum AckedRanges {
     Single(Vec<Vec<u64>>),
     Double(Vec<(u64, u64)>),
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum QuicFrameTypeName {
     Padding,
@@ -500,7 +500,7 @@ pub enum QuicFrame {
     },
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct PreferredAddress {
     pub ip_v4: String,
     pub ip_v6: String,
@@ -513,7 +513,7 @@ pub struct PreferredAddress {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct VersionInformation {
     pub server_versions: Option<Vec<Bytes>>,
     pub client_versions: Option<Vec<Bytes>>,
@@ -521,7 +521,7 @@ pub struct VersionInformation {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct AlpnInformation {
     pub server_alpns: Option<Vec<Bytes>>,
     pub client_alpns: Option<Vec<Bytes>>,
@@ -529,7 +529,7 @@ pub struct AlpnInformation {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct TransportParametersSet {
     pub owner: Option<TransportOwner>,
 
@@ -561,7 +561,7 @@ pub struct TransportParametersSet {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct TransportParametersRestored {
     pub disable_active_migration: Option<bool>,
 
@@ -578,7 +578,7 @@ pub struct TransportParametersRestored {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct DatagramsReceived {
     pub count: Option<u16>,
 
@@ -588,7 +588,7 @@ pub struct DatagramsReceived {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct DatagramsSent {
     pub count: Option<u16>,
 
@@ -598,7 +598,7 @@ pub struct DatagramsSent {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct DatagramDropped {
     pub raw: Option<RawInfo>,
 }
@@ -650,7 +650,7 @@ pub struct PacketSent {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct PacketDropped {
     pub header: Option<PacketHeader>,
 
@@ -661,7 +661,7 @@ pub struct PacketDropped {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct PacketBuffered {
     pub header: Option<PacketHeader>,
 
@@ -672,14 +672,14 @@ pub struct PacketBuffered {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct PacketsAcked {
     pub packet_number_space: Option<PacketNumberSpace>,
     pub packet_numbers: Option<Vec<u64>>,
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct StreamStateUpdated {
     pub stream_id: u64,
     pub stream_type: Option<StreamType>,
@@ -699,7 +699,7 @@ pub struct FramesProcessed {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct DataMoved {
     pub stream_id: Option<u64>,
     pub offset: Option<u64>,
@@ -748,7 +748,7 @@ pub struct MetricsUpdated {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct CongestionStateUpdated {
     pub old: Option<String>,
     pub new: String,

--- a/qlog/src/events/security.rs
+++ b/qlog/src/events/security.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use super::Bytes;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum KeyType {
     ServerInitialSecret,
@@ -48,7 +48,7 @@ pub enum KeyType {
     Client1RttSecret,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum KeyUpdateOrRetiredTrigger {
     Tls,
@@ -57,7 +57,7 @@ pub enum KeyUpdateOrRetiredTrigger {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct KeyUpdated {
     pub key_type: KeyType,
 
@@ -70,7 +70,7 @@ pub struct KeyUpdated {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct KeyRetired {
     pub key_type: KeyType,
     pub key: Option<Bytes>,

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -559,7 +559,7 @@ impl TraceSeq {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct VantagePoint {
     pub name: Option<String>,
 
@@ -569,7 +569,7 @@ pub struct VantagePoint {
     pub flow: Option<VantagePointType>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum VantagePointType {
     Client,
@@ -607,7 +607,7 @@ pub struct CommonFields {
     // TODO: additionalUserSpecifiedProperty
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum TokenType {
     Retry,
@@ -616,7 +616,7 @@ pub enum TokenType {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct Token {
     #[serde(rename(serialize = "type"))]
     pub ty: Option<TokenType>,
@@ -747,7 +747,7 @@ mod tests {
 
         let pkt_hdr = make_pkt_hdr(PacketType::Initial);
         let ev_data = EventData::PacketSent(PacketSent {
-            header: pkt_hdr.clone(),
+            header: pkt_hdr,
             frames: None,
             is_coalesced: None,
             retry_token: None,
@@ -818,7 +818,7 @@ mod tests {
         });
 
         let ev_data = EventData::PacketSent(PacketSent {
-            header: pkt_hdr.clone(),
+            header: pkt_hdr,
             frames: Some(frames),
             is_coalesced: None,
             retry_token: None,

--- a/qlog/src/streamer.rs
+++ b/qlog/src/streamer.rs
@@ -40,7 +40,7 @@ use crate::events::EventType;
 /// [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 use super::*;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum StreamerState {
     Initial,
     Ready,
@@ -306,7 +306,7 @@ mod tests {
             retry_token: None,
             stateless_reset_token: Some("reset_token".to_string()),
             supported_versions: None,
-            raw: raw.clone(),
+            raw,
             datagram_id: None,
             trigger: None,
         });
@@ -341,7 +341,7 @@ mod tests {
         // here, not timing specifics.
         let now = std::time::Instant::now();
 
-        assert!(matches!(s.add_event_with_instant(ev3.clone(), now), Ok(())));
+        assert!(matches!(s.add_event_with_instant(ev3, now), Ok(())));
 
         assert!(matches!(s.finish_log(), Ok(())));
 

--- a/quiche/src/crypto.rs
+++ b/quiche/src/crypto.rs
@@ -38,7 +38,7 @@ use crate::Result;
 use crate::packet;
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Level {
     Initial   = 0,
     ZeroRTT   = 1,
@@ -60,7 +60,7 @@ impl Level {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Algorithm {
     #[allow(non_camel_case_types)]
     AES128_GCM,

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -47,14 +47,14 @@ pub const MAX_DGRAM_OVERHEAD: usize = 2;
 pub const MAX_STREAM_OVERHEAD: usize = 12;
 pub const MAX_STREAM_SIZE: u64 = 1 << 62;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EcnCounts {
     ect0_count: u64,
     ect1_count: u64,
     ecn_ce_count: u64,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum Frame {
     Padding {
         len: usize,
@@ -1377,7 +1377,7 @@ mod tests {
         };
 
         assert_eq!(wire_len, 1);
-        assert_eq!(&d[..wire_len], [0x01 as u8]);
+        assert_eq!(&d[..wire_len], [0x01_u8]);
 
         let mut b = octets::Octets::with_slice(&d);
         assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));

--- a/quiche/src/h3/frame.rs
+++ b/quiche/src/h3/frame.rs
@@ -47,7 +47,7 @@ pub const SETTINGS_H3_DATAGRAM: u64 = 0x276;
 // Permit between 16 maximally-encoded and 128 minimally-encoded SETTINGS.
 const MAX_SETTINGS_PAYLOAD_SIZE: usize = 256;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum Frame {
     Data {
         payload: Vec<u8>,

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -355,7 +355,7 @@ const QLOG_STREAM_TYPE_SET: EventType =
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// An HTTP/3 error.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
     /// There is no error or no work to do
     Done,
@@ -564,7 +564,7 @@ pub trait NameValue {
 }
 
 /// An owned name-value pair representing a raw HTTP header.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Header(Vec<u8>, Vec<u8>);
 
 fn try_print_as_readable(hdr: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
@@ -604,7 +604,7 @@ impl NameValue for Header {
 }
 
 /// A non-owned name-value pair representing a raw HTTP header.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HeaderRef<'a>(&'a [u8], &'a [u8]);
 
 impl<'a> HeaderRef<'a> {
@@ -625,7 +625,7 @@ impl<'a> NameValue for HeaderRef<'a> {
 }
 
 /// An HTTP/3 connection event.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Event {
     /// Request/response headers were received.
     Headers {
@@ -696,7 +696,7 @@ pub enum Event {
 /// Structured Fields Dictionary field value. I.e, use `TryFrom` to parse the
 /// value of a Priority header field or a PRIORITY_UPDATE frame. Using this
 /// trait requires the `sfv` feature to be enabled.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct Priority {
     urgency: u8,

--- a/quiche/src/h3/qpack/mod.rs
+++ b/quiche/src/h3/qpack/mod.rs
@@ -40,7 +40,7 @@ const LITERAL_WITH_NAME_REF: u8 = 0b0100_0000;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// A QPACK error.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
     /// The provided buffer is too short.
     BufferTooShort,

--- a/quiche/src/h3/stream.rs
+++ b/quiche/src/h3/stream.rs
@@ -36,7 +36,7 @@ pub const QPACK_DECODER_STREAM_TYPE_ID: u64 = 0x3;
 
 const MAX_STATE_BUF_SIZE: usize = (1 << 24) - 1;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Type {
     Control,
     Request,
@@ -60,7 +60,7 @@ impl Type {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum State {
     /// Reading the stream's type.
     StreamType,

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -62,7 +62,7 @@ pub const EPOCH_COUNT: usize = 3;
 pub type Epoch = usize;
 
 /// QUIC packet type.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Type {
     /// Initial packet.
     Initial,
@@ -238,7 +238,7 @@ impl<'a> std::fmt::Debug for ConnectionId<'a> {
 }
 
 /// A QUIC packet's header.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Header<'a> {
     /// The type of the packet.
     pub ty: Type,
@@ -970,7 +970,7 @@ mod tests {
         assert!(hdr.to_bytes(&mut b).is_ok());
 
         // Add fake retry integrity token.
-        b.put_bytes(&vec![0xba; 16]).unwrap();
+        b.put_bytes(&[0xba; 16]).unwrap();
 
         let mut b = octets::OctetsMut::with_slice(&mut d);
         assert_eq!(Header::from_bytes(&mut b, 9).unwrap(), hdr);
@@ -1879,7 +1879,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(written, expected_pkt.len());
-        assert_eq!(&out[..written], &expected_pkt[..]);
+        assert_eq!(&out[..written], expected_pkt);
     }
 
     #[test]

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -71,7 +71,7 @@ impl PathState {
 }
 
 /// A path-specific event.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PathEvent {
     /// A new network path (local address, peer address) has been seen on a
     /// received packet. Note that this event is only triggered for servers, as

--- a/quiche/src/ranges.rs
+++ b/quiche/src/ranges.rs
@@ -30,7 +30,7 @@ use std::collections::btree_map;
 use std::collections::BTreeMap;
 use std::collections::Bound;
 
-#[derive(Clone, PartialEq, PartialOrd)]
+#[derive(Clone, PartialEq, Eq, PartialOrd)]
 pub struct RangeSet {
     inner: BTreeMap<u64, u64>,
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -1005,7 +1005,7 @@ impl Recovery {
 ///
 /// This enum provides currently available list of congestion control
 /// algorithms.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub enum CongestionControlAlgorithm {
     /// Reno congestion control algorithm. `reno` in a string form.

--- a/tools/http3_test/src/lib.rs
+++ b/tools/http3_test/src/lib.rs
@@ -332,7 +332,7 @@ macro_rules! assert_headers {
 /// however they like.
 pub type Http3Assert = fn(&[Http3Req]);
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Http3TestError {
     HandshakeFail,
     HttpFail,


### PR DESCRIPTION
Done using `cargo clippy --fix` against Rust 1.63.0