### PR TITLE
apps: display a friendlier message for bad --connect-to

### DIFF
--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -65,7 +65,7 @@ pub fn connect(
 
     // Resolve server address.
     let peer_addr = if let Some(addr) = &args.connect_to {
-        addr.parse().unwrap()
+        addr.parse().expect("--connect-to is expected to be a string containing an IPv4 or IPv6 address with a port. E.g. 192.0.2.0:443")
     } else {
         connect_url.to_socket_addrs().unwrap().next().unwrap()
     };


### PR DESCRIPTION
It expects an IP address and port, so let's just say that.

Fixes #1081
