### PR TITLE
Multipath support with non-zero length Connection IDs

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -31,6 +31,8 @@ ring = "0.16"
 quiche = { path = "../quiche" }
 libc = "0.2"
 nix = { version = "0.27", features = ["net", "socket", "uio"] }
+slab = "0.4"
+itertools = "0.10"
 
 [lib]
 crate-type = ["lib"]

--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -57,6 +57,7 @@ pub struct CommonArgs {
     pub qpack_blocked_streams: Option<u64>,
     pub initial_cwnd_packets: u64,
     pub multipath: bool,
+    pub multipath_old: bool,
 }
 
 /// Creates a new `CommonArgs` structure using the provided [`Docopt`].
@@ -196,6 +197,7 @@ impl Args for CommonArgs {
             .unwrap();
 
         let multipath = args.get_bool("--multipath");
+        let multipath_old = args.get_bool("--multipath-old");
 
         CommonArgs {
             alpns,
@@ -221,6 +223,7 @@ impl Args for CommonArgs {
             qpack_blocked_streams,
             initial_cwnd_packets,
             multipath,
+            multipath_old,
         }
     }
 }
@@ -251,6 +254,7 @@ impl Default for CommonArgs {
             qpack_blocked_streams: None,
             initial_cwnd_packets: 10,
             multipath: false,
+            multipath_old: false,
         }
     }
 }
@@ -289,6 +293,7 @@ Options:
   --enable-active-migration   Enable active connection migration.
   --perform-migration      Perform connection migration on another source port.
   --multipath              Enable multipath support.
+  --multipath-old          Enable (old v4) multipath support.
   -A --address ADDR ...    Specify addresses to be used instead of the unspecified address. Non-routable addresses will lead to connectivity issues.
   -H --header HEADER ...   Add a request header.
   -n --requests REQUESTS   Send the given number of identical requests [default: 1].
@@ -484,6 +489,7 @@ Options:
   --disable-pacing            Disable pacing (linux only).
   --initial-cwnd-packets PACKETS      The initial congestion window size in terms of packet count [default: 10].
   --multipath                 Enable multipath support.
+  --multipath-old             Enable (old v4) multipath support.
   -h --help                   Show this screen.
 ";
 

--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -289,7 +289,7 @@ Options:
   --enable-active-migration   Enable active connection migration.
   --perform-migration      Perform connection migration on another source port.
   --multipath              Enable multipath support.
-  -A --address ADDR ...    Additional client addresses to use.
+  -A --address ADDR ...    Specify addresses to be used instead of the unspecified address. Non-routable addresses will lead to connectivity issues.
   -H --header HEADER ...   Add a request header.
   -n --requests REQUESTS   Send the given number of identical requests [default: 1].
   --send-priority-update   Send HTTP/3 priority updates if the query string params 'u' or 'i' are present in URLs

--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -58,7 +58,6 @@ pub struct CommonArgs {
     pub qpack_blocked_streams: Option<u64>,
     pub initial_cwnd_packets: u64,
     pub multipath: bool,
-    pub multipath_old: bool,
 }
 
 /// Creates a new `CommonArgs` structure using the provided [`Docopt`].
@@ -198,7 +197,6 @@ impl Args for CommonArgs {
             .unwrap();
 
         let multipath = args.get_bool("--multipath");
-        let multipath_old = args.get_bool("--multipath-old");
 
         CommonArgs {
             alpns,
@@ -224,7 +222,6 @@ impl Args for CommonArgs {
             qpack_blocked_streams,
             initial_cwnd_packets,
             multipath,
-            multipath_old,
         }
     }
 }
@@ -255,7 +252,6 @@ impl Default for CommonArgs {
             qpack_blocked_streams: None,
             initial_cwnd_packets: 10,
             multipath: false,
-            multipath_old: false,
         }
     }
 }
@@ -294,7 +290,6 @@ Options:
   --enable-active-migration   Enable active connection migration.
   --perform-migration      Perform connection migration on another source port.
   --multipath              Enable multipath support.
-  --multipath-old          Enable (old v4) multipath support.
   -A --address ADDR ...    Specify addresses to be used instead of the unspecified address. Non-routable addresses will lead to connectivity issues.
   -R --rm-addr TIMEADDR ...   Specify addresses to stop using after the provided time (format time,addr).
   -S --status TIMEADDRSTAT ...   Specify availability status to advertise to the peer after the provided time (format time,addr,available).
@@ -543,7 +538,6 @@ Options:
   --disable-pacing            Disable pacing (linux only).
   --initial-cwnd-packets PACKETS      The initial congestion window size in terms of packet count [default: 10].
   --multipath                 Enable multipath support.
-  --multipath-old             Enable (old v4) multipath support.
   -h --help                   Show this screen.
 ";
 

--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -297,7 +297,7 @@ Options:
   --multipath-old          Enable (old v4) multipath support.
   -A --address ADDR ...    Specify addresses to be used instead of the unspecified address. Non-routable addresses will lead to connectivity issues.
   -R --rm-addr TIMEADDR ...   Specify addresses to stop using after the provided time (format time,addr).
-  -S --status TIMEADDRSTAT ...   Specify status to advertise to the peer after the provided time (format time,addr,status).
+  -S --status TIMEADDRSTAT ...   Specify availability status to advertise to the peer after the provided time (format time,addr,available).
   -H --header HEADER ...   Add a request header.
   -n --requests REQUESTS   Send the given number of identical requests [default: 1].
   --send-priority-update   Send HTTP/3 priority updates if the query string params 'u' or 'i' are present in URLs
@@ -329,7 +329,7 @@ pub struct ClientArgs {
     pub send_priority_update: bool,
     pub addrs: Vec<SocketAddr>,
     pub rm_addrs: Vec<(std::time::Duration, SocketAddr)>,
-    pub status: Vec<(std::time::Duration, SocketAddr, u64)>,
+    pub status: Vec<(std::time::Duration, SocketAddr, bool)>,
 }
 
 impl Args for ClientArgs {
@@ -450,7 +450,8 @@ impl Args for ClientArgs {
                     Err(_) => return None,
                 };
                 let status = match s[2].parse::<u64>() {
-                    Ok(s) => s,
+                    Ok(0) => false,
+                    Ok(_) => true,
                     Err(_) => return None,
                 };
                 Some((std::time::Duration::from_secs(secs), addr, status))

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -125,7 +125,6 @@ fn main() {
         usize::try_from(conn_args.initial_cwnd_packets).unwrap(),
     );
     config.set_multipath(conn_args.multipath);
-    config.set_multipath_v4(conn_args.multipath_old);
 
     config.set_max_connection_window(conn_args.max_window);
     config.set_max_stream_window(conn_args.max_stream_window);

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -724,7 +724,7 @@ fn handle_path_events(client: &mut Client) {
                 );
             },
 
-            quiche::PathEvent::Closed(local_addr, peer_addr) => {
+            quiche::PathEvent::Closed(local_addr, peer_addr, _err, _reason) => {
                 info!(
                     "{} Path ({}, {}) is now closed and unusable",
                     client.conn.trace_id(),

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -125,6 +125,7 @@ fn main() {
         usize::try_from(conn_args.initial_cwnd_packets).unwrap(),
     );
     config.set_multipath(conn_args.multipath);
+    config.set_multipath_v4(conn_args.multipath_old);
 
     config.set_max_connection_window(conn_args.max_window);
     config.set_max_stream_window(conn_args.max_stream_window);

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -439,7 +439,7 @@ pub fn connect(
                     );
                 },
 
-                quiche::PathEvent::Closed(local_addr, peer_addr) => {
+                quiche::PathEvent::Closed(local_addr, peer_addr, _e, _reason) => {
                     info!(
                         "Path ({}, {}) is now closed and unusable",
                         local_addr, peer_addr

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -129,7 +129,6 @@ pub fn connect(
     config.set_disable_active_migration(!conn_args.enable_active_migration);
     config.set_active_connection_id_limit(conn_args.max_active_cids);
     config.set_multipath(conn_args.multipath);
-    config.set_multipath_v4(conn_args.multipath_old);
 
     config.set_max_connection_window(conn_args.max_window);
     config.set_max_stream_window(conn_args.max_stream_window);

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -125,6 +125,7 @@ pub fn connect(
     config.set_disable_active_migration(!conn_args.enable_active_migration);
     config.set_active_connection_id_limit(conn_args.max_active_cids);
     config.set_multipath(conn_args.multipath);
+    config.set_multipath_v4(conn_args.multipath_old);
 
     config.set_max_connection_window(conn_args.max_window);
     config.set_max_stream_window(conn_args.max_stream_window);
@@ -418,7 +419,7 @@ pub fn connect(
                         "Path ({}, {}) is now validated",
                         local_addr, peer_addr
                     );
-                    if conn_args.multipath {
+                    if conn.is_multipath_enabled() {
                         conn.set_active(local_addr, peer_addr, true).ok();
                     } else if args.perform_migration {
                         conn.migrate(local_addr, peer_addr).unwrap();
@@ -473,7 +474,7 @@ pub fn connect(
             scid_sent = true;
         }
 
-        if conn_args.multipath &&
+        if (conn_args.multipath || conn_args.multipath_old) &&
             probed_paths < addrs.len() &&
             conn.available_dcids() > 0 &&
             conn.probe_path(addrs[probed_paths], peer_addr).is_ok()

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -83,6 +83,18 @@ pub fn connect(
         }
     }
 
+    // Warn the user if there are more usable addresses than the advertised
+    // `active_connection_id_limit`.
+    if addrs.len() as u64 > conn_args.max_active_cids {
+        warn!(
+            "{} addresses provided, but configuration restricts to at most {} \
+               active CIDs; increase the --max-active-cids parameter to use all \
+               the provided addresses",
+            addrs.len(),
+            conn_args.max_active_cids
+        );
+    }
+
     // Create the configuration for the QUIC connection.
     let mut config = quiche::Config::new(args.version).unwrap();
 

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -476,7 +476,7 @@ pub fn connect(
             scid_sent = true;
         }
 
-        if (conn_args.multipath || conn_args.multipath_old) &&
+        if conn_args.multipath &&
             probed_paths < addrs.len() &&
             conn.available_dcids() > 0 &&
             conn.probe_path(addrs[probed_paths], peer_addr).is_ok()

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -36,7 +36,6 @@ use std::rc::Rc;
 
 use std::cell::RefCell;
 
-use quiche::PathStatus;
 use ring::rand::*;
 
 use slab::Slab;
@@ -513,14 +512,10 @@ pub fn connect(
                 }
             });
 
-            status.retain(|(d, addr, s)| {
+            status.retain(|(d, addr, available)| {
                 if app_data_start.elapsed() >= *d {
-                    info!("Advertising path status {s} to {addr:?}");
-                    let status = match s {
-                        1 => PathStatus::Standby,
-                        2 => PathStatus::Available,
-                        s => PathStatus::Unknown(*s),
-                    };
+                    let status = (*available).into();
+                    info!("Advertising path status {status:?} to {addr:?}");
                     conn.set_path_status(*addr, peer_addr, status, true)
                         .is_err()
                 } else {

--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -510,15 +510,13 @@ pub enum QuicFrame {
     },
 
     PathAbandon {
-        identifier_type: u64,
-        path_identifier: Option<u64>,
+        dcid_seq_num: u64,
         error_code: u64,
         reason: Option<String>,
     },
 
     PathStatus {
-        identifier_type: u64,
-        path_identifier: Option<u64>,
+        dcid_seq_num: u64,
         seq_num: u64,
         status: u64,
     },

--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -372,6 +372,9 @@ pub enum QuicFrameTypeName {
     ApplicationClose,
     HandshakeDone,
     Datagram,
+    AckMp,
+    PathAbandon,
+    PathStatus,
     Unknown,
 }
 
@@ -491,6 +494,33 @@ pub enum QuicFrame {
         length: u64,
 
         raw: Option<Bytes>,
+    },
+
+    AckMp {
+        space_identifier: u64,
+
+        ack_delay: Option<f32>,
+        acked_ranges: Option<AckedRanges>,
+
+        ect1: Option<u64>,
+
+        ect0: Option<u64>,
+
+        ce: Option<u64>,
+    },
+
+    PathAbandon {
+        identifier_type: u64,
+        path_identifier: Option<u64>,
+        error_code: u64,
+        reason: Option<String>,
+    },
+
+    PathStatus {
+        identifier_type: u64,
+        path_identifier: Option<u64>,
+        seq_num: u64,
+        status: u64,
     },
 
     Unknown {

--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -515,10 +515,14 @@ pub enum QuicFrame {
         reason: Option<String>,
     },
 
-    PathStatus {
+    PathStandby {
         dcid_seq_num: u64,
         seq_num: u64,
-        status: u64,
+    },
+
+    PathAvailable {
+        dcid_seq_num: u64,
+        seq_num: u64,
     },
 
     Unknown {

--- a/quiche/src/cid.rs
+++ b/quiche/src/cid.rs
@@ -593,9 +593,9 @@ impl ConnectionIdentifiers {
     /// Updates the Source Connection ID entry with the provided sequence number
     /// to indicate that it is now linked to the provided path ID.
     pub fn link_scid_to_path_id(
-        &mut self, dcid_seq: u64, path_id: usize,
+        &mut self, scid_seq: u64, path_id: usize,
     ) -> Result<()> {
-        let e = self.scids.get_mut(dcid_seq).ok_or(Error::InvalidState)?;
+        let e = self.scids.get_mut(scid_seq).ok_or(Error::InvalidState)?;
         e.path_id = Some(path_id);
         Ok(())
     }
@@ -696,6 +696,18 @@ impl ConnectionIdentifiers {
     #[inline]
     pub fn oldest_dcid(&self) -> &ConnectionIdEntry {
         self.dcids.get_oldest()
+    }
+
+    /// Returns the lowest DCID sequence number still in use.
+    #[inline]
+    pub fn min_dcid_seq(&self) -> u64 {
+        self.dcids.iter().map(|e| e.seq).min().unwrap_or(0)
+    }
+
+    /// Returns the lowest SCID sequence number still in use.
+    #[inline]
+    pub fn min_scid_seq(&self) -> u64 {
+        self.scids.iter().map(|e| e.seq).min().unwrap_or(0)
     }
 
     /// Adds or remove the source Connection ID sequence number from the

--- a/quiche/src/cid.rs
+++ b/quiche/src/cid.rs
@@ -824,43 +824,6 @@ impl ConnectionIdentifiers {
     pub fn largest_dcid_seq(&self) -> u64 {
         self.largest_destination_seq
     }
-
-    /// Translates the wire-format path identifier as used by PATH_ABANDON and
-    /// PATH_STATUS frames into internal PIDs.
-    ///
-    /// The wire-format path identifier is differently handled depending whether
-    /// we sent or received it. The mode 0 (resp. 1) refers to the sequence
-    /// number of the CID issued by the sender (resp. receiver). When acting as
-    /// a sender, this corresponds to a source (resp. destination) CID, while
-    /// when acting as a receiver, this corresponds to a destination (resp.
-    /// source) CID. Given that we need to process it when we receive them and
-    /// when we got notified that a PATH_ABANDON got acknowledged, we need to
-    /// handle both cases. This is done by the `from_peer` parameter, which is
-    /// set to `true` when acting as a receiver of the path identifier.
-    pub fn path_id_from_wire(
-        &self, wire_pid: (u64, Option<u64>), recv_pid: usize, from_peer: bool,
-    ) -> Result<usize> {
-        let wire_pid = if from_peer {
-            wire_pid
-        } else {
-            match wire_pid {
-                (0x00, x) => (0x01, x),
-                (0x01, x) => (0x00, x),
-                _ => wire_pid,
-            }
-        };
-        match wire_pid {
-            // In `path_id_to_wire`, we store in the `Option` part of the tuple
-            // the internal path ID.
-            (0x02, Some(pid)) => Ok(pid as usize),
-            (0x02, None) => Ok(recv_pid),
-            (0x00, Some(dcid_seq)) =>
-                self.get_dcid(dcid_seq)?.path_id.ok_or(Error::InvalidFrame),
-            (0x01, Some(scid_seq)) =>
-                self.get_scid(scid_seq)?.path_id.ok_or(Error::InvalidFrame),
-            _ => Err(Error::InvalidFrame),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -183,18 +183,21 @@ pub enum Frame {
         ack_delay: u64,
         ranges: ranges::RangeSet,
         ecn_counts: Option<EcnCounts>,
+        v5: bool,
     },
 
     PathAbandon {
         dcid_seq_num: u64,
         error_code: u64,
         reason: Vec<u8>,
+        v5: bool,
     },
 
     PathStatus {
         dcid_seq_num: u64,
         seq_num: u64,
         status: u64,
+        v5: bool,
     },
 }
 
@@ -326,18 +329,21 @@ impl Frame {
 
             0x30 | 0x31 => parse_datagram_frame(frame_type, b)?,
 
-            0xbaba00..=0xbaba01 => parse_ack_mp_frame(frame_type, b)?,
+            0xbaba00..=0xbaba01 | 0x15228c00..=0x15228c01 =>
+                parse_ack_mp_frame(frame_type, b)?,
 
-            0xbaba05 => Frame::PathAbandon {
+            0xbaba05 | 0x15228c05 => Frame::PathAbandon {
                 dcid_seq_num: b.get_varint()?,
                 error_code: b.get_varint()?,
                 reason: b.get_bytes_with_varint_length()?.to_vec(),
+                v5: frame_type == 0x15228c05,
             },
 
-            0xbaba06 => Frame::PathStatus {
+            0xbaba06 | 0x15228c06 => Frame::PathStatus {
                 dcid_seq_num: b.get_varint()?,
                 seq_num: b.get_varint()?,
                 status: b.get_varint()?,
+                v5: frame_type == 0x15228c06,
             },
 
             _ => return Err(Error::InvalidFrame),
@@ -585,9 +591,16 @@ impl Frame {
                 ack_delay,
                 ranges,
                 ecn_counts,
+                v5,
             } => {
                 if ecn_counts.is_none() {
-                    b.put_varint(0xbaba00)?;
+                    if *v5 {
+                        b.put_varint(0x15228c00)?;
+                    } else {
+                        b.put_varint(0xbaba00)?;
+                    }
+                } else if *v5 {
+                    b.put_varint(0x15228c01)?;
                 } else {
                     b.put_varint(0xbaba01)?;
                 }
@@ -599,8 +612,13 @@ impl Frame {
                 dcid_seq_num,
                 error_code,
                 reason,
+                v5,
             } => {
-                b.put_varint(0xbaba05)?;
+                if *v5 {
+                    b.put_varint(0x15228c05)?;
+                } else {
+                    b.put_varint(0xbaba05)?;
+                }
 
                 b.put_varint(*dcid_seq_num)?;
                 b.put_varint(*error_code)?;
@@ -612,8 +630,13 @@ impl Frame {
                 dcid_seq_num,
                 seq_num,
                 status,
+                v5,
             } => {
-                b.put_varint(0xbaba06)?;
+                if *v5 {
+                    b.put_varint(0x15228c06)?;
+                } else {
+                    b.put_varint(0xbaba06)?;
+                }
 
                 b.put_varint(*dcid_seq_num)?;
                 b.put_varint(*seq_num)?;
@@ -812,6 +835,7 @@ impl Frame {
                 ack_delay,
                 ranges,
                 ecn_counts,
+                ..
             } => {
                 4 + // frame_type
                 octets::varint_len(*space_identifier) + // space_identifier
@@ -822,6 +846,7 @@ impl Frame {
                 dcid_seq_num,
                 error_code,
                 reason,
+                ..
             } => {
                 4 + // frame type
                 octets::varint_len(*dcid_seq_num) +
@@ -834,6 +859,7 @@ impl Frame {
                 dcid_seq_num,
                 seq_num,
                 status,
+                ..
             } => {
                 4 + // frame size
                 octets::varint_len(*dcid_seq_num) +
@@ -1059,6 +1085,7 @@ impl Frame {
                 ack_delay,
                 ranges,
                 ecn_counts,
+                ..
             } => {
                 let ack_ranges = AckedRanges::Double(
                     ranges.iter().map(|r| (r.start, r.end - 1)).collect(),
@@ -1088,6 +1115,7 @@ impl Frame {
                 dcid_seq_num,
                 error_code,
                 reason,
+                ..
             } => QuicFrame::PathAbandon {
                 dcid_seq_num: *dcid_seq_num,
                 error_code: *error_code,
@@ -1098,6 +1126,7 @@ impl Frame {
                 dcid_seq_num,
                 seq_num,
                 status,
+                ..
             } => QuicFrame::PathStatus {
                 dcid_seq_num: *dcid_seq_num,
                 seq_num: *seq_num,
@@ -1276,6 +1305,7 @@ impl std::fmt::Debug for Frame {
                 ack_delay,
                 ranges,
                 ecn_counts,
+                ..
             } => {
                 write!(
                     f,
@@ -1287,6 +1317,7 @@ impl std::fmt::Debug for Frame {
                 dcid_seq_num,
                 error_code,
                 reason,
+                ..
             } => {
                 write!(
                     f,
@@ -1298,6 +1329,7 @@ impl std::fmt::Debug for Frame {
                 dcid_seq_num,
                 seq_num,
                 status,
+                ..
             } => {
                 write!(
                     f,
@@ -1384,6 +1416,7 @@ fn parse_ack_mp_frame(ty: u64, b: &mut octets::Octets) -> Result<Frame> {
         ack_delay,
         ranges,
         ecn_counts,
+        v5: ty & 0x15228c00 == 0x15228c00,
     })
 }
 
@@ -2315,13 +2348,14 @@ mod tests {
     }
 
     #[test]
-    fn path_abandon() {
+    fn path_abandon_v4() {
         let mut d = [42; 128];
 
         let frame = Frame::PathAbandon {
             dcid_seq_num: 421_124,
             error_code: 0xbeef,
             reason: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            v5: false,
         };
 
         let wire_len = {
@@ -2348,7 +2382,41 @@ mod tests {
     }
 
     #[test]
-    fn ack_mp() {
+    fn path_abandon_v5() {
+        let mut d = [42; 128];
+
+        let frame = Frame::PathAbandon {
+            dcid_seq_num: 421_124,
+            error_code: 0xbeef,
+            reason: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            v5: true,
+        };
+
+        let wire_len = {
+            let mut b = octets::OctetsMut::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, 25);
+
+        let mut b = octets::Octets::with_slice(&mut d);
+        assert_eq!(
+            Frame::from_bytes(&mut b, packet::Type::Short),
+            Ok(frame.clone())
+        );
+
+        let mut b = octets::Octets::with_slice(&mut d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
+
+        let mut b = octets::Octets::with_slice(&mut d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
+
+        let mut b = octets::Octets::with_slice(&mut d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
+    }
+
+    #[test]
+    fn ack_mp_v4() {
         let mut d = [42; 128];
 
         let mut ranges = ranges::RangeSet::default();
@@ -2362,6 +2430,7 @@ mod tests {
             ack_delay: 874_656_534,
             ranges,
             ecn_counts: None,
+            v5: false,
         };
 
         let wire_len = {
@@ -2385,7 +2454,7 @@ mod tests {
     }
 
     #[test]
-    fn ack_mp_ecn() {
+    fn ack_mp_ecn_v4() {
         let mut d = [42; 128];
 
         let mut ranges = ranges::RangeSet::default();
@@ -2405,6 +2474,7 @@ mod tests {
             ack_delay: 874_656_534,
             ranges,
             ecn_counts,
+            v5: false,
         };
 
         let wire_len = {
@@ -2428,7 +2498,89 @@ mod tests {
     }
 
     #[test]
-    fn path_status() {
+    fn ack_mp_v5() {
+        let mut d = [42; 128];
+
+        let mut ranges = ranges::RangeSet::default();
+        ranges.insert(4..7);
+        ranges.insert(9..12);
+        ranges.insert(15..19);
+        ranges.insert(3000..5000);
+
+        let frame = Frame::ACKMP {
+            space_identifier: 894_994,
+            ack_delay: 874_656_534,
+            ranges,
+            ecn_counts: None,
+            v5: true,
+        };
+
+        let wire_len = {
+            let mut b = octets::OctetsMut::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, 24);
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
+    }
+
+    #[test]
+    fn ack_mp_ecn_v5() {
+        let mut d = [42; 128];
+
+        let mut ranges = ranges::RangeSet::default();
+        ranges.insert(4..7);
+        ranges.insert(9..12);
+        ranges.insert(15..19);
+        ranges.insert(3000..5000);
+
+        let ecn_counts = Some(EcnCounts {
+            ect0_count: 100,
+            ect1_count: 200,
+            ecn_ce_count: 300,
+        });
+
+        let frame = Frame::ACKMP {
+            space_identifier: 894_994,
+            ack_delay: 874_656_534,
+            ranges,
+            ecn_counts,
+            v5: true,
+        };
+
+        let wire_len = {
+            let mut b = octets::OctetsMut::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(wire_len, 30);
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
+    }
+
+    #[test]
+    fn path_status_v4() {
         let mut d = [42; 128];
 
         let dcid_seq_num = 0xabcdef00;
@@ -2439,6 +2591,43 @@ mod tests {
             dcid_seq_num,
             seq_num,
             status,
+            v5: false,
+        };
+
+        let wire_len = {
+            let mut b = octets::OctetsMut::with_slice(&mut d);
+            frame.to_bytes(&mut b).unwrap()
+        };
+
+        assert_eq!(frame.wire_len(), wire_len);
+        assert_eq!(wire_len, 15);
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert_eq!(Frame::from_bytes(&mut b, packet::Type::Short), Ok(frame));
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::Initial).is_err());
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::ZeroRTT).is_err());
+
+        let mut b = octets::Octets::with_slice(&d);
+        assert!(Frame::from_bytes(&mut b, packet::Type::Handshake).is_err());
+    }
+
+    #[test]
+    fn path_status_v5() {
+        let mut d = [42; 128];
+
+        let dcid_seq_num = 0xabcdef00;
+        let seq_num = 0x42;
+        let status = 1;
+
+        let frame = Frame::PathStatus {
+            dcid_seq_num,
+            seq_num,
+            status,
+            v5: true,
         };
 
         let wire_len = {

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -382,6 +382,7 @@ impl Frame {
         };
 
         if !allowed {
+            error!("Bad frame: {:?}", frame);
             return Err(Error::InvalidPacket);
         }
 

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -1323,8 +1323,7 @@ impl std::fmt::Debug for Frame {
             } => {
                 write!(
                     f,
-                    "ACK_MP space_id={} delay={} blocks={:?} ecn_counts={:?}",
-                    space_identifier, ack_delay, ranges, ecn_counts
+                    "ACK_MP space_id={space_identifier} delay={ack_delay} blocks={ranges:?} ecn_counts={ecn_counts:?}",
                 )?;
             },
 
@@ -1336,8 +1335,7 @@ impl std::fmt::Debug for Frame {
             } => {
                 write!(
                     f,
-                    "PATH_ABANDON id_type={} path_id={:x?} err={:x} reason={:x?}",
-                    identifier_type, path_identifier, error_code, reason
+                    "PATH_ABANDON id_type={identifier_type} path_id={path_identifier:x?} err={error_code:x} reason={reason:x?}",
                 )?;
             },
 
@@ -1349,8 +1347,7 @@ impl std::fmt::Debug for Frame {
             } => {
                 write!(
                     f,
-                    "PATH_STATUS id_type={} path_id={:x?} seq_num={:x} status={:x}",
-                    identifier_type, path_identifier, seq_num, status,
+                    "PATH_STATUS id_type={identifier_type} path_id={path_identifier:x?} seq_num={seq_num:x} status={status:x}",
                 )?;
             },
         }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6737,7 +6737,7 @@ impl Connection {
     }
 
     fn encode_transport_params(&mut self) -> Result<()> {
-        let mut raw_params = [0; 128];
+        let mut raw_params = [0; 168];
 
         let raw_params = TransportParams::encode(
             &self.local_transport_params,

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6727,13 +6727,6 @@ impl Connection {
         self.is_server
     }
 
-    /// Returns the sequence number of the provided source Connection ID, or
-    /// `None` if the provided Connection ID does not match any known source
-    /// Connection ID.
-    pub fn find_scid_seq(&self, scid: &ConnectionId) -> Option<u64> {
-        self.ids.find_scid_seq(scid).map(|(seq, _)| seq)
-    }
-
     fn encode_transport_params(&mut self) -> Result<()> {
         let mut raw_params = [0; 128];
 
@@ -9262,7 +9255,10 @@ pub mod testing {
         );
 
         let space_seq = if conn.is_multipath_enabled() {
-            conn.find_scid_seq(&hdr.dcid).unwrap() as u32
+            conn.ids
+                .find_scid_seq(&hdr.dcid)
+                .map(|(seq, _)| seq)
+                .unwrap() as u32
         } else {
             packet::INITIAL_PACKET_NUMBER_SPACE_ID as u32
         };
@@ -12247,7 +12243,11 @@ mod tests {
         }
 
         let space_seq = if pipe.client.is_multipath_enabled() {
-            pipe.client.find_scid_seq(&hdr.dcid).unwrap() as u32
+            pipe.client
+                .ids
+                .find_scid_seq(&hdr.dcid)
+                .map(|(seq, _)| seq)
+                .unwrap() as u32
         } else {
             packet::INITIAL_PACKET_NUMBER_SPACE_ID as u32
         };

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -7936,7 +7936,7 @@ impl Connection {
         }
 
         let mut consider_standby = false;
-        let dgrams_to_emit = self.dgram_max_writable_len().is_some();
+        let dgrams_to_emit = self.dgram_send_queue.has_pending();
         let stream_to_emit = self.streams.has_flushable();
         // When using aggregate mode, favour lowest-latency path on which CWIN
         // is open. This should only be used when data need to be sent.
@@ -17059,6 +17059,8 @@ mod tests {
         config.set_initial_max_stream_data_bidi_local(100000);
         config.set_initial_max_stream_data_bidi_remote(100000);
         config.set_initial_max_streams_bidi(2);
+        // To test with enabled datagrams.
+        config.enable_dgram(true, 10, 10);
         config.set_multipath(true);
 
         let mut pipe = pipe_with_exchanged_cids(&mut config, 16, 16, 1);

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1132,13 +1132,20 @@ impl Config {
         self.local_transport_params.disable_active_migration = v;
     }
 
+    /// Sets whether the multipath extension follows v4 instead of v5.
+    ///
+    /// The default vale is `false`.
+    pub fn set_multipath_v4(&mut self, v: bool) {
+        self.local_transport_params.enable_multipath_v4 =
+            if v { Some(1) } else { None };
+    }
+
     /// Sets the `enable_multipath` transport parameter, negotiating the usage
     /// of the multipath extension over this connection.
     ///
     /// The default value is `false`.
     pub fn set_multipath(&mut self, v: bool) {
-        self.local_transport_params.enable_multipath =
-            if v { Some(1) } else { None };
+        self.local_transport_params.enable_multipath = v;
     }
 
     /// Sets the congestion control algorithm used by string.
@@ -1882,7 +1889,8 @@ impl Connection {
 
         // Don't support multipath with zero-length CIDs.
         if conn.ids.zero_length_scid() || conn.ids.zero_length_dcid() {
-            conn.local_transport_params.enable_multipath = None;
+            conn.local_transport_params.enable_multipath_v4 = None;
+            conn.local_transport_params.enable_multipath = false;
         }
 
         if let Some(odcid) = odcid {
@@ -3547,6 +3555,7 @@ impl Connection {
             }
         }
 
+        let v5 = self.paths.v5();
         let consider_standby_paths = self.paths.consider_standby_paths();
         let is_app_limited = self.delivery_rate_check_if_app_limited(send_pid);
         let n_paths = self.paths.len();
@@ -3763,6 +3772,7 @@ impl Connection {
                         ranges: pns.recv_pkt_need_ack.clone(),
                         ecn_counts: None, /* sending ECN is not supported at
                                            * this time */
+                        v5,
                     };
 
                     if push_frame_to_pkt!(b, frames, frame, left) {
@@ -3809,6 +3819,7 @@ impl Connection {
                                 ecn_counts: None, /* sending ECN is not
                                                    * supported at
                                                    * this time */
+                                v5,
                             };
 
                             if push_frame_to_pkt!(b, frames, frame, left) {
@@ -4107,6 +4118,7 @@ impl Connection {
                     dcid_seq_num,
                     error_code,
                     reason,
+                    v5,
                 };
                 if push_frame_to_pkt!(b, frames, frame, left) {
                     self.paths.on_path_abandon_sent(pid, now)?;
@@ -4128,6 +4140,7 @@ impl Connection {
                     dcid_seq_num,
                     seq_num,
                     status,
+                    v5,
                 };
                 if push_frame_to_pkt!(b, frames, frame, left) {
                     self.paths.on_path_status_sent();
@@ -6820,16 +6833,20 @@ impl Connection {
         self.ids
             .set_source_conn_id_limit(peer_params.active_conn_id_limit);
 
-        if let Some(mp) = self
+        if self.local_transport_params.enable_multipath &&
+            peer_params.enable_multipath
+        {
+            self.paths.set_multipath(true, true);
+        } else if let Some(mp) = self
             .local_transport_params
-            .enable_multipath
-            .zip(peer_params.enable_multipath)
+            .enable_multipath_v4
+            .zip(peer_params.enable_multipath_v4)
             .map(|(l, p)| l & p)
         {
             if mp > 1 {
                 return Err(Error::InvalidTransportParam);
             }
-            self.paths.set_multipath(mp == 1);
+            self.paths.set_multipath(mp == 1, false);
         }
 
         self.peer_transport_params = peer_params;
@@ -7627,6 +7644,7 @@ impl Connection {
                 dcid_seq_num,
                 error_code,
                 reason,
+                ..
             } => {
                 if !self.use_path_pkt_num_space(epoch) {
                     return Err(Error::MultiPathViolation);
@@ -7647,6 +7665,7 @@ impl Connection {
                 dcid_seq_num,
                 seq_num,
                 status,
+                ..
             } => {
                 if !self.use_path_pkt_num_space(epoch) {
                     return Err(Error::MultiPathViolation);
@@ -8291,9 +8310,9 @@ pub struct TransportParams {
     pub retry_source_connection_id: Option<ConnectionId<'static>>,
     /// DATAGRAM frame extension parameter, if any.
     pub max_datagram_frame_size: Option<u64>,
+    pub enable_multipath_v4: Option<u64>,   
     /// Multipath extension parameter, if any.
-    pub enable_multipath: Option<u64>,
-    // pub preferred_address: ...,
+    pub enable_multipath: bool,
 }
 
 impl Default for TransportParams {
@@ -8316,7 +8335,8 @@ impl Default for TransportParams {
             initial_source_connection_id: None,
             retry_source_connection_id: None,
             max_datagram_frame_size: None,
-            enable_multipath: None,
+            enable_multipath_v4: None,
+            enable_multipath: false,
         }
     }
 }
@@ -8468,7 +8488,11 @@ impl TransportParams {
                 },
 
                 0x0f739bbc1b666d04 => {
-                    tp.enable_multipath = Some(val.get_varint()?);
+                    tp.enable_multipath_v4 = Some(val.get_varint()?);
+                },
+
+                0x0f739bbc1b666d05 => {
+                    tp.enable_multipath = true;
                 },
 
                 // Ignore unknown parameters.
@@ -8633,13 +8657,17 @@ impl TransportParams {
             b.put_varint(max_datagram_frame_size)?;
         }
 
-        if let Some(enable_multipath) = tp.enable_multipath {
+        if let Some(enable_multipath) = tp.enable_multipath_v4 {
             TransportParams::encode_param(
                 &mut b,
                 0x0f739bbc1b666d04,
                 octets::varint_len(enable_multipath),
             )?;
             b.put_varint(enable_multipath)?;
+        }
+
+        if tp.enable_multipath {
+            TransportParams::encode_param(&mut b, 0x0f739bbc1b666d05, 0)?;
         }
 
         let out_len = b.off();
@@ -9275,13 +9303,14 @@ mod tests {
             initial_source_connection_id: Some(b"woot woot".to_vec().into()),
             retry_source_connection_id: Some(b"retry".to_vec().into()),
             max_datagram_frame_size: Some(32),
-            enable_multipath: Some(1),
+            enable_multipath_v4: Some(1),
+            enable_multipath: true,
         };
 
         let mut raw_params = [42; 256];
         let raw_params =
             TransportParams::encode(&tp, true, &mut raw_params).unwrap();
-        assert_eq!(raw_params.len(), 104);
+        assert_eq!(raw_params.len(), 113);
 
         let new_tp = TransportParams::decode(raw_params, false).unwrap();
 
@@ -9306,13 +9335,14 @@ mod tests {
             initial_source_connection_id: Some(b"woot woot".to_vec().into()),
             retry_source_connection_id: None,
             max_datagram_frame_size: Some(32),
-            enable_multipath: Some(1),
+            enable_multipath_v4: Some(1),
+            enable_multipath: true,
         };
 
         let mut raw_params = [42; 256];
         let raw_params =
             TransportParams::encode(&tp, false, &mut raw_params).unwrap();
-        assert_eq!(raw_params.len(), 79);
+        assert_eq!(raw_params.len(), 88);
 
         let new_tp = TransportParams::decode(raw_params, true).unwrap();
 
@@ -17225,6 +17255,206 @@ mod tests {
         let pipe = pipe_with_exchanged_cids(&mut config, 0, 16, 1);
 
         assert_eq!(pipe.client.is_multipath_enabled(), false);
+    }
+
+    #[test]
+    fn multipath_v4() {
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config
+            .set_application_protos(&[b"proto1", b"proto2"])
+            .unwrap();
+        config.verify_peer(false);
+        config.set_active_connection_id_limit(3);
+        config.set_initial_max_data(100000);
+        config.set_initial_max_stream_data_bidi_local(100000);
+        config.set_initial_max_stream_data_bidi_remote(100000);
+        config.set_initial_max_streams_bidi(2);
+        // To test with enabled datagrams.
+        config.enable_dgram(true, 10, 10);
+        config.set_multipath_v4(true);
+
+        let mut pipe = pipe_with_exchanged_cids(&mut config, 16, 16, 1);
+
+        assert_eq!(pipe.client.is_multipath_enabled(), true);
+        assert_eq!(pipe.server.is_multipath_enabled(), true);
+
+        let client_addr = testing::Pipe::client_addr();
+        let server_addr = testing::Pipe::server_addr();
+        let client_addr_2 = "127.0.0.1:5678".parse().unwrap();
+
+        let cid_c2s_0 = pipe.client.destination_id().into_owned();
+        let cid_s2c_0 = pipe.server.destination_id().into_owned();
+
+        assert_eq!(pipe.client.probe_path(client_addr_2, server_addr), Ok(1));
+        assert_eq!(pipe.advance(), Ok(()));
+        assert_eq!(
+            pipe.client.path_event_next(),
+            Some(PathEvent::Validated(client_addr_2, server_addr))
+        );
+        assert_eq!(pipe.client.path_event_next(), None);
+        assert_eq!(
+            pipe.server.path_event_next(),
+            Some(PathEvent::New(server_addr, client_addr_2))
+        );
+        assert_eq!(
+            pipe.server.path_event_next(),
+            Some(PathEvent::Validated(server_addr, client_addr_2))
+        );
+        assert_eq!(pipe.server.path_event_next(), None);
+
+        let pid_c2s_0 = pipe
+            .client
+            .paths
+            .path_id_from_addrs(&(client_addr, server_addr))
+            .expect("no such path");
+        let pid_c2s_1 = pipe
+            .client
+            .paths
+            .path_id_from_addrs(&(client_addr_2, server_addr))
+            .expect("no such path");
+        let pid_s2c_0 = pipe
+            .server
+            .paths
+            .path_id_from_addrs(&(server_addr, client_addr))
+            .expect("no such path");
+        let pid_s2c_1 = pipe
+            .server
+            .paths
+            .path_id_from_addrs(&(server_addr, client_addr_2))
+            .expect("no such path");
+
+        let path_c2s_0 = pipe.client.paths.get(pid_c2s_0).expect("no such path");
+        let path_c2s_1 = pipe.client.paths.get(pid_c2s_1).expect("no such path");
+        let path_s2c_0 = pipe.server.paths.get(pid_s2c_0).expect("no such path");
+        let path_s2c_1 = pipe.server.paths.get(pid_s2c_1).expect("no such path");
+
+        assert_eq!(path_c2s_0.active(), true);
+        assert_eq!(path_c2s_1.active(), false);
+        assert_eq!(path_s2c_0.active(), true);
+        assert_eq!(path_s2c_1.active(), false);
+
+        assert_eq!(
+            pipe.client.set_active(client_addr_2, server_addr, true,),
+            Ok(())
+        );
+        assert_eq!(
+            pipe.server.set_active(server_addr, client_addr_2, true,),
+            Ok(())
+        );
+
+        let path_c2s_0 = pipe.client.paths.get(pid_c2s_0).expect("no such path");
+        let path_c2s_1 = pipe.client.paths.get(pid_c2s_1).expect("no such path");
+        let path_s2c_0 = pipe.server.paths.get(pid_s2c_0).expect("no such path");
+        let path_s2c_1 = pipe.server.paths.get(pid_s2c_1).expect("no such path");
+
+        assert_eq!(path_c2s_0.active(), true);
+        assert_eq!(path_c2s_1.active(), true);
+        assert_eq!(path_s2c_0.active(), true);
+        assert_eq!(path_s2c_1.active(), true);
+
+        // Flush the ACK_MP on the newly active path.
+        assert_eq!(pipe.advance(), Ok(()));
+
+        // Emit enough data to use both paths, but no more than their initial
+        // summed CWIN.
+        const DATA_BYTES: usize = 24000;
+        let buf = [42; DATA_BYTES];
+        let mut recv_buf = [0; DATA_BYTES];
+
+        assert_eq!(pipe.server.stream_send(1, &buf, true), Ok(DATA_BYTES));
+        assert_eq!(pipe.advance(), Ok(()));
+        let (rcv_data, fin) = pipe.client.stream_recv(1, &mut recv_buf).unwrap();
+        assert_eq!(fin, true);
+        assert_eq!(rcv_data, DATA_BYTES);
+
+        assert_eq!(pipe.server.path_event_next(), None);
+
+        let path_c2s_0 = pipe.client.paths.get(pid_c2s_0).expect("no such path");
+        let path_c2s_1 = pipe.client.paths.get(pid_c2s_1).expect("no such path");
+        let path_s2c_0 = pipe.server.paths.get(pid_s2c_0).expect("no such path");
+        let path_s2c_1 = pipe.server.paths.get(pid_s2c_1).expect("no such path");
+
+        assert_eq!(path_c2s_0.active(), true);
+        assert_eq!(path_c2s_1.active(), true);
+        assert_eq!(path_s2c_0.active(), true);
+        assert_eq!(path_s2c_1.active(), true);
+        assert!(path_s2c_0.recovery.bytes_sent >= DATA_BYTES / 2);
+        assert!(path_s2c_1.recovery.bytes_sent >= DATA_BYTES / 2);
+
+        // Now close the initial path.
+        assert_eq!(
+            pipe.client.abandon_path(
+                client_addr,
+                server_addr,
+                0,
+                "no error".into(),
+            ),
+            Ok(()),
+        );
+
+        let path_c2s_0 = pipe.client.paths.get(pid_c2s_0).expect("no such path");
+        let path_c2s_1 = pipe.client.paths.get(pid_c2s_1).expect("no such path");
+        let path_s2c_0 = pipe.server.paths.get(pid_s2c_0).expect("no such path");
+        let path_s2c_1 = pipe.server.paths.get(pid_s2c_1).expect("no such path");
+
+        assert_eq!(path_c2s_0.active(), false);
+        assert_eq!(path_c2s_1.active(), true);
+        assert_eq!(path_s2c_0.active(), true);
+        assert_eq!(path_s2c_1.active(), true);
+
+        assert_eq!(pipe.advance(), Ok(()));
+
+        let path_c2s_0 = pipe.client.paths.get(pid_c2s_0).expect("no such path");
+        let path_c2s_1 = pipe.client.paths.get(pid_c2s_1).expect("no such path");
+        let path_s2c_0 = pipe.server.paths.get(pid_s2c_0).expect("no such path");
+        let path_s2c_1 = pipe.server.paths.get(pid_s2c_1).expect("no such path");
+
+        assert_eq!(path_c2s_0.active(), false);
+        assert_eq!(path_c2s_1.active(), true);
+        assert_eq!(path_s2c_0.active(), false);
+        assert_eq!(path_s2c_1.active(), true);
+
+        // No more in-flight packets on closed paths.
+        assert_eq!(
+            path_c2s_0.recovery.cwnd(),
+            path_c2s_0.recovery.cwnd_available()
+        );
+        assert_eq!(
+            path_s2c_0.recovery.cwnd(),
+            path_s2c_0.recovery.cwnd_available()
+        );
+
+        assert_eq!(pipe.server.retired_scid_next(), Some(cid_c2s_0));
+        assert_eq!(pipe.server.retired_scid_next(), None);
+
+        assert_eq!(
+            pipe.server.path_event_next(),
+            Some(PathEvent::Closed(
+                server_addr,
+                client_addr,
+                0,
+                "no error".into(),
+            ))
+        );
+
+        assert_eq!(pipe.client.retired_scid_next(), Some(cid_s2c_0));
+        assert_eq!(pipe.client.retired_scid_next(), None);
+
+        assert_eq!(
+            pipe.client.path_event_next(),
+            Some(PathEvent::Closed(
+                client_addr,
+                server_addr,
+                0,
+                "no error".into(),
+            ))
+        );
     }
 }
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -7649,11 +7649,15 @@ impl Connection {
                 if !self.use_path_pkt_num_space(epoch) {
                     return Err(Error::MultiPathViolation);
                 }
-                let abandon_pid = self
+                let abandon_pid = match self
                     .ids
                     .get_dcid(dcid_seq_num)?
                     .path_id
-                    .ok_or(Error::InvalidFrame)?;
+                    .ok_or(Error::InvalidFrame)
+                {
+                    Ok(ap) => ap,
+                    Err(_) => return Ok(()),
+                };
                 self.paths.on_path_abandon_received(
                     abandon_pid,
                     error_code,
@@ -17463,6 +17467,7 @@ pub use crate::packet::Header;
 pub use crate::packet::Type;
 
 pub use crate::path::PathEvent;
+pub use crate::path::PathState;
 pub use crate::path::PathStats;
 pub use crate::path::PathStatus;
 pub use crate::path::SocketAddrIter;

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1245,7 +1245,7 @@ pub struct Connection {
     trace_id: String,
 
     /// Packet number spaces.
-    pkt_num_spaces: [packet::PktNumSpace; packet::Epoch::count()],
+    pkt_num_spaces: packet::PktNumSpaceMap,
 
     /// Peer's transport parameters.
     peer_transport_params: TransportParams,
@@ -1737,11 +1737,7 @@ impl Connection {
 
             trace_id: scid_as_hex.join(""),
 
-            pkt_num_spaces: [
-                packet::PktNumSpace::new(),
-                packet::PktNumSpace::new(),
-                packet::PktNumSpace::new(),
-            ],
+            pkt_num_spaces: packet::PktNumSpaceMap::new(),
 
             peer_transport_params: TransportParams::default(),
 
@@ -1900,10 +1896,14 @@ impl Connection {
                 active_path_id,
             )?;
 
-            conn.pkt_num_spaces[packet::Epoch::Initial].crypto_open =
-                Some(aead_open);
-            conn.pkt_num_spaces[packet::Epoch::Initial].crypto_seal =
-                Some(aead_seal);
+            conn.pkt_num_spaces
+                .crypto
+                .get_mut(packet::Epoch::Initial)
+                .crypto_open = Some(aead_open);
+            conn.pkt_num_spaces
+                .crypto
+                .get_mut(packet::Epoch::Initial)
+                .crypto_seal = Some(aead_seal);
 
             conn.derived_initial_secrets = true;
         }
@@ -2167,7 +2167,10 @@ impl Connection {
     fn process_undecrypted_0rtt_packets(&mut self) -> Result<()> {
         // Process previously undecryptable 0-RTT packets if the decryption key
         // is now available.
-        if self.pkt_num_spaces[packet::Epoch::Application]
+        if self
+            .pkt_num_spaces
+            .crypto
+            .get(packet::Epoch::Application)
             .crypto_0rtt_open
             .is_some()
         {
@@ -2331,10 +2334,14 @@ impl Connection {
             self.got_peer_conn_id = false;
             self.handshake.clear()?;
 
-            self.pkt_num_spaces[packet::Epoch::Initial].crypto_open =
-                Some(aead_open);
-            self.pkt_num_spaces[packet::Epoch::Initial].crypto_seal =
-                Some(aead_seal);
+            self.pkt_num_spaces
+                .crypto
+                .get_mut(packet::Epoch::Initial)
+                .crypto_open = Some(aead_open);
+            self.pkt_num_spaces
+                .crypto
+                .get_mut(packet::Epoch::Initial)
+                .crypto_seal = Some(aead_seal);
 
             self.handshake
                 .use_legacy_codepoint(self.version != PROTOCOL_VERSION_V1);
@@ -2396,10 +2403,14 @@ impl Connection {
             self.got_peer_conn_id = false;
             self.handshake.clear()?;
 
-            self.pkt_num_spaces[packet::Epoch::Initial].crypto_open =
-                Some(aead_open);
-            self.pkt_num_spaces[packet::Epoch::Initial].crypto_seal =
-                Some(aead_seal);
+            self.pkt_num_spaces
+                .crypto
+                .get_mut(packet::Epoch::Initial)
+                .crypto_open = Some(aead_open);
+            self.pkt_num_spaces
+                .crypto
+                .get_mut(packet::Epoch::Initial)
+                .crypto_seal = Some(aead_seal);
 
             return Err(Error::Done);
         }
@@ -2460,10 +2471,14 @@ impl Connection {
                 self.is_server,
             )?;
 
-            self.pkt_num_spaces[packet::Epoch::Initial].crypto_open =
-                Some(aead_open);
-            self.pkt_num_spaces[packet::Epoch::Initial].crypto_seal =
-                Some(aead_seal);
+            self.pkt_num_spaces
+                .crypto
+                .get_mut(packet::Epoch::Initial)
+                .crypto_open = Some(aead_open);
+            self.pkt_num_spaces
+                .crypto
+                .get_mut(packet::Epoch::Initial)
+                .crypto_seal = Some(aead_seal);
 
             self.derived_initial_secrets = true;
         }
@@ -2474,10 +2489,14 @@ impl Connection {
         // Select AEAD context used to open incoming packet.
         let aead = if hdr.ty == packet::Type::ZeroRTT {
             // Only use 0-RTT key if incoming packet is 0-RTT.
-            self.pkt_num_spaces[epoch].crypto_0rtt_open.as_ref()
+            self.pkt_num_spaces
+                .crypto
+                .get(epoch)
+                .crypto_0rtt_open
+                .as_ref()
         } else {
             // Otherwise use the packet number space's main key.
-            self.pkt_num_spaces[epoch].crypto_open.as_ref()
+            self.pkt_num_spaces.crypto.get(epoch).crypto_open.as_ref()
         };
 
         // Finally, discard packet if no usable key is available.
@@ -2518,8 +2537,18 @@ impl Connection {
             drop_pkt_on_err(e, self.recv_count, self.is_server, &self.trace_id)
         })?;
 
+        let space_id = packet::INITIAL_PACKET_NUMBER_SPACE_ID;
+
+        // This might be a new space identifier yet unseen before. In such case,
+        // it should start with 0.
+        let largest_rx_pkt_num = self
+            .pkt_num_spaces
+            .spaces
+            .get(epoch, space_id)
+            .map(|pns| pns.largest_rx_pkt_num)
+            .unwrap_or(0);
         let pn = packet::decode_pkt_num(
-            self.pkt_num_spaces[epoch].largest_rx_pkt_num,
+            largest_rx_pkt_num,
             hdr.pkt_num,
             hdr.pkt_num_len,
         );
@@ -2546,7 +2575,10 @@ impl Connection {
             hdr.key_phase != self.key_phase
         {
             // Check if this packet arrived before key update.
-            if let Some(key_update) = self.pkt_num_spaces[epoch]
+            if let Some(key_update) = self
+                .pkt_num_spaces
+                .crypto
+                .get(epoch)
                 .key_update
                 .as_ref()
                 .and_then(|key_update| {
@@ -2558,12 +2590,16 @@ impl Connection {
                 trace!("{} peer-initiated key update", self.trace_id);
 
                 aead_next = Some((
-                    self.pkt_num_spaces[epoch]
+                    self.pkt_num_spaces
+                        .crypto
+                        .get(epoch)
                         .crypto_open
                         .as_ref()
                         .unwrap()
                         .derive_next_packet_key()?,
-                    self.pkt_num_spaces[epoch]
+                    self.pkt_num_spaces
+                        .crypto
+                        .get(epoch)
                         .crypto_seal
                         .as_ref()
                         .unwrap()
@@ -2578,6 +2614,7 @@ impl Connection {
 
         let mut payload = packet::decrypt_pkt(
             &mut b,
+            space_id as u32,
             pn,
             pn_len,
             payload_len,
@@ -2587,7 +2624,11 @@ impl Connection {
             drop_pkt_on_err(e, self.recv_count, self.is_server, &self.trace_id)
         })?;
 
-        if self.pkt_num_spaces[epoch].recv_pkt_num.contains(pn) {
+        let pkt_num_space = self
+            .pkt_num_spaces
+            .spaces
+            .get_mut_or_create(epoch, space_id);
+        if pkt_num_space.recv_pkt_num.contains(pn) {
             trace!("{} ignored duplicate packet {}", self.trace_id, pn);
             return Err(Error::Done);
         }
@@ -2610,7 +2651,10 @@ impl Connection {
         // The key update is verified once a packet is successfully decrypted
         // using the new keys.
         if let Some((open_next, seal_next)) = aead_next {
-            if !self.pkt_num_spaces[epoch]
+            if !self
+                .pkt_num_spaces
+                .crypto
+                .get(epoch)
                 .key_update
                 .as_ref()
                 .map_or(true, |prev| prev.update_acked)
@@ -2621,21 +2665,30 @@ impl Connection {
 
             trace!("{} key update verified", self.trace_id);
 
-            let _ = self.pkt_num_spaces[epoch].crypto_seal.replace(seal_next);
+            let _ = self
+                .pkt_num_spaces
+                .crypto
+                .get_mut(epoch)
+                .crypto_seal
+                .replace(seal_next);
 
-            let open_prev = self.pkt_num_spaces[epoch]
+            let open_prev = self
+                .pkt_num_spaces
+                .crypto
+                .get_mut(epoch)
                 .crypto_open
                 .replace(open_next)
                 .unwrap();
 
             let recv_path = self.paths.get_mut(recv_pid)?;
 
-            self.pkt_num_spaces[epoch].key_update = Some(packet::KeyUpdate {
-                crypto_open: open_prev,
-                pn_on_update: pn,
-                update_acked: false,
-                timer: now + (recv_path.recovery.pto() * 3),
-            });
+            self.pkt_num_spaces.crypto.get_mut(epoch).key_update =
+                Some(packet::KeyUpdate {
+                    crypto_open: open_prev,
+                    pn_on_update: pn,
+                    update_acked: false,
+                    timer: now + (recv_path.recovery.pto() * 3),
+                });
 
             self.key_phase = !self.key_phase;
 
@@ -2808,14 +2861,18 @@ impl Connection {
                         // largest acknowledged in the sent ACK frame that, in
                         // turn, got acked.
                         if let Some(largest_acked) = ranges.last() {
-                            self.pkt_num_spaces[epoch]
+                            self.pkt_num_spaces
+                                .spaces
+                                .get_mut(epoch, 0)?
                                 .recv_pkt_need_ack
                                 .remove_until(largest_acked);
                         }
                     },
 
                     frame::Frame::CryptoHeader { offset, length } => {
-                        self.pkt_num_spaces[epoch]
+                        self.pkt_num_spaces
+                            .crypto
+                            .get_mut(epoch)
                             .crypto_stream
                             .send
                             .ack_and_drop(offset, length);
@@ -2893,12 +2950,11 @@ impl Connection {
 
         // Now that we processed all the frames, if there is a path that has no
         // Destination CID, try to allocate one.
-        let no_dcid = self
+        for (pid, p) in self
             .paths
             .iter_mut()
-            .filter(|(_, p)| p.active_dcid_seq.is_none());
-
-        for (pid, p) in no_dcid {
+            .filter(|(_, p)| p.active_dcid_seq.is_none())
+        {
             if self.ids.zero_length_dcid() {
                 p.active_dcid_seq = Some(0);
                 continue;
@@ -2909,39 +2965,38 @@ impl Connection {
                 None => break,
             };
 
-            self.ids.link_dcid_to_path_id(dcid_seq, pid)?;
-
-            p.active_dcid_seq = Some(dcid_seq);
+            update_dcid(&mut self.ids, pid, p, Some(dcid_seq))?;
         }
+
+        let pkt_num_space =
+            self.pkt_num_spaces.spaces.get_mut(epoch, space_id)?;
 
         // We only record the time of arrival of the largest packet number
         // that still needs to be acked, to be used for ACK delay calculation.
-        if self.pkt_num_spaces[epoch].recv_pkt_need_ack.last() < Some(pn) {
-            self.pkt_num_spaces[epoch].largest_rx_pkt_time = now;
+        if pkt_num_space.recv_pkt_need_ack.last() < Some(pn) {
+            pkt_num_space.largest_rx_pkt_time = now;
         }
 
-        self.pkt_num_spaces[epoch].recv_pkt_num.insert(pn);
+        pkt_num_space.recv_pkt_num.insert(pn);
 
-        self.pkt_num_spaces[epoch].recv_pkt_need_ack.push_item(pn);
+        pkt_num_space.recv_pkt_need_ack.push_item(pn);
 
-        self.pkt_num_spaces[epoch].ack_elicited =
-            cmp::max(self.pkt_num_spaces[epoch].ack_elicited, ack_elicited);
+        pkt_num_space.ack_elicited =
+            cmp::max(pkt_num_space.ack_elicited, ack_elicited);
 
-        self.pkt_num_spaces[epoch].largest_rx_pkt_num =
-            cmp::max(self.pkt_num_spaces[epoch].largest_rx_pkt_num, pn);
+        pkt_num_space.largest_rx_pkt_num =
+            cmp::max(pkt_num_space.largest_rx_pkt_num, pn);
 
         if !probing {
-            self.pkt_num_spaces[epoch].largest_rx_non_probing_pkt_num = cmp::max(
-                self.pkt_num_spaces[epoch].largest_rx_non_probing_pkt_num,
-                pn,
-            );
+            pkt_num_space.largest_rx_non_probing_pkt_num =
+                cmp::max(pkt_num_space.largest_rx_non_probing_pkt_num, pn);
 
             // Did the peer migrated to another path?
             let active_path_id = self.paths.get_active_path_id()?;
 
             if self.is_server &&
                 recv_pid != active_path_id &&
-                self.pkt_num_spaces[epoch].largest_rx_non_probing_pkt_num == pn
+                pkt_num_space.largest_rx_non_probing_pkt_num == pn
             {
                 self.on_peer_migrated(recv_pid, self.disable_dcid_reuse, now)?;
             }
@@ -3279,14 +3334,18 @@ impl Connection {
         };
 
         let epoch = pkt_type.to_epoch()?;
-        let pkt_space = &mut self.pkt_num_spaces[epoch];
 
         // Process lost frames. There might be several paths having lost frames.
         for (_, p) in self.paths.iter_mut() {
             for lost in p.recovery.lost[epoch].drain(..) {
                 match lost {
                     frame::Frame::CryptoHeader { offset, length } => {
-                        pkt_space.crypto_stream.send.retransmit(offset, length);
+                        self.pkt_num_spaces
+                            .crypto
+                            .get_mut(epoch)
+                            .crypto_stream
+                            .send
+                            .retransmit(offset, length);
 
                         self.stream_retrans_bytes += length as u64;
                         p.stream_retrans_bytes += length as u64;
@@ -3333,9 +3392,11 @@ impl Connection {
                         p.retrans_count += 1;
                     },
 
-                    frame::Frame::ACK { .. } => {
-                        pkt_space.ack_elicited = true;
-                    },
+                    frame::Frame::ACK { .. } =>
+                        self.pkt_num_spaces
+                            .spaces
+                            .get_mut(epoch, 0)?
+                            .ack_elicited = true,
 
                     frame::Frame::ResetStream {
                         stream_id,
@@ -3380,15 +3441,22 @@ impl Connection {
         let n_paths = self.paths.len();
         let path = self.paths.get_mut(send_pid)?;
         let flow_control = &mut self.flow_control;
-        let pkt_space = &mut self.pkt_num_spaces[epoch];
+        let crypto_space = self.pkt_num_spaces.crypto.get_mut(epoch);
 
         let mut left = b.cap();
+
+        let space_id = packet::INITIAL_PACKET_NUMBER_SPACE_ID;
+        let pkt_space = self
+            .pkt_num_spaces
+            .spaces
+            .get_mut_or_create(epoch, space_id);
 
         let pn = pkt_space.next_pkt_num;
         let pn_len = packet::pkt_num_len(pn)?;
 
         // The AEAD overhead at the current encryption level.
-        let crypto_overhead = pkt_space.crypto_overhead().ok_or(Error::Done)?;
+        let crypto_overhead =
+            crypto_space.crypto_overhead().ok_or(Error::Done)?;
 
         let dcid_seq = path.active_dcid_seq.ok_or(Error::OutOfIdentifiers)?;
 
@@ -3591,7 +3659,7 @@ impl Connection {
                 }
             }
 
-            if let Some(key_update) = pkt_space.key_update.as_mut() {
+            if let Some(key_update) = crypto_space.key_update.as_mut() {
                 key_update.update_acked = true;
             }
         }
@@ -3856,12 +3924,12 @@ impl Connection {
         }
 
         // Create CRYPTO frame.
-        if pkt_space.crypto_stream.is_flushable() &&
+        if crypto_space.crypto_stream.is_flushable() &&
             left > frame::MAX_CRYPTO_OVERHEAD &&
             !is_closing &&
             path.active()
         {
-            let crypto_off = pkt_space.crypto_stream.send.off_front();
+            let crypto_off = crypto_space.crypto_stream.send.off_front();
 
             // Encode the frame.
             //
@@ -3886,7 +3954,7 @@ impl Connection {
                     b.split_at(hdr_off + hdr_len)?;
 
                 // Write stream data into the packet buffer.
-                let (len, _) = pkt_space
+                let (len, _) = crypto_space
                     .crypto_stream
                     .send
                     .emit(&mut crypto_payload.as_mut()[..max_len])?;
@@ -4255,13 +4323,14 @@ impl Connection {
             }
         });
 
-        let aead = match pkt_space.crypto_seal {
+        let aead = match crypto_space.crypto_seal {
             Some(ref v) => v,
             None => return Err(Error::InvalidState),
         };
 
         let written = packet::encrypt_pkt(
             &mut b,
+            space_id as u32,
             pn,
             pn_len,
             payload_len,
@@ -4270,8 +4339,10 @@ impl Connection {
             aead,
         )?;
 
+        let pkt_num = recovery::SpacedPktNum::new(space_id as u32, pn);
+
         let sent_pkt = recovery::Sent {
-            pkt_num: pn,
+            pkt_num,
             frames,
             time_sent: now,
             time_acked: None,
@@ -4295,7 +4366,10 @@ impl Connection {
         pkt_space.next_pkt_num += 1;
 
         let handshake_status = recovery::HandshakeStatus {
-            has_handshake_keys: self.pkt_num_spaces[packet::Epoch::Handshake]
+            has_handshake_keys: self
+                .pkt_num_spaces
+                .crypto
+                .get(packet::Epoch::Handshake)
                 .has_keys(),
             peer_verified_address: self.peer_verified_initial_address,
             completed: self.handshake_completed,
@@ -5446,7 +5520,9 @@ impl Connection {
                 max_len = max_len.saturating_sub(packet::MAX_PKT_NUM_LEN);
                 // ...subtract the crypto overhead...
                 max_len = max_len.saturating_sub(
-                    self.pkt_num_spaces[packet::Epoch::Application]
+                    self.pkt_num_spaces
+                        .crypto
+                        .get(packet::Epoch::Application)
                         .crypto_overhead()?,
                 );
                 // ...clamp to what peer can support...
@@ -5486,18 +5562,15 @@ impl Connection {
             // detection timers. If they are both unset (i.e. `None`) then the
             // result is `None`, but if at least one of them is set then a
             // `Some(...)` value is returned.
-            let path_timer = self
-                .paths
-                .iter()
-                .filter_map(|(_, p)| p.recovery.loss_detection_timer())
-                .min();
-
-            let key_update_timer = self.pkt_num_spaces
-                [packet::Epoch::Application]
+            let path_timer =
+                self.paths.iter().filter_map(|(_, p)| p.path_timer()).min();
+            let key_update_timer = self
+                .pkt_num_spaces
+                .crypto
+                .get(packet::Epoch::Application)
                 .key_update
                 .as_ref()
                 .map(|key_update| key_update.timer);
-
             let timers = [self.idle_timer, path_timer, key_update_timer];
 
             timers.iter().filter_map(|&x| x).min()
@@ -5559,14 +5632,20 @@ impl Connection {
             }
         }
 
-        if let Some(timer) = self.pkt_num_spaces[packet::Epoch::Application]
+        if let Some(timer) = self
+            .pkt_num_spaces
+            .crypto
+            .get(packet::Epoch::Application)
             .key_update
             .as_ref()
             .map(|key_update| key_update.timer)
         {
             if timer <= now {
                 // Discard previous key once key update timer expired.
-                let _ = self.pkt_num_spaces[packet::Epoch::Application]
+                let _ = self
+                    .pkt_num_spaces
+                    .crypto
+                    .get_mut(packet::Epoch::Application)
                     .key_update
                     .take();
             }
@@ -5756,7 +5835,7 @@ impl Connection {
     /// This triggers sending NEW_CONNECTION_ID frames if the provided Source
     /// Connection ID is not already present. In the case the caller tries to
     /// reuse a Connection ID with a different reset token, this raises an
-    /// `InvalidState`.
+    /// [`InvalidState`].
     ///
     /// At any time, the peer cannot have more Destination Connection IDs than
     /// the maximum number of active Connection IDs it negotiated. In such case
@@ -5866,14 +5945,13 @@ impl Connection {
         if let Some(pid) = self.ids.retire_dcid(dcid_seq)? {
             // The retired Destination CID was associated to a given path. Let's
             // find an available DCID to associate to that path.
-            let path = self.paths.get_mut(pid)?;
             let dcid_seq = self.ids.lowest_available_dcid_seq();
+            let path = self.paths.get_mut(pid)?;
+            update_dcid(&mut self.ids, pid, path, dcid_seq)?;
 
-            if let Some(dcid_seq) = dcid_seq {
-                self.ids.link_dcid_to_path_id(dcid_seq, pid)?;
-            }
-
-            path.active_dcid_seq = dcid_seq;
+            self.pkt_num_spaces
+                .spaces
+                .update_lowest_active_tx_id(self.ids.min_dcid_seq());
         }
 
         Ok(())
@@ -6498,7 +6576,10 @@ impl Connection {
                     // Downgrade the epoch to Initial as the remote peer might
                     // not be able to decrypt handshake packets yet.
                     packet::Epoch::Handshake
-                        if self.pkt_num_spaces[packet::Epoch::Initial]
+                        if self
+                            .pkt_num_spaces
+                            .crypto
+                            .get(packet::Epoch::Initial)
                             .has_keys() =>
                         return Ok(packet::Type::Initial),
 
@@ -6513,12 +6594,11 @@ impl Connection {
             packet::Epoch::Initial..=packet::Epoch::Application,
         ) {
             // Only send packets in a space when we have the send keys for it.
-            if self.pkt_num_spaces[epoch].crypto_seal.is_none() {
+            if self.pkt_num_spaces.crypto.get(epoch).crypto_seal.is_none() {
                 continue;
             }
 
-            // We are ready to send data for this packet number space.
-            if self.pkt_num_spaces[epoch].ready() {
+            if self.pkt_num_spaces.is_ready(epoch, None) {
                 return Ok(packet::Type::from_epoch(epoch));
             }
 
@@ -6621,6 +6701,7 @@ impl Connection {
                     }
 
                     let (lost_packets, lost_bytes) = p.recovery.on_ack_received(
+                        0,
                         &ranges,
                         ack_delay,
                         epoch,
@@ -6740,7 +6821,12 @@ impl Connection {
 
             frame::Frame::Crypto { data } => {
                 // Push the data to the stream so it can be re-ordered.
-                self.pkt_num_spaces[epoch].crypto_stream.recv.write(data)?;
+                self.pkt_num_spaces
+                    .crypto
+                    .get_mut(epoch)
+                    .crypto_stream
+                    .recv
+                    .write(data)?;
 
                 // Feed crypto data to the TLS state, if there's data
                 // available at the expected offset.
@@ -6748,7 +6834,8 @@ impl Connection {
 
                 let level = crypto::Level::from_epoch(epoch);
 
-                let stream = &mut self.pkt_num_spaces[epoch].crypto_stream;
+                let stream =
+                    &mut self.pkt_num_spaces.crypto.get_mut(epoch).crypto_stream;
 
                 while let Ok((read, _)) = stream.recv.emit(&mut crypto_buf) {
                     let recv_buf = &crypto_buf[..read];
@@ -6932,21 +7019,15 @@ impl Connection {
                         continue;
                     }
 
-                    if let Some(new_dcid_seq) =
-                        self.ids.lowest_available_dcid_seq()
-                    {
-                        path.active_dcid_seq = Some(new_dcid_seq);
+                    let new_dcid_seq = self.ids.lowest_available_dcid_seq();
+                    update_dcid(&mut self.ids, pid, path, new_dcid_seq)?;
 
-                        self.ids.link_dcid_to_path_id(new_dcid_seq, pid)?;
-
+                    if let Some(new_dcid_seq) = new_dcid_seq {
                         trace!(
                             "{} path ID {} changed DCID: old seq num {} new seq num {}",
                             self.trace_id, pid, dcid_seq, new_dcid_seq,
                         );
                     } else {
-                        // We cannot use this path anymore for now.
-                        path.active_dcid_seq = None;
-
                         trace!(
                             "{} path ID {} cannot be used; DCID seq num {} has been retired",
                             self.trace_id, pid, dcid_seq,
@@ -6970,6 +7051,10 @@ impl Connection {
                         // host is willing to.
                         path.active_scid_seq = None;
                     }
+
+                    self.pkt_num_spaces
+                        .spaces
+                        .update_lowest_active_rx_id(self.ids.min_scid_seq());
                 }
             },
 
@@ -7045,13 +7130,13 @@ impl Connection {
 
     /// Drops the keys and recovery state for the given epoch.
     fn drop_epoch_state(&mut self, epoch: packet::Epoch, now: time::Instant) {
-        if self.pkt_num_spaces[epoch].crypto_open.is_none() {
+        if self.pkt_num_spaces.crypto.get(epoch).crypto_open.is_none() {
             return;
         }
 
-        self.pkt_num_spaces[epoch].crypto_open = None;
-        self.pkt_num_spaces[epoch].crypto_seal = None;
-        self.pkt_num_spaces[epoch].clear();
+        self.pkt_num_spaces.crypto.get_mut(epoch).crypto_open = None;
+        self.pkt_num_spaces.crypto.get_mut(epoch).crypto_seal = None;
+        self.pkt_num_spaces.clear(epoch);
 
         let handshake_status = self.handshake_status();
         for (_, p) in self.paths.iter_mut() {
@@ -7120,7 +7205,10 @@ impl Connection {
     /// Returns the connection's handshake status for use in loss recovery.
     fn handshake_status(&self) -> recovery::HandshakeStatus {
         recovery::HandshakeStatus {
-            has_handshake_keys: self.pkt_num_spaces[packet::Epoch::Handshake]
+            has_handshake_keys: self
+                .pkt_num_spaces
+                .crypto
+                .get(packet::Epoch::Handshake)
                 .has_keys(),
 
             peer_verified_address: self.peer_verified_initial_address,
@@ -7185,20 +7273,19 @@ impl Connection {
         &mut self, recv_pid: Option<usize>, dcid: &ConnectionId, buf_len: usize,
         info: &RecvInfo,
     ) -> Result<usize> {
-        let ids = &mut self.ids;
-
         let (in_scid_seq, mut in_scid_pid) =
-            ids.find_scid_seq(dcid).ok_or(Error::InvalidState)?;
+            self.ids.find_scid_seq(dcid).ok_or(Error::InvalidState)?;
 
         if let Some(recv_pid) = recv_pid {
             // If the path observes a change of SCID used, note it.
             let recv_path = self.paths.get_mut(recv_pid)?;
 
-            let cid_entry =
-                recv_path.active_scid_seq.and_then(|v| ids.get_scid(v).ok());
+            let cid_entry = recv_path
+                .active_scid_seq
+                .and_then(|v| self.ids.get_scid(v).ok());
 
             if cid_entry.map(|e| &e.cid) != Some(dcid) {
-                let incoming_cid_entry = ids.get_scid(in_scid_seq)?;
+                let incoming_cid_entry = self.ids.get_scid(in_scid_seq)?;
 
                 let prev_recv_pid =
                     incoming_cid_entry.path_id.unwrap_or(recv_pid);
@@ -7222,8 +7309,8 @@ impl Connection {
                     in_scid_seq
                 );
 
-                recv_path.active_scid_seq = Some(in_scid_seq);
-                ids.link_scid_to_path_id(in_scid_seq, recv_pid)?;
+                let recv_path = self.paths.get_mut(recv_pid)?;
+                update_scid(&mut self.ids, recv_pid, recv_path, in_scid_seq)?;
             }
 
             return Ok(recv_pid);
@@ -7233,7 +7320,7 @@ impl Connection {
         // another path.
 
         // Ignore this step if are using zero-length SCID.
-        if ids.zero_length_scid() {
+        if self.ids.zero_length_scid() {
             in_scid_pid = None;
         }
 
@@ -7270,17 +7357,14 @@ impl Connection {
             path::Path::new(info.to, info.from, &self.recovery_config, false);
 
         path.max_send_bytes = buf_len * MAX_AMPLIFICATION_FACTOR;
-        path.active_scid_seq = Some(in_scid_seq);
 
         // Automatically probes the new path.
         path.request_validation();
 
         let pid = self.paths.insert_path(path, self.is_server)?;
 
-        // Do not record path reuse.
-        if in_scid_pid.is_none() {
-            ids.link_scid_to_path_id(in_scid_seq, pid)?;
-        }
+        let path = self.paths.get_mut(pid)?;
+        update_scid(&mut self.ids, pid, path, in_scid_seq)?;
 
         Ok(pid)
     }
@@ -7389,15 +7473,15 @@ impl Connection {
                 .ok_or(Error::OutOfIdentifiers)?
         };
 
-        let mut path =
+        let path =
             path::Path::new(local_addr, peer_addr, &self.recovery_config, false);
-        path.active_dcid_seq = Some(dcid_seq);
 
         let pid = self
             .paths
             .insert_path(path, false)
             .map_err(|_| Error::OutOfIdentifiers)?;
-        self.ids.link_dcid_to_path_id(dcid_seq, pid)?;
+        let path = self.paths.get_mut(pid)?;
+        update_dcid(&mut self.ids, pid, path, Some(dcid_seq))?;
 
         Ok(pid)
     }
@@ -7436,6 +7520,38 @@ fn drop_pkt_on_err(
     // Ignore other invalid packets that haven't been authenticated to prevent
     // man-in-the-middle and man-on-the-side attacks.
     Error::Done
+}
+
+/// Sets the DCID sequence number of the provided path identifier and
+/// updates our internal state.
+/// `path_id` must be the identifier of `path`.
+fn update_dcid(
+    ids: &mut cid::ConnectionIdentifiers, path_id: usize, path: &mut path::Path,
+    dcid_seq: Option<u64>,
+) -> Result<()> {
+    let dcid_seq = match dcid_seq {
+        Some(s) => s,
+        None => {
+            path.active_dcid_seq = None;
+            return Ok(());
+        },
+    };
+    ids.link_dcid_to_path_id(dcid_seq, path_id)?;
+    path.active_dcid_seq = Some(dcid_seq);
+
+    Ok(())
+}
+
+/// Sets the SCID sequence number of the provided path identifier and
+/// updates our internal state.
+fn update_scid(
+    ids: &mut cid::ConnectionIdentifiers, path_id: usize, path: &mut path::Path,
+    scid_seq: u64,
+) -> Result<()> {
+    ids.link_scid_to_path_id(scid_seq, path_id)?;
+    path.active_scid_seq = Some(scid_seq);
+
+    Ok(())
 }
 
 struct AddrTupleFmt(SocketAddr, SocketAddr);
@@ -8208,8 +8324,16 @@ pub mod testing {
         }
 
         pub fn client_update_key(&mut self) -> Result<()> {
-            let space =
-                &mut self.client.pkt_num_spaces[packet::Epoch::Application];
+            let space = self
+                .client
+                .pkt_num_spaces
+                .crypto
+                .get_mut(packet::Epoch::Application);
+            let pkt_space = self
+                .client
+                .pkt_num_spaces
+                .spaces
+                .get(packet::Epoch::Application, 0)?;
 
             let open_next = space
                 .crypto_open
@@ -8229,7 +8353,7 @@ pub mod testing {
 
             space.key_update = Some(packet::KeyUpdate {
                 crypto_open: open_prev.unwrap(),
-                pn_on_update: space.next_pkt_num,
+                pn_on_update: pkt_space.next_pkt_num,
                 update_acked: true,
                 timer: time::Instant::now(),
             });
@@ -8329,9 +8453,7 @@ pub mod testing {
 
         let epoch = pkt_type.to_epoch()?;
 
-        let space = &mut conn.pkt_num_spaces[epoch];
-
-        let pn = space.next_pkt_num;
+        let pn = conn.pkt_num_spaces.spaces.get(epoch, 0)?.next_pkt_num;
         let pn_len = 4;
 
         let send_path = conn.paths.get_active()?;
@@ -8365,7 +8487,13 @@ pub mod testing {
         let payload_len = frames.iter().fold(0, |acc, x| acc + x.wire_len());
 
         if pkt_type != packet::Type::Short {
-            let len = pn_len + payload_len + space.crypto_overhead().unwrap();
+            let len = pn_len +
+                payload_len +
+                conn.pkt_num_spaces
+                    .crypto
+                    .get(epoch)
+                    .crypto_overhead()
+                    .unwrap();
             b.put_varint(len as u64)?;
         }
 
@@ -8379,13 +8507,16 @@ pub mod testing {
             frame.to_bytes(&mut b)?;
         }
 
-        let aead = match space.crypto_seal {
+        let aead = match conn.pkt_num_spaces.crypto.get(epoch).crypto_seal {
             Some(ref v) => v,
             None => return Err(Error::InvalidState),
         };
 
+        let path_seq = packet::INITIAL_PACKET_NUMBER_SPACE_ID as u32;
+
         let written = packet::encrypt_pkt(
             &mut b,
+            path_seq,
             pn,
             pn_len,
             payload_len,
@@ -8394,7 +8525,7 @@ pub mod testing {
             aead,
         )?;
 
-        space.next_pkt_num += 1;
+        conn.pkt_num_spaces.spaces.get_mut(epoch, 0)?.next_pkt_num += 1;
 
         Ok(written)
     }
@@ -8408,21 +8539,35 @@ pub mod testing {
 
         let epoch = hdr.ty.to_epoch()?;
 
-        let aead = conn.pkt_num_spaces[epoch].crypto_open.as_ref().unwrap();
+        let aead = conn
+            .pkt_num_spaces
+            .crypto
+            .get(epoch)
+            .crypto_open
+            .as_ref()
+            .unwrap();
 
         let payload_len = b.cap();
 
         packet::decrypt_hdr(&mut b, &mut hdr, aead).unwrap();
 
         let pn = packet::decode_pkt_num(
-            conn.pkt_num_spaces[epoch].largest_rx_pkt_num,
+            conn.pkt_num_spaces.spaces.get(epoch, 0)?.largest_rx_pkt_num,
             hdr.pkt_num,
             hdr.pkt_num_len,
         );
 
-        let mut payload =
-            packet::decrypt_pkt(&mut b, pn, hdr.pkt_num_len, payload_len, aead)
-                .unwrap();
+        let path_seq = packet::INITIAL_PACKET_NUMBER_SPACE_ID as u32;
+
+        let mut payload = packet::decrypt_pkt(
+            &mut b,
+            path_seq,
+            pn,
+            hdr.pkt_num_len,
+            payload_len,
+            aead,
+        )
+        .unwrap();
 
         let mut frames = Vec::new();
 
@@ -9308,7 +9453,10 @@ mod tests {
 
         // Ensure ACK for key update.
         assert!(
-            pipe.server.pkt_num_spaces[packet::Epoch::Application]
+            pipe.server
+                .pkt_num_spaces
+                .crypto
+                .get(packet::Epoch::Application)
                 .key_update
                 .as_ref()
                 .unwrap()
@@ -10346,7 +10494,11 @@ mod tests {
         // Note that `largest_rx_pkt_num` is initialized to 0, so we need to
         // send another 1-RTT packet to make this check meaningful.
         assert_eq!(
-            pipe.server.pkt_num_spaces[packet::Epoch::Application]
+            pipe.server
+                .pkt_num_spaces
+                .spaces
+                .get(packet::Epoch::Application, 0)
+                .unwrap()
                 .largest_rx_pkt_num,
             0
         );
@@ -10357,7 +10509,11 @@ mod tests {
         assert!(pipe.server.is_established());
 
         assert_eq!(
-            pipe.server.pkt_num_spaces[packet::Epoch::Application]
+            pipe.server
+                .pkt_num_spaces
+                .spaces
+                .get(packet::Epoch::Application, 0)
+                .unwrap()
                 .largest_rx_pkt_num,
             0
         );
@@ -11380,15 +11536,18 @@ mod tests {
             frame.to_bytes(&mut b).unwrap();
         }
 
-        let space = &mut pipe.client.pkt_num_spaces[epoch];
+        let path_seq = 0;
+
+        let crypto = pipe.client.pkt_num_spaces.crypto.get(epoch);
 
         // Use correct payload length when encrypting the packet.
         let payload_len = frames.iter().fold(0, |acc, x| acc + x.wire_len());
 
-        let aead = space.crypto_seal.as_ref().unwrap();
+        let aead = crypto.crypto_seal.as_ref().unwrap();
 
         let written = packet::encrypt_pkt(
             &mut b,
+            path_seq,
             pn,
             pn_len,
             payload_len,
@@ -12577,7 +12736,16 @@ mod tests {
 
         let epoch = packet::Epoch::Application;
 
-        assert_eq!(pipe.server.pkt_num_spaces[epoch].recv_pkt_need_ack.len(), 0);
+        assert_eq!(
+            pipe.server
+                .pkt_num_spaces
+                .spaces
+                .get(epoch, 0)
+                .unwrap()
+                .recv_pkt_need_ack
+                .len(),
+            0
+        );
 
         let frames = [frame::Frame::Ping, frame::Frame::Padding { len: 3 }];
 
@@ -12588,7 +12756,13 @@ mod tests {
         for _ in 0..512 {
             let recv_count = pipe.server.recv_count;
 
-            last_packet_sent = pipe.client.pkt_num_spaces[epoch].next_pkt_num;
+            last_packet_sent = pipe
+                .client
+                .pkt_num_spaces
+                .spaces
+                .get(epoch, 0)
+                .unwrap()
+                .next_pkt_num;
 
             pipe.send_pkt_to_server(pkt_type, &frames, &mut buf)
                 .unwrap();
@@ -12596,21 +12770,44 @@ mod tests {
             assert_eq!(pipe.server.recv_count, recv_count + 1);
 
             // Skip packet number.
-            pipe.client.pkt_num_spaces[epoch].next_pkt_num += 1;
+            pipe.client
+                .pkt_num_spaces
+                .spaces
+                .get_mut(epoch, 0)
+                .unwrap()
+                .next_pkt_num += 1;
         }
 
         assert_eq!(
-            pipe.server.pkt_num_spaces[epoch].recv_pkt_need_ack.len(),
+            pipe.server
+                .pkt_num_spaces
+                .spaces
+                .get(epoch, 0)
+                .unwrap()
+                .recv_pkt_need_ack
+                .len(),
             MAX_ACK_RANGES
         );
 
         assert_eq!(
-            pipe.server.pkt_num_spaces[epoch].recv_pkt_need_ack.first(),
+            pipe.server
+                .pkt_num_spaces
+                .spaces
+                .get(epoch, 0)
+                .unwrap()
+                .recv_pkt_need_ack
+                .first(),
             Some(last_packet_sent - ((MAX_ACK_RANGES as u64) - 1) * 2)
         );
 
         assert_eq!(
-            pipe.server.pkt_num_spaces[epoch].recv_pkt_need_ack.last(),
+            pipe.server
+                .pkt_num_spaces
+                .spaces
+                .get(epoch, 0)
+                .unwrap()
+                .recv_pkt_need_ack
+                .last(),
             Some(last_packet_sent)
         );
     }
@@ -15102,6 +15299,12 @@ mod tests {
         let client_addr_2 = "127.0.0.1:5678".parse().unwrap();
         assert_eq!(pipe.client.probe_path(client_addr_2, server_addr), Ok(1));
 
+        let mut got = pipe.client.paths_iter(client_addr_2).collect::<Vec<_>>();
+        let mut expected = vec![server_addr];
+        got.sort();
+        expected.sort();
+        assert_eq!(got, expected);
+
         let mut buf = [0; 65535];
         // There is nothing to send on the initial path.
         assert_eq!(
@@ -15153,6 +15356,18 @@ mod tests {
         assert_eq!(pipe.client.probe_path(client_addr_3, server_addr), Ok(3));
         // Just to fit in two packets.
         assert_eq!(pipe.client.stream_send(0, &buf[..1201], true), Ok(1201));
+
+        let mut got = pipe.client.paths_iter(client_addr).collect::<Vec<_>>();
+        let mut expected = vec![server_addr, server_addr_2];
+        got.sort();
+        expected.sort();
+        assert_eq!(got, expected);
+
+        let mut got = pipe.client.paths_iter(client_addr_3).collect::<Vec<_>>();
+        let mut expected = vec![server_addr];
+        got.sort();
+        expected.sort();
+        assert_eq!(got, expected);
 
         // PATH_CHALLENGE
         let (sent, si) = pipe
@@ -15724,6 +15939,7 @@ mod tests {
         let server_active_path = pipe.server.paths.get_active().unwrap();
         assert_eq!(server_active_path.local_addr(), server_addr);
         assert_eq!(server_active_path.peer_addr(), client_addr);
+        assert_eq!(server_active_path.active(), true);
         assert_eq!(pipe.advance(), Ok(()));
         let (rcv_data_2, fin) =
             pipe.client.stream_recv(1, &mut recv_buf).unwrap();

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -1059,6 +1059,10 @@ impl PktNumSpaceImplMap {
             self.remove_dangling_application_pkt_num_spaces();
         }
     }
+
+    pub fn application_data_space_ids(&self) -> impl Iterator<Item = u64> + '_ {
+        self.application_pkt_num_spaces.keys().copied()
+    }
 }
 
 pub struct PktNumSpaceCryptoMap {

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -24,6 +24,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::ops::Index;
 use std::ops::IndexMut;
@@ -106,6 +107,8 @@ where
         self.index_mut(usize::from(index))
     }
 }
+
+pub const INITIAL_PACKET_NUMBER_SPACE_ID: u64 = 0;
 
 /// QUIC packet type.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -649,8 +652,8 @@ pub fn decode_pkt_num(largest_pn: u64, truncated_pn: u64, pn_len: usize) -> u64 
 }
 
 pub fn decrypt_pkt<'a>(
-    b: &'a mut octets::OctetsMut, pn: u64, pn_len: usize, payload_len: usize,
-    aead: &crypto::Open,
+    b: &'a mut octets::OctetsMut, path_seq: u32, pn: u64, pn_len: usize,
+    payload_len: usize, aead: &crypto::Open,
 ) -> Result<octets::Octets<'a>> {
     let payload_offset = b.off();
 
@@ -662,8 +665,12 @@ pub fn decrypt_pkt<'a>(
 
     let mut ciphertext = payload.peek_bytes_mut(payload_len)?;
 
-    let payload_len =
-        aead.open_with_u64_counter(pn, header.as_ref(), ciphertext.as_mut())?;
+    let payload_len = aead.open_with_u64_counter(
+        path_seq,
+        pn,
+        header.as_ref(),
+        ciphertext.as_mut(),
+    )?;
 
     Ok(b.get_bytes(payload_len)?)
 }
@@ -694,13 +701,16 @@ pub fn encrypt_hdr(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn encrypt_pkt(
-    b: &mut octets::OctetsMut, pn: u64, pn_len: usize, payload_len: usize,
-    payload_offset: usize, extra_in: Option<&[u8]>, aead: &crypto::Seal,
+    b: &mut octets::OctetsMut, path_seq: u32, pn: u64, pn_len: usize,
+    payload_len: usize, payload_offset: usize, extra_in: Option<&[u8]>,
+    aead: &crypto::Seal,
 ) -> Result<usize> {
     let (mut header, mut payload) = b.split_at(payload_offset)?;
 
     let ciphertext_len = aead.seal_with_u64_counter(
+        path_seq,
         pn,
         header.as_ref(),
         payload.as_mut(),
@@ -867,16 +877,6 @@ pub struct PktNumSpace {
     pub recv_pkt_num: PktNumWindow,
 
     pub ack_elicited: bool,
-
-    pub key_update: Option<KeyUpdate>,
-
-    pub crypto_open: Option<crypto::Open>,
-    pub crypto_seal: Option<crypto::Seal>,
-
-    pub crypto_0rtt_open: Option<crypto::Open>,
-    pub crypto_0rtt_seal: Option<crypto::Seal>,
-
-    pub crypto_stream: stream::Stream,
 }
 
 impl PktNumSpace {
@@ -895,7 +895,33 @@ impl PktNumSpace {
             recv_pkt_num: PktNumWindow::default(),
 
             ack_elicited: false,
+        }
+    }
 
+    fn clear(&mut self) {
+        self.ack_elicited = false;
+    }
+
+    fn ready(&self) -> bool {
+        self.ack_elicited
+    }
+}
+
+pub struct PktNumSpaceCrypto {
+    pub key_update: Option<KeyUpdate>,
+
+    pub crypto_open: Option<crypto::Open>,
+    pub crypto_seal: Option<crypto::Seal>,
+
+    pub crypto_0rtt_open: Option<crypto::Open>,
+    pub crypto_0rtt_seal: Option<crypto::Seal>,
+
+    pub crypto_stream: stream::Stream,
+}
+
+impl PktNumSpaceCrypto {
+    pub fn new() -> PktNumSpaceCrypto {
+        PktNumSpaceCrypto {
             key_update: None,
 
             crypto_open: None,
@@ -915,7 +941,7 @@ impl PktNumSpace {
         }
     }
 
-    pub fn clear(&mut self) {
+    fn clear(&mut self) {
         self.crypto_stream = stream::Stream::new(
             0, // dummy
             u64::MAX,
@@ -924,20 +950,167 @@ impl PktNumSpace {
             true,
             stream::MAX_STREAM_WINDOW,
         );
-
-        self.ack_elicited = false;
     }
 
     pub fn crypto_overhead(&self) -> Option<usize> {
         Some(self.crypto_seal.as_ref()?.alg().tag_len())
     }
 
-    pub fn ready(&self) -> bool {
-        self.crypto_stream.is_flushable() || self.ack_elicited
+    fn ready(&self) -> bool {
+        self.crypto_stream.is_flushable()
     }
 
     pub fn has_keys(&self) -> bool {
         self.crypto_open.is_some() && self.crypto_seal.is_some()
+    }
+}
+
+pub struct PktNumSpaceImplMap {
+    pkt_num_spaces: [PktNumSpace; Epoch::Application as usize],
+    application_pkt_num_spaces: BTreeMap<u64, PktNumSpace>,
+
+    /// Lowest possible RX space ID still in use.
+    lowest_rx_space_id: u64,
+    /// Lowest possible TX space ID still in use.
+    lowest_tx_space_id: u64,
+}
+
+impl PktNumSpaceImplMap {
+    fn new() -> PktNumSpaceImplMap {
+        PktNumSpaceImplMap {
+            pkt_num_spaces: [PktNumSpace::new(), PktNumSpace::new()],
+            application_pkt_num_spaces: BTreeMap::from([(0, PktNumSpace::new())]),
+
+            lowest_rx_space_id: 0,
+            lowest_tx_space_id: 0,
+        }
+    }
+
+    pub fn get(&self, epoch: Epoch, space_id: u64) -> Result<&PktNumSpace> {
+        match epoch {
+            Epoch::Application => self
+                .application_pkt_num_spaces
+                .get(&space_id)
+                .ok_or(Error::InvalidState),
+            e => Ok(&self.pkt_num_spaces[e]),
+        }
+    }
+
+    pub fn get_mut_or_create(
+        &mut self, epoch: Epoch, space_id: u64,
+    ) -> &mut PktNumSpace {
+        match epoch {
+            Epoch::Application => self
+                .application_pkt_num_spaces
+                .entry(space_id)
+                .or_insert_with(PktNumSpace::new),
+            e => &mut self.pkt_num_spaces[e],
+        }
+    }
+
+    pub fn get_mut(
+        &mut self, epoch: Epoch, space_id: u64,
+    ) -> Result<&mut PktNumSpace> {
+        match epoch {
+            Epoch::Application => self
+                .application_pkt_num_spaces
+                .get_mut(&space_id)
+                .ok_or(Error::InvalidState),
+            e => Ok(&mut self.pkt_num_spaces[e]),
+        }
+    }
+
+    fn is_ready(&self, epoch: Epoch, space_id: Option<u64>) -> bool {
+        match (epoch, space_id) {
+            (Epoch::Application, None) => self
+                .application_pkt_num_spaces
+                .values()
+                .any(|pns| pns.ready()),
+            (e, Some(s)) => match self.get(e, s) {
+                Ok(pns) => pns.ready(),
+                Err(_) => false,
+            },
+            (e, None) => match self.get(e, 0) {
+                Ok(pns) => pns.ready(),
+                Err(_) => false,
+            },
+        }
+    }
+
+    /// Remove application packet number spaces whose connection IDs have been
+    /// retired, to free their memory.
+    fn remove_dangling_application_pkt_num_spaces(&mut self) {
+        let lowest_space_id =
+            std::cmp::min(self.lowest_rx_space_id, self.lowest_tx_space_id);
+        self.application_pkt_num_spaces
+            .retain(|&s, _| s >= lowest_space_id)
+    }
+
+    pub fn update_lowest_active_rx_id(&mut self, rx_id: u64) {
+        if rx_id > self.lowest_rx_space_id {
+            self.lowest_rx_space_id = rx_id;
+            self.remove_dangling_application_pkt_num_spaces();
+        }
+    }
+
+    pub fn update_lowest_active_tx_id(&mut self, tx_id: u64) {
+        if tx_id > self.lowest_tx_space_id {
+            self.lowest_tx_space_id = tx_id;
+            self.remove_dangling_application_pkt_num_spaces();
+        }
+    }
+}
+
+pub struct PktNumSpaceCryptoMap {
+    inner: [PktNumSpaceCrypto; Epoch::count()],
+}
+
+impl PktNumSpaceCryptoMap {
+    fn new() -> PktNumSpaceCryptoMap {
+        PktNumSpaceCryptoMap {
+            inner: [
+                PktNumSpaceCrypto::new(),
+                PktNumSpaceCrypto::new(),
+                PktNumSpaceCrypto::new(),
+            ],
+        }
+    }
+
+    #[inline]
+    pub fn get(&self, epoch: Epoch) -> &PktNumSpaceCrypto {
+        &self.inner[epoch]
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, epoch: Epoch) -> &mut PktNumSpaceCrypto {
+        &mut self.inner[epoch]
+    }
+}
+
+pub struct PktNumSpaceMap {
+    pub spaces: PktNumSpaceImplMap,
+    pub crypto: PktNumSpaceCryptoMap,
+}
+
+impl PktNumSpaceMap {
+    pub fn new() -> PktNumSpaceMap {
+        PktNumSpaceMap {
+            spaces: PktNumSpaceImplMap::new(),
+            crypto: PktNumSpaceCryptoMap::new(),
+        }
+    }
+
+    pub fn clear(&mut self, epoch: Epoch) {
+        self.spaces.get_mut(epoch, 0).map(|pns| pns.clear()).ok();
+        self.crypto.get_mut(epoch).clear();
+    }
+
+    /// Returns whether the epoch is ready.
+    /// When specifying the Epoch::Application, if `space_id` is `None`, it will
+    /// consider all the application data packet number spaces; otherwise it
+    /// only consider the specified `space_id`.
+    pub fn is_ready(&self, epoch: Epoch, space_id: Option<u64>) -> bool {
+        self.crypto.get(epoch).ready() || self.spaces.is_ready(epoch, space_id)
     }
 }
 
@@ -1310,7 +1483,8 @@ mod tests {
         assert_eq!(pn, expected_pn);
 
         let payload =
-            decrypt_pkt(&mut b, pn, hdr.pkt_num_len, payload_len, &aead).unwrap();
+            decrypt_pkt(&mut b, 0, pn, hdr.pkt_num_len, payload_len, &aead)
+                .unwrap();
 
         let payload = payload.as_ref();
         assert_eq!(&payload[..expected_frames.len()], expected_frames);
@@ -1528,7 +1702,8 @@ mod tests {
         assert_eq!(pn, 654_360_564);
 
         let payload =
-            decrypt_pkt(&mut b, pn, hdr.pkt_num_len, payload_len, &aead).unwrap();
+            decrypt_pkt(&mut b, 0, pn, hdr.pkt_num_len, payload_len, &aead)
+                .unwrap();
 
         let payload = payload.as_ref();
         assert_eq!(&payload, &[0x01]);
@@ -1560,6 +1735,7 @@ mod tests {
 
         let written = encrypt_pkt(
             &mut b,
+            0,
             pn,
             pn_len,
             payload_len,
@@ -1897,6 +2073,7 @@ mod tests {
 
         let written = encrypt_pkt(
             &mut b,
+            0,
             pn,
             pn_len,
             payload_len,
@@ -1937,7 +2114,7 @@ mod tests {
             crypto::derive_initial_key_material(b"", hdr.version, true).unwrap();
 
         assert_eq!(
-            decrypt_pkt(&mut b, 0, 1, payload_len, &aead),
+            decrypt_pkt(&mut b, 0, 0, 1, payload_len, &aead),
             Err(Error::InvalidPacket)
         );
     }
@@ -1970,7 +2147,7 @@ mod tests {
             crypto::derive_initial_key_material(b"", hdr.version, true).unwrap();
 
         assert_eq!(
-            decrypt_pkt(&mut b, 0, 1, payload_len, &aead),
+            decrypt_pkt(&mut b, 0, 0, 1, payload_len, &aead),
             Err(Error::CryptoFail)
         );
     }

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -683,6 +683,9 @@ pub struct PathMap {
     /// Whether the multipath extensions are enabled.
     multipath: bool,
 
+    /// Support version 5?
+    v5: bool,
+
     /// Path identifiers requiring sending PATH_ABANDON frames.
     path_abandon: VecDeque<usize>,
 
@@ -720,6 +723,7 @@ impl PathMap {
             path_abandon: VecDeque::new(),
             path_status_to_advertise: VecDeque::new(),
             next_path_status_seq_num: 0,
+            v5: false,
         }
     }
 
@@ -1034,9 +1038,15 @@ impl PathMap {
         self.multipath
     }
 
+    /// Return if supporting v5.
+    pub fn v5(&self) -> bool {
+        self.v5
+    }
+
     /// Sets whether multipath extension is enabled.
-    pub fn set_multipath(&mut self, v: bool) {
+    pub fn set_multipath(&mut self, v: bool, v5: bool) {
         self.multipath = v;
+        self.v5 = v5;
     }
 
     /// Changes the state of the path with the identifier `path_id` according to

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -688,7 +688,7 @@ pub struct PathMap {
 
     /// Whether a connection-wide PATH_STATUS frame should be sent.
     path_status_to_advertise: VecDeque<(usize, u64, u64)>,
-    /// The sequence number for the next PATH_ABANDON.
+    /// The sequence number for the next PATH_STATUS.
     next_path_status_seq_num: u64,
 }
 

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -683,9 +683,6 @@ pub struct PathMap {
     /// Whether the multipath extensions are enabled.
     multipath: bool,
 
-    /// Support version 5?
-    v5: bool,
-
     /// Path identifiers requiring sending PATH_ABANDON frames.
     path_abandon: VecDeque<usize>,
 
@@ -723,7 +720,6 @@ impl PathMap {
             path_abandon: VecDeque::new(),
             path_status_to_advertise: VecDeque::new(),
             next_path_status_seq_num: 0,
-            v5: false,
         }
     }
 
@@ -1042,15 +1038,9 @@ impl PathMap {
         self.multipath
     }
 
-    /// Return if supporting v5.
-    pub fn v5(&self) -> bool {
-        self.v5
-    }
-
     /// Sets whether multipath extension is enabled.
-    pub fn set_multipath(&mut self, v: bool, v5: bool) {
+    pub fn set_multipath(&mut self, v: bool) {
         self.multipath = v;
-        self.v5 = v5;
     }
 
     /// Changes the state of the path with the identifier `path_id` according to

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -74,7 +74,7 @@ impl PathValidationState {
 
 /// The different usage states of the path.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-enum PathState {
+pub enum PathState {
     /// The path only sends probing packets.
     Unused,
     /// The path can send non-probing packets.
@@ -1014,6 +1014,10 @@ impl PathMap {
         if is_server && nb_paths == 1 {
             return Err(Error::UnavailablePath);
         }
+        // If the path was already closed, just close it.
+        if abandon_path.closed() {
+            return Ok(());
+        }
         let was_closing = abandon_path.is_closing();
         abandon_path.set_state(PathState::Closing(error_code, reason))?;
         abandon_path.on_abandon_received();
@@ -1188,7 +1192,7 @@ pub struct PathStats {
     pub validation_state: PathValidationState,
 
     /// The path state.
-    state: PathState,
+    pub state: PathState,
 
     /// Is it active?
     pub active: bool,

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -1109,28 +1109,6 @@ impl PathMap {
         Ok(())
     }
 
-    /// Handles potential connection migration.
-    pub fn on_peer_migrated(
-        &mut self, new_pid: usize, disable_dcid_reuse: bool,
-    ) -> Result<()> {
-        let active_path_id = self.get_active_path_id()?;
-
-        if active_path_id == new_pid {
-            return Ok(());
-        }
-
-        self.set_active_path(new_pid)?;
-
-        let no_spare_dcid = self.get_mut(new_pid)?.active_dcid_seq.is_none();
-
-        if no_spare_dcid && !disable_dcid_reuse {
-            self.get_mut(new_pid)?.active_dcid_seq =
-                self.get_mut(active_path_id)?.active_dcid_seq;
-        }
-
-        Ok(())
-    }
-
     /// Sets the provided `status` on he path identified by `path_id`.
     pub fn set_path_status(
         &mut self, path_id: usize, status: PathStatus,

--- a/quiche/src/recovery/bbr/mod.rs
+++ b/quiche/src/recovery/bbr/mod.rs
@@ -417,7 +417,7 @@ mod tests {
         // Send 5 packets.
         for pn in 0..5 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -452,6 +452,7 @@ mod tests {
 
         assert_eq!(
             r.on_ack_received(
+                0,
                 &acked,
                 25,
                 packet::Epoch::Application,
@@ -487,7 +488,7 @@ mod tests {
         // Send 5 packets.
         for pn in 0..5 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -523,6 +524,7 @@ mod tests {
         // 2 acked, 2 x MSS lost.
         assert_eq!(
             r.on_ack_received(
+                0,
                 &acked,
                 25,
                 packet::Epoch::Application,
@@ -556,7 +558,7 @@ mod tests {
         // Stop right before filled_pipe=true.
         for _ in 0..3 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -592,6 +594,7 @@ mod tests {
 
             assert_eq!(
                 r.on_ack_received(
+                    0,
                     &acked,
                     25,
                     packet::Epoch::Application,
@@ -607,7 +610,7 @@ mod tests {
         // Stop at right before filled_pipe=true.
         for _ in 0..5 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -646,6 +649,7 @@ mod tests {
 
         assert_eq!(
             r.on_ack_received(
+                0,
                 &acked,
                 25,
                 packet::Epoch::Application,
@@ -679,7 +683,7 @@ mod tests {
         // smaller than BBRInFlight(1).
         for (pn, _) in (0..4).enumerate() {
             let pkt = Sent {
-                pkt_num: pn as u64,
+                pkt_num: SpacedPktNum(0, pn as u64),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -712,6 +716,7 @@ mod tests {
 
             assert_eq!(
                 r.on_ack_received(
+                    0,
                     &acked,
                     25,
                     packet::Epoch::Application,
@@ -750,7 +755,7 @@ mod tests {
         // smaller than BBRInFlight(1).
         for _ in 0..4 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -785,6 +790,7 @@ mod tests {
 
             assert_eq!(
                 r.on_ack_received(
+                    0,
                     &acked,
                     25,
                     packet::Epoch::Application,
@@ -804,7 +810,7 @@ mod tests {
         let now = now + RTPROP_FILTER_LEN;
 
         let pkt = Sent {
-            pkt_num: pn,
+            pkt_num: SpacedPktNum(0, pn),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -841,6 +847,7 @@ mod tests {
 
         assert_eq!(
             r.on_ack_received(
+                0,
                 &acked,
                 25,
                 packet::Epoch::Application,

--- a/quiche/src/recovery/bbr2/mod.rs
+++ b/quiche/src/recovery/bbr2/mod.rs
@@ -729,7 +729,7 @@ mod tests {
         // Send 5 packets.
         for pn in 0..5 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -764,6 +764,7 @@ mod tests {
 
         assert!(r
             .on_ack_received(
+                0,
                 &acked,
                 25,
                 packet::Epoch::Application,
@@ -798,7 +799,7 @@ mod tests {
         // Send 5 packets.
         for pn in 0..5 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -834,6 +835,7 @@ mod tests {
         // 2 acked, 2 x MSS lost.
         assert!(r
             .on_ack_received(
+                0,
                 &acked,
                 25,
                 packet::Epoch::Application,
@@ -870,7 +872,7 @@ mod tests {
         // Stop right before filled_pipe=true.
         for _ in 0..3 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -906,6 +908,7 @@ mod tests {
 
             assert!(r
                 .on_ack_received(
+                    0,
                     &acked,
                     25,
                     packet::Epoch::Application,
@@ -920,7 +923,7 @@ mod tests {
         // Stop at right before filled_pipe=true.
         for _ in 0..5 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -959,6 +962,7 @@ mod tests {
 
         assert!(r
             .on_ack_received(
+                0,
                 &acked,
                 25,
                 packet::Epoch::Application,
@@ -992,7 +996,7 @@ mod tests {
         // smaller than BBRInFlight(1).
         for _ in 0..4 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -1027,6 +1031,7 @@ mod tests {
 
             assert!(r
                 .on_ack_received(
+                    0,
                     &acked,
                     25,
                     packet::Epoch::Application,
@@ -1045,7 +1050,7 @@ mod tests {
         let now = now + PROBE_RTT_INTERVAL;
 
         let pkt = Sent {
-            pkt_num: pn,
+            pkt_num: SpacedPktNum(0, pn),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -1082,6 +1087,7 @@ mod tests {
 
         assert!(r
             .on_ack_received(
+                0,
                 &acked,
                 25,
                 packet::Epoch::Application,

--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -606,7 +606,7 @@ mod tests {
         let prev_cwnd = r.cwnd();
 
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -650,7 +650,7 @@ mod tests {
         }
 
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -726,7 +726,7 @@ mod tests {
 
         // Trigger congestion event to update ssthresh
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -1107,7 +1107,7 @@ mod tests {
 
         // Trigger congestion event to update ssthresh
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -1168,7 +1168,7 @@ mod tests {
 
         // Trigger another congestion event.
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -1243,7 +1243,7 @@ mod tests {
 
         // Trigger congestion event to update ssthresh
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -1309,7 +1309,7 @@ mod tests {
         // cwnd is not fully recovered to w_max, w_max will be
         // further reduced.
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,

--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -475,7 +475,7 @@ mod tests {
         let now = Instant::now();
 
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -527,7 +527,7 @@ mod tests {
         let now = Instant::now();
 
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -694,7 +694,7 @@ mod tests {
         // 5 ACKs to increase cwnd by 1 MSS.
         for _ in 0..5 {
             let mut acked = vec![Acked {
-                pkt_num: 0,
+                pkt_num: recovery::SpacedPktNum(0, 0),
                 time_sent: now,
                 size: r.max_datagram_size,
                 delivered: 0,
@@ -758,7 +758,7 @@ mod tests {
         );
 
         let mut acked = vec![Acked {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             // To exit from recovery
             time_sent: now + Duration::from_millis(1),
             size: r.max_datagram_size,
@@ -791,7 +791,7 @@ mod tests {
         let epoch = packet::Epoch::Application;
 
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -810,18 +810,19 @@ mod tests {
 
         // 1st round.
         let n_rtt_sample = hystart::N_RTT_SAMPLE;
-        let mut send_pn = 0;
-        let mut ack_pn = 0;
+        let mut send_pn = recovery::SpacedPktNum(0, 0);
+        let mut ack_pn = recovery::SpacedPktNum(0, 0);
 
         let rtt_1st = Duration::from_millis(50);
 
         // Send 1st round packets.
         for _ in 0..n_rtt_sample {
             r.on_packet_sent_cc(p.size, now);
-            send_pn += 1;
+            send_pn.1 += 1;
         }
 
-        r.hystart.start_round(send_pn - 1);
+        r.hystart
+            .start_round(recovery::SpacedPktNum(send_pn.0, send_pn.1 - 1));
 
         // Receiving Acks.
         let now = now + rtt_1st;
@@ -842,7 +843,7 @@ mod tests {
             }];
 
             r.on_packets_acked(&mut acked, epoch, now);
-            ack_pn += 1;
+            ack_pn.1 += 1;
         }
 
         // Not in CSS yet.
@@ -855,9 +856,10 @@ mod tests {
         // Send 2nd round packets.
         for _ in 0..n_rtt_sample {
             r.on_packet_sent_cc(p.size, now);
-            send_pn += 1;
+            send_pn.1 += 1;
         }
-        r.hystart.start_round(send_pn - 1);
+        r.hystart
+            .start_round(recovery::SpacedPktNum(send_pn.0, send_pn.1 - 1));
 
         // Receiving Acks.
         // Last ack will cause to exit to CSS.
@@ -881,7 +883,7 @@ mod tests {
             }];
 
             r.on_packets_acked(&mut acked, epoch, now);
-            ack_pn += 1;
+            ack_pn.1 += 1;
 
             // Keep increasing RTT so that hystart exits to CSS.
             rtt_2nd += rtt_2nd.saturating_add(Duration::from_millis(4));
@@ -900,9 +902,10 @@ mod tests {
         // Send 3nd round packets.
         for _ in 0..n_rtt_sample {
             r.on_packet_sent_cc(p.size, now);
-            send_pn += 1;
+            send_pn.1 += 1;
         }
-        r.hystart.start_round(send_pn - 1);
+        r.hystart
+            .start_round(recovery::SpacedPktNum(send_pn.0, send_pn.1 - 1));
 
         // Receiving Acks.
         // Last ack will cause to exit to SS.
@@ -923,7 +926,7 @@ mod tests {
             }];
 
             r.on_packets_acked(&mut acked, epoch, now);
-            ack_pn += 1;
+            ack_pn.1 += 1;
         }
 
         // Now we are back in Slow Start.
@@ -947,7 +950,7 @@ mod tests {
         let epoch = packet::Epoch::Application;
 
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -966,18 +969,19 @@ mod tests {
 
         // 1st round.
         let n_rtt_sample = hystart::N_RTT_SAMPLE;
-        let mut send_pn = 0;
-        let mut ack_pn = 0;
+        let mut send_pn = recovery::SpacedPktNum(0, 0);
+        let mut ack_pn = recovery::SpacedPktNum(0, 0);
 
         let rtt_1st = Duration::from_millis(50);
 
         // Send 1st round packets.
         for _ in 0..n_rtt_sample {
             r.on_packet_sent_cc(p.size, now);
-            send_pn += 1;
+            send_pn.1 += 1;
         }
 
-        r.hystart.start_round(send_pn - 1);
+        r.hystart
+            .start_round(recovery::SpacedPktNum(send_pn.0, send_pn.1 - 1));
 
         // Receiving Acks.
         let now = now + rtt_1st;
@@ -998,7 +1002,7 @@ mod tests {
             }];
 
             r.on_packets_acked(&mut acked, epoch, now);
-            ack_pn += 1;
+            ack_pn.1 += 1;
         }
 
         // Not in CSS yet.
@@ -1011,9 +1015,10 @@ mod tests {
         // Send 2nd round packets.
         for _ in 0..n_rtt_sample {
             r.on_packet_sent_cc(p.size, now);
-            send_pn += 1;
+            send_pn.1 += 1;
         }
-        r.hystart.start_round(send_pn - 1);
+        r.hystart
+            .start_round(recovery::SpacedPktNum(send_pn.0, send_pn.1 - 1));
 
         // Receiving Acks.
         // Last ack will cause to exit to CSS.
@@ -1037,7 +1042,7 @@ mod tests {
             }];
 
             r.on_packets_acked(&mut acked, epoch, now);
-            ack_pn += 1;
+            ack_pn.1 += 1;
 
             // Keep increasing RTT so that hystart exits to CSS.
             rtt_2nd += rtt_2nd.saturating_add(Duration::from_millis(4));
@@ -1055,9 +1060,10 @@ mod tests {
             // Send a round of packets.
             for _ in 0..n_rtt_sample {
                 r.on_packet_sent_cc(p.size, now);
-                send_pn += 1;
+                send_pn.1 += 1;
             }
-            r.hystart.start_round(send_pn - 1);
+            r.hystart
+                .start_round(recovery::SpacedPktNum(send_pn.0, send_pn.1 - 1));
 
             // Receiving Acks.
             for _ in 0..n_rtt_sample {
@@ -1077,7 +1083,7 @@ mod tests {
                 }];
 
                 r.on_packets_acked(&mut acked, epoch, now);
-                ack_pn += 1;
+                ack_pn.1 += 1;
             }
         }
 
@@ -1132,7 +1138,7 @@ mod tests {
         let rtt = Duration::from_millis(100);
 
         let mut acked = vec![Acked {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             // To exit from recovery
             time_sent: now + rtt,
             size: r.max_datagram_size,
@@ -1194,7 +1200,7 @@ mod tests {
         let rtt = Duration::from_millis(100);
 
         let mut acked = vec![Acked {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             // To exit from recovery
             time_sent: now + rtt,
             size: r.max_datagram_size,
@@ -1279,7 +1285,7 @@ mod tests {
         // 5 ACKs to increase cwnd by 1 MSS.
         for _ in 0..5 {
             let mut acked = vec![Acked {
-                pkt_num: 0,
+                pkt_num: recovery::SpacedPktNum(0, 0),
                 time_sent: now,
                 size: r.max_datagram_size,
                 delivered: 0,

--- a/quiche/src/recovery/delivery_rate.rs
+++ b/quiche/src/recovery/delivery_rate.rs
@@ -34,6 +34,7 @@ use std::time::Instant;
 
 use crate::recovery::Acked;
 use crate::recovery::Sent;
+use crate::recovery::SpacedPktNum;
 
 #[derive(Debug)]
 pub struct Rate {
@@ -44,13 +45,13 @@ pub struct Rate {
     first_sent_time: Instant,
 
     // Packet number of the last sent packet with app limited.
-    end_of_app_limited: u64,
+    end_of_app_limited: SpacedPktNum,
 
     // Packet number of the last sent packet.
-    last_sent_packet: u64,
+    last_sent_packet: SpacedPktNum,
 
     // Packet number of the largest acked packet.
-    largest_acked: u64,
+    largest_acked: SpacedPktNum,
 
     // Sample of rate estimation.
     rate_sample: RateSample,
@@ -67,11 +68,11 @@ impl Default for Rate {
 
             first_sent_time: now,
 
-            end_of_app_limited: 0,
+            end_of_app_limited: SpacedPktNum(0, 0),
 
-            last_sent_packet: 0,
+            last_sent_packet: SpacedPktNum(0, 0),
 
-            largest_acked: 0,
+            largest_acked: SpacedPktNum(0, 0),
 
             rate_sample: RateSample::default(),
         }
@@ -157,11 +158,15 @@ impl Rate {
     }
 
     pub fn update_app_limited(&mut self, v: bool) {
-        self.end_of_app_limited = if v { self.last_sent_packet.max(1) } else { 0 }
+        self.end_of_app_limited = if v {
+            self.last_sent_packet.max(SpacedPktNum(0, 1))
+        } else {
+            SpacedPktNum(0, 0)
+        }
     }
 
     pub fn app_limited(&mut self) -> bool {
-        self.end_of_app_limited != 0
+        self.end_of_app_limited.1 != 0
     }
 
     pub fn delivered(&self) -> usize {
@@ -229,7 +234,7 @@ mod tests {
         // Send 2 packets.
         for pn in 0..2 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -261,7 +266,7 @@ mod tests {
         // Ack 2 packets.
         for pn in 0..2 {
             let acked = Acked {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 time_sent: now,
                 size: mss,
                 rtt,
@@ -297,7 +302,7 @@ mod tests {
         // Send 10 packets to fill cwnd.
         for pn in 0..10 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -338,7 +343,7 @@ mod tests {
         // Send 5 packets.
         for pn in 0..5 {
             let pkt = Sent {
-                pkt_num: pn,
+                pkt_num: SpacedPktNum(0, pn),
                 frames: smallvec![],
                 time_sent: now,
                 time_acked: None,
@@ -372,6 +377,7 @@ mod tests {
 
         assert_eq!(
             r.on_ack_received(
+                0,
                 &acked,
                 25,
                 packet::Epoch::Application,

--- a/quiche/src/recovery/hystart.rs
+++ b/quiche/src/recovery/hystart.rs
@@ -52,7 +52,7 @@ pub const CSS_ROUNDS: usize = 5;
 pub struct Hystart {
     enabled: bool,
 
-    window_end: Option<u64>,
+    window_end: Option<recovery::SpacedPktNum>,
 
     last_round_min_rtt: Duration,
 
@@ -114,7 +114,7 @@ impl Hystart {
             self.css_start_time().is_some()
     }
 
-    pub fn start_round(&mut self, pkt_num: u64) {
+    pub fn start_round(&mut self, pkt_num: recovery::SpacedPktNum) {
         if self.window_end.is_none() {
             self.window_end = Some(pkt_num);
 
@@ -214,7 +214,7 @@ mod tests {
     #[test]
     fn start_round() {
         let mut hspp = Hystart::default();
-        let pkt_num = 100;
+        let pkt_num = recovery::SpacedPktNum(0, 100);
 
         hspp.start_round(pkt_num);
 
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn congestion_event() {
         let mut hspp = Hystart::default();
-        let pkt_num = 100;
+        let pkt_num = recovery::SpacedPktNum(0, 100);
 
         hspp.start_round(pkt_num);
 

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -205,7 +205,7 @@ mod tests {
         let now = Instant::now();
 
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -258,7 +258,7 @@ mod tests {
         let now = Instant::now();
 
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -413,7 +413,7 @@ mod tests {
         let rtt = Duration::from_millis(100);
 
         let mut acked = vec![Acked {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             // To exit from recovery
             time_sent: now + rtt,
             // More than cur_cwnd to increase cwnd

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -339,7 +339,7 @@ mod tests {
         let now = Instant::now();
 
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -380,7 +380,7 @@ mod tests {
         r.on_packet_sent_cc(20000, now);
 
         let p = recovery::Sent {
-            pkt_num: 0,
+            pkt_num: recovery::SpacedPktNum(0, 0),
             frames: smallvec![],
             time_sent: now,
             time_acked: None,

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -917,7 +917,7 @@ impl Drop for Handshake {
 pub struct ExData<'a> {
     pub application_protos: &'a Vec<Vec<u8>>,
 
-    pub pkt_num_spaces: &'a mut [packet::PktNumSpace; packet::Epoch::count()],
+    pub pkt_num_spaces: &'a mut packet::PktNumSpaceMap,
 
     pub session: &'a mut Option<Vec<u8>>,
 
@@ -964,14 +964,22 @@ extern fn set_read_secret(
     trace!("{} set read secret lvl={:?}", ex_data.trace_id, level);
 
     let space = match level {
-        crypto::Level::Initial =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Initial],
-        crypto::Level::ZeroRTT =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
-        crypto::Level::Handshake =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Handshake],
-        crypto::Level::OneRTT =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
+        crypto::Level::Initial => ex_data
+            .pkt_num_spaces
+            .crypto
+            .get_mut(packet::Epoch::Initial),
+        crypto::Level::ZeroRTT => ex_data
+            .pkt_num_spaces
+            .crypto
+            .get_mut(packet::Epoch::Application),
+        crypto::Level::Handshake => ex_data
+            .pkt_num_spaces
+            .crypto
+            .get_mut(packet::Epoch::Handshake),
+        crypto::Level::OneRTT => ex_data
+            .pkt_num_spaces
+            .crypto
+            .get_mut(packet::Epoch::Application),
     };
 
     let aead = match get_cipher_from_ptr(cipher) {
@@ -1015,14 +1023,22 @@ extern fn set_write_secret(
     trace!("{} set write secret lvl={:?}", ex_data.trace_id, level);
 
     let space = match level {
-        crypto::Level::Initial =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Initial],
-        crypto::Level::ZeroRTT =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
-        crypto::Level::Handshake =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Handshake],
-        crypto::Level::OneRTT =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
+        crypto::Level::Initial => ex_data
+            .pkt_num_spaces
+            .crypto
+            .get_mut(packet::Epoch::Initial),
+        crypto::Level::ZeroRTT => ex_data
+            .pkt_num_spaces
+            .crypto
+            .get_mut(packet::Epoch::Application),
+        crypto::Level::Handshake => ex_data
+            .pkt_num_spaces
+            .crypto
+            .get_mut(packet::Epoch::Handshake),
+        crypto::Level::OneRTT => ex_data
+            .pkt_num_spaces
+            .crypto
+            .get_mut(packet::Epoch::Application),
     };
 
     let aead = match get_cipher_from_ptr(cipher) {
@@ -1067,13 +1083,19 @@ extern fn add_handshake_data(
     let buf = unsafe { slice::from_raw_parts(data, len) };
 
     let space = match level {
-        crypto::Level::Initial =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Initial],
+        crypto::Level::Initial => ex_data
+            .pkt_num_spaces
+            .crypto
+            .get_mut(packet::Epoch::Initial),
         crypto::Level::ZeroRTT => unreachable!(),
-        crypto::Level::Handshake =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Handshake],
-        crypto::Level::OneRTT =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
+        crypto::Level::Handshake => ex_data
+            .pkt_num_spaces
+            .crypto
+            .get_mut(packet::Epoch::Handshake),
+        crypto::Level::OneRTT => ex_data
+            .pkt_num_spaces
+            .crypto
+            .get_mut(packet::Epoch::Application),
     };
 
     if space.crypto_stream.send.write(buf, false).is_err() {


### PR DESCRIPTION
This commits introduces the following features.

- Leave to the application to choose the multipath extensions or not
- Build on the `PathEvent`s to let the application decide which paths to use
- Provide default reasonable behavior into `quiche` while letting the
  application provide optimised behavior

== Requesting the Multipath feature

The application can request multipath through the `Config` structure using a
specific API,`set_multipath()`.
```rust
config.set_multipath(true);
```
The boolean value determines whether the underlying connection negotiates the
multipath extension. Once the handshake succeeded, the application can check
whether the connection has the multipath feature enabled using the
`is_multipath_enabled()` API on the `Connection` structure.

== Path management

The API requires the application to specify on which paths/4-tuples it wants
to send non-probing packets. Paths must first be validated before using them.
This is automatically done for servers, and client must use `probe_path()`.
Once the path is validated, the application decides whether it wants active
usage through the `set_active()` API. It provides a single API entrypoint to
request its usage or not. For active path usage, it can use the following.

```rust
if let Some(PathEvent::Validated(local, peer)) = conn.path_event_next() {
    conn.set_active(local, peer, true).unwrap();
}
```
Then, the path will then be considered to use non-probing packets.

On the other hand, if for some reason the application wants to temporarily
stop sending non-probing frames on a given path, it can do the following.

```rust
conn.set_active(local, peer, false).unwrap();
```
Note that in such state, quiche still replies to PATH_CHALLENGEs observed on
that path.

Finally, the multipath design allows a QUIC endpoint to close/abandon a
given path along with an error code and error message, without altering the
connection's operations as long as another path is available.

```rust
conn.abandon_path(local, peer, 42, "Some error message".into()).unwrap();
```

-- Retrocompatibility note

- The `Closed` variant of `PathEvent` is now a 4-tuple that, in addition to
the local and peer `SocketAddr`, also contains an `u64` error code and a
`Vec<u8>` reason message.
- There is a new variant of `PathEvent`: `PeerPathStatus` reports to the
application that the peer advertised some status for a given 4-tuple.
- There are two new `Error` variants: `UnavailablePath` and
`MultiPathViolation`.

-- Note

Currently this API is only available when multipath feature is enabled over
the session (i.e., `conn.is_multipath_enabled()` returns `true`). If the
extension is not enabled, `set_active()` and `abandon_path()` return an
`Error::InvalidState`. Actually, this API might sound "double usage" along
with the `migrate()` API (as there is no real "connection migration" with
multipath). Should we just keep the `set_active()` or similarly named API
and include the `migrate()` functionality in `set_active()`? Actually, an
client application without the multipath feature could just migrate using
`set_active(local, peer, true)`, setting the previous path in unused mode
under the hood.

== Scheduling sent packets

Similarly to the connection migration PR, there are two ways to control how
`quiche` schedules packets on paths.

The first consists in letting `quiche` handles this by itself. The
application simply uses the `send()` method. In the current master code,
`quiche` automatically handles path validation processing thanks to the
internal `get_send_path_id()` `Connection` method. The multipath patch
extends this method and iterates over all active paths following the lowest
latency path having its congestion window open heuristic (a reasonable
default in multipath protocols).

```rust
loop {
    let (write, send_info) = match conn.send(&mut out) {
            Ok(v) => v,

            Err(quiche::Error::Done) => break,

            Err(e) => {
                conn.close(false, 0x1, b"fail").ok();
                break;
            },
        };
        // write to socket bound to `send_info.from`
}
```

The second option is to let the application choose on which path it wants
to send the next packet. The application can iterate over the available paths
and their corresponding statistics using `path_stats()` and schedules packets
using `send_on_path()` method. This can be useful when the use case requires
some specific scheduling strategies. See `apps/src/client.rs` for an example
of such application-driven scheduling.