### PR TITLE
refactor per-path stats

### DIFF
--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -556,9 +556,10 @@ fn main() {
 
             if c.conn.is_closed() {
                 info!(
-                    "{} connection collected {:?}",
+                    "{} connection collected {:?} {:?}",
                     c.conn.trace_id(),
-                    c.conn.stats()
+                    c.conn.stats(),
+                    c.conn.path_stats().collect::<Vec<quiche::PathStats>>()
                 );
             }
 

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -317,7 +317,11 @@ pub fn connect(
         trace!("done reading");
 
         if conn.is_closed() {
-            info!("connection closed, {:?}", conn.stats());
+            info!(
+                "connection closed, {:?} {:?}",
+                conn.stats(),
+                conn.path_stats().collect::<Vec<quiche::PathStats>>()
+            );
 
             if !conn.is_established() {
                 error!(
@@ -560,7 +564,11 @@ pub fn connect(
         }
 
         if conn.is_closed() {
-            info!("connection closed, {:?}", conn.stats());
+            info!(
+                "connection closed, {:?} {:?}",
+                conn.stats(),
+                conn.path_stats().collect::<Vec<quiche::PathStats>>()
+            );
 
             if !conn.is_established() {
                 error!(

--- a/quiche/examples/client.c
+++ b/quiche/examples/client.c
@@ -211,11 +211,13 @@ static void timeout_cb(EV_P_ ev_timer *w, int revents) {
 
     if (quiche_conn_is_closed(conn_io->conn)) {
         quiche_stats stats;
+        quiche_path_stats path_stats;
 
         quiche_conn_stats(conn_io->conn, &stats);
+        quiche_conn_path_stats(conn_io->conn, 0, &path_stats);
 
         fprintf(stderr, "connection closed, recv=%zu sent=%zu lost=%zu rtt=%" PRIu64 "ns\n",
-                stats.recv, stats.sent, stats.lost, stats.paths[0].rtt);
+                stats.recv, stats.sent, stats.lost, path_stats.rtt);
 
         ev_break(EV_A_ EVBREAK_ONE);
         return;

--- a/quiche/examples/http3-client.c
+++ b/quiche/examples/http3-client.c
@@ -339,11 +339,13 @@ static void timeout_cb(EV_P_ ev_timer *w, int revents) {
 
     if (quiche_conn_is_closed(conn_io->conn)) {
         quiche_stats stats;
+        quiche_path_stats path_stats;
 
         quiche_conn_stats(conn_io->conn, &stats);
+        quiche_conn_path_stats(conn_io->conn, 0, &path_stats);
 
         fprintf(stderr, "connection closed, recv=%zu sent=%zu lost=%zu rtt=%" PRIu64 "ns\n",
-                stats.recv, stats.sent, stats.lost, stats.paths[0].rtt);
+                stats.recv, stats.sent, stats.lost, path_stats.rtt);
 
         ev_break(EV_A_ EVBREAK_ONE);
         return;

--- a/quiche/examples/http3-server.c
+++ b/quiche/examples/http3-server.c
@@ -478,10 +478,13 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
 
         if (quiche_conn_is_closed(conn_io->conn)) {
             quiche_stats stats;
+            quiche_path_stats path_stats;
 
             quiche_conn_stats(conn_io->conn, &stats);
+            quiche_conn_path_stats(conn_io->conn, 0, &path_stats);
+
             fprintf(stderr, "connection closed, recv=%zu sent=%zu lost=%zu rtt=%" PRIu64 "ns cwnd=%zu\n",
-                    stats.recv, stats.sent, stats.lost, stats.paths[0].rtt, stats.paths[0].cwnd);
+                    stats.recv, stats.sent, stats.lost, path_stats.rtt, path_stats.cwnd);
 
             HASH_DELETE(hh, conns->h, conn_io);
 
@@ -503,10 +506,13 @@ static void timeout_cb(EV_P_ ev_timer *w, int revents) {
 
     if (quiche_conn_is_closed(conn_io->conn)) {
         quiche_stats stats;
+        quiche_path_stats path_stats;
 
         quiche_conn_stats(conn_io->conn, &stats);
+        quiche_conn_path_stats(conn_io->conn, 0, &path_stats);
+
         fprintf(stderr, "connection closed, recv=%zu sent=%zu lost=%zu rtt=%" PRIu64 "ns cwnd=%zu\n",
-                stats.recv, stats.sent, stats.lost, stats.paths[0].rtt, stats.paths[0].cwnd);
+                stats.recv, stats.sent, stats.lost, path_stats.rtt, path_stats.cwnd);
 
         HASH_DELETE(hh, conns->h, conn_io);
 

--- a/quiche/examples/server.c
+++ b/quiche/examples/server.c
@@ -401,10 +401,13 @@ static void recv_cb(EV_P_ ev_io *w, int revents) {
 
         if (quiche_conn_is_closed(conn_io->conn)) {
             quiche_stats stats;
+            quiche_path_stats path_stats;
 
             quiche_conn_stats(conn_io->conn, &stats);
+            quiche_conn_path_stats(conn_io->conn, 0, &path_stats);
+
             fprintf(stderr, "connection closed, recv=%zu sent=%zu lost=%zu rtt=%" PRIu64 "ns cwnd=%zu\n",
-                    stats.recv, stats.sent, stats.lost, stats.paths[0].rtt, stats.paths[0].cwnd);
+                    stats.recv, stats.sent, stats.lost, path_stats.rtt, path_stats.cwnd);
 
             HASH_DELETE(hh, conns->h, conn_io);
 
@@ -425,10 +428,13 @@ static void timeout_cb(EV_P_ ev_timer *w, int revents) {
 
     if (quiche_conn_is_closed(conn_io->conn)) {
         quiche_stats stats;
+        quiche_path_stats path_stats;
 
         quiche_conn_stats(conn_io->conn, &stats);
+        quiche_conn_path_stats(conn_io->conn, 0, &path_stats);
+
         fprintf(stderr, "connection closed, recv=%zu sent=%zu lost=%zu rtt=%" PRIu64 "ns cwnd=%zu\n",
-                stats.recv, stats.sent, stats.lost, stats.paths[0].rtt, stats.paths[0].cwnd);
+                stats.recv, stats.sent, stats.lost, path_stats.rtt, path_stats.cwnd);
 
         HASH_DELETE(hh, conns->h, conn_io);
 

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -464,6 +464,77 @@ bool quiche_stream_iter_next(quiche_stream_iter *iter, uint64_t *stream_id);
 void quiche_stream_iter_free(quiche_stream_iter *iter);
 
 typedef struct {
+    // The number of QUIC packets received on this connection.
+    size_t recv;
+
+    // The number of QUIC packets sent on this connection.
+    size_t sent;
+
+    // The number of QUIC packets that were lost.
+    size_t lost;
+
+    // The number of sent QUIC packets with retransmitted data.
+    size_t retrans;
+
+    // The number of sent bytes.
+    uint64_t sent_bytes;
+
+    // The number of received bytes.
+    uint64_t recv_bytes;
+
+    // The number of bytes lost.
+    uint64_t lost_bytes;
+
+    // The number of stream bytes retransmitted.
+    uint64_t stream_retrans_bytes;
+
+    // The number of known paths for the connection.
+    size_t paths_count;
+
+    // The maximum idle timeout.
+    uint64_t peer_max_idle_timeout;
+
+    // The maximum UDP payload size.
+    uint64_t peer_max_udp_payload_size;
+
+    // The initial flow control maximum data for the connection.
+    uint64_t peer_initial_max_data;
+
+    // The initial flow control maximum data for local bidirectional streams.
+    uint64_t peer_initial_max_stream_data_bidi_local;
+
+    // The initial flow control maximum data for remote bidirectional streams.
+    uint64_t peer_initial_max_stream_data_bidi_remote;
+
+    // The initial flow control maximum data for unidirectional streams.
+    uint64_t peer_initial_max_stream_data_uni;
+
+    // The initial maximum bidirectional streams.
+    uint64_t peer_initial_max_streams_bidi;
+
+    // The initial maximum unidirectional streams.
+    uint64_t peer_initial_max_streams_uni;
+
+    // The ACK delay exponent.
+    uint64_t peer_ack_delay_exponent;
+
+    // The max ACK delay.
+    uint64_t peer_max_ack_delay;
+
+    // Whether active migration is disabled.
+    bool peer_disable_active_migration;
+
+    // The active connection ID limit.
+    uint64_t peer_active_conn_id_limit;
+
+    // DATAGRAM frame extension parameter, if any.
+    ssize_t peer_max_datagram_frame_size;
+} quiche_stats;
+
+// Collects and returns statistics about the connection.
+void quiche_conn_stats(quiche_conn *conn, quiche_stats *out);
+
+typedef struct {
     // The local address used by this path.
     struct sockaddr_storage local_addr;
     socklen_t local_addr_len;
@@ -515,79 +586,12 @@ typedef struct {
     uint64_t delivery_rate;
 } quiche_path_stats;
 
-typedef struct {
-    // The number of QUIC packets received on this connection.
-    size_t recv;
 
-    // The number of QUIC packets sent on this connection.
-    size_t sent;
-
-    // The number of QUIC packets that were lost.
-    size_t lost;
-
-    // The number of sent QUIC packets with retransmitted data.
-    size_t retrans;
-
-    // The number of sent bytes.
-    uint64_t sent_bytes;
-
-    // The number of received bytes.
-    uint64_t recv_bytes;
-
-    // The number of bytes lost.
-    uint64_t lost_bytes;
-
-    // The number of stream bytes retransmitted.
-    uint64_t stream_retrans_bytes;
-
-    // The maximum idle timeout.
-    uint64_t peer_max_idle_timeout;
-
-    // The maximum UDP payload size.
-    uint64_t peer_max_udp_payload_size;
-
-    // The initial flow control maximum data for the connection.
-    uint64_t peer_initial_max_data;
-
-    // The initial flow control maximum data for local bidirectional streams.
-    uint64_t peer_initial_max_stream_data_bidi_local;
-
-    // The initial flow control maximum data for remote bidirectional streams.
-    uint64_t peer_initial_max_stream_data_bidi_remote;
-
-    // The initial flow control maximum data for unidirectional streams.
-    uint64_t peer_initial_max_stream_data_uni;
-
-    // The initial maximum bidirectional streams.
-    uint64_t peer_initial_max_streams_bidi;
-
-    // The initial maximum unidirectional streams.
-    uint64_t peer_initial_max_streams_uni;
-
-    // The ACK delay exponent.
-    uint64_t peer_ack_delay_exponent;
-
-    // The max ACK delay.
-    uint64_t peer_max_ack_delay;
-
-    // Whether active migration is disabled.
-    bool peer_disable_active_migration;
-
-    // The active connection ID limit.
-    uint64_t peer_active_conn_id_limit;
-
-    // DATAGRAM frame extension parameter, if any.
-    ssize_t peer_max_datagram_frame_size;
-
-    // The stats of the connection's paths.
-    quiche_path_stats paths[8];
-
-    // The number of stats of the connection's paths.
-    size_t paths_len;
-} quiche_stats;
-
-// Collects and returns statistics about the connection.
-void quiche_conn_stats(quiche_conn *conn, quiche_stats *out);
+// Collects and returns statistics about the specified path for the connection.
+//
+// The `idx` argument represent the path's index (also see the `paths_count`
+// field of `quiche_stats`).
+int quiche_conn_path_stats(quiche_conn *conn, size_t idx, quiche_path_stats *out);
 
 // Returns the maximum DATAGRAM payload that can be sent.
 ssize_t quiche_conn_dgram_max_writable_len(quiche_conn *conn);


### PR DESCRIPTION
Instead of returning stats for all paths from the `stats()` method, add
a new method specific to path stats. This also allows us to return an
iterator for the path stats list, rather than have to collect the
iterator into a `Vec` (thus avoiding an allocation and also having to
iterate over all paths).