### PR TITLE
Logging of reference_time as part of common_fields in qlog

### DIFF
--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -605,7 +605,7 @@ pub struct CommonFields {
     pub group_id: Option<String>,
     pub protocol_type: Option<Vec<String>>,
 
-    pub reference_time: Option<f32>,
+    pub reference_time: Option<f64>,
     pub time_format: Option<String>,
     // TODO: additionalUserSpecifiedProperty
 }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1883,7 +1883,15 @@ impl Connection {
                 time_offset: Some(0.0),
                 original_uris: None,
             }),
-            None,
+            Some(qlog::CommonFields {
+                group_id: None,
+                protocol_type: None,
+                reference_time: Some(time::SystemTime::now()
+                .duration_since(time::UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_secs_f64()),
+                time_format: None,
+            }),
         );
 
         let mut streamer = qlog::streamer::QlogStreamer::new(


### PR DESCRIPTION
This pull request aims to log the starting time of a connection. 

'Main logging schema for qlog' [1] suggest to specify a full 'reference_time' time stamp as part of 'common_fields' for logs that use relative style timestamps.

We first update the definition of reference_time to float64 to align better with 'Main logging schema for qlog' [1]. Then, we enable logging of reference_time to beginning of the connection.

[1] https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-main-schema/