### PR TITLE
packet: fix hard-coding constants

### DIFF
--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -625,7 +625,8 @@ pub fn decrypt_pkt<'a>(
 pub fn encrypt_hdr(
     b: &mut octets::OctetsMut, pn_len: usize, payload: &[u8], aead: &crypto::Seal,
 ) -> Result<()> {
-    let sample = &payload[4 - pn_len..16 + (4 - pn_len)];
+    let sample = &payload
+        [MAX_PKT_NUM_LEN - pn_len..SAMPLE_LEN + (MAX_PKT_NUM_LEN - pn_len)];
 
     let mask = aead.new_mask(sample)?;
 


### PR DESCRIPTION
Previously, both MAX_PKT_NUM_LEN and SAMPLE_LEN are hard-coded at `encrypt_hdr` while it is not the case at `decrypt_hdr`. If any of the constant is changed in the future, one must carefully sync up the redundant hard-coded constant at `encrypt_hdr`. After the change, it is more consistent and the hard-coding is alleviated.

No functional code is changed.