### PR TITLE
Explicit Congestion Notification support

### DIFF
--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -54,6 +54,8 @@ pub struct CommonArgs {
     pub qpack_max_table_capacity: Option<u64>,
     pub qpack_blocked_streams: Option<u64>,
     pub initial_cwnd_packets: u64,
+    pub enable_ecn: bool,
+    pub use_ect1: bool,
 }
 
 /// Creates a new `CommonArgs` structure using the provided [`Docopt`].
@@ -80,6 +82,8 @@ pub struct CommonArgs {
 /// --qpack-max-table-capacity BYTES  Max capacity of dynamic QPACK decoding.
 /// --qpack-blocked-streams STREAMS  Limit of blocked streams while decoding.
 /// --initial-cwnd-packets      Size of initial congestion window, in packets.
+/// --enable-ecn                Enable ECN support.
+/// --use-ect1                  Use ECT(1) instead of ECT(0).
 ///
 /// [`Docopt`]: https://docs.rs/docopt/1.1.0/docopt/
 impl Args for CommonArgs {
@@ -191,6 +195,9 @@ impl Args for CommonArgs {
             .parse::<u64>()
             .unwrap();
 
+        let enable_ecn = args.get_bool("--enable-ecn");
+        let use_ect1 = args.get_bool("--use-ect1");
+
         CommonArgs {
             alpns,
             max_data,
@@ -214,6 +221,8 @@ impl Args for CommonArgs {
             qpack_max_table_capacity,
             qpack_blocked_streams,
             initial_cwnd_packets,
+            enable_ecn,
+            use_ect1,
         }
     }
 }
@@ -243,6 +252,8 @@ impl Default for CommonArgs {
             qpack_max_table_capacity: None,
             qpack_blocked_streams: None,
             initial_cwnd_packets: 10,
+            enable_ecn: false,
+            use_ect1: false,
         }
     }
 }
@@ -289,6 +300,8 @@ Options:
   --session-file PATH      File used to cache a TLS session for resumption.
   --source-port PORT       Source port to use when connecting to the server [default: 0].
   --initial-cwnd-packets PACKETS   The initial congestion window size in terms of packet count [default: 10].
+  --enable-ecn             Enable ECN support.
+  --use-ect1               Use ECT(1) instead of ECT(0).
   -h --help                Show this screen.
 ";
 
@@ -464,6 +477,8 @@ Options:
   --disable-gso               Disable GSO (linux only).
   --disable-pacing            Disable pacing (linux only).
   --initial-cwnd-packets PACKETS      The initial congestion window size in terms of packet count [default: 10].
+  --enable-ecn                Enable ECN support.
+  --use-ect1                  Use ECT(1) instead of ECT(0).
   -h --help                   Show this screen.
 ";
 

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -407,6 +407,7 @@ fn main() {
             let recv_info = quiche::RecvInfo {
                 to: local_addr,
                 from,
+                ecn: 0,
             };
 
             // Process potentially coalesced packets.

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -41,6 +41,7 @@ use std::rc::Rc;
 
 use std::cell::RefCell;
 
+use quiche_apps::recvfrom::recv_from;
 use ring::rand::*;
 
 use quiche_apps::args::*;
@@ -127,6 +128,7 @@ fn main() {
     config.set_max_stream_window(conn_args.max_stream_window);
 
     config.enable_pacing(pacing);
+    config.enable_ecn(conn_args.enable_ecn);
 
     let mut keylog = None;
 
@@ -202,7 +204,12 @@ fn main() {
                 break 'read;
             }
 
-            let (len, from) = match socket.recv_from(&mut buf) {
+            let (len, recv_info) = match recv_from(
+                &socket,
+                local_addr,
+                &mut buf,
+                conn_args.enable_ecn,
+            ) {
                 Ok(v) => v,
 
                 Err(e) => {
@@ -270,7 +277,7 @@ fn main() {
 
                     let out = &out[..len];
 
-                    if let Err(e) = socket.send_to(out, from) {
+                    if let Err(e) = socket.send_to(out, recv_info.from) {
                         if e.kind() == std::io::ErrorKind::WouldBlock {
                             trace!("send() would block");
                             break;
@@ -295,7 +302,7 @@ fn main() {
                         warn!("Doing stateless retry");
 
                         let scid = quiche::ConnectionId::from_ref(&scid);
-                        let new_token = mint_token(&hdr, &from);
+                        let new_token = mint_token(&hdr, &recv_info.from);
 
                         let len = quiche::retry(
                             &hdr.scid,
@@ -309,7 +316,7 @@ fn main() {
 
                         let out = &out[..len];
 
-                        if let Err(e) = socket.send_to(out, from) {
+                        if let Err(e) = socket.send_to(out, recv_info.from) {
                             if e.kind() == std::io::ErrorKind::WouldBlock {
                                 trace!("send() would block");
                                 break;
@@ -320,7 +327,7 @@ fn main() {
                         continue 'read;
                     }
 
-                    odcid = validate_token(&from, token);
+                    odcid = validate_token(&recv_info.from, token);
 
                     // The token was not valid, meaning the retry failed, so
                     // drop the packet.
@@ -348,7 +355,7 @@ fn main() {
                     &scid,
                     odcid.as_ref(),
                     local_addr,
-                    from,
+                    recv_info.from,
                     &mut config,
                 )
                 .unwrap();
@@ -402,12 +409,6 @@ fn main() {
                 };
 
                 clients.get_mut(cid).unwrap()
-            };
-
-            let recv_info = quiche::RecvInfo {
-                to: local_addr,
-                from,
-                ecn: 0,
             };
 
             // Process potentially coalesced packets.
@@ -586,6 +587,7 @@ fn main() {
                 client.max_datagram_size,
                 pacing,
                 enable_gso,
+                conn_args.enable_ecn,
             ) {
                 if e.kind() == std::io::ErrorKind::WouldBlock {
                     trace!("send() would block");

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -129,6 +129,7 @@ fn main() {
 
     config.enable_pacing(pacing);
     config.enable_ecn(conn_args.enable_ecn);
+    config.set_ecn_use_ect1(conn_args.use_ect1);
 
     let mut keylog = None;
 

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -307,6 +307,7 @@ pub fn connect(
                 let recv_info = quiche::RecvInfo {
                     to: local_addr,
                     from,
+                    ecn: 0,
                 };
 
                 // Process potentially coalesced packets.

--- a/apps/src/cmsg.rs
+++ b/apps/src/cmsg.rs
@@ -1,0 +1,144 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Taken from https://github.com/mxinden/udp-socket/blob/master/src/cmsg.rs,
+// which is itself inspired from
+// https://github.com/quinn-rs/quinn/blob/main/quinn-udp/src/cmsg.rs.
+
+use std::mem;
+use std::ptr;
+
+#[derive(Copy, Clone)]
+#[repr(align(8))] // Conservative bound for align_of<cmsghdr>
+pub struct Aligned<T>(pub T);
+
+/// Helper to encode a series of control messages ("cmsgs") to a buffer for use
+/// in `sendmsg`.
+///
+/// The operation must be "finished" for the msghdr to be usable, either by
+/// calling `finish` explicitly or by dropping the `Encoder`.
+pub struct Encoder<'a> {
+    hdr: &'a mut libc::msghdr,
+    cmsg: Option<&'a mut libc::cmsghdr>,
+    len: usize,
+}
+
+impl<'a> Encoder<'a> {
+    /// # Safety
+    /// - `hdr.msg_control` must be a suitably aligned pointer to
+    ///   `hdr.msg_controllen` bytes that can be safely written
+    /// - The `Encoder` must be dropped before `hdr` is passed to a system call,
+    ///   and must not be leaked.
+    pub unsafe fn new(hdr: &'a mut libc::msghdr) -> Self {
+        Self {
+            cmsg: libc::CMSG_FIRSTHDR(hdr).as_mut(),
+            hdr,
+            len: 0,
+        }
+    }
+
+    /// Append a control message to the buffer.
+    ///
+    /// # Panics
+    /// - If insufficient buffer space remains.
+    /// - If `T` has stricter alignment requirements than `cmsghdr`
+    pub fn push<T: Copy + ?Sized>(
+        &mut self, level: libc::c_int, ty: libc::c_int, value: T,
+    ) {
+        assert!(mem::align_of::<T>() <= mem::align_of::<libc::cmsghdr>());
+        let space =
+            unsafe { libc::CMSG_SPACE(mem::size_of_val(&value) as _) as usize };
+        assert!(
+            self.hdr.msg_controllen as usize >= self.len + space,
+            "control message buffer too small"
+        );
+        let cmsg = self.cmsg.take().expect("no control buffer space remaining");
+        cmsg.cmsg_level = level;
+        cmsg.cmsg_type = ty;
+        cmsg.cmsg_len =
+            unsafe { libc::CMSG_LEN(mem::size_of_val(&value) as _) } as _;
+        unsafe {
+            ptr::write(libc::CMSG_DATA(cmsg) as *const T as *mut T, value);
+        }
+        self.len += space;
+        self.cmsg = unsafe { libc::CMSG_NXTHDR(self.hdr, cmsg).as_mut() };
+    }
+
+    /// Finishes appending control messages to the buffer
+    pub fn finish(self) {
+        // Delegates to the `Drop` impl
+    }
+}
+
+// Statically guarantees that the encoding operation is "finished" before the
+// control buffer is read by `sendmsg`.
+impl<'a> Drop for Encoder<'a> {
+    fn drop(&mut self) {
+        self.hdr.msg_controllen = self.len as _;
+    }
+}
+
+/// # Safety
+///
+/// `cmsg` must refer to a cmsg containing a payload of type `T`
+pub unsafe fn decode<T: Copy>(cmsg: &libc::cmsghdr) -> T {
+    assert!(mem::align_of::<T>() <= mem::align_of::<libc::cmsghdr>());
+    debug_assert_eq!(
+        cmsg.cmsg_len as usize,
+        libc::CMSG_LEN(mem::size_of::<T>() as _) as usize
+    );
+    ptr::read(libc::CMSG_DATA(cmsg) as *const T)
+}
+
+pub struct Iter<'a> {
+    hdr: &'a libc::msghdr,
+    cmsg: Option<&'a libc::cmsghdr>,
+}
+
+impl<'a> Iter<'a> {
+    /// # Safety
+    ///
+    /// `hdr.msg_control` must point to memory outliving `'a` which can be
+    /// soundly read for the lifetime of the constructed `Iter` and contains
+    /// a buffer of cmsgs, i.e. is aligned for `cmsghdr`, is fully
+    /// initialized, and has correct internal links.
+    pub unsafe fn new(hdr: &'a libc::msghdr) -> Self {
+        Self {
+            hdr,
+            cmsg: libc::CMSG_FIRSTHDR(hdr).as_ref(),
+        }
+    }
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a libc::cmsghdr;
+
+    fn next(&mut self) -> Option<&'a libc::cmsghdr> {
+        let current = self.cmsg.take()?;
+        self.cmsg = unsafe { libc::CMSG_NXTHDR(self.hdr, current).as_ref() };
+        Some(current)
+    }
+}

--- a/apps/src/cmsg.rs
+++ b/apps/src/cmsg.rs
@@ -72,7 +72,7 @@ impl<'a> Encoder<'a> {
         let space =
             unsafe { libc::CMSG_SPACE(mem::size_of_val(&value) as _) as usize };
         assert!(
-            self.hdr.msg_controllen as usize >= self.len + space,
+            self.hdr.msg_controllen >= self.len + space,
             "control message buffer too small"
         );
         let cmsg = self.cmsg.take().expect("no control buffer space remaining");
@@ -107,7 +107,7 @@ impl<'a> Drop for Encoder<'a> {
 pub unsafe fn decode<T: Copy>(cmsg: &libc::cmsghdr) -> T {
     assert!(mem::align_of::<T>() <= mem::align_of::<libc::cmsghdr>());
     debug_assert_eq!(
-        cmsg.cmsg_len as usize,
+        cmsg.cmsg_len,
         libc::CMSG_LEN(mem::size_of::<T>() as _) as usize
     );
     ptr::read(libc::CMSG_DATA(cmsg) as *const T)

--- a/apps/src/lib.rs
+++ b/apps/src/lib.rs
@@ -29,5 +29,7 @@ extern crate log;
 
 pub mod args;
 pub mod client;
+pub mod cmsg;
 pub mod common;
+pub mod recvfrom;
 pub mod sendto;

--- a/apps/src/lib.rs
+++ b/apps/src/lib.rs
@@ -29,6 +29,7 @@ extern crate log;
 
 pub mod args;
 pub mod client;
+#[cfg(target_os = "linux")]
 pub mod cmsg;
 pub mod common;
 pub mod recvfrom;

--- a/apps/src/recvfrom.rs
+++ b/apps/src/recvfrom.rs
@@ -1,0 +1,158 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use quiche::RecvInfo;
+use std::io;
+use std::net::SocketAddr;
+
+#[cfg(target_os = "linux")]
+fn set_ecn_support(socket: &mio::net::UdpSocket) -> std::io::Result<()> {
+    use crate::common::setsockopt;
+    use libc::IPPROTO_IP;
+    use libc::IPPROTO_IPV6;
+    use libc::IPV6_RECVTCLASS;
+    use libc::IP_RECVTOS;
+    use std::os::unix::io::AsRawFd;
+
+    let recv_ecn: u32 = 1;
+
+    // Opportunistically set support on both address families.
+    let res1 = unsafe {
+        setsockopt(socket.as_raw_fd(), IPPROTO_IP, IP_RECVTOS, recv_ecn)
+    };
+    let res2 = unsafe {
+        setsockopt(socket.as_raw_fd(), IPPROTO_IPV6, IPV6_RECVTCLASS, recv_ecn)
+    };
+    if res1.is_ok() {
+        res1
+    } else {
+        res2
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn set_ecn_support(_socket: &mio::net::UdpSocket) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "ecn not supported",
+    ))
+}
+
+// The following is taken from https://github.com/mxinden/udp-socket,
+// with some adaptations.
+
+#[cfg(target_os = "linux")]
+fn recvmsg(
+    socket: &mio::net::UdpSocket, local_addr: SocketAddr, buf: &mut [u8],
+) -> std::io::Result<(usize, RecvInfo)> {
+    use std::io::IoSliceMut;
+    use std::mem::MaybeUninit;
+    use std::os::unix::io::AsRawFd;
+
+    use libc::CMSG_LEN;
+
+    use crate::cmsg;
+    use crate::common;
+
+    let mut iov = IoSliceMut::new(buf);
+    let mut name = MaybeUninit::<libc::sockaddr_storage>::uninit();
+    let mut ctrl = cmsg::Aligned(MaybeUninit::<
+        [u8; (std::mem::size_of::<libc::in6_pktinfo>() as _)],
+    >::uninit());
+    let mut hdr = unsafe { std::mem::zeroed::<libc::msghdr>() };
+
+    hdr.msg_name = name.as_mut_ptr() as _;
+    hdr.msg_namelen = std::mem::size_of::<libc::sockaddr_storage>() as _;
+    hdr.msg_iov = (&mut iov) as *mut IoSliceMut as *mut libc::iovec;
+    hdr.msg_iovlen = 1;
+    hdr.msg_control = ctrl.0.as_mut_ptr() as _;
+    hdr.msg_controllen = CMSG_LEN as _;
+    hdr.msg_flags = 0;
+
+    let read = common::macro_helper::syscall!(recvmsg(
+        socket.as_raw_fd(),
+        (&mut hdr) as *mut libc::msghdr,
+        0
+    ))?;
+
+    let name = unsafe { name.assume_init() };
+    let mut ecn_bits = 0;
+
+    let cmsg_iter = unsafe { cmsg::Iter::new(&hdr) };
+    for cmsg in cmsg_iter {
+        match (cmsg.cmsg_level, cmsg.cmsg_type) {
+            // FreeBSD uses IP_RECVTOS here, and we can be liberal because cmsgs
+            // are opt-in.
+            (libc::IPPROTO_IP, libc::IP_TOS) |
+            (libc::IPPROTO_IP, libc::IP_RECVTOS) => unsafe {
+                ecn_bits = cmsg::decode::<u8>(cmsg);
+            },
+            (libc::IPPROTO_IPV6, libc::IPV6_TCLASS) => unsafe {
+                ecn_bits = cmsg::decode::<libc::c_int>(cmsg) as u8;
+            },
+            _ => {},
+        }
+    }
+
+    let source = match libc::c_int::from(name.ss_family) {
+        libc::AF_INET => unsafe {
+            SocketAddr::V4(std::ptr::read(&name as *const _ as _))
+        },
+        libc::AF_INET6 => unsafe {
+            SocketAddr::V6(std::ptr::read(&name as *const _ as _))
+        },
+        _ => unreachable!(),
+    };
+
+    Ok((read as usize, RecvInfo {
+        from: source,
+        to: local_addr,
+        ecn: ecn_bits,
+    }))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn recvmsg(
+    socket: &mio::net::UdpSocket, local_addr: SocketAddr, buf: &mut [u8],
+) -> std::io::Result<(usize, RecvInfo)> {
+    let (len, from) = socket.recv_from(buf)?;
+    Ok((len, RecvInfo {
+        from,
+        to: local_addr,
+        ecn: 0,
+    }))
+}
+
+pub fn recv_from(
+    socket: &mio::net::UdpSocket, local_addr: SocketAddr, buf: &mut [u8],
+    enable_ecn: bool,
+) -> io::Result<(usize, RecvInfo)> {
+    if enable_ecn {
+        set_ecn_support(socket).ok();
+    }
+
+    recvmsg(socket, local_addr, buf)
+}

--- a/apps/src/recvfrom.rs
+++ b/apps/src/recvfrom.rs
@@ -84,7 +84,7 @@ fn recvmsg(
     let mut iov = IoSliceMut::new(buf);
     let mut name = MaybeUninit::<libc::sockaddr_storage>::uninit();
     let mut ctrl = cmsg::Aligned(MaybeUninit::<
-        [u8; (std::mem::size_of::<libc::in6_pktinfo>() as _)],
+        [u8; std::mem::size_of::<libc::in6_pktinfo>() as _],
     >::uninit());
     let mut hdr = unsafe { std::mem::zeroed::<libc::msghdr>() };
 

--- a/fuzz/src/packet_recv_client.rs
+++ b/fuzz/src/packet_recv_client.rs
@@ -46,7 +46,7 @@ fuzz_target!(|data: &[u8]| {
     )
     .unwrap();
 
-    let info = quiche::RecvInfo { from, to };
+    let info = quiche::RecvInfo { from, to, ecn: 0 };
 
     conn.recv(&mut buf, info).ok();
 });

--- a/fuzz/src/packet_recv_server.rs
+++ b/fuzz/src/packet_recv_server.rs
@@ -47,7 +47,7 @@ fuzz_target!(|data: &[u8]| {
         quiche::accept(&SCID, None, to, from, &mut CONFIG.lock().unwrap())
             .unwrap();
 
-    let info = quiche::RecvInfo { from, to };
+    let info = quiche::RecvInfo { from, to, ecn: 0 };
 
     conn.recv(&mut buf, info).ok();
 });

--- a/nginx/nginx-1.16.patch
+++ b/nginx/nginx-1.16.patch
@@ -20,7 +20,7 @@ Subject: [PATCH] Initial QUIC and HTTP/3 implementation using quiche
  src/event/ngx_event.h                   |    4 -
  src/event/ngx_event_posted.c            |    1 +
  src/event/ngx_event_posted.h            |    3 +
- src/event/ngx_event_quic.c              |  902 +++++++++
+ src/event/ngx_event_quic.c              |  904 +++++++++
  src/event/ngx_event_quic.h              |   63 +
  src/event/ngx_event_udp.c               |   39 +-
  src/http/modules/ngx_http_ssl_module.c  |   13 +-
@@ -638,7 +638,7 @@ new file mode 100644
 index 000000000..bc73cffc9
 --- /dev/null
 +++ b/src/event/ngx_event_quic.c
-@@ -0,0 +1,902 @@
+@@ -0,0 +1,904 @@
 +
 +/*
 + * Copyright (C) Cloudflare, Inc.
@@ -866,6 +866,7 @@ index 000000000..bc73cffc9
 +        c->socklen,
 +        c->local_sockaddr,
 +        c->local_socklen,
++        0,
 +    };
 +
 +    /* Process the client's Initial packet, which was saved into c->buffer by
@@ -932,6 +933,7 @@ index 000000000..bc73cffc9
 +            c->socklen,
 +            c->local_sockaddr,
 +            c->local_socklen,
++            0,
 +        };
 +
 +        ssize_t done = quiche_conn_recv(c->quic->conn, b, n, &recv_info);

--- a/quiche/examples/client.rs
+++ b/quiche/examples/client.rs
@@ -172,6 +172,7 @@ fn main() {
             let recv_info = quiche::RecvInfo {
                 to: socket.local_addr().unwrap(),
                 from,
+                ecn: 0,
             };
 
             // Process potentially coalesced packets.

--- a/quiche/examples/http3-client.rs
+++ b/quiche/examples/http3-client.rs
@@ -191,6 +191,7 @@ fn main() {
             let recv_info = quiche::RecvInfo {
                 to: local_addr,
                 from,
+                ecn: 0,
             };
 
             // Process potentially coalesced packets.

--- a/quiche/examples/http3-server.rs
+++ b/quiche/examples/http3-server.rs
@@ -292,6 +292,7 @@ fn main() {
             let recv_info = quiche::RecvInfo {
                 to: socket.local_addr().unwrap(),
                 from,
+                ecn: 0,
             };
 
             // Process potentially coalesced packets.

--- a/quiche/examples/server.rs
+++ b/quiche/examples/server.rs
@@ -289,6 +289,7 @@ fn main() {
             let recv_info = quiche::RecvInfo {
                 to: socket.local_addr().unwrap(),
                 from,
+                ecn: 0,
             };
 
             // Process potentially coalesced packets.

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -352,6 +352,9 @@ typedef struct {
 
     // The time to send the packet out.
     struct timespec at;
+
+    // The ECN marking for the outgoing packet.
+    uint8_t ecn;
 } quiche_send_info;
 
 // Writes a single QUIC packet to be sent to the peer.

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -332,6 +332,9 @@ typedef struct {
     // The local address the packet was received on.
     struct sockaddr *to;
     socklen_t to_len;
+
+    // The ECN marking on the incoming packet.
+    uint8_t ecn;
 } quiche_recv_info;
 
 // Processes QUIC packets received from the peer.

--- a/quiche/src/ecn.rs
+++ b/quiche/src/ecn.rs
@@ -223,6 +223,11 @@ impl Ecn {
             self.state = EcnState::Unsupported;
         }
     }
+
+    /// Returns the latest ECN counters.
+    pub fn ecn_counts(&self) -> [packet::EcnCounts; packet::Epoch::count()] {
+        self.last_ecn_counts
+    }
 }
 
 #[cfg(test)]

--- a/quiche/src/ecn.rs
+++ b/quiche/src/ecn.rs
@@ -1,0 +1,415 @@
+// Copyright (C) 2022, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::packet;
+use crate::packet::Epoch;
+
+const ECN_VALIDATION_COUNT: u64 = 10;
+const ECN_LOSS_THRESHOLD: u64 = 3;
+
+pub const ECN_NOT_ECT: u8 = 0;
+pub const ECN_ECT1: u8 = 1;
+pub const ECN_ECT0: u8 = 2;
+pub const ECN_CE: u8 = 3;
+
+#[derive(Debug)]
+enum EcnState {
+    /// Send up to 10 packets marked to ECT(0) or ECT(1) and move to
+    /// `Validating`.
+    Probing(u8),
+    /// Stop sending ECN-enabled packets, but wait for possible ACK reception
+    /// confirming ECN usage or disabling it.
+    Validating(u8),
+    /// Validation succeeded, always send ECT(0) or ECT(1) packets.
+    Capable(u8),
+    /// Either ECN is disabled or validation failed. No ECN-enabled packet is
+    /// sent.
+    Unsupported,
+}
+
+/// Structure keeping the ECN state.
+#[derive(Debug)]
+pub struct Ecn {
+    state: EcnState,
+    ecn_pkts_sent: u64,
+    ecn_pkts_lost: u64,
+    last_ecn_counts: [packet::EcnCounts; packet::Epoch::count()],
+    enabled: bool,
+    use_ect1: bool,
+}
+
+impl Ecn {
+    /// Creates a new `Ecn` structure.
+    pub fn new(
+        enabled: bool, use_ect1: bool,
+        base_ecn_counts: [packet::EcnCounts; packet::Epoch::count()],
+    ) -> Ecn {
+        let state = if enabled {
+            let ect_value = if use_ect1 { ECN_ECT1 } else { ECN_ECT0 };
+            EcnState::Probing(ect_value)
+        } else {
+            EcnState::Unsupported
+        };
+        Ecn {
+            state,
+            ecn_pkts_sent: 0,
+            ecn_pkts_lost: 0,
+            last_ecn_counts: base_ecn_counts,
+            enabled,
+            use_ect1,
+        }
+    }
+
+    /// An endpoint thus attempts to use ECN and validates this for each new
+    /// connection, when switching to a server's preferred address, and on
+    /// active connection migration to a new path.
+    pub fn reset(
+        &mut self, base_ecn_counts: [packet::EcnCounts; packet::Epoch::count()],
+    ) {
+        self.state = if self.enabled {
+            let ect_value = if self.use_ect1 { ECN_ECT1 } else { ECN_ECT0 };
+            EcnState::Probing(ect_value)
+        } else {
+            EcnState::Unsupported
+        };
+        self.ecn_pkts_sent = 0;
+        self.last_ecn_counts = base_ecn_counts;
+    }
+
+    /// Returns the ECN value to assign to the packet to send.
+    ///
+    /// By calling this method, we assume that the packet to be marked is
+    /// actually sent. When probing a path for ECN-capability, this method may
+    /// return different values if too many packets were sent (calling this
+    /// method) before getting any acknowledgment ([`on_ack_received()`]).
+    ///
+    /// [`on_ack_received()`]: struct.Ecn.html#method.on_ack_received
+    pub fn get_ecn_value_to_send(&mut self) -> u8 {
+        match self.state {
+            EcnState::Probing(ect_value) => {
+                self.ecn_pkts_sent += 1;
+                if self.ecn_pkts_sent >= ECN_VALIDATION_COUNT {
+                    self.state = EcnState::Validating(ect_value);
+                }
+                ect_value
+            },
+
+            EcnState::Capable(ect_value) => ect_value,
+
+            EcnState::Validating(_) | EcnState::Unsupported => ECN_NOT_ECT,
+        }
+    }
+
+    /// Returns whether the next packet to send will be ECN-marked.
+    pub fn is_next_sent_pkt_ecn_marked(&self) -> bool {
+        matches!(self.state, EcnState::Probing(_) | EcnState::Capable(_))
+    }
+
+    /// This method should be called when we receive an ACK frame increasing the
+    /// largest acknowledged packet number that acknowledged ECN-marked sent
+    /// packets.
+    ///
+    /// This returns the number of newly acknowledged packets with ECN-CE mark.
+    pub fn on_ack_received(
+        &mut self, epoch: Epoch, newly_ecn_marked_acked: u64,
+        ecn_counts: Option<packet::EcnCounts>,
+    ) -> u64 {
+        if matches!(self.state, EcnState::Unsupported) {
+            return 0;
+        }
+        // If an ACK frame newly acknowledges a packet that the endpoint sent
+        // with either the ECT(0) or ECT(1) codepoint set, ECN validation fails
+        // if the corresponding ECN counts are not present in the ACK frame.
+        let ecn_counts = match ecn_counts {
+            Some(e) => e,
+            None => {
+                warn!("received ACK without ECN counts; disable ECN");
+                self.state = EcnState::Unsupported;
+                return 0;
+            },
+        };
+
+        let last_ecn_counts = self.last_ecn_counts[epoch];
+
+        // Validation will fail when an endpoint receives a non-zero ECN count
+        // corresponding to an ECT codepoint that it never applied.
+        if (self.use_ect1 && ecn_counts.ect0_count != last_ecn_counts.ect0_count) ||
+            (!self.use_ect1 &&
+                ecn_counts.ect1_count != last_ecn_counts.ect1_count)
+        {
+            warn!("received ECN count increase for unsent marking; disable ECN");
+            self.state = EcnState::Unsupported;
+            return 0;
+        }
+
+        // Strange reordering cases or buggy implementations may provide lower
+        // ECN counts than the last remembered values. Skip their processing.
+        if ecn_counts.ect0_count < last_ecn_counts.ect0_count ||
+            ecn_counts.ect1_count < last_ecn_counts.ect1_count ||
+            ecn_counts.ecn_ce_count < last_ecn_counts.ecn_ce_count
+        {
+            return 0;
+        }
+
+        // ECN validation also fails if the sum of the increase in ECT(0) and
+        // ECN-CE counts is less than the number of newly acknowledged packets
+        // that were originally sent with an ECT(0) marking. Similarly, ECN
+        // validation fails if the sum of the increases to ECT(1) and ECN-CE
+        // counts is less than the number of newly acknowledged packets sent
+        // with an ECT(1) marking.
+        let ecn_count_increase = ecn_counts.ect0_count -
+            last_ecn_counts.ect0_count +
+            ecn_counts.ect1_count -
+            last_ecn_counts.ect1_count +
+            ecn_counts.ecn_ce_count -
+            last_ecn_counts.ecn_ce_count;
+        if ecn_count_increase < newly_ecn_marked_acked {
+            warn!("sum of ECN count increase lower than number of ECN-marked acked packets; disable ECN");
+            self.state = EcnState::Unsupported;
+            return 0;
+        }
+
+        let ecn_ce_increase =
+            ecn_counts.ecn_ce_count - last_ecn_counts.ecn_ce_count;
+        match self.state {
+            EcnState::Probing(e) | EcnState::Validating(e) =>
+                self.state = EcnState::Capable(e),
+            _ => {},
+        }
+        self.last_ecn_counts[epoch] = ecn_counts;
+        // Reset the number of lost packets.
+        self.ecn_pkts_lost = 0;
+
+        ecn_ce_increase
+    }
+
+    /// This method should be called when a non-zero number of ECN-marked sent
+    /// packets were declared lost.
+    pub fn on_packets_lost(
+        &mut self, lost_ecn_marked_ack_eliciting_packets: u64,
+    ) {
+        if matches!(self.state, EcnState::Unsupported) {
+            return;
+        }
+        self.ecn_pkts_lost += lost_ecn_marked_ack_eliciting_packets;
+        if self.ecn_pkts_lost >= ECN_LOSS_THRESHOLD {
+            warn!(
+                "Lost {} ECN-marked packets; disable ECN",
+                self.ecn_pkts_lost
+            );
+            self.state = EcnState::Unsupported;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ecn::ECN_LOSS_THRESHOLD;
+    use crate::packet;
+
+    use super::Ecn;
+    use super::ECN_ECT0;
+    use super::ECN_ECT1;
+    use super::ECN_NOT_ECT;
+    use super::ECN_VALIDATION_COUNT;
+
+    #[test]
+    fn disabled_ecn() {
+        let mut ecn = Ecn::new(false, false, [packet::EcnCounts::default(); 3]);
+        for _ in 0..1000 {
+            assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), false);
+            assert_eq!(ecn.get_ecn_value_to_send(), ECN_NOT_ECT);
+        }
+    }
+
+    #[test]
+    fn ecn_marked_pkt_acked_without_ecn_counts() {
+        let mut ecn = Ecn::new(true, false, [packet::EcnCounts::default(); 3]);
+
+        assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), true);
+        assert_eq!(ecn.get_ecn_value_to_send(), ECN_ECT0);
+
+        // The packet gets acknowledged, but in an ACK frame without ECN counts.
+        let ce_events = ecn.on_ack_received(packet::Epoch::Application, 1, None);
+        assert_eq!(ce_events, 0);
+        // This disables ECN marks.
+        assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), false);
+        assert_eq!(ecn.get_ecn_value_to_send(), ECN_NOT_ECT);
+    }
+
+    #[test]
+    fn received_ecn_counts_ect1_when_marking_ect0() {
+        let mut ecn_counts = [packet::EcnCounts::default(); 3];
+        let mut ecn = Ecn::new(true, false, ecn_counts);
+
+        assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), true);
+        assert_eq!(ecn.get_ecn_value_to_send(), ECN_ECT0);
+
+        // The packet gets acknowledged, but in an ACK frame increasing the ECN
+        // count of an ECT different from the one being used.
+        ecn_counts[packet::Epoch::Application].ect1_count += 1;
+        let ce_events = ecn.on_ack_received(
+            packet::Epoch::Application,
+            1,
+            Some(ecn_counts[packet::Epoch::Application]),
+        );
+        assert_eq!(ce_events, 0);
+        // This disables ECN marks.
+        assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), false);
+        assert_eq!(ecn.get_ecn_value_to_send(), ECN_NOT_ECT);
+    }
+
+    #[test]
+    fn received_ecn_counts_ect0_when_marking_ect1() {
+        let mut ecn_counts = [packet::EcnCounts::default(); 3];
+        let mut ecn = Ecn::new(true, true, ecn_counts);
+
+        assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), true);
+        assert_eq!(ecn.get_ecn_value_to_send(), ECN_ECT1);
+
+        // The packet gets acknowledged, but in an ACK frame increasing the ECN
+        // count of an ECT different from the one being used.
+        ecn_counts[packet::Epoch::Application].ect0_count += 1;
+        let ce_events = ecn.on_ack_received(
+            packet::Epoch::Application,
+            1,
+            Some(ecn_counts[packet::Epoch::Application]),
+        );
+        assert_eq!(ce_events, 0);
+        // This disables ECN marks.
+        assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), false);
+        assert_eq!(ecn.get_ecn_value_to_send(), ECN_NOT_ECT);
+    }
+
+    #[test]
+    fn sum_of_counts_lower_than_acked_ecn_marked_pkts() {
+        let mut ecn_counts = [packet::EcnCounts::default(); 3];
+        let mut ecn = Ecn::new(true, false, ecn_counts);
+
+        assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), true);
+        assert_eq!(ecn.get_ecn_value_to_send(), ECN_ECT0);
+
+        // The packet gets acknowledged, but the ACK frame increases the ECN
+        // counters such that it includes a lower number of packets than the
+        // numbers of ECN-marked packets actually acknowledged.
+        ecn_counts[packet::Epoch::Application].ect0_count += 3;
+        ecn_counts[packet::Epoch::Application].ecn_ce_count += 2;
+        let ce_events = ecn.on_ack_received(
+            packet::Epoch::Application,
+            6,
+            Some(ecn_counts[packet::Epoch::Application]),
+        );
+        assert_eq!(ce_events, 0);
+        // This disables ECN marks.
+        assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), false);
+        assert_eq!(ecn.get_ecn_value_to_send(), ECN_NOT_ECT);
+    }
+
+    #[test]
+    fn probing_ect0_then_validated() {
+        let mut ecn_counts = [packet::EcnCounts::default(); 3];
+        let mut ecn = Ecn::new(true, false, ecn_counts);
+        for _ in 0..ECN_VALIDATION_COUNT {
+            assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), true);
+            assert_eq!(ecn.get_ecn_value_to_send(), ECN_ECT0);
+        }
+        // Once we sent ECN_VALIDATION_COUNT packets, wait for any ECN
+        // validation before sending ECN marks again.
+        assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), false);
+        assert_eq!(ecn.get_ecn_value_to_send(), ECN_NOT_ECT);
+
+        // Our first 10 packets got acked correctly. ECN should now be enabled.
+        ecn_counts[packet::Epoch::Application].ect0_count += 8;
+        ecn_counts[packet::Epoch::Application].ecn_ce_count += 2;
+        let ce_events = ecn.on_ack_received(
+            packet::Epoch::Application,
+            10,
+            Some(ecn_counts[packet::Epoch::Application]),
+        );
+        assert_eq!(ce_events, 2);
+        for _ in 0..1000 {
+            assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), true);
+            assert_eq!(ecn.get_ecn_value_to_send(), ECN_ECT0);
+        }
+    }
+
+    #[test]
+    fn probing_ect1_then_validated() {
+        let mut ecn_counts = [packet::EcnCounts::default(); 3];
+        let mut ecn = Ecn::new(true, true, ecn_counts);
+        for _ in 0..ECN_VALIDATION_COUNT {
+            assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), true);
+            assert_eq!(ecn.get_ecn_value_to_send(), ECN_ECT1);
+        }
+        // Once we sent ECN_VALIDATION_COUNT packets, wait for any ECN
+        // validation before sending ECN marks again.
+        assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), false);
+        assert_eq!(ecn.get_ecn_value_to_send(), ECN_NOT_ECT);
+
+        // Our first 10 packets got acked correctly. ECN should now be enabled.
+        ecn_counts[packet::Epoch::Application].ect1_count += 8;
+        ecn_counts[packet::Epoch::Application].ecn_ce_count += 2;
+        let ce_events = ecn.on_ack_received(
+            packet::Epoch::Application,
+            10,
+            Some(ecn_counts[packet::Epoch::Application]),
+        );
+        assert_eq!(ce_events, 2);
+        for _ in 0..1000 {
+            assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), true);
+            assert_eq!(ecn.get_ecn_value_to_send(), ECN_ECT1);
+        }
+    }
+
+    #[test]
+    fn probing_ect0_but_lost_packets() {
+        let mut ecn_counts = [packet::EcnCounts::default(); 3];
+        let mut ecn = Ecn::new(true, false, ecn_counts);
+        for _ in 0..3 {
+            assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), true);
+            assert_eq!(ecn.get_ecn_value_to_send(), ECN_ECT0);
+        }
+        ecn.on_packets_lost(2);
+
+        // Our first 10 packets got acked correctly. ECN should now be enabled.
+        ecn_counts[packet::Epoch::Application].ect0_count += 1;
+        let ce_events = ecn.on_ack_received(
+            packet::Epoch::Application,
+            1,
+            Some(ecn_counts[packet::Epoch::Application]),
+        );
+        assert_eq!(ce_events, 0);
+        for _ in 0..ECN_LOSS_THRESHOLD {
+            assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), true);
+            assert_eq!(ecn.get_ecn_value_to_send(), ECN_ECT0);
+        }
+        ecn.on_packets_lost(ECN_LOSS_THRESHOLD);
+        for _ in 0..1000 {
+            assert_eq!(ecn.is_next_sent_pkt_ecn_marked(), false);
+            assert_eq!(ecn.get_ecn_value_to_send(), ECN_NOT_ECT);
+        }
+    }
+}

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -720,6 +720,7 @@ pub struct RecvInfo<'a> {
     from_len: socklen_t,
     to: &'a sockaddr,
     to_len: socklen_t,
+    ecn: u8,
 }
 
 impl<'a> From<&RecvInfo<'a>> for crate::RecvInfo {
@@ -727,6 +728,7 @@ impl<'a> From<&RecvInfo<'a>> for crate::RecvInfo {
         crate::RecvInfo {
             from: std_addr_from_c(info.from, info.from_len),
             to: std_addr_from_c(info.to, info.to_len),
+            ecn: info.ecn,
         }
     }
 }

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -758,6 +758,8 @@ pub struct SendInfo {
     to_len: socklen_t,
 
     at: timespec,
+
+    ecn: u8,
 }
 
 #[no_mangle]
@@ -776,6 +778,8 @@ pub extern fn quiche_conn_send(
             out_info.to_len = std_addr_to_c(&info.to, &mut out_info.to);
 
             std_time_to_c(&info.at, &mut out_info.at);
+
+            out_info.ecn = info.ecn;
 
             v as ssize_t
         },

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -47,13 +47,6 @@ pub const MAX_DGRAM_OVERHEAD: usize = 2;
 pub const MAX_STREAM_OVERHEAD: usize = 12;
 pub const MAX_STREAM_SIZE: u64 = 1 << 62;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EcnCounts {
-    ect0_count: u64,
-    ect1_count: u64,
-    ecn_ce_count: u64,
-}
-
 #[derive(Clone, PartialEq, Eq)]
 pub enum Frame {
     Padding {
@@ -65,7 +58,7 @@ pub enum Frame {
     ACK {
         ack_delay: u64,
         ranges: ranges::RangeSet,
-        ecn_counts: Option<EcnCounts>,
+        ecn_counts: Option<packet::EcnCounts>,
     },
 
     ResetStream {
@@ -1207,7 +1200,7 @@ fn parse_ack_frame(ty: u64, b: &mut octets::Octets) -> Result<Frame> {
     }
 
     let ecn_counts = if first & 0x01 != 0 {
-        let ecn = EcnCounts {
+        let ecn = packet::EcnCounts {
             ect0_count: b.get_varint()?,
             ect1_count: b.get_varint()?,
             ecn_ce_count: b.get_varint()?,
@@ -1427,7 +1420,7 @@ mod tests {
         ranges.insert(15..19);
         ranges.insert(3000..5000);
 
-        let ecn_counts = Some(EcnCounts {
+        let ecn_counts = Some(packet::EcnCounts {
             ect0_count: 100,
             ect1_count: 200,
             ecn_ce_count: 300,

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -16437,14 +16437,18 @@ mod tests {
             ecn_ce_count: 1,
         });
 
-        assert_eq!(
-            iter.next(),
-            Some(&frame::Frame::ACK {
-                ack_delay: 0,
-                ranges,
-                ecn_counts,
-            })
-        );
+        let ack = iter.next();
+        assert!(matches!(ack, Some(&frame::Frame::ACK { .. })));
+        let (ack_ranges, ack_ecn_counts) = match ack {
+            Some(frame::Frame::ACK {
+                ranges: r,
+                ecn_counts: ec,
+                ..
+            }) => (r, ec),
+            _ => unreachable!(),
+        };
+        assert_eq!(*ack_ranges, ranges);
+        assert_eq!(*ack_ecn_counts, ecn_counts);
     }
 }
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -742,6 +742,9 @@ pub struct Config {
     max_stream_window: u64,
 
     disable_dcid_reuse: bool,
+
+    ecn_enabled: bool,
+    ecn_use_ect1: bool,
 }
 
 // See https://quicwg.org/base-drafts/rfc9000.html#section-15
@@ -807,6 +810,9 @@ impl Config {
             max_stream_window: stream::MAX_STREAM_WINDOW,
 
             disable_dcid_reuse: false,
+
+            ecn_enabled: false,
+            ecn_use_ect1: false,
         })
     }
 
@@ -1261,6 +1267,21 @@ impl Config {
     /// The default value is `false`.
     pub fn set_disable_dcid_reuse(&mut self, v: bool) {
         self.disable_dcid_reuse = v;
+    }
+
+    /// Sets whether the QUIC connection should send packets with ECN support.
+    ///
+    /// The default value is `false`.
+    pub fn enable_ecn(&mut self, v: bool) {
+        self.ecn_enabled = v;
+    }
+
+    /// Sets whether the QUIC connection should send packets with ECN support
+    /// with ECT(1) marking instead of ECT(0).
+    ///
+    /// The default value is `false`.
+    pub fn set_ecn_use_ect1(&mut self, v: bool) {
+        self.ecn_use_ect1 = v;
     }
 }
 
@@ -2991,7 +3012,7 @@ impl Connection {
         self.pkt_num_spaces[epoch].largest_rx_pkt_num =
             cmp::max(self.pkt_num_spaces[epoch].largest_rx_pkt_num, pn);
 
-        if info.ecn > 0 {
+        if info.ecn != ecn::ECN_NOT_ECT {
             // Create the `EcnCounts` struct if this is the first non-zero ECN
             // value received.
             if self.pkt_num_spaces[epoch].ecn_counts.is_none() {
@@ -3003,14 +3024,13 @@ impl Connection {
                 self.pkt_num_spaces[epoch].ecn_counts
             {
                 match info.ecn {
-                    // ECN capable (ECT(0)).
-                    0x01 => ecn_counts.ect0_count += 1,
-                    0x02 => ecn_counts.ect1_count += 1,
+                    ecn::ECN_ECT0 => ecn_counts.ect0_count += 1,
 
-                    // Congestion event (ECN-CE).
-                    0x03 => ecn_counts.ecn_ce_count += 1,
+                    ecn::ECN_ECT1 => ecn_counts.ect1_count += 1,
 
-                    _ => unreachable!(),
+                    ecn::ECN_CE => ecn_counts.ecn_ce_count += 1,
+
+                    e => warn!("{} invalid ECN value {}", self.trace_id, e),
                 };
             }
         }
@@ -3327,7 +3347,7 @@ impl Connection {
             done += pad_len;
         }
 
-        let send_path = self.paths.get(send_pid)?;
+        let send_path = self.paths.get_mut(send_pid)?;
 
         let info = SendInfo {
             from: send_path.local_addr(),
@@ -3335,7 +3355,7 @@ impl Connection {
 
             at: send_path.recovery.get_packet_send_time(),
 
-            ecn: 0x01, // ECT(0)
+            ecn: send_path.recovery.ecn.get_ecn_value_to_send(),
         };
 
         Ok((done, info))
@@ -4373,6 +4393,7 @@ impl Connection {
             tx_in_flight: 0,
             lost: 0,
             has_data,
+            ecn_marked: path.recovery.ecn.is_next_sent_pkt_ecn_marked(),
         };
 
         if in_flight && is_app_limited {
@@ -16442,6 +16463,7 @@ pub use crate::stream::StreamIter;
 mod cid;
 mod crypto;
 mod dgram;
+mod ecn;
 #[cfg(feature = "ffi")]
 mod ffi;
 mod flowcontrol;

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -376,6 +376,7 @@
 //! [boring]: https://crates.io/crates/boring
 //! [qlog]: https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-main-schema
 
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::upper_case_acronyms)]
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -662,6 +663,9 @@ pub struct SendInfo {
     ///
     /// [Pacing]: index.html#pacing
     pub at: time::Instant,
+
+    /// The ECN marking for the outgoing packet.
+    pub ecn: u8,
 }
 
 /// Represents information carried by `CONNECTION_CLOSE` frames.
@@ -3330,6 +3334,8 @@ impl Connection {
             to: send_path.peer_addr(),
 
             at: send_path.recovery.get_packet_send_time(),
+
+            ecn: 0x01, // ECT(0)
         };
 
         Ok((done, info))
@@ -6682,7 +6688,9 @@ impl Connection {
             frame::Frame::Ping => (),
 
             frame::Frame::ACK {
-                ranges, ack_delay, ..
+                ranges,
+                ack_delay,
+                ecn_counts,
             } => {
                 let ack_delay = ack_delay
                     .checked_mul(2_u64.pow(
@@ -6709,6 +6717,7 @@ impl Connection {
                     let (lost_packets, lost_bytes) = p.recovery.on_ack_received(
                         &ranges,
                         ack_delay,
+                        ecn_counts,
                         epoch,
                         handshake_status,
                         now,

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -870,6 +870,8 @@ pub struct PktNumSpace {
 
     pub key_update: Option<KeyUpdate>,
 
+    pub ecn_counts: Option<EcnCounts>,
+
     pub crypto_open: Option<crypto::Open>,
     pub crypto_seal: Option<crypto::Seal>,
 
@@ -897,6 +899,8 @@ impl PktNumSpace {
             ack_elicited: false,
 
             key_update: None,
+
+            ecn_counts: None,
 
             crypto_open: None,
             crypto_seal: None,
@@ -986,6 +990,13 @@ impl PktNumWindow {
             .saturating_add(std::mem::size_of::<u128>() as u64 * 8) -
             1
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct EcnCounts {
+    pub ect0_count: u64,
+    pub ect1_count: u64,
+    pub ecn_ce_count: u64,
 }
 
 #[cfg(test)]

--- a/quiche/src/recovery/bbr/mod.rs
+++ b/quiche/src/recovery/bbr/mod.rs
@@ -432,6 +432,7 @@ mod tests {
                 tx_in_flight: 0,
                 lost: 0,
                 has_data: false,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -503,6 +504,7 @@ mod tests {
                 tx_in_flight: 0,
                 lost: 0,
                 has_data: false,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -573,6 +575,7 @@ mod tests {
                 tx_in_flight: 0,
                 lost: 0,
                 has_data: false,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -625,6 +628,7 @@ mod tests {
                 tx_in_flight: 0,
                 lost: 0,
                 has_data: false,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -698,6 +702,7 @@ mod tests {
                 tx_in_flight: 0,
                 lost: 0,
                 has_data: false,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -770,6 +775,7 @@ mod tests {
                 tx_in_flight: 0,
                 lost: 0,
                 has_data: false,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -825,6 +831,7 @@ mod tests {
             tx_in_flight: 0,
             lost: 0,
             has_data: false,
+            ecn_marked: false,
         };
 
         r.on_packet_sent(

--- a/quiche/src/recovery/bbr/mod.rs
+++ b/quiche/src/recovery/bbr/mod.rs
@@ -454,6 +454,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
+                None,
                 packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
@@ -525,6 +526,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
+                None,
                 packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
@@ -594,6 +596,7 @@ mod tests {
                 r.on_ack_received(
                     &acked,
                     25,
+                    None,
                     packet::Epoch::Application,
                     HandshakeStatus::default(),
                     now,
@@ -648,6 +651,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
+                None,
                 packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
@@ -714,6 +718,7 @@ mod tests {
                 r.on_ack_received(
                     &acked,
                     25,
+                    None,
                     packet::Epoch::Application,
                     HandshakeStatus::default(),
                     now,
@@ -787,6 +792,7 @@ mod tests {
                 r.on_ack_received(
                     &acked,
                     25,
+                    None,
                     packet::Epoch::Application,
                     HandshakeStatus::default(),
                     now,
@@ -843,6 +849,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
+                None,
                 packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,

--- a/quiche/src/recovery/bbr2/mod.rs
+++ b/quiche/src/recovery/bbr2/mod.rs
@@ -744,6 +744,7 @@ mod tests {
                 tx_in_flight: 0,
                 lost: 0,
                 has_data: false,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -814,6 +815,7 @@ mod tests {
                 tx_in_flight: 0,
                 lost: 0,
                 has_data: false,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -887,6 +889,7 @@ mod tests {
                 tx_in_flight: 0,
                 lost: 0,
                 has_data: false,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -938,6 +941,7 @@ mod tests {
                 tx_in_flight: 0,
                 lost: 0,
                 has_data: false,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -1011,6 +1015,7 @@ mod tests {
                 tx_in_flight: 0,
                 lost: 0,
                 has_data: false,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -1065,6 +1070,7 @@ mod tests {
             tx_in_flight: 0,
             lost: 0,
             has_data: false,
+            ecn_marked: false,
         };
 
         r.on_packet_sent(

--- a/quiche/src/recovery/bbr2/mod.rs
+++ b/quiche/src/recovery/bbr2/mod.rs
@@ -766,6 +766,7 @@ mod tests {
             .on_ack_received(
                 &acked,
                 25,
+                None,
                 packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
@@ -836,6 +837,7 @@ mod tests {
             .on_ack_received(
                 &acked,
                 25,
+                None,
                 packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
@@ -908,6 +910,7 @@ mod tests {
                 .on_ack_received(
                     &acked,
                     25,
+                    None,
                     packet::Epoch::Application,
                     HandshakeStatus::default(),
                     now,
@@ -961,6 +964,7 @@ mod tests {
             .on_ack_received(
                 &acked,
                 25,
+                None,
                 packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
@@ -1029,6 +1033,7 @@ mod tests {
                 .on_ack_received(
                     &acked,
                     25,
+                    None,
                     packet::Epoch::Application,
                     HandshakeStatus::default(),
                     now,
@@ -1084,6 +1089,7 @@ mod tests {
             .on_ack_received(
                 &acked,
                 25,
+                None,
                 packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,

--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -490,6 +490,7 @@ mod tests {
             tx_in_flight: 0,
             lost: 0,
             has_data: false,
+            ecn_marked: false,
         };
 
         // Send initcwnd full MSS packets to become no longer app limited
@@ -542,6 +543,7 @@ mod tests {
             tx_in_flight: 0,
             lost: 0,
             has_data: false,
+            ecn_marked: false,
         };
 
         // Send initcwnd full MSS packets to become no longer app limited
@@ -621,6 +623,7 @@ mod tests {
             has_data: false,
             tx_in_flight: 0,
             lost: 0,
+            ecn_marked: false,
         };
 
         r.congestion_event(
@@ -665,6 +668,7 @@ mod tests {
             has_data: false,
             tx_in_flight: 0,
             lost: 0,
+            ecn_marked: false,
         };
 
         // Trigger congestion event to update ssthresh
@@ -741,6 +745,7 @@ mod tests {
             has_data: false,
             tx_in_flight: 0,
             lost: 0,
+            ecn_marked: false,
         };
 
         r.congestion_event(
@@ -806,6 +811,7 @@ mod tests {
             tx_in_flight: 0,
             lost: 0,
             has_data: false,
+            ecn_marked: false,
         };
 
         // 1st round.
@@ -962,6 +968,7 @@ mod tests {
             tx_in_flight: 0,
             lost: 0,
             has_data: false,
+            ecn_marked: false,
         };
 
         // 1st round.
@@ -1116,6 +1123,7 @@ mod tests {
             has_data: false,
             tx_in_flight: 0,
             lost: 0,
+            ecn_marked: false,
         };
 
         r.congestion_event(
@@ -1177,6 +1185,7 @@ mod tests {
             has_data: false,
             tx_in_flight: 0,
             lost: 0,
+            ecn_marked: false,
         };
 
         let prev_cwnd = r.cwnd();
@@ -1252,6 +1261,7 @@ mod tests {
             has_data: false,
             tx_in_flight: 0,
             lost: 0,
+            ecn_marked: false,
         };
 
         r.congestion_event(
@@ -1318,6 +1328,7 @@ mod tests {
             has_data: false,
             tx_in_flight: 0,
             lost: 0,
+            ecn_marked: false,
         };
 
         r.congestion_event(

--- a/quiche/src/recovery/delivery_rate.rs
+++ b/quiche/src/recovery/delivery_rate.rs
@@ -374,6 +374,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
+                None,
                 packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,

--- a/quiche/src/recovery/delivery_rate.rs
+++ b/quiche/src/recovery/delivery_rate.rs
@@ -244,6 +244,7 @@ mod tests {
                 has_data: false,
                 tx_in_flight: 0,
                 lost: 0,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -312,6 +313,7 @@ mod tests {
                 has_data: false,
                 tx_in_flight: 0,
                 lost: 0,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(
@@ -353,6 +355,7 @@ mod tests {
                 has_data: false,
                 tx_in_flight: 0,
                 lost: 0,
+                ecn_marked: false,
             };
 
             r.on_packet_sent(

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -220,6 +220,7 @@ mod tests {
             tx_in_flight: 0,
             lost: 0,
             has_data: false,
+            ecn_marked: false,
         };
 
         // Send initcwnd full MSS packets to become no longer app limited
@@ -273,6 +274,7 @@ mod tests {
             tx_in_flight: 0,
             lost: 0,
             has_data: false,
+            ecn_marked: false,
         };
 
         // Send initcwnd full MSS packets to become no longer app limited
@@ -354,6 +356,7 @@ mod tests {
             has_data: false,
             tx_in_flight: 0,
             lost: 0,
+            ecn_marked: false,
         };
 
         r.congestion_event(
@@ -395,6 +398,7 @@ mod tests {
             has_data: false,
             tx_in_flight: 0,
             lost: 0,
+            ecn_marked: false,
         };
 
         // Trigger congestion event to update ssthresh

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -187,6 +187,7 @@ pub fn run(
             let recv_info = quiche::RecvInfo {
                 from,
                 to: local_addr,
+                ecn: 0,
             };
 
             // Process potentially coalesced packets.


### PR DESCRIPTION
This PR extends the commits of the WIP ECN PR (#1287) and addresses the remaining TODO points, namely the ACK ECN validation, the ECN path probing, and the actual ECN support to the apps `quiche-client` and `quiche-server`.