### PR TITLE
Fix handling of a final grease frame

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -1501,6 +1501,8 @@ impl HttpConn for Http3Conn {
                     );
                 },
 
+                Ok((_unkn_id, quiche::h3::Event::Unknown)) => {},
+
                 Err(quiche::h3::Error::Done) => {
                     break;
                 },
@@ -1716,6 +1718,8 @@ impl HttpConn for Http3Conn {
                     self.h3_conn
                         .send_goaway(conn, self.largest_processed_request)?;
                 },
+
+                Ok((_unkn_id, quiche::h3::Event::Unknown)) => {},
 
                 Err(quiche::h3::Error::Done) => {
                     break;

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -711,6 +711,9 @@ pub enum Event {
 
     /// GOAWAY was received.
     GoAway,
+
+    /// Unknown frame type, skip
+    Unknown,
 }
 
 /// Extensible Priorities parameters.
@@ -2801,7 +2804,7 @@ impl Connection {
                 // TODO: we only implement this if we implement server push
             },
 
-            frame::Frame::Unknown { .. } => (),
+            frame::Frame::Unknown { .. } => return Ok((0, Event::Unknown)),
         }
 
         Err(Error::Done)


### PR DESCRIPTION
This fixes https://github.com/cloudflare/quiche/issues/1394.  It adds an event type to fix the interplay between process_readable_stream and handle_responses, so that unknown frames can bubble up outside of process_readable_stream.