### PR TITLE
Link crypto and ssl libraries with whole-archive

### DIFF
--- a/quiche/src/build.rs
+++ b/quiche/src/build.rs
@@ -236,13 +236,13 @@ fn main() {
         let build_dir = format!("{}/build/{}", bssl_dir, build_path);
         println!("cargo:rustc-link-search=native={}", build_dir);
 
-        println!("cargo:rustc-link-lib=static=ssl");
-        println!("cargo:rustc-link-lib=static=crypto");
+        println!("cargo:rustc-link-lib=static:+whole-archive=ssl");
+        println!("cargo:rustc-link-lib=static:+whole-archive=crypto");
     }
 
     if cfg!(feature = "boringssl-boring-crate") {
-        println!("cargo:rustc-link-lib=static=ssl");
-        println!("cargo:rustc-link-lib=static=crypto");
+        println!("cargo:rustc-link-lib=static:+whole-archive=ssl");
+        println!("cargo:rustc-link-lib=static:+whole-archive=crypto");
     }
 
     // MacOS: Allow cdylib to link with undefined symbols


### PR DESCRIPTION
Rust 1.61.0 changed the linker. Previously native static libraries were linked as whole-archive in some cases, but now rustc tries not to use whole-archive unless explicitly requested. To address these errors, specify the `whole-archive` modifier.

See: https://github.com/rust-lang/rust/blob/1.61.0/RELEASES.md#compatibility-notes
See: https://bugs.gentoo.org/847583