### PR TITLE
lib: STREAM_DATA_BLOCKED only due to flow control

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4409,7 +4409,7 @@ impl Connection {
 
         let empty_fin = buf.is_empty() && fin;
 
-        if sent < buf.len() {
+        if sent < buf.len() && !writable {
             let max_off = stream.send.max_off();
 
             if stream.send.blocked_at() != Some(max_off) {


### PR DESCRIPTION
Previously, quiche would emit a STREAM_DATA_BLOCKED frame any time that
it was able to write some data but not as much data as an application
wished to.

Since quiche stream sends consider congestion window size in
determining how much data can be sent, it was possible for us to emit
STREAM_DATA_BLOCKED due to congestion control reasons rather than flow
control reasons. This isn't stricly in line with the recommendation
in https://www.rfc-editor.org/rfc/rfc9000.html#section-19.13, which says
A sender SHOULD send a STREAM_DATA_BLOCKED frame (type=0x15) when it
wishes to send data but is unable to do so due to stream-level flow control.

This change introduces a check on the stream's writable() state, which
factors in the count of data sent vs the maximum allowed to be sent. The
result being that STREAM_DATA_BLOCKED frames are sent only when stream
flow control is blocking sending.
