### PR TITLE
lib: don't init qlog pkt hdr unilaterally

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3195,13 +3195,17 @@ impl Connection {
         let hdr_ty = hdr.ty;
 
         #[cfg(feature = "qlog")]
-        let qlog_pkt_hdr = qlog::events::quic::PacketHeader::with_type(
-            hdr.ty.to_qlog(),
-            pn,
-            Some(hdr.version),
-            Some(&hdr.scid),
-            Some(&hdr.dcid),
-        );
+        let qlog_pkt_hdr = if self.qlog.streamer.is_some() {
+            Some(qlog::events::quic::PacketHeader::with_type(
+                hdr.ty.to_qlog(),
+                pn,
+                Some(hdr.version),
+                Some(&hdr.scid),
+                Some(&hdr.dcid),
+            ))
+        } else {
+            None
+        };
 
         // Calculate the space required for the packet, including the header
         // the payload length, the packet number and the AEAD overhead.
@@ -3966,34 +3970,36 @@ impl Connection {
         }
 
         qlog_with_type!(QLOG_PACKET_TX, self.qlog, q, {
-            // Qlog packet raw info described at
-            // https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-main-schema-00#section-5.1
-            //
-            // `length` includes packet headers and trailers (AEAD tag).
-            let length = payload_len + payload_offset + crypto_overhead;
-            let qlog_raw_info = RawInfo {
-                length: Some(length as u64),
-                payload_length: Some(payload_len as u64),
-                data: None,
-            };
+            if let Some(header) = qlog_pkt_hdr {
+                // Qlog packet raw info described at
+                // https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-main-schema-00#section-5.1
+                //
+                // `length` includes packet headers and trailers (AEAD tag).
+                let length = payload_len + payload_offset + crypto_overhead;
+                let qlog_raw_info = RawInfo {
+                    length: Some(length as u64),
+                    payload_length: Some(payload_len as u64),
+                    data: None,
+                };
 
-            let send_at_time =
-                now.duration_since(q.start_time()).as_secs_f32() * 1000.0;
+                let send_at_time =
+                    now.duration_since(q.start_time()).as_secs_f32() * 1000.0;
 
-            let ev_data = EventData::PacketSent(qlog::events::quic::PacketSent {
-                header: qlog_pkt_hdr,
-                frames: Some(qlog_frames),
-                is_coalesced: None,
-                retry_token: None,
-                stateless_reset_token: None,
-                supported_versions: None,
-                raw: Some(qlog_raw_info),
-                datagram_id: None,
-                send_at_time: Some(send_at_time),
-                trigger: None,
-            });
+                let ev_data = EventData::PacketSent(qlog::events::quic::PacketSent {
+                    header,
+                    frames: Some(qlog_frames),
+                    is_coalesced: None,
+                    retry_token: None,
+                    stateless_reset_token: None,
+                    supported_versions: None,
+                    raw: Some(qlog_raw_info),
+                    datagram_id: None,
+                    send_at_time: Some(send_at_time),
+                    trigger: None,
+                });
 
-            q.add_event_data_with_instant(ev_data, now).ok();
+                q.add_event_data_with_instant(ev_data, now).ok();
+            }
         });
 
         let aead = match self.pkt_num_spaces[epoch].crypto_seal {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3195,17 +3195,15 @@ impl Connection {
         let hdr_ty = hdr.ty;
 
         #[cfg(feature = "qlog")]
-        let qlog_pkt_hdr = if self.qlog.streamer.is_some() {
-            Some(qlog::events::quic::PacketHeader::with_type(
+        let qlog_pkt_hdr = self.qlog.streamer.as_ref().map(|_q| {
+            qlog::events::quic::PacketHeader::with_type(
                 hdr.ty.to_qlog(),
                 pn,
                 Some(hdr.version),
                 Some(&hdr.scid),
                 Some(&hdr.dcid),
-            ))
-        } else {
-            None
-        };
+            )
+        });
 
         // Calculate the space required for the packet, including the header
         // the payload length, the packet number and the AEAD overhead.
@@ -3985,18 +3983,19 @@ impl Connection {
                 let send_at_time =
                     now.duration_since(q.start_time()).as_secs_f32() * 1000.0;
 
-                let ev_data = EventData::PacketSent(qlog::events::quic::PacketSent {
-                    header,
-                    frames: Some(qlog_frames),
-                    is_coalesced: None,
-                    retry_token: None,
-                    stateless_reset_token: None,
-                    supported_versions: None,
-                    raw: Some(qlog_raw_info),
-                    datagram_id: None,
-                    send_at_time: Some(send_at_time),
-                    trigger: None,
-                });
+                let ev_data =
+                    EventData::PacketSent(qlog::events::quic::PacketSent {
+                        header,
+                        frames: Some(qlog_frames),
+                        is_coalesced: None,
+                        retry_token: None,
+                        stateless_reset_token: None,
+                        supported_versions: None,
+                        raw: Some(qlog_raw_info),
+                        datagram_id: None,
+                        send_at_time: Some(send_at_time),
+                        trigger: None,
+                    });
 
                 q.add_event_data_with_instant(ev_data, now).ok();
             }


### PR DESCRIPTION
qlog packet have a mandatory PacketHeader type that contains several
optional fields. When creating packets to send, some of the fields
needed for qlog would upset the borrow checker later on, so previously
we constructed a PacketHeader early to avoid problems. This was
optionaly compiled via the qlog feature flag but there were no runtime
checks to see if the active connection had a qlog streamer configured.
That lead to unilateral construction of the object in quiche builds
that had the feature but didn't use it, leading to wasted effort.

With this change, the PacketHeader is only constructed if a connection
has actually been configured to output qlogs.

I also did a sweep for any other instances of similar unilateral
construction but this seems to be the only one.
