### PR TITLE
C API: added quiche_config_enable_pacing(..)

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -212,6 +212,9 @@ void quiche_config_set_cc_algorithm(quiche_config *config, enum quiche_cc_algori
 // Configures whether to use HyStart++.
 void quiche_config_enable_hystart(quiche_config *config, bool v);
 
+// Configures whether to enable pacing (enabled by default).
+void quiche_config_enable_pacing(quiche_config *config, bool v);
+
 // Configures whether to enable receiving DATAGRAM frames.
 void quiche_config_enable_dgram(quiche_config *config, bool enabled,
                                 size_t recv_queue_len,

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -330,6 +330,11 @@ pub extern fn quiche_config_enable_hystart(config: &mut Config, v: bool) {
 }
 
 #[no_mangle]
+pub extern fn quiche_config_enable_pacing(config: &mut Config, v: bool) {
+    config.enable_pacing(v);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_enable_dgram(
     config: &mut Config, enabled: bool, recv_queue_len: size_t,
     send_queue_len: size_t,


### PR DESCRIPTION
A config option to completely disable pacing was introduced in #1348.
This PR adds the corresponding C API function:
```c++
// Configures whether to enable pacing (enabled by default).
void quiche_config_enable_pacing(quiche_config *config, bool v);
```