### PR TITLE
apps: add --disable-gso option

### DIFF
--- a/apps/run_endpoint.sh
+++ b/apps/run_endpoint.sh
@@ -15,7 +15,8 @@ DOWNLOAD_DIR=/downloads
 QUICHE_CLIENT=quiche-client
 QUICHE_SERVER=quiche-server
 QUICHE_CLIENT_OPT="--no-verify --dump-responses ${DOWNLOAD_DIR} --wire-version 00000001"
-QUICHE_SERVER_OPT_COMMON="--listen [::]:443 --root $WWW_DIR --cert /certs/cert.pem --key /certs/priv.key"
+# interop container has tso off. need to disable gso as well.
+QUICHE_SERVER_OPT_COMMON="--listen [::]:443 --root $WWW_DIR --cert /certs/cert.pem --key /certs/priv.key --disable-gso"
 QUICHE_SERVER_OPT="$QUICHE_SERVER_OPT_COMMON --no-retry "
 LOG_DIR=/logs
 LOG=$LOG_DIR/log.txt

--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -443,6 +443,7 @@ Options:
   --max-field-section-size BYTES    Max size of uncompressed HTTP/3 field section. Default is unlimited.
   --qpack-max-table-capacity BYTES  Max capacity of QPACK dynamic table decoding. Any value other that 0 is currently unsupported.
   --qpack-blocked-streams STREAMS   Limit of streams that can be blocked while decoding. Any value other that 0 is currently unsupported.
+  --disable-gso               Disable GSO (linux only).
   -h --help                   Show this screen.
 ";
 
@@ -454,6 +455,7 @@ pub struct ServerArgs {
     pub index: String,
     pub cert: String,
     pub key: String,
+    pub disable_gso: bool,
 }
 
 impl Args for ServerArgs {
@@ -466,6 +468,7 @@ impl Args for ServerArgs {
         let index = args.get_str("--index").to_string();
         let cert = args.get_str("--cert").to_string();
         let key = args.get_str("--key").to_string();
+        let disable_gso = args.get_bool("--disable-gso");
 
         ServerArgs {
             listen,
@@ -474,6 +477,7 @@ impl Args for ServerArgs {
             index,
             cert,
             key,
+            disable_gso,
         }
     }
 }

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -90,7 +90,11 @@ fn main() {
         .unwrap();
 
     let max_datagram_size = MAX_DATAGRAM_SIZE;
-    let enable_gso = detect_gso(&socket, max_datagram_size);
+    let enable_gso = if args.disable_gso {
+        false
+    } else {
+        detect_gso(&socket, max_datagram_size)
+    };
 
     trace!("GSO detected: {}", enable_gso);
 


### PR DESCRIPTION
Linux GSO will be detected automatically but some cases (quic-interop-runner) we need a way to explicitly disable it.