### PR TITLE
lib: distinguish length field from payload length

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2379,11 +2379,7 @@ impl Connection {
         let mut qlog_frames = vec![];
 
         let mut payload = packet::decrypt_pkt(
-            &mut b,
-            pn,
-            pn_len,
-            len_field,
-            aead,
+            &mut b, pn, pn_len, len_field, aead,
         )
         .map_err(|e| {
             drop_pkt_on_err(e, self.recv_count, self.is_server, &self.trace_id)

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2483,9 +2483,9 @@ impl Connection {
             }
         }
 
-        let payload_len = payload.len();
-
         qlog_with_type!(QLOG_PACKET_RX, self.qlog, q, {
+            let payload_len = payload.len();
+
             let packet_size = b.len();
 
             let qlog_pkt_hdr = qlog::events::quic::PacketHeader::with_type(

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -603,16 +603,15 @@ pub fn decode_pkt_num(largest_pn: u64, truncated_pn: u64, pn_len: usize) -> u64 
 }
 
 pub fn decrypt_pkt<'a>(
-    b: &'a mut octets::OctetsMut, pn: u64, pn_len: usize, payload_len: usize,
+    b: &'a mut octets::OctetsMut, pn: u64, pn_len: usize, len_field: usize,
     aead: &crypto::Open,
 ) -> Result<octets::Octets<'a>> {
     let payload_offset = b.off();
 
     let (header, mut payload) = b.split_at(payload_offset)?;
 
-    let payload_len = payload_len
-        .checked_sub(pn_len)
-        .ok_or(Error::InvalidPacket)?;
+    let payload_len =
+        len_field.checked_sub(pn_len).ok_or(Error::InvalidPacket)?;
 
     let mut ciphertext = payload.peek_bytes_mut(payload_len)?;
 


### PR DESCRIPTION
Previously, at `recv_single`, the length field of the packet is named as `payload_len`. Although the decoding process correctly treats it as a length field, the `trace!` log and qlog are not.

According to `send_single`, `trace!` set `len` as the length of the actual plaintext payload. But `trace!` at `recv_single` set `len` as the length field of the packet.

Also according to `send_single` and qlog definition at <https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-main-schema-00#section-5.1>, `payload_length` in `RawInfo` should be "the byte length of the entity's payload, without headers or trailers". But at `recv_single`, this `payload_length` in `RawInfo` takes the length field of the packet instead.

After the change, the `trace!` log and qlog are consistent with the decoding process. Also, the variable name is corrected.