### PR TITLE
dgram: schedule both stream and dgram using the urgency

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -5000,7 +5000,7 @@ impl Connection {
         self.dgram_send_vec_priority(buf, DEFAULT_URGENCY)
     }
     
-    /// Sends data in a DATAGRAM frame.
+    /// Sends data in a DATAGRAM frame with a specified urgency.
     ///
     /// This is the same as [`dgram_send()`] but takes a `Vec<u8>` instead of
     /// a slice.

--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -44,8 +44,6 @@ use crate::Result;
 use crate::flowcontrol;
 use crate::ranges;
 
-const DEFAULT_URGENCY: u8 = 127;
-
 #[cfg(test)]
 const SEND_BUFFER_SIZE: usize = 5;
 
@@ -624,6 +622,11 @@ impl StreamMap {
                 self.local_max_streams_uni - self.peer_opened_streams_uni
     }
 
+    /// Returns the urgency of the stream which has the highest priority.
+    pub fn highest_priority(&self) -> u8 {
+        self.flushable.iter().next().map(|(u, _)| *u).unwrap_or(crate::DEFAULT_URGENCY)
+    }
+
     /// Returns the number of active streams in the map.
     #[cfg(test)]
     pub fn len(&self) -> usize {
@@ -668,7 +671,7 @@ impl Stream {
             bidi,
             local,
             data: None,
-            urgency: DEFAULT_URGENCY,
+            urgency: crate::DEFAULT_URGENCY,
             incremental: true,
         }
     }


### PR DESCRIPTION
This allows the application to set the priority of dgrams using dgram_send_priority() instead of dgram_send().
And this changes the way of sending stream and dgram to schedule them using the urgency.