### PR TITLE
consume incoming stream data when stream is draining

### DIFF
--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -716,6 +716,11 @@ impl Stream {
             (false, false) => self.recv.is_fin(),
         }
     }
+
+    /// Returns true if the stream is not storing incoming data.
+    pub fn is_draining(&self) -> bool {
+        self.recv.drain
+    }
 }
 
 /// Returns true if the stream was created locally.


### PR DESCRIPTION
When a stream is in draining state and stream data is received, the data will be dropped and the stream's state updated. However, because the application can't read the dropped data, it can never "consume" it freeing connection-level flow control credits for that data.

This change marks the received data as consumed automatically when a stream is in draining state, so that the flow control limits can be updated.

Fixes #1320.