### PR TITLE
quic: API for app to elicit ACK from peer

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -627,6 +627,14 @@ ssize_t quiche_conn_dgram_send(quiche_conn *conn, const uint8_t *buf,
 void quiche_conn_dgram_purge_outgoing(quiche_conn *conn,
                                       bool (*f)(uint8_t *, size_t));
 
+// Schedule an ack-eliciting packet on the active path.
+ssize_t quiche_conn_send_ack_eliciting(quiche_conn *conn);
+
+// Schedule an ack-eliciting packet on the specified path.
+ssize_t quiche_conn_send_ack_eliciting_on_path(quiche_conn *conn,
+                           const struct sockaddr *local, size_t local_len,
+                           const struct sockaddr *peer, size_t peer_len);
+
 // Frees the connection object.
 void quiche_conn_free(quiche_conn *conn);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1274,6 +1274,27 @@ pub extern fn quiche_conn_dgram_purge_outgoing(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_send_ack_eliciting(conn: &mut Connection) -> ssize_t {
+    match conn.send_ack_eliciting() {
+        Ok(()) => 0,
+        Err(e) => e.to_c(),
+    }
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_send_ack_eliciting_on_path(
+    conn: &mut Connection, local: &sockaddr, local_len: socklen_t,
+    peer: &sockaddr, peer_len: socklen_t,
+) -> ssize_t {
+    let local = std_addr_from_c(local, local_len);
+    let peer = std_addr_from_c(peer, peer_len);
+    match conn.send_ack_eliciting_on_path(local, peer) {
+        Ok(()) => 0,
+        Err(e) => e.to_c(),
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_free(conn: *mut Connection) {
     unsafe { Box::from_raw(conn) };
 }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4815,7 +4815,7 @@ impl Connection {
     /// frames, this method ensures that a PING frame sent.
     ///
     /// Calling this method multiple times before [`send()`] has no effect.
-
+    ///
     /// [`send()`]: struct.Connection.html#method.send
     pub fn send_ack_eliciting(&mut self) -> Result<()> {
         if self.is_closed() || self.is_draining() {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4807,6 +4807,9 @@ impl Connection {
     /// Queue a PING frame to be sent for the active path if no other
     /// ACK-eliciting frame would otherwise be sent. See
     /// [`send_ack_eliciting_on_path()`] for more detail.
+    ///
+    /// [`send_ack_eliciting_on_path()`]:
+    /// struct.Connection.html#method.send_ack_eliciting_on_path
     pub fn send_ack_eliciting(&mut self) -> Result<()> {
         if self.is_closed() || self.is_draining() {
             return Ok(());

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3890,7 +3890,12 @@ impl Connection {
         // Create PING for PTO probe if no other ack-eliciting frame is sent or if
         // we've sent too many non ACK eliciting packets without having
         // sent an ACK eliciting one
-        if ack_elicit_required && !ack_eliciting && left >= 1 && !is_closing {
+        let path = self.paths.get_mut(send_pid)?;
+        if (ack_elicit_required || path.needs_ack_eliciting) &&
+            !ack_eliciting &&
+            left >= 1 &&
+            !is_closing
+        {
             let frame = frame::Frame::Ping;
 
             if push_frame_to_pkt!(b, frames, frame, left) {
@@ -3900,18 +3905,15 @@ impl Connection {
         }
 
         if ack_eliciting {
-            self.paths.get_mut(send_pid)?.recovery.loss_probes[epoch] =
-                self.paths.get(send_pid)?.recovery.loss_probes[epoch]
-                    .saturating_sub(1);
+            path.needs_ack_eliciting = false;
+            path.recovery.loss_probes[epoch] =
+                path.recovery.loss_probes[epoch].saturating_sub(1);
         }
 
         if frames.is_empty() {
             // When we reach this point we are not able to write more, so set
             // app_limited to false.
-            self.paths
-                .get_mut(send_pid)?
-                .recovery
-                .update_app_limited(false);
+            path.recovery.update_app_limited(false);
             return Err(Error::Done);
         }
 
@@ -3923,7 +3925,7 @@ impl Connection {
         // as Initial always requires padding.
         //
         // 2) this is a probing packet towards an unvalidated peer address.
-        if (has_initial || !self.paths.get(send_pid)?.validated()) &&
+        if (has_initial || !path.validated()) &&
             pkt_type == packet::Type::Short &&
             left >= 1
         {
@@ -3965,10 +3967,7 @@ impl Connection {
             hdr_trace.unwrap_or_default(),
             payload_len,
             pn,
-            AddrTupleFmt(
-                self.paths.get(send_pid)?.local_addr(),
-                self.paths.get(send_pid)?.peer_addr()
-            )
+            AddrTupleFmt(path.local_addr(), path.peer_addr())
         );
 
         #[cfg(feature = "qlog")]
@@ -4803,6 +4802,34 @@ impl Connection {
         // Allow for 1200 bytes (minimum QUIC packet size) during the
         // handshake.
         MIN_CLIENT_INITIAL_LEN
+    }
+
+    /// Queue a PING frame to be sent for the active path if no other
+    /// ACK-eliciting frame would otherwise be sent. See
+    /// [`send_ack_eliciting_on_path()`] for more detail.
+    pub fn send_ack_eliciting(&mut self) -> Result<()> {
+        if self.is_closed() || self.is_draining() {
+            return Ok(());
+        }
+        self.paths.get_active_mut()?.needs_ack_eliciting = true;
+        Ok(())
+    }
+
+    /// Queue a PING frame to be sent for the specified path if no other
+    /// ACK-eliciting frame would otherwise be sent. Calling this method
+    /// multiple times before calling send will have no effect.
+    pub fn send_ack_eliciting_on_path(
+        &mut self, local: SocketAddr, peer: SocketAddr,
+    ) -> Result<()> {
+        if self.is_closed() || self.is_draining() {
+            return Ok(());
+        }
+        let path_id = self
+            .paths
+            .path_id_from_addrs(&(local, peer))
+            .ok_or(Error::InvalidState)?;
+        self.paths.get_mut(path_id)?.needs_ack_eliciting = true;
+        Ok(())
     }
 
     /// Reads the first received DATAGRAM.
@@ -6117,6 +6144,7 @@ impl Connection {
                 self.streams.has_stopped() ||
                 self.ids.has_new_scids() ||
                 self.ids.has_retire_dcids() ||
+                send_path.needs_ack_eliciting ||
                 send_path.probing_required())
         {
             // Only clients can send 0-RTT packets.
@@ -14758,6 +14786,57 @@ mod tests {
                 .any(|frame| matches!(frame, frame::Frame::Ping)),
             "found a PING"
         );
+    }
+
+    #[test]
+    fn ping() {
+        // First establish a connection
+        let mut pipe = testing::Pipe::default().unwrap();
+        assert_eq!(pipe.handshake(), Ok(()));
+
+        // Queue a PING frame
+        pipe.server.send_ack_eliciting().unwrap();
+
+        // Make sure ping is sent
+        let mut buf = [0; 1500];
+        let (len, _) = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+        let mut iter = frames.iter();
+
+        assert_eq!(iter.next(), Some(&frame::Frame::Ping));
+    }
+
+    #[test]
+    fn ping_not_needed() {
+        // First establish a connection
+        let mut pipe = testing::Pipe::default().unwrap();
+        assert_eq!(pipe.handshake(), Ok(()));
+
+        // Queue a PING frame
+        pipe.server.send_ack_eliciting().unwrap();
+
+        // Send a stream frame, which is ACK-eliciting to make sure the ping is
+        // not sent
+        assert_eq!(pipe.server.stream_send(1, b"a", false), Ok(1));
+
+        // Make sure ping is not sent
+        let mut buf = [0; 1500];
+        let (len, _) = pipe.server.send(&mut buf).unwrap();
+
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
+        let mut iter = frames.iter();
+
+        assert!(matches!(
+            iter.next(),
+            Some(&frame::Frame::Stream {
+                stream_id: 1,
+                data: _
+            })
+        ));
+        assert!(iter.next().is_none());
     }
 }
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4815,6 +4815,8 @@ impl Connection {
     /// frames, this method ensures that a PING frame sent.
     ///
     /// Calling this method multiple times before [`send()`] has no effect.
+    
+    /// [`send()`]: struct.Connection.html#method.send
     pub fn send_ack_eliciting(&mut self) -> Result<()> {
         if self.is_closed() || self.is_draining() {
             return Ok(());

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -14803,7 +14803,7 @@ mod tests {
     }
 
     #[test]
-    fn ping() {
+    fn send_ack_eliciting_causes_ping() {
         // First establish a connection
         let mut pipe = testing::Pipe::default().unwrap();
         assert_eq!(pipe.handshake(), Ok(()));
@@ -14823,7 +14823,7 @@ mod tests {
     }
 
     #[test]
-    fn ping_not_needed() {
+    fn send_ack_eliciting_no_ping() {
         // First establish a connection
         let mut pipe = testing::Pipe::default().unwrap();
         assert_eq!(pipe.handshake(), Ok(()));

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4815,7 +4815,7 @@ impl Connection {
     /// frames, this method ensures that a PING frame sent.
     ///
     /// Calling this method multiple times before [`send()`] has no effect.
-    
+
     /// [`send()`]: struct.Connection.html#method.send
     pub fn send_ack_eliciting(&mut self) -> Result<()> {
         if self.is_closed() || self.is_draining() {

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -187,6 +187,9 @@ pub struct Path {
     /// Whether the connection tries to migrate to this path, but it still needs
     /// to be validated.
     migrating: bool,
+
+    /// Whether or not we should force eliciting of an ACK (e.g. via PING frame)
+    pub needs_ack_eliciting: bool,
 }
 
 impl Path {
@@ -227,6 +230,7 @@ impl Path {
             challenge_requested: false,
             failure_notified: false,
             migrating: false,
+            needs_ack_eliciting: false,
         }
     }
 


### PR DESCRIPTION
- useful for keepalives
- ack-elicit is per-path to increase compatibility with multi-path work in #1310 
- not exactly a PING API since it doesn't send a PING if you would already send an ACK-eliciting packet. May or may not address #635 
- if this is interesting, we can update the C API too