### PR TITLE
Allow sending ACK only packets when the cwnd is full

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -11851,7 +11851,10 @@ mod tests {
         let frames =
             testing::decode_pkt(&mut pipe.server, &mut buf, sent).unwrap();
         assert_eq!(1, frames.len());
-        assert!(matches!(frames[0], frame::Frame::ACK { .. }), "the packet sent by the client must be an ACK only packet");
+        assert!(
+            matches!(frames[0], frame::Frame::ACK { .. }),
+            "the packet sent by the client must be an ACK only packet"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Addresses issue #1277.

Without this PR, having no space available in the congestion window prevents to send acknowledgements for the newly received packets. This can lead to situations with poor performance where no ACK is sent during a noticeable amount of time.

To implement this behaviour, we now only consider the available buffer size (`buf_cap`) when packing ACK frames.
When ACK frames are packed, reduce `left_for_congestion_controlled_packets` (new name for the `left` variable) to take the ACK frame size into account when packing the next non-ACK frames.

I added a new unit test verifying the inteded behaviour (`sends_ack_only_pkt_when_full_cwnd_and_ack_elicited`). This new test fails without the changes of this PR.


Do not hesitate to test, review and modify anything you want.

François