### PR TITLE
h3: better support 0-length payload frame parsing

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -4889,6 +4889,36 @@ mod tests {
     }
 
     #[test]
+    /// Tests that receiving an empty SETTINGS frame is handled and reported.
+    fn empty_settings() {
+        let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
+        config.set_initial_max_data(1500);
+        config.set_initial_max_stream_data_bidi_local(150);
+        config.set_initial_max_stream_data_bidi_remote(150);
+        config.set_initial_max_stream_data_uni(150);
+        config.set_initial_max_streams_bidi(5);
+        config.set_initial_max_streams_uni(5);
+        config.verify_peer(false);
+        config.set_ack_delay_exponent(8);
+        config.grease(false);
+
+        let h3_config = Config::new().unwrap();
+        let mut s = Session::with_configs(&mut config, &h3_config).unwrap();
+
+        s.handshake().unwrap();
+
+        assert!(s.client.peer_settings_raw().is_some());
+        assert!(s.server.peer_settings_raw().is_some());
+    }
+
+    #[test]
     /// Tests that receiving a H3_DATAGRAM setting is ok.
     fn dgram_setting() {
         let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();


### PR DESCRIPTION
In HTTP/3 some frames can legitimately have 0-length payloads, such as SETTINGS.

Previously, the HTTP/3 frame streaming parsing could get confused by these
frames, whereby it would try to read 0 bytes from the transport layer via
stream_recv(). In some cases, quiche could determine the stream is not
readable, because there are no more bytes to read - imagine a an empty
SETTINGS frame that arrived as the last frame on the control stream. In such a
case, quiche would return Error:Done, which would cascade up to the
HTTP/3 layer's frame parsing and cause it to quit early before parsing
the frame. The insidious thing here is that the HTTP/3 layer would
continue trying to read this stream on every call to `poll()`, but it
would always fail as long as the stream was determined to be not
readable (likely because there is nothing more to send in the control
stream).

With this change, we add a check for this scenario inside the HTTP/3
layer. If a frame's payload is 0-bytes, exit early by returning Ok(())
so that the frame can be consumed immediately. This also helps avoid
wasted work trying to read nothing over and over again.
