### PR TITLE
Better support for Immediate Close during Handshake

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -5569,7 +5569,11 @@ impl Connection {
     /// Closes the connection with the given error and reason.
     ///
     /// The `app` parameter specifies whether an application close should be
-    /// sent to the peer. Otherwise a normal connection close is sent.
+    /// sent to the peer. Otherwise a normal connection close is sent. If `app`
+    /// is true but the connection is not in a state that is safe to send an
+    /// application error (not established nor in early data), the error is
+    /// details are cleared in accordance with
+    /// https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2.3-3.
     ///
     /// Returns [`Done`] if the connection had already been closed.
     ///
@@ -5593,11 +5597,23 @@ impl Connection {
             return Err(Error::Done);
         }
 
-        self.local_error = Some(ConnectionError {
-            is_app: app,
-            error_code: err,
-            reason: reason.to_vec(),
-        });
+        let is_safe_to_send_app_data =
+            self.is_established() || self.is_in_early_data();
+
+        if app && !is_safe_to_send_app_data {
+            // Clear error information.
+            self.local_error = Some(ConnectionError {
+                is_app: false,
+                error_code: 0x0c,
+                reason: vec![],
+            });
+        } else {
+            self.local_error = Some(ConnectionError {
+                is_app: app,
+                error_code: err,
+                reason: reason.to_vec(),
+            });
+        }
 
         // When no packet was successfully processed close connection immediately.
         if self.recv_count == 0 {
@@ -12980,7 +12996,57 @@ mod tests {
     }
 
     #[test]
-    fn app_close_by_server_during_handshake() {
+    fn app_close_by_server_during_handshake_not_established() {
+        let mut pipe = testing::Pipe::default().unwrap();
+
+        // Client sends initial flight.
+        let flight = testing::emit_flight(&mut pipe.client).unwrap();
+        testing::process_flight(&mut pipe.server, flight).unwrap();
+
+        let flight = testing::emit_flight(&mut pipe.server).unwrap();
+
+        // Both connections are not established.
+        assert!(!pipe.client.is_established() && !pipe.server.is_established());
+
+        // Server closes before connection is established.
+        pipe.server.close(true, 123, b"fail whale").unwrap();
+
+        testing::process_flight(&mut pipe.client, flight).unwrap();
+
+        // Connection is established on the client.
+        assert!(pipe.client.is_established());
+
+        // Client sends after connection is established.
+        pipe.client.stream_send(0, b"badauthtoken", true).unwrap();
+
+        let flight = testing::emit_flight(&mut pipe.client).unwrap();
+        testing::process_flight(&mut pipe.server, flight).unwrap();
+
+        // Connection is not established on the server (and never will be)
+        assert!(!pipe.server.is_established());
+
+        assert_eq!(pipe.advance(), Ok(()));
+
+        assert_eq!(
+            pipe.server.local_error(),
+            Some(&ConnectionError {
+                is_app: false,
+                error_code: 0x0c,
+                reason: vec![],
+            })
+        );
+        assert_eq!(
+            pipe.client.peer_error(),
+            Some(&ConnectionError {
+                is_app: false,
+                error_code: 0x0c,
+                reason: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn app_close_by_server_during_handshake_established() {
         let mut pipe = testing::Pipe::default().unwrap();
 
         // Client sends initial flight.

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -5572,9 +5572,11 @@ impl Connection {
     /// sent to the peer. Otherwise a normal connection close is sent.
     ///
     /// If `app` is true but the connection is not in a state that is safe to
-    /// send an application error (not established nor in early data), the error
-    /// is details are cleared in accordance with [RFC
-    /// 9000](https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2.3-3).
+    /// send an application error (not established nor in early data), in
+    /// accordance with [RFC
+    /// 9000](https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2.3-3), the
+    /// error code is changed to APPLICATION_ERROR and the reason phrase is
+    /// cleared.
     ///
     /// Returns [`Done`] if the connection had already been closed.
     ///

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -5573,7 +5573,7 @@ impl Connection {
     /// is true but the connection is not in a state that is safe to send an
     /// application error (not established nor in early data), the error is
     /// details are cleared in accordance with
-    /// https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2.3-3.
+    /// [RFC 9000](https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2.3-3).
     ///
     /// Returns [`Done`] if the connection had already been closed.
     ///

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -5569,11 +5569,12 @@ impl Connection {
     /// Closes the connection with the given error and reason.
     ///
     /// The `app` parameter specifies whether an application close should be
-    /// sent to the peer. Otherwise a normal connection close is sent. If `app`
-    /// is true but the connection is not in a state that is safe to send an
-    /// application error (not established nor in early data), the error is
-    /// details are cleared in accordance with
-    /// [RFC 9000](https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2.3-3).
+    /// sent to the peer. Otherwise a normal connection close is sent.
+    ///
+    /// If `app` is true but the connection is not in a state that is safe to
+    /// send an application error (not established nor in early data), the error
+    /// is details are cleared in accordance with [RFC
+    /// 9000](https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2.3-3).
     ///
     /// Returns [`Done`] if the connection had already been closed.
     ///


### PR DESCRIPTION
Previously, when a quiche connection was closed using `close()` with
`app` true, the connection might not already have been in a state
where it was safe to emit the application CONNECTION_CLOSE frame. Because
calling `close()` puts the connection into a terminal state where
newly received packets are discarded rather than processed, it is
possible that a connection in this state cannot emit a suitable
CONNECTION_CLOSE. In some circumstances, this could have led to a
connection becoming idle and then silently closed.

Applications could have worked around this by carefully managing the
use of `close()` based on connection states. For example, by
manually converting to a connection level close (`app` false)
or by deferring the close until a later moment.

This change modifies the `close()` method so that it automatically
detects connection state and follows the recommendations in
https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2.3-3. If
`close()` is called with `app` true, and it is not safe to emit,
the application error information is cleared and replaced with
a connection error of type 0x0c and empty reason.