### PR TITLE
qlog: add send_at_time to PacketSent event

### DIFF
--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -647,6 +647,8 @@ pub struct PacketSent {
 
     pub trigger: Option<PacketSentTrigger>,
 
+    pub send_at_time: Option<f32>,
+
     pub frames: Option<Vec<QuicFrame>>,
 }
 

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -141,6 +141,7 @@
 //!         supported_versions: None,
 //!         raw: Some(raw),
 //!         datagram_id: None,
+//!         send_at_time: None,
 //!         trigger: None,
 //!     });
 //!
@@ -344,6 +345,7 @@
 //!         supported_versions: None,
 //!         raw: None,
 //!         datagram_id: None,
+//!         send_at_time: None,
 //!         trigger: None,
 //!     });
 //!
@@ -759,6 +761,7 @@ mod tests {
                 data: None,
             }),
             datagram_id: None,
+            send_at_time: None,
             trigger: None,
         });
 
@@ -830,6 +833,7 @@ mod tests {
                 data: None,
             }),
             datagram_id: None,
+            send_at_time: None,
             trigger: None,
         });
 
@@ -949,6 +953,7 @@ mod tests {
                 data: None,
             }),
             datagram_id: None,
+            send_at_time: None,
             trigger: None,
         });
 

--- a/qlog/src/streamer.rs
+++ b/qlog/src/streamer.rs
@@ -223,6 +223,10 @@ impl QlogStreamer {
     pub fn writer(&self) -> &Box<dyn std::io::Write + Send + Sync> {
         &self.writer
     }
+
+    pub fn start_time(&self) -> std::time::Instant {
+        self.start_time
+    }
 }
 
 #[cfg(test)]
@@ -264,6 +268,7 @@ mod tests {
             supported_versions: None,
             raw: raw.clone(),
             datagram_id: None,
+            send_at_time: None,
             trigger: None,
         });
 
@@ -294,6 +299,7 @@ mod tests {
             supported_versions: None,
             raw: raw.clone(),
             datagram_id: None,
+            send_at_time: None,
             trigger: None,
         });
 
@@ -308,6 +314,7 @@ mod tests {
             supported_versions: None,
             raw,
             datagram_id: None,
+            send_at_time: None,
             trigger: None,
         });
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3977,6 +3977,17 @@ impl Connection {
                 data: None,
             };
 
+            let send_at_time = match self.paths.get(send_pid) {
+                Ok(v) => {
+                    let send_time = v.recovery.get_packet_send_time();
+                    let dur = send_time.duration_since(q.start_time());
+
+                    Some(dur.as_secs_f32() * 1000.0)
+                },
+
+                _ => None,
+            };
+
             let ev_data = EventData::PacketSent(qlog::events::quic::PacketSent {
                 header: qlog_pkt_hdr,
                 frames: Some(qlog_frames),
@@ -3986,6 +3997,7 @@ impl Connection {
                 supported_versions: None,
                 raw: Some(qlog_raw_info),
                 datagram_id: None,
+                send_at_time,
                 trigger: None,
             });
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3977,16 +3977,8 @@ impl Connection {
                 data: None,
             };
 
-            let send_at_time = match self.paths.get(send_pid) {
-                Ok(v) => {
-                    let send_time = v.recovery.get_packet_send_time();
-                    let dur = send_time.duration_since(q.start_time());
-
-                    Some(dur.as_secs_f32() * 1000.0)
-                },
-
-                _ => None,
-            };
+            let send_at_time =
+                now.duration_since(q.start_time()).as_secs_f32() * 1000.0;
 
             let ev_data = EventData::PacketSent(qlog::events::quic::PacketSent {
                 header: qlog_pkt_hdr,
@@ -3997,7 +3989,7 @@ impl Connection {
                 supported_versions: None,
                 raw: Some(qlog_raw_info),
                 datagram_id: None,
-                send_at_time,
+                send_at_time: Some(send_at_time),
                 trigger: None,
             });
 


### PR DESCRIPTION
This allows us to record the time that the packet pacer would
send this packet at. Since the qlog crate only uses relative
time since log start, the packet send Instant is converted
into a qlog time base and we log the duration since log start.
