### PR TITLE
qlog: align reference_time field with qlog spec

### DIFF
--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -605,7 +605,7 @@ pub struct CommonFields {
     pub group_id: Option<String>,
     pub protocol_type: Option<Vec<String>>,
 
-    pub reference_time: Option<f32>,
+    pub reference_time: Option<f64>,
     pub time_format: Option<String>,
     // TODO: additionalUserSpecifiedProperty
 }


### PR DESCRIPTION
Separated reference_time alignment as suggested in pull request [#1390](https://github.com/cloudflare/quiche/pull/1390)