### PR TITLE
h3: return InternalError when flow control blocks control stream

### DIFF
--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -418,14 +418,21 @@ fn main() {
                         None
                     };
 
-                    client.http_conn = Some(Http3Conn::with_conn(
+                    client.http_conn = match Http3Conn::with_conn(
                         &mut client.conn,
                         conn_args.max_field_section_size,
                         conn_args.qpack_max_table_capacity,
                         conn_args.qpack_blocked_streams,
                         dgram_sender,
                         Rc::new(RefCell::new(stdout_sink)),
-                    ));
+                    ) {
+                        Ok(v) => Some(v),
+
+                        Err(e) => {
+                            trace!("{} {}", client.conn.trace_id(), e);
+                            None
+                        },
+                    };
 
                     client.app_proto_selected = true;
                 } else if alpns::SIDUCK.contains(&app_proto) {

--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -973,8 +973,7 @@ impl Http3Conn {
                     qpack_max_table_capacity,
                     qpack_blocked_streams,
                 ),
-            )
-            .unwrap(),
+            ).expect("Unable to create HTTP/3 connection, check the server's uni stream limit and window size"),
             reqs_hdrs_sent: 0,
             reqs_complete: 0,
             largest_processed_request: 0,
@@ -995,17 +994,18 @@ impl Http3Conn {
         qpack_blocked_streams: Option<u64>,
         dgram_sender: Option<Http3DgramSender>,
         output_sink: Rc<RefCell<dyn FnMut(String)>>,
-    ) -> Box<dyn HttpConn> {
+    ) -> std::result::Result<Box<dyn HttpConn>, String> {
+        let h3_conn = quiche::h3::Connection::with_transport(
+            conn,
+            &make_h3_config(
+                max_field_section_size,
+                qpack_max_table_capacity,
+                qpack_blocked_streams,
+            ),
+        ).map_err(|_| "Unable to create HTTP/3 connection, check the client's uni stream limit and window size")?;
+
         let h_conn = Http3Conn {
-            h3_conn: quiche::h3::Connection::with_transport(
-                conn,
-                &make_h3_config(
-                    max_field_section_size,
-                    qpack_max_table_capacity,
-                    qpack_blocked_streams,
-                ),
-            )
-            .unwrap(),
+            h3_conn,
             reqs_hdrs_sent: 0,
             reqs_complete: 0,
             largest_processed_request: 0,
@@ -1017,7 +1017,7 @@ impl Http3Conn {
             output_sink,
         };
 
-        Box::new(h_conn)
+        Ok(Box::new(h_conn))
     }
 
     /// Builds an HTTP/3 response given a request.

--- a/quiche/examples/http3-client.rs
+++ b/quiche/examples/http3-client.rs
@@ -219,7 +219,7 @@ fn main() {
         if conn.is_established() && http3_conn.is_none() {
             http3_conn = Some(
                 quiche::h3::Connection::with_transport(&mut conn, &h3_config)
-                    .unwrap(),
+                .expect("Unable to create HTTP/3 connection, check the server's uni stream limit and window size"),
             );
         }
 

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -903,9 +903,13 @@ impl Connection {
     /// On success the new connection is returned.
     ///
     /// The [`StreamLimit`] error is returned when the HTTP/3 control stream
-    /// cannot be created.
+    /// cannot be created due to stream limits.
     ///
-    /// [`StreamLimit`]: ../enum.Error.html#variant.InvalidState
+    /// The [`InternalError`] error is returned when the HTTP/3 control stream
+    /// cannot be created due to flow control limits.
+    ///
+    /// [`StreamLimit`]: ../enum.Error.html#variant.StreamLimit
+    /// [`InternalError`]: ../enum.Error.html#variant.InternalError
     pub fn with_transport(
         conn: &mut super::Connection, config: &Config,
     ) -> Result<Connection> {
@@ -1966,8 +1970,21 @@ impl Connection {
 
     /// Sends SETTINGS frame based on HTTP/3 configuration.
     fn send_settings(&mut self, conn: &mut super::Connection) -> Result<()> {
-        let stream_id =
-            self.open_uni_stream(conn, stream::HTTP3_CONTROL_STREAM_TYPE_ID)?;
+        let stream_id = match self
+            .open_uni_stream(conn, stream::HTTP3_CONTROL_STREAM_TYPE_ID)
+        {
+            Ok(v) => v,
+
+            Err(e) => {
+                trace!("{} Control stream blocked", conn.trace_id(),);
+
+                if e == Error::Done {
+                    return Err(Error::InternalError);
+                }
+
+                return Err(e);
+            },
+        };
 
         self.control_stream_id = Some(stream_id);
 


### PR DESCRIPTION
When creating a new h3:Connection, quiche attempts to open
unidirectional streams. We care about the control stream
being opened and will return an Error if that can't happen.

In the case where the control stream failure occurred due to
stream ID limits, quiche returns a StreamLimit error to
indicate that.

In the case where the control stream failure occured due to
flow control being too small to send SETTINGS, we would
return a generic Error:Done, which is potentially confusing.

With this change, failures due to flow control are
more clearly marked as InternalError, since this is an implementation
choice. Trace logging has also been added to help better
communicate the control flow through quiche.

To mirror these changes, applications have been updated
with clearer error handling.

Fixes #1249
