### PR TITLE
quic: avoid panics for non-utf8 reasons/errors

### DIFF
--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -969,7 +969,7 @@ impl Frame {
                 error_space: Some(ErrorSpace::TransportError),
                 error_code: Some(*error_code),
                 raw_error_code: None, // raw error is no different for us
-                reason: String::from_utf8(reason.clone()).ok(),
+                reason: Some(String::from_utf8_lossy(&reason).into_owned()),
                 trigger_frame_type: None, // don't know trigger type
             },
 
@@ -978,7 +978,7 @@ impl Frame {
                     error_space: Some(ErrorSpace::ApplicationError),
                     error_code: Some(*error_code),
                     raw_error_code: None, // raw error is no different for us
-                    reason: String::from_utf8(reason.clone()).ok(),
+                    reason: Some(String::from_utf8_lossy(&reason).into_owned()),
                     trigger_frame_type: None, // don't know trigger type
                 },
 

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -969,7 +969,7 @@ impl Frame {
                 error_space: Some(ErrorSpace::TransportError),
                 error_code: Some(*error_code),
                 raw_error_code: None, // raw error is no different for us
-                reason: Some(String::from_utf8(reason.clone()).unwrap()),
+                reason: String::from_utf8(reason.clone()).ok(),
                 trigger_frame_type: None, // don't know trigger type
             },
 
@@ -978,7 +978,7 @@ impl Frame {
                     error_space: Some(ErrorSpace::ApplicationError),
                     error_code: Some(*error_code),
                     raw_error_code: None, // raw error is no different for us
-                    reason: Some(String::from_utf8(reason.clone()).unwrap()),
+                    reason: String::from_utf8(reason.clone()).ok(),
                     trigger_frame_type: None, // don't know trigger type
                 },
 

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -1154,9 +1154,7 @@ fn log_ssl_error() {
         ERR_error_string_n(e, err.as_ptr(), err.len());
     }
 
-    if let Ok(s) = std::str::from_utf8(&err) {
-        trace!("{:?}", s);
-    }
+    trace!("{}", std::str::from_utf8(&err).unwrap());
 }
 
 extern {

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -1154,7 +1154,9 @@ fn log_ssl_error() {
         ERR_error_string_n(e, err.as_ptr(), err.len());
     }
 
-    trace!("{}", std::str::from_utf8(&err).unwrap());
+    if let Ok(s) = std::str::from_utf8(&err) {
+        trace!("{:?}", s);
+    }
 }
 
 extern {


### PR DESCRIPTION
If quiche receives non-utf8 reason bytes for conn/app close and attempts to write to qlog, it will panic. 