### PR TITLE
refactor Epoch to be an enum instead of usize consts

### DIFF
--- a/quiche/src/crypto.rs
+++ b/quiche/src/crypto.rs
@@ -49,13 +49,11 @@ pub enum Level {
 impl Level {
     pub fn from_epoch(e: packet::Epoch) -> Level {
         match e {
-            packet::EPOCH_INITIAL => Level::Initial,
+            packet::Epoch::Initial => Level::Initial,
 
-            packet::EPOCH_HANDSHAKE => Level::Handshake,
+            packet::Epoch::Handshake => Level::Handshake,
 
-            packet::EPOCH_APPLICATION => Level::OneRTT,
-
-            _ => unreachable!(),
+            packet::Epoch::Application => Level::OneRTT,
         }
     }
 }

--- a/quiche/src/recovery/bbr/mod.rs
+++ b/quiche/src/recovery/bbr/mod.rs
@@ -426,7 +426,7 @@ mod tests {
 
             r.on_packet_sent(
                 pkt,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -444,7 +444,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -493,7 +493,7 @@ mod tests {
 
             r.on_packet_sent(
                 pkt,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -512,7 +512,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -559,7 +559,7 @@ mod tests {
 
             r.on_packet_sent(
                 pkt,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -578,7 +578,7 @@ mod tests {
                 r.on_ack_received(
                     &acked,
                     25,
-                    packet::EPOCH_APPLICATION,
+                    packet::Epoch::Application,
                     HandshakeStatus::default(),
                     now,
                     "",
@@ -607,7 +607,7 @@ mod tests {
 
             r.on_packet_sent(
                 pkt,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -629,7 +629,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -678,7 +678,7 @@ mod tests {
 
             r.on_packet_sent(
                 pkt,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -696,7 +696,7 @@ mod tests {
                 r.on_ack_received(
                     &acked,
                     25,
-                    packet::EPOCH_APPLICATION,
+                    packet::Epoch::Application,
                     HandshakeStatus::default(),
                     now,
                     "",
@@ -748,7 +748,7 @@ mod tests {
 
             r.on_packet_sent(
                 pkt,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -766,7 +766,7 @@ mod tests {
                 r.on_ack_received(
                     &acked,
                     25,
-                    packet::EPOCH_APPLICATION,
+                    packet::Epoch::Application,
                     HandshakeStatus::default(),
                     now,
                     "",
@@ -799,7 +799,7 @@ mod tests {
 
         r.on_packet_sent(
             pkt,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
@@ -819,7 +819,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",

--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -503,7 +503,7 @@ mod tests {
             rtt: Duration::ZERO,
         }];
 
-        r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
+        r.on_packets_acked(acked, packet::Epoch::Application, now);
 
         // Check if cwnd increased by packet size (slow start)
         assert_eq!(r.cwnd(), cwnd_prev + p.size);
@@ -573,7 +573,7 @@ mod tests {
             },
         ];
 
-        r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
+        r.on_packets_acked(acked, packet::Epoch::Application, now);
 
         // Acked 3 packets.
         assert_eq!(r.cwnd(), cwnd_prev + p.size * 3);
@@ -591,7 +591,7 @@ mod tests {
         r.congestion_event(
             r.max_datagram_size,
             now,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             now,
         );
 
@@ -618,7 +618,7 @@ mod tests {
         r.congestion_event(
             r.max_datagram_size,
             now,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             now,
         );
 
@@ -651,7 +651,7 @@ mod tests {
                 rtt: Duration::ZERO,
             }];
 
-            r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
+            r.on_packets_acked(acked, packet::Epoch::Application, now);
             now += rtt;
         }
 
@@ -673,7 +673,7 @@ mod tests {
         r.congestion_event(
             r.max_datagram_size,
             now,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             now,
         );
 
@@ -696,7 +696,7 @@ mod tests {
             rtt: Duration::ZERO,
         }];
 
-        r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
+        r.on_packets_acked(acked, packet::Epoch::Application, now);
 
         // Slow start again - cwnd will be increased by 1 MSS
         assert_eq!(
@@ -713,7 +713,7 @@ mod tests {
 
         let mut r = Recovery::new(&cfg);
         let now = Instant::now();
-        let epoch = packet::EPOCH_APPLICATION;
+        let epoch = packet::Epoch::Application;
 
         let p = recovery::Sent {
             pkt_num: 0,
@@ -861,7 +861,7 @@ mod tests {
 
         let mut r = Recovery::new(&cfg);
         let now = Instant::now();
-        let epoch = packet::EPOCH_APPLICATION;
+        let epoch = packet::Epoch::Application;
 
         let p = recovery::Sent {
             pkt_num: 0,
@@ -1012,7 +1012,7 @@ mod tests {
         r.congestion_event(
             r.max_datagram_size,
             now,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             now,
         );
 
@@ -1040,7 +1040,7 @@ mod tests {
         // Trigger detecting spurious congestion event
         r.on_packets_acked(
             acked,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             now + rtt + Duration::from_millis(5),
         );
 
@@ -1054,7 +1054,7 @@ mod tests {
         r.congestion_event(
             r.max_datagram_size,
             now,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             now,
         );
 
@@ -1082,7 +1082,7 @@ mod tests {
         // Trigger detecting spurious congestion event.
         r.on_packets_acked(
             acked,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             now + rtt + Duration::from_millis(5),
         );
 
@@ -1108,7 +1108,7 @@ mod tests {
         r.congestion_event(
             r.max_datagram_size,
             now,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             now,
         );
 
@@ -1140,7 +1140,7 @@ mod tests {
                 rtt: Duration::ZERO,
             }];
 
-            r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
+            r.on_packets_acked(acked, packet::Epoch::Application, now);
             now += rtt;
         }
 
@@ -1154,7 +1154,7 @@ mod tests {
         r.congestion_event(
             r.max_datagram_size,
             now,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             now,
         );
 

--- a/quiche/src/recovery/delivery_rate.rs
+++ b/quiche/src/recovery/delivery_rate.rs
@@ -232,7 +232,7 @@ mod tests {
 
             r.on_packet_sent(
                 pkt,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -296,7 +296,7 @@ mod tests {
 
             r.on_packet_sent(
                 pkt,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -335,7 +335,7 @@ mod tests {
 
             r.on_packet_sent(
                 pkt,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",
@@ -352,7 +352,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 "",

--- a/quiche/src/recovery/hystart.rs
+++ b/quiche/src/recovery/hystart.rs
@@ -110,7 +110,7 @@ impl Hystart {
 
     pub fn in_css(&self, epoch: packet::Epoch) -> bool {
         self.enabled &&
-            epoch == packet::EPOCH_APPLICATION &&
+            epoch == packet::Epoch::Application &&
             self.css_start_time().is_some()
     }
 
@@ -131,7 +131,7 @@ impl Hystart {
         &mut self, epoch: packet::Epoch, packet: &recovery::Acked, rtt: Duration,
         now: Instant,
     ) -> bool {
-        if !(self.enabled && epoch == packet::EPOCH_APPLICATION) {
+        if !(self.enabled && epoch == packet::Epoch::Application) {
             return false;
         }
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -79,11 +79,12 @@ pub struct Recovery {
 
     pto_count: u32,
 
-    time_of_last_sent_ack_eliciting_pkt: [Option<Instant>; packet::EPOCH_COUNT],
+    time_of_last_sent_ack_eliciting_pkt:
+        [Option<Instant>; packet::Epoch::count()],
 
-    largest_acked_pkt: [u64; packet::EPOCH_COUNT],
+    largest_acked_pkt: [u64; packet::Epoch::count()],
 
-    largest_sent_pkt: [u64; packet::EPOCH_COUNT],
+    largest_sent_pkt: [u64; packet::Epoch::count()],
 
     latest_rtt: Duration,
 
@@ -97,21 +98,21 @@ pub struct Recovery {
 
     pub max_ack_delay: Duration,
 
-    loss_time: [Option<Instant>; packet::EPOCH_COUNT],
+    loss_time: [Option<Instant>; packet::Epoch::count()],
 
-    sent: [VecDeque<Sent>; packet::EPOCH_COUNT],
+    sent: [VecDeque<Sent>; packet::Epoch::count()],
 
-    pub lost: [Vec<frame::Frame>; packet::EPOCH_COUNT],
+    pub lost: [Vec<frame::Frame>; packet::Epoch::count()],
 
-    pub acked: [Vec<frame::Frame>; packet::EPOCH_COUNT],
+    pub acked: [Vec<frame::Frame>; packet::Epoch::count()],
 
     pub lost_count: usize,
 
     pub lost_spurious_count: usize,
 
-    pub loss_probes: [usize; packet::EPOCH_COUNT],
+    pub loss_probes: [usize; packet::Epoch::count()],
 
-    in_flight_count: [usize; packet::EPOCH_COUNT],
+    in_flight_count: [usize; packet::Epoch::count()],
 
     app_limited: bool,
 
@@ -197,11 +198,11 @@ impl Recovery {
 
             pto_count: 0,
 
-            time_of_last_sent_ack_eliciting_pkt: [None; packet::EPOCH_COUNT],
+            time_of_last_sent_ack_eliciting_pkt: [None; packet::Epoch::count()],
 
-            largest_acked_pkt: [std::u64::MAX; packet::EPOCH_COUNT],
+            largest_acked_pkt: [std::u64::MAX; packet::Epoch::count()],
 
-            largest_sent_pkt: [0; packet::EPOCH_COUNT],
+            largest_sent_pkt: [0; packet::Epoch::count()],
 
             latest_rtt: Duration::ZERO,
 
@@ -219,7 +220,7 @@ impl Recovery {
 
             max_ack_delay: recovery_config.max_ack_delay,
 
-            loss_time: [None; packet::EPOCH_COUNT],
+            loss_time: [None; packet::Epoch::count()],
 
             sent: [VecDeque::new(), VecDeque::new(), VecDeque::new()],
 
@@ -230,9 +231,9 @@ impl Recovery {
             lost_count: 0,
             lost_spurious_count: 0,
 
-            loss_probes: [0; packet::EPOCH_COUNT],
+            loss_probes: [0; packet::Epoch::count()],
 
-            in_flight_count: [0; packet::EPOCH_COUNT],
+            in_flight_count: [0; packet::Epoch::count()],
 
             congestion_window: initial_congestion_window,
 
@@ -296,7 +297,7 @@ impl Recovery {
 
     pub fn reset(&mut self) {
         self.congestion_window = self.max_datagram_size * INITIAL_WINDOW_PACKETS;
-        self.in_flight_count = [0; packet::EPOCH_COUNT];
+        self.in_flight_count = [0; packet::Epoch::count()];
         self.congestion_recovery_start_time = None;
         self.ssthresh = std::usize::MAX;
         (self.cc_ops.reset)(self);
@@ -350,7 +351,7 @@ impl Recovery {
 
         // HyStart++: Start of the round in a slow start.
         if self.hystart.enabled() &&
-            epoch == packet::EPOCH_APPLICATION &&
+            epoch == packet::Epoch::Application &&
             self.congestion_window < self.ssthresh
         {
             self.hystart.start_round(pkt_num);
@@ -396,10 +397,10 @@ impl Recovery {
     ) {
         // Don't pace in any of these cases:
         //   * Packet contains no data.
-        //   * Packet epoch is not EPOCH_APPLICATION.
+        //   * Packet epoch is not Epoch::Application.
         //   * The congestion window is within initcwnd.
 
-        let is_app = epoch == packet::EPOCH_APPLICATION;
+        let is_app = epoch == packet::Epoch::Application;
 
         let in_initcwnd =
             self.bytes_sent < self.max_datagram_size * INITIAL_WINDOW_PACKETS;
@@ -543,7 +544,7 @@ impl Recovery {
             let latest_rtt =
                 now.saturating_duration_since(largest_newly_acked_sent_time);
 
-            let ack_delay = if epoch == packet::EPOCH_APPLICATION {
+            let ack_delay = if epoch == packet::Epoch::Application {
                 Duration::from_micros(ack_delay)
             } else {
                 Duration::from_micros(0)
@@ -599,9 +600,9 @@ impl Recovery {
             // more anti-amplification credit, a Handshake packet proves address
             // ownership.
             if handshake_status.has_handshake_keys {
-                packet::EPOCH_HANDSHAKE
+                packet::Epoch::Handshake
             } else {
-                packet::EPOCH_INITIAL
+                packet::Epoch::Initial
             }
         };
 
@@ -757,11 +758,13 @@ impl Recovery {
     }
 
     fn loss_time_and_space(&self) -> (Option<Instant>, packet::Epoch) {
-        let mut epoch = packet::EPOCH_INITIAL;
+        let mut epoch = packet::Epoch::Initial;
         let mut time = self.loss_time[epoch];
 
         // Iterate over all packet number spaces starting from Handshake.
-        for e in packet::EPOCH_HANDSHAKE..packet::EPOCH_COUNT {
+        for &e in packet::Epoch::epochs(
+            packet::Epoch::Handshake..=packet::Epoch::Application,
+        ) {
             let new_time = self.loss_time[e];
 
             if time.is_none() || new_time < time {
@@ -781,22 +784,24 @@ impl Recovery {
         // Arm PTO from now when there are no inflight packets.
         if self.bytes_in_flight == 0 {
             if handshake_status.has_handshake_keys {
-                return (Some(now + duration), packet::EPOCH_HANDSHAKE);
+                return (Some(now + duration), packet::Epoch::Handshake);
             } else {
-                return (Some(now + duration), packet::EPOCH_INITIAL);
+                return (Some(now + duration), packet::Epoch::Initial);
             }
         }
 
         let mut pto_timeout = None;
-        let mut pto_space = packet::EPOCH_INITIAL;
+        let mut pto_space = packet::Epoch::Initial;
 
         // Iterate over all packet number spaces.
-        for e in packet::EPOCH_INITIAL..packet::EPOCH_COUNT {
+        for &e in packet::Epoch::epochs(
+            packet::Epoch::Initial..=packet::Epoch::Application,
+        ) {
             if self.in_flight_count[e] == 0 {
                 continue;
             }
 
-            if e == packet::EPOCH_APPLICATION {
+            if e == packet::Epoch::Application {
                 // Skip Application Data until handshake completes.
                 if !handshake_status.completed {
                     return (pto_timeout, pto_space);
@@ -1412,7 +1417,7 @@ mod tests {
 
         let mut now = Instant::now();
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 0);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
 
         // Start by sending a few packets.
         let p = Sent {
@@ -1433,12 +1438,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 1);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 1);
         assert_eq!(r.bytes_in_flight, 1000);
 
         let p = Sent {
@@ -1459,12 +1464,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 2);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 2);
         assert_eq!(r.bytes_in_flight, 2000);
 
         let p = Sent {
@@ -1485,12 +1490,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 3);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 3);
         assert_eq!(r.bytes_in_flight, 3000);
 
         let p = Sent {
@@ -1511,12 +1516,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 4);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 4);
         assert_eq!(r.bytes_in_flight, 4000);
 
         // Wait for 10ms.
@@ -1530,7 +1535,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 ""
@@ -1538,7 +1543,7 @@ mod tests {
             Ok((0, 0))
         );
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 2);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 2);
         assert_eq!(r.bytes_in_flight, 2000);
         assert_eq!(r.lost_count, 0);
 
@@ -1547,7 +1552,7 @@ mod tests {
 
         // PTO.
         r.on_loss_detection_timeout(HandshakeStatus::default(), now, "");
-        assert_eq!(r.loss_probes[packet::EPOCH_APPLICATION], 1);
+        assert_eq!(r.loss_probes[packet::Epoch::Application], 1);
         assert_eq!(r.lost_count, 0);
         assert_eq!(r.pto_count, 1);
 
@@ -1569,12 +1574,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 3);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 3);
         assert_eq!(r.bytes_in_flight, 3000);
 
         let p = Sent {
@@ -1595,12 +1600,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 4);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 4);
         assert_eq!(r.bytes_in_flight, 4000);
         assert_eq!(r.lost_count, 0);
 
@@ -1615,7 +1620,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 ""
@@ -1623,7 +1628,7 @@ mod tests {
             Ok((2, 2000))
         );
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 4);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 4);
         assert_eq!(r.bytes_in_flight, 0);
 
         assert_eq!(r.lost_count, 2);
@@ -1631,9 +1636,9 @@ mod tests {
         // Wait 1 RTT.
         now += r.rtt();
 
-        r.detect_lost_packets(packet::EPOCH_APPLICATION, now, "");
+        r.detect_lost_packets(packet::Epoch::Application, now, "");
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 0);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
     }
 
     #[test]
@@ -1645,7 +1650,7 @@ mod tests {
 
         let mut now = Instant::now();
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 0);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
 
         // Start by sending a few packets.
         let p = Sent {
@@ -1666,12 +1671,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 1);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 1);
         assert_eq!(r.bytes_in_flight, 1000);
 
         let p = Sent {
@@ -1692,12 +1697,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 2);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 2);
         assert_eq!(r.bytes_in_flight, 2000);
 
         let p = Sent {
@@ -1718,12 +1723,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 3);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 3);
         assert_eq!(r.bytes_in_flight, 3000);
 
         let p = Sent {
@@ -1744,12 +1749,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 4);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 4);
         assert_eq!(r.bytes_in_flight, 4000);
 
         // Wait for 10ms.
@@ -1764,7 +1769,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 ""
@@ -1772,7 +1777,7 @@ mod tests {
             Ok((0, 0))
         );
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 2);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 2);
         assert_eq!(r.bytes_in_flight, 1000);
         assert_eq!(r.lost_count, 0);
 
@@ -1781,9 +1786,9 @@ mod tests {
 
         // Packet is declared lost.
         r.on_loss_detection_timeout(HandshakeStatus::default(), now, "");
-        assert_eq!(r.loss_probes[packet::EPOCH_APPLICATION], 0);
+        assert_eq!(r.loss_probes[packet::Epoch::Application], 0);
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 2);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 2);
         assert_eq!(r.bytes_in_flight, 0);
 
         assert_eq!(r.lost_count, 1);
@@ -1791,9 +1796,9 @@ mod tests {
         // Wait 1 RTT.
         now += r.rtt();
 
-        r.detect_lost_packets(packet::EPOCH_APPLICATION, now, "");
+        r.detect_lost_packets(packet::Epoch::Application, now, "");
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 0);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
     }
 
     #[test]
@@ -1805,7 +1810,7 @@ mod tests {
 
         let mut now = Instant::now();
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 0);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
 
         // Start by sending a few packets.
         let p = Sent {
@@ -1826,12 +1831,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 1);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 1);
         assert_eq!(r.bytes_in_flight, 1000);
 
         let p = Sent {
@@ -1852,12 +1857,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 2);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 2);
         assert_eq!(r.bytes_in_flight, 2000);
 
         let p = Sent {
@@ -1878,12 +1883,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 3);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 3);
         assert_eq!(r.bytes_in_flight, 3000);
 
         let p = Sent {
@@ -1904,12 +1909,12 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 4);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 4);
         assert_eq!(r.bytes_in_flight, 4000);
 
         // Wait for 10ms.
@@ -1923,7 +1928,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 ""
@@ -1942,7 +1947,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 25,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 ""
@@ -1950,7 +1955,7 @@ mod tests {
             Ok((0, 0))
         );
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 4);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 4);
         assert_eq!(r.bytes_in_flight, 0);
 
         // Spurious loss.
@@ -1963,9 +1968,9 @@ mod tests {
         // Wait 1 RTT.
         now += r.rtt();
 
-        r.detect_lost_packets(packet::EPOCH_APPLICATION, now, "");
+        r.detect_lost_packets(packet::Epoch::Application, now, "");
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 0);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
     }
 
     #[test]
@@ -1977,7 +1982,7 @@ mod tests {
 
         let mut now = Instant::now();
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 0);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
 
         // send out first packet (a full initcwnd).
         let p = Sent {
@@ -1998,13 +2003,13 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 1);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 1);
         assert_eq!(r.bytes_in_flight, 12000);
 
         // First packet will be sent out immediately.
@@ -2021,7 +2026,7 @@ mod tests {
             r.on_ack_received(
                 &acked,
                 10,
-                packet::EPOCH_APPLICATION,
+                packet::Epoch::Application,
                 HandshakeStatus::default(),
                 now,
                 ""
@@ -2029,7 +2034,7 @@ mod tests {
             Ok((0, 0))
         );
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 0);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
         assert_eq!(r.bytes_in_flight, 0);
         assert_eq!(r.smoothed_rtt.unwrap(), Duration::from_millis(50));
 
@@ -2055,13 +2060,13 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 1);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 1);
         assert_eq!(r.bytes_in_flight, 6000);
 
         // Pacing is not done during initial phase of connection.
@@ -2086,13 +2091,13 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 2);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 2);
         assert_eq!(r.bytes_in_flight, 12000);
 
         // Send the third packet out.
@@ -2114,13 +2119,13 @@ mod tests {
 
         r.on_packet_sent(
             p,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             HandshakeStatus::default(),
             now,
             "",
         );
 
-        assert_eq!(r.sent[packet::EPOCH_APPLICATION].len(), 3);
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 3);
         assert_eq!(r.bytes_in_flight, 13000);
 
         // We pace this outgoing packet. as all conditions for pacing

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -233,7 +233,7 @@ mod tests {
             rtt: Duration::ZERO,
         }];
 
-        r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
+        r.on_packets_acked(acked, packet::Epoch::Application, now);
 
         // Check if cwnd increased by packet size (slow start).
         assert_eq!(r.cwnd(), cwnd_prev + p.size);
@@ -304,7 +304,7 @@ mod tests {
             },
         ];
 
-        r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now);
+        r.on_packets_acked(acked, packet::Epoch::Application, now);
 
         // Acked 3 packets.
         assert_eq!(r.cwnd(), cwnd_prev + p.size * 3);
@@ -324,7 +324,7 @@ mod tests {
         r.congestion_event(
             r.max_datagram_size,
             now,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             now,
         );
 
@@ -348,7 +348,7 @@ mod tests {
         r.congestion_event(
             r.max_datagram_size,
             now,
-            packet::EPOCH_APPLICATION,
+            packet::Epoch::Application,
             now,
         );
 
@@ -374,7 +374,7 @@ mod tests {
 
         // Ack more than cwnd bytes with rtt=100ms
         r.update_rtt(rtt, Duration::from_millis(0), now);
-        r.on_packets_acked(acked, packet::EPOCH_APPLICATION, now + rtt * 2);
+        r.on_packets_acked(acked, packet::Epoch::Application, now + rtt * 2);
 
         // After acking more than cwnd, expect cwnd increased by MSS
         assert_eq!(r.cwnd(), cur_cwnd + r.max_datagram_size);

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -817,7 +817,7 @@ impl Drop for Handshake {
 pub struct ExData<'a> {
     pub application_protos: &'a Vec<Vec<u8>>,
 
-    pub pkt_num_spaces: &'a mut [packet::PktNumSpace; packet::EPOCH_COUNT],
+    pub pkt_num_spaces: &'a mut [packet::PktNumSpace; packet::Epoch::count()],
 
     pub session: &'a mut Option<Vec<u8>>,
 
@@ -865,13 +865,13 @@ extern fn set_read_secret(
 
     let space = match level {
         crypto::Level::Initial =>
-            &mut ex_data.pkt_num_spaces[packet::EPOCH_INITIAL],
+            &mut ex_data.pkt_num_spaces[packet::Epoch::Initial],
         crypto::Level::ZeroRTT =>
-            &mut ex_data.pkt_num_spaces[packet::EPOCH_APPLICATION],
+            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
         crypto::Level::Handshake =>
-            &mut ex_data.pkt_num_spaces[packet::EPOCH_HANDSHAKE],
+            &mut ex_data.pkt_num_spaces[packet::Epoch::Handshake],
         crypto::Level::OneRTT =>
-            &mut ex_data.pkt_num_spaces[packet::EPOCH_APPLICATION],
+            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
     };
 
     let aead = match get_cipher_from_ptr(cipher) {
@@ -916,13 +916,13 @@ extern fn set_write_secret(
 
     let space = match level {
         crypto::Level::Initial =>
-            &mut ex_data.pkt_num_spaces[packet::EPOCH_INITIAL],
+            &mut ex_data.pkt_num_spaces[packet::Epoch::Initial],
         crypto::Level::ZeroRTT =>
-            &mut ex_data.pkt_num_spaces[packet::EPOCH_APPLICATION],
+            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
         crypto::Level::Handshake =>
-            &mut ex_data.pkt_num_spaces[packet::EPOCH_HANDSHAKE],
+            &mut ex_data.pkt_num_spaces[packet::Epoch::Handshake],
         crypto::Level::OneRTT =>
-            &mut ex_data.pkt_num_spaces[packet::EPOCH_APPLICATION],
+            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
     };
 
     let aead = match get_cipher_from_ptr(cipher) {
@@ -968,12 +968,12 @@ extern fn add_handshake_data(
 
     let space = match level {
         crypto::Level::Initial =>
-            &mut ex_data.pkt_num_spaces[packet::EPOCH_INITIAL],
+            &mut ex_data.pkt_num_spaces[packet::Epoch::Initial],
         crypto::Level::ZeroRTT => unreachable!(),
         crypto::Level::Handshake =>
-            &mut ex_data.pkt_num_spaces[packet::EPOCH_HANDSHAKE],
+            &mut ex_data.pkt_num_spaces[packet::Epoch::Handshake],
         crypto::Level::OneRTT =>
-            &mut ex_data.pkt_num_spaces[packet::EPOCH_APPLICATION],
+            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
     };
 
     if space.crypto_stream.send.write(buf, false).is_err() {


### PR DESCRIPTION
Currently, epoch values are just `usize` constants over the code. The handling of the different epochs is done through arrays and the epoch-specific structure is accessed using the raw value behind the constant. While this should not happen, it might be possible to index a value out-of-bound (for instance, when doing some arithmetics on epoch values).

This commit replaces the plain `usize` typedef of `Epoch` by a dedicated `enum`, and implements the `Index(Mut)` traits to minimize the impact on the existing code (i.e., `Epoch` enum can be used to index the array).

Note that this change is also present in the refactoring commit in PR #1310, but proposing this specific refactoring in single-path sounds relevant and can then decrease the diff of the previous PR.