### PR TITLE
Add the ability to provide a custom BufFactory to a quiche connection

### DIFF
--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -30,8 +30,8 @@ use crate::Error;
 use crate::Result;
 
 use crate::packet;
+use crate::range_buf::RangeBuf;
 use crate::ranges;
-use crate::stream;
 
 #[cfg(feature = "qlog")]
 use qlog::events::quic::AckedRanges;
@@ -80,7 +80,7 @@ pub enum Frame {
     },
 
     Crypto {
-        data: stream::RangeBuf,
+        data: RangeBuf,
     },
 
     CryptoHeader {
@@ -94,7 +94,7 @@ pub enum Frame {
 
     Stream {
         stream_id: u64,
-        data: stream::RangeBuf,
+        data: RangeBuf,
     },
 
     StreamHeader {
@@ -216,7 +216,7 @@ impl Frame {
             0x06 => {
                 let offset = b.get_varint()?;
                 let data = b.get_bytes_with_varint_length()?;
-                let data = stream::RangeBuf::from(data.as_ref(), offset, false);
+                let data = <RangeBuf>::from(data.as_ref(), offset, false);
 
                 Frame::Crypto { data }
             },
@@ -1303,7 +1303,7 @@ fn parse_stream_frame(ty: u64, b: &mut octets::Octets) -> Result<Frame> {
     let fin = first & 0x01 != 0;
 
     let data = b.get_bytes(len)?;
-    let data = stream::RangeBuf::from(data.as_ref(), offset, fin);
+    let data = <RangeBuf>::from(data.as_ref(), offset, fin);
 
     Ok(Frame::Stream { stream_id, data })
 }
@@ -1525,7 +1525,7 @@ mod tests {
         let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
         let frame = Frame::Crypto {
-            data: stream::RangeBuf::from(&data, 1230976, false),
+            data: <RangeBuf>::from(&data, 1230976, false),
         };
 
         let wire_len = {
@@ -1584,7 +1584,7 @@ mod tests {
 
         let frame = Frame::Stream {
             stream_id: 32,
-            data: stream::RangeBuf::from(&data, 1230976, true),
+            data: <RangeBuf>::from(&data, 1230976, true),
         };
 
         let wire_len = {
@@ -1615,7 +1615,7 @@ mod tests {
 
         let frame = Frame::Stream {
             stream_id: 32,
-            data: stream::RangeBuf::from(&data, MAX_STREAM_SIZE - 11, true),
+            data: <RangeBuf>::from(&data, MAX_STREAM_SIZE - 11, true),
         };
 
         let wire_len = {

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -312,6 +312,8 @@ use qlog::events::EventImportance;
 #[cfg(feature = "qlog")]
 use qlog::events::EventType;
 
+use crate::range_buf::BufFactory;
+
 /// List of ALPN tokens of supported HTTP/3 versions.
 ///
 /// This can be passed directly to the [`Config::set_application_protos()`]
@@ -920,8 +922,8 @@ impl Connection {
     ///
     /// [`StreamLimit`]: ../enum.Error.html#variant.StreamLimit
     /// [`InternalError`]: ../enum.Error.html#variant.InternalError
-    pub fn with_transport(
-        conn: &mut super::Connection, config: &Config,
+    pub fn with_transport<F: BufFactory>(
+        conn: &mut super::Connection<F>, config: &Config,
     ) -> Result<Connection> {
         let is_client = !conn.is_server;
         if is_client && !(conn.is_established() || conn.is_in_early_data()) {
@@ -971,8 +973,8 @@ impl Connection {
     ///
     /// [`send_body()`]: struct.Connection.html#method.send_body
     /// [`StreamBlocked`]: enum.Error.html#variant.StreamBlocked
-    pub fn send_request<T: NameValue>(
-        &mut self, conn: &mut super::Connection, headers: &[T], fin: bool,
+    pub fn send_request<T: NameValue, F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, headers: &[T], fin: bool,
     ) -> Result<u64> {
         // If we received a GOAWAY from the peer, MUST NOT initiate new
         // requests.
@@ -983,7 +985,7 @@ impl Connection {
         let stream_id = self.next_request_stream_id;
 
         self.streams
-            .insert(stream_id, stream::Stream::new(stream_id, true));
+            .insert(stream_id, <stream::Stream>::new(stream_id, true));
 
         // The underlying QUIC stream does not exist yet, so calls to e.g.
         // stream_capacity() will fail. By writing a 0-length buffer, we force
@@ -1024,9 +1026,9 @@ impl Connection {
     ///
     /// [`send_body()`]: struct.Connection.html#method.send_body
     /// [`StreamBlocked`]: enum.Error.html#variant.StreamBlocked
-    pub fn send_response<T: NameValue>(
-        &mut self, conn: &mut super::Connection, stream_id: u64, headers: &[T],
-        fin: bool,
+    pub fn send_response<T: NameValue, F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, stream_id: u64,
+        headers: &[T], fin: bool,
     ) -> Result<()> {
         let priority = Default::default();
 
@@ -1051,9 +1053,9 @@ impl Connection {
     ///
     /// [`StreamBlocked`]: enum.Error.html#variant.StreamBlocked
     /// [Extensible Priority]: https://www.rfc-editor.org/rfc/rfc9218.html#section-4.
-    pub fn send_response_with_priority<T: NameValue>(
-        &mut self, conn: &mut super::Connection, stream_id: u64, headers: &[T],
-        priority: &Priority, fin: bool,
+    pub fn send_response_with_priority<T: NameValue, F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, stream_id: u64,
+        headers: &[T], priority: &Priority, fin: bool,
     ) -> Result<()> {
         if !self.streams.contains_key(&stream_id) {
             return Err(Error::FrameUnexpected);
@@ -1090,9 +1092,9 @@ impl Connection {
         Ok(header_block)
     }
 
-    fn send_headers<T: NameValue>(
-        &mut self, conn: &mut super::Connection, stream_id: u64, headers: &[T],
-        fin: bool,
+    fn send_headers<T: NameValue, F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, stream_id: u64,
+        headers: &[T], fin: bool,
     ) -> Result<()> {
         let mut d = [42; 10];
         let mut b = octets::OctetsMut::with_slice(&mut d);
@@ -1186,8 +1188,8 @@ impl Connection {
     /// writable again.
     ///
     /// [`Done`]: enum.Error.html#variant.Done
-    pub fn send_body(
-        &mut self, conn: &mut super::Connection, stream_id: u64, body: &[u8],
+    pub fn send_body<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, stream_id: u64, body: &[u8],
         fin: bool,
     ) -> Result<usize> {
         let mut d = [42; 10];
@@ -1301,7 +1303,9 @@ impl Connection {
     /// method.
     ///
     /// [`poll()`]: struct.Connection.html#method.poll
-    pub fn dgram_enabled_by_peer(&self, conn: &super::Connection) -> bool {
+    pub fn dgram_enabled_by_peer<F: BufFactory>(
+        &self, conn: &super::Connection<F>,
+    ) -> bool {
         self.peer_settings.h3_datagram == Some(1) &&
             conn.dgram_max_writable_len().is_some()
     }
@@ -1328,8 +1332,9 @@ impl Connection {
     /// [`poll()`]: struct.Connection.html#method.poll
     /// [`Data`]: enum.Event.html#variant.Data
     /// [`Done`]: enum.Error.html#variant.Done
-    pub fn recv_body(
-        &mut self, conn: &mut super::Connection, stream_id: u64, out: &mut [u8],
+    pub fn recv_body<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, stream_id: u64,
+        out: &mut [u8],
     ) -> Result<usize> {
         let mut total = 0;
 
@@ -1402,8 +1407,8 @@ impl Connection {
     ///
     /// [`StreamBlocked`]: enum.Error.html#variant.StreamBlocked
     /// [Extensible Priority]: https://www.rfc-editor.org/rfc/rfc9218.html#section-4.
-    pub fn send_priority_update_for_request(
-        &mut self, conn: &mut super::Connection, stream_id: u64,
+    pub fn send_priority_update_for_request<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, stream_id: u64,
         priority: &Priority,
     ) -> Result<()> {
         let mut d = [42; 20];
@@ -1551,7 +1556,9 @@ impl Connection {
     /// [`recv_dgram()`]: struct.Connection.html#method.recv_dgram
     /// [`take_last_priority_update()`]: struct.Connection.html#method.take_last_priority_update
     /// [`close()`]: ../struct.Connection.html#method.close
-    pub fn poll(&mut self, conn: &mut super::Connection) -> Result<(u64, Event)> {
+    pub fn poll<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>,
+    ) -> Result<(u64, Event)> {
         // When connection close is initiated by the local application (e.g. due
         // to a protocol error), the connection itself might be in a broken
         // state, so return early.
@@ -1643,8 +1650,8 @@ impl Connection {
     /// required to call [`close()`] themselves.
     ///
     /// [`close()`]: ../struct.Connection.html#method.close
-    pub fn send_goaway(
-        &mut self, conn: &mut super::Connection, id: u64,
+    pub fn send_goaway<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, id: u64,
     ) -> Result<()> {
         let mut id = id;
 
@@ -1707,8 +1714,8 @@ impl Connection {
         self.peer_settings.raw.as_deref()
     }
 
-    fn open_uni_stream(
-        &mut self, conn: &mut super::Connection, ty: u64,
+    fn open_uni_stream<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, ty: u64,
     ) -> Result<u64> {
         let stream_id = self.next_uni_stream_id;
 
@@ -1744,8 +1751,8 @@ impl Connection {
         Ok(stream_id)
     }
 
-    fn open_qpack_encoder_stream(
-        &mut self, conn: &mut super::Connection,
+    fn open_qpack_encoder_stream<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>,
     ) -> Result<()> {
         let stream_id =
             self.open_uni_stream(conn, stream::QPACK_ENCODER_STREAM_TYPE_ID)?;
@@ -1766,8 +1773,8 @@ impl Connection {
         Ok(())
     }
 
-    fn open_qpack_decoder_stream(
-        &mut self, conn: &mut super::Connection,
+    fn open_qpack_decoder_stream<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>,
     ) -> Result<()> {
         let stream_id =
             self.open_uni_stream(conn, stream::QPACK_DECODER_STREAM_TYPE_ID)?;
@@ -1789,8 +1796,8 @@ impl Connection {
     }
 
     /// Send GREASE frames on the provided stream ID.
-    fn send_grease_frames(
-        &mut self, conn: &mut super::Connection, stream_id: u64,
+    fn send_grease_frames<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, stream_id: u64,
     ) -> Result<()> {
         let mut d = [0; 8];
 
@@ -1882,7 +1889,9 @@ impl Connection {
 
     /// Opens a new unidirectional stream with a GREASE type and sends some
     /// unframed payload.
-    fn open_grease_stream(&mut self, conn: &mut super::Connection) -> Result<()> {
+    fn open_grease_stream<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>,
+    ) -> Result<()> {
         match self.open_uni_stream(conn, grease_value()) {
             Ok(stream_id) => {
                 conn.stream_send(stream_id, b"GREASE is the word", true)?;
@@ -1914,7 +1923,9 @@ impl Connection {
     }
 
     /// Sends SETTINGS frame based on HTTP/3 configuration.
-    fn send_settings(&mut self, conn: &mut super::Connection) -> Result<()> {
+    fn send_settings<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>,
+    ) -> Result<()> {
         let stream_id = match self
             .open_uni_stream(conn, stream::HTTP3_CONTROL_STREAM_TYPE_ID)
         {
@@ -1997,8 +2008,8 @@ impl Connection {
         Ok(())
     }
 
-    fn process_control_stream(
-        &mut self, conn: &mut super::Connection, stream_id: u64,
+    fn process_control_stream<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, stream_id: u64,
     ) -> Result<(u64, Event)> {
         if conn.stream_finished(stream_id) {
             conn.close(
@@ -2031,12 +2042,12 @@ impl Connection {
         Err(Error::Done)
     }
 
-    fn process_readable_stream(
-        &mut self, conn: &mut super::Connection, stream_id: u64, polling: bool,
+    fn process_readable_stream<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, stream_id: u64, polling: bool,
     ) -> Result<(u64, Event)> {
         self.streams
             .entry(stream_id)
-            .or_insert_with(|| stream::Stream::new(stream_id, false));
+            .or_insert_with(|| <stream::Stream>::new(stream_id, false));
 
         // We need to get a fresh reference to the stream for each
         // iteration, to avoid borrowing `self` for the entire duration
@@ -2345,8 +2356,8 @@ impl Connection {
         };
     }
 
-    fn process_frame(
-        &mut self, conn: &mut super::Connection, stream_id: u64,
+    fn process_frame<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, stream_id: u64,
         frame: frame::Frame, payload_len: u64,
     ) -> Result<(u64, Event)> {
         trace!(
@@ -2656,7 +2667,7 @@ impl Connection {
                 // If the stream did not yet exist, create it and store.
                 let stream =
                     self.streams.entry(prioritized_element_id).or_insert_with(
-                        || stream::Stream::new(prioritized_element_id, false),
+                        || <stream::Stream>::new(prioritized_element_id, false),
                     );
 
                 let had_priority_update = stream.has_last_priority_update();
@@ -3132,7 +3143,7 @@ mod tests {
 
         let frames = [crate::frame::Frame::Stream {
             stream_id: 6,
-            data: crate::stream::RangeBuf::from(b"aaaaa", 0, true),
+            data: <crate::range_buf::RangeBuf>::from(b"aaaaa", 0, true),
         }];
 
         assert_eq!(

--- a/quiche/src/h3/stream.rs
+++ b/quiche/src/h3/stream.rs
@@ -24,6 +24,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::range_buf::BufFactory;
+
 use super::Error;
 use super::Result;
 
@@ -389,8 +391,8 @@ impl Stream {
     ///
     /// When not enough data can be read to complete the state, this returns
     /// `Error::Done`.
-    pub fn try_fill_buffer(
-        &mut self, conn: &mut crate::Connection,
+    pub fn try_fill_buffer<F: BufFactory>(
+        &mut self, conn: &mut crate::Connection<F>,
     ) -> Result<()> {
         // If no bytes are required to be read, return early.
         if self.state_buffer_complete() {
@@ -506,8 +508,8 @@ impl Stream {
     }
 
     /// Tries to read DATA payload from the transport stream.
-    pub fn try_consume_data(
-        &mut self, conn: &mut crate::Connection, out: &mut [u8],
+    pub fn try_consume_data<F: BufFactory>(
+        &mut self, conn: &mut crate::Connection<F>, out: &mut [u8],
     ) -> Result<(usize, bool)> {
         let left = std::cmp::min(out.len(), self.state_len - self.state_off);
 
@@ -636,7 +638,7 @@ mod tests {
     use super::*;
 
     fn open_uni(b: &mut octets::OctetsMut, ty: u64) -> Result<Stream> {
-        let stream = Stream::new(2, false);
+        let stream = <Stream>::new(2, false);
         assert_eq!(stream.state, State::StreamType);
 
         b.put_varint(ty)?;
@@ -950,7 +952,7 @@ mod tests {
 
     #[test]
     fn request_no_data() {
-        let mut stream = Stream::new(0, false);
+        let mut stream = <Stream>::new(0, false);
 
         assert_eq!(stream.ty, Some(Type::Request));
         assert_eq!(stream.state, State::FrameType);
@@ -960,7 +962,7 @@ mod tests {
 
     #[test]
     fn request_good() {
-        let mut stream = Stream::new(0, false);
+        let mut stream = <Stream>::new(0, false);
 
         let mut d = vec![42; 128];
         let mut b = octets::OctetsMut::with_slice(&mut d);
@@ -1136,7 +1138,7 @@ mod tests {
 
     #[test]
     fn data_before_headers() {
-        let mut stream = Stream::new(0, false);
+        let mut stream = <Stream>::new(0, false);
 
         let mut d = vec![42; 128];
         let mut b = octets::OctetsMut::with_slice(&mut d);
@@ -1210,7 +1212,7 @@ mod tests {
         let mut d = vec![42; 128];
         let mut b = octets::OctetsMut::with_slice(&mut d);
 
-        let mut stream = Stream::new(0, false);
+        let mut stream = <Stream>::new(0, false);
 
         assert_eq!(stream.ty, Some(Type::Request));
         assert_eq!(stream.state, State::FrameType);

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -417,6 +417,8 @@ use std::collections::VecDeque;
 
 use smallvec::SmallVec;
 
+use range_buf::DefaultBufFactory;
+
 /// The current QUIC wire version.
 pub const PROTOCOL_VERSION: u32 = PROTOCOL_VERSION_V1;
 
@@ -1234,7 +1236,10 @@ impl Config {
 }
 
 /// A QUIC connection.
-pub struct Connection {
+pub struct Connection<F = DefaultBufFactory>
+where
+    F: BufFactory,
+{
     /// QUIC wire version used for the connection.
     version: u32,
 
@@ -1321,7 +1326,7 @@ pub struct Connection {
     lost_bytes: u64,
 
     /// Streams map, indexed by stream ID.
-    streams: stream::StreamMap,
+    streams: stream::StreamMap<F>,
 
     /// Peer's original destination connection ID. Used by the client to
     /// validate the server's transport parameter.
@@ -1469,6 +1474,21 @@ pub fn accept(
     Ok(conn)
 }
 
+/// Creates a new server-side connection, with a custom buffer generation
+/// method.
+///
+/// The buffers generated can be anything that can be drereferenced as a byte
+/// slice. See [`accept`] and [`BufFactory`] for more info.
+#[inline]
+pub fn accept_with_buf_factory<F: BufFactory>(
+    scid: &ConnectionId, odcid: Option<&ConnectionId>, local: SocketAddr,
+    peer: SocketAddr, config: &mut Config,
+) -> Result<Connection<F>> {
+    let conn = Connection::new(scid, odcid, local, peer, config, true)?;
+
+    Ok(conn)
+}
+
 /// Creates a new client-side connection.
 ///
 /// The `scid` parameter is used as the connection's source connection ID,
@@ -1492,6 +1512,25 @@ pub fn connect(
     server_name: Option<&str>, scid: &ConnectionId, local: SocketAddr,
     peer: SocketAddr, config: &mut Config,
 ) -> Result<Connection> {
+    let mut conn = Connection::new(scid, None, local, peer, config, false)?;
+
+    if let Some(server_name) = server_name {
+        conn.handshake.set_host_name(server_name)?;
+    }
+
+    Ok(conn)
+}
+
+/// Creates a new client-side connection, with a custom buffer generation
+/// method.
+///
+/// The buffers generated can be anything that can be drereferenced as a byte
+/// slice. See [`connect`] and [`BufFactory`] for more info.
+#[inline]
+pub fn connect_with_buffer_factory<F: BufFactory>(
+    server_name: Option<&str>, scid: &ConnectionId, local: SocketAddr,
+    peer: SocketAddr, config: &mut Config,
+) -> Result<Connection<F>> {
     let mut conn = Connection::new(scid, None, local, peer, config, false)?;
 
     if let Some(server_name) = server_name {
@@ -1694,11 +1733,11 @@ impl Default for QlogInfo {
     }
 }
 
-impl Connection {
+impl<F: BufFactory> Connection<F> {
     fn new(
         scid: &ConnectionId, odcid: Option<&ConnectionId>, local: SocketAddr,
         peer: SocketAddr, config: &mut Config, is_server: bool,
-    ) -> Result<Connection> {
+    ) -> Result<Connection<F>> {
         let tls = config.tls_ctx.new_handshake()?;
         Connection::with_tls(scid, odcid, local, peer, config, tls, is_server)
     }
@@ -1706,7 +1745,7 @@ impl Connection {
     fn with_tls(
         scid: &ConnectionId, odcid: Option<&ConnectionId>, local: SocketAddr,
         peer: SocketAddr, config: &Config, tls: tls::Handshake, is_server: bool,
-    ) -> Result<Connection> {
+    ) -> Result<Connection<F>> {
         let max_rx_data = config.local_transport_params.initial_max_data;
 
         let scid_as_hex: Vec<String> =
@@ -5428,7 +5467,7 @@ impl Connection {
     /// # Ok::<(), quiche::Error>(())
     /// ```
     #[inline]
-    pub fn dgram_purge_outgoing<F: Fn(&[u8]) -> bool>(&mut self, f: F) {
+    pub fn dgram_purge_outgoing<FN: Fn(&[u8]) -> bool>(&mut self, f: FN) {
         self.dgram_send_queue.purge(f);
     }
 
@@ -6600,7 +6639,7 @@ impl Connection {
     /// a new one otherwise.
     fn get_or_create_stream(
         &mut self, id: u64, local: bool,
-    ) -> Result<&mut stream::Stream> {
+    ) -> Result<&mut stream::Stream<F>> {
         self.streams.get_or_create(
             id,
             &self.local_transport_params,
@@ -8287,8 +8326,8 @@ pub mod testing {
         }
     }
 
-    pub fn recv_send(
-        conn: &mut Connection, buf: &mut [u8], len: usize,
+    pub fn recv_send<F: BufFactory>(
+        conn: &mut Connection<F>, buf: &mut [u8], len: usize,
     ) -> Result<usize> {
         let active_path = conn.paths.get_active()?;
         let info = RecvInfo {
@@ -8498,6 +8537,8 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
+    use crate::range_buf::RangeBuf;
+
     use super::*;
 
     #[test]
@@ -9001,7 +9042,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"aaaaa", 0, true),
+            data: <RangeBuf>::from(b"aaaaa", 0, true),
         }];
 
         assert_eq!(
@@ -9062,7 +9103,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"aaaaa", 0, true),
+            data: <RangeBuf>::from(b"aaaaa", 0, true),
         }];
 
         let len =
@@ -9132,7 +9173,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"aaaaa", 0, true),
+            data: <RangeBuf>::from(b"aaaaa", 0, true),
         }];
 
         let len =
@@ -9297,7 +9338,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"aaaaa", 0, false),
+            data: <RangeBuf>::from(b"aaaaa", 0, false),
         }];
 
         let pkt_type = packet::Type::Short;
@@ -9310,7 +9351,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"", 5, true),
+            data: <RangeBuf>::from(b"", 5, true),
         }];
 
         let pkt_type = packet::Type::Short;
@@ -9323,7 +9364,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"", 15, true),
+            data: <RangeBuf>::from(b"", 15, true),
         }];
 
         let pkt_type = packet::Type::Short;
@@ -9384,7 +9425,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"hello", 0, false),
+            data: <RangeBuf>::from(b"hello", 0, false),
         }];
 
         // Client sends stream frame with key update request.
@@ -9510,15 +9551,15 @@ mod tests {
         let frames = [
             frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"aaaaaaaaaaaaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaaaaaaaaaaaa", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 4,
-                data: stream::RangeBuf::from(b"aaaaaaaaaaaaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaaaaaaaaaaaa", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 8,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
         ];
 
@@ -9540,16 +9581,16 @@ mod tests {
             // One byte less than stream limit.
             frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"aaaaaaaaaaaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaaaaaaaaaaa", 0, false),
             },
             // Same stream, but one byte more.
             frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"aaaaaaaaaaaaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaaaaaaaaaaaa", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 8,
-                data: stream::RangeBuf::from(b"aaaaaaaaaaaaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaaaaaaaaaaaa", 0, false),
             },
         ];
 
@@ -9567,11 +9608,11 @@ mod tests {
         let frames = [
             frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"aaaaaaaaaaaaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaaaaaaaaaaaa", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 4,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
         ];
 
@@ -9584,7 +9625,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"a", 1, false),
+            data: <RangeBuf>::from(b"a", 1, false),
         }];
 
         let len = pipe
@@ -9653,7 +9694,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"aaaaaaaaaaaaaaaa", 0, true),
+            data: <RangeBuf>::from(b"aaaaaaaaaaaaaaaa", 0, true),
         }];
 
         let pkt_type = packet::Type::Short;
@@ -9672,7 +9713,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 2,
-            data: stream::RangeBuf::from(b"aaaaaaaaaaa", 0, true),
+            data: <RangeBuf>::from(b"aaaaaaaaaaa", 0, true),
         }];
 
         let pkt_type = packet::Type::Short;
@@ -9691,7 +9732,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"aaaaaaaaa", 0, false),
+            data: <RangeBuf>::from(b"aaaaaaaaa", 0, false),
         }];
 
         let pkt_type = packet::Type::Short;
@@ -9702,7 +9743,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"a", 9, false),
+            data: <RangeBuf>::from(b"a", 9, false),
         }];
 
         let len = pipe
@@ -9789,31 +9830,31 @@ mod tests {
         let frames = [
             frame::Frame::Stream {
                 stream_id: 4,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 8,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 12,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 16,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 20,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 24,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 28,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
         ];
 
@@ -9857,31 +9898,31 @@ mod tests {
         let frames = [
             frame::Frame::Stream {
                 stream_id: 2,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 6,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 10,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 14,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 18,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 22,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 26,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
         ];
 
@@ -10186,15 +10227,15 @@ mod tests {
         let frames = [
             frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"aaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaa", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"bbbbb", 3, false),
+                data: <RangeBuf>::from(b"bbbbb", 3, false),
             },
             frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"ccccc", 6, false),
+                data: <RangeBuf>::from(b"ccccc", 6, false),
             },
         ];
 
@@ -10216,15 +10257,15 @@ mod tests {
         let frames = [
             frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"aaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaa", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"ccccc", 6, false),
+                data: <RangeBuf>::from(b"ccccc", 6, false),
             },
             frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"bbbbb", 3, false),
+                data: <RangeBuf>::from(b"bbbbb", 3, false),
             },
         ];
 
@@ -10377,11 +10418,11 @@ mod tests {
         let frames = [
             frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"aaaaaaaaaaaaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaaaaaaaaaaaa", 0, false),
             },
             frame::Frame::Stream {
                 stream_id: 4,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::ResetStream {
                 stream_id: 4,
@@ -10390,7 +10431,7 @@ mod tests {
             },
             frame::Frame::Stream {
                 stream_id: 8,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
         ];
 
@@ -10413,7 +10454,7 @@ mod tests {
         let frames = [
             frame::Frame::Stream {
                 stream_id: 4,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             },
             frame::Frame::ResetStream {
                 stream_id: 4,
@@ -10489,7 +10530,7 @@ mod tests {
         // Send 1-RTT packet #0.
         let frames = [frame::Frame::Stream {
             stream_id: 0,
-            data: stream::RangeBuf::from(b"hello, world", 0, true),
+            data: <RangeBuf>::from(b"hello, world", 0, true),
         }];
 
         let pkt_type = packet::Type::Short;
@@ -10502,7 +10543,7 @@ mod tests {
         // Send 1-RTT packet #1.
         let frames = [frame::Frame::Stream {
             stream_id: 4,
-            data: stream::RangeBuf::from(b"hello, world", 0, true),
+            data: <RangeBuf>::from(b"hello, world", 0, true),
         }];
 
         let written =
@@ -11180,7 +11221,7 @@ mod tests {
             iter.next(),
             Some(&frame::Frame::Stream {
                 stream_id: 8,
-                data: stream::RangeBuf::from(b"aaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaa", 0, false),
             })
         );
 
@@ -11193,7 +11234,7 @@ mod tests {
             frames.first(),
             Some(&frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"aaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaa", 0, false),
             })
         );
 
@@ -11206,7 +11247,7 @@ mod tests {
             frames.first(),
             Some(&frame::Frame::Stream {
                 stream_id: 4,
-                data: stream::RangeBuf::from(b"aaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaa", 0, false),
             })
         );
     }
@@ -11931,7 +11972,7 @@ mod tests {
 
         let frames = [frame::Frame::Stream {
             stream_id: 0,
-            data: stream::RangeBuf::from(b"aa", 0, false),
+            data: <RangeBuf>::from(b"aa", 0, false),
         }];
 
         let pkt_type = packet::Type::Short;
@@ -12239,7 +12280,7 @@ mod tests {
             iter.next(),
             Some(&frame::Frame::Stream {
                 stream_id: 8,
-                data: stream::RangeBuf::from(b"aaaaaaaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaaaaaaa", 0, false),
             })
         );
 
@@ -12285,7 +12326,7 @@ mod tests {
             iter.next(),
             Some(&frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"aaaaaaaaaaaaaaa", 0, false),
+                data: <RangeBuf>::from(b"aaaaaaaaaaaaaaa", 0, false),
             })
         );
 
@@ -12307,7 +12348,7 @@ mod tests {
             iter.next(),
             Some(&frame::Frame::Stream {
                 stream_id: 4,
-                data: stream::RangeBuf::from(b"a", 0, false),
+                data: <RangeBuf>::from(b"a", 0, false),
             })
         );
 
@@ -12893,7 +12934,7 @@ mod tests {
 
             assert_eq!(stream, &frame::Frame::Stream {
                 stream_id: 8,
-                data: stream::RangeBuf::from(&out, off, false),
+                data: <RangeBuf>::from(&out, off, false),
             });
 
             off = match stream {
@@ -12916,7 +12957,7 @@ mod tests {
 
             assert_eq!(stream, &frame::Frame::Stream {
                 stream_id: 16,
-                data: stream::RangeBuf::from(&out, off, false),
+                data: <RangeBuf>::from(&out, off, false),
             });
 
             off = match stream {
@@ -12939,7 +12980,7 @@ mod tests {
 
             assert_eq!(stream, &frame::Frame::Stream {
                 stream_id: 20,
-                data: stream::RangeBuf::from(&out, off, false),
+                data: <RangeBuf>::from(&out, off, false),
             });
 
             off = match stream {
@@ -12963,7 +13004,7 @@ mod tests {
                 frames.first(),
                 Some(&frame::Frame::Stream {
                     stream_id: 12,
-                    data: stream::RangeBuf::from(&out, off, false),
+                    data: <RangeBuf>::from(&out, off, false),
                 })
             );
 
@@ -12977,7 +13018,7 @@ mod tests {
 
             assert_eq!(stream, &frame::Frame::Stream {
                 stream_id: 4,
-                data: stream::RangeBuf::from(&out, off, false),
+                data: <RangeBuf>::from(&out, off, false),
             });
 
             off = match stream {
@@ -13000,7 +13041,7 @@ mod tests {
 
             assert_eq!(stream, &frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(&out, off, false),
+                data: <RangeBuf>::from(&out, off, false),
             });
 
             off = match stream {
@@ -13082,7 +13123,7 @@ mod tests {
             frames.first(),
             Some(&frame::Frame::Stream {
                 stream_id: 8,
-                data: stream::RangeBuf::from(b"b", 0, false),
+                data: <RangeBuf>::from(b"b", 0, false),
             })
         );
 
@@ -13096,7 +13137,7 @@ mod tests {
             frames.first(),
             Some(&frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(b"b", 0, false),
+                data: <RangeBuf>::from(b"b", 0, false),
             })
         );
 
@@ -13110,7 +13151,7 @@ mod tests {
             frames.first(),
             Some(&frame::Frame::Stream {
                 stream_id: 12,
-                data: stream::RangeBuf::from(b"b", 0, false),
+                data: <RangeBuf>::from(b"b", 0, false),
             })
         );
 
@@ -13123,7 +13164,7 @@ mod tests {
             frames.first(),
             Some(&frame::Frame::Stream {
                 stream_id: 4,
-                data: stream::RangeBuf::from(b"b", 0, false),
+                data: <RangeBuf>::from(b"b", 0, false),
             })
         );
 
@@ -13204,7 +13245,7 @@ mod tests {
             let mut frame_iter = frames.iter();
 
             assert_eq!(frame_iter.next().unwrap(), &frame::Frame::Datagram {
-                data: out.into(),
+                data: out.into()
             });
             assert_eq!(frame_iter.next(), None);
 
@@ -13219,7 +13260,7 @@ mod tests {
 
             assert_eq!(stream, &frame::Frame::Stream {
                 stream_id: 0,
-                data: stream::RangeBuf::from(&out, off_0, false),
+                data: <RangeBuf>::from(&out, off_0, false),
             });
 
             off_0 = match stream {
@@ -13238,7 +13279,7 @@ mod tests {
             let mut frame_iter = frames.iter();
 
             assert_eq!(frame_iter.next().unwrap(), &frame::Frame::Datagram {
-                data: out.into(),
+                data: out.into()
             });
             assert_eq!(frame_iter.next(), None);
 
@@ -13253,7 +13294,7 @@ mod tests {
 
             assert_eq!(stream, &frame::Frame::Stream {
                 stream_id: 4,
-                data: stream::RangeBuf::from(&out, off_4, false),
+                data: <RangeBuf>::from(&out, off_4, false),
             });
 
             off_4 = match stream {
@@ -13322,7 +13363,7 @@ mod tests {
             iter.next(),
             Some(&frame::Frame::Stream {
                 stream_id: 4,
-                data: stream::RangeBuf::from(b"b", 0, false),
+                data: <RangeBuf>::from(b"b", 0, false),
             })
         );
         assert_eq!(pipe.client.stats().retrans, 1);
@@ -16302,6 +16343,8 @@ pub use crate::recovery::CongestionControlAlgorithm;
 
 pub use crate::stream::StreamIter;
 
+pub use crate::range_buf::BufFactory;
+
 mod cid;
 mod crypto;
 mod dgram;
@@ -16314,6 +16357,7 @@ mod minmax;
 mod packet;
 mod path;
 mod rand;
+mod range_buf;
 mod ranges;
 mod recovery;
 mod stream;

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -904,7 +904,7 @@ impl PktNumSpace {
             crypto_0rtt_open: None,
             crypto_0rtt_seal: None,
 
-            crypto_stream: stream::Stream::new(
+            crypto_stream: <stream::Stream>::new(
                 0, // dummy
                 u64::MAX,
                 u64::MAX,
@@ -916,7 +916,7 @@ impl PktNumSpace {
     }
 
     pub fn clear(&mut self) {
-        self.crypto_stream = stream::Stream::new(
+        self.crypto_stream = <stream::Stream>::new(
             0, // dummy
             u64::MAX,
             u64::MAX,

--- a/quiche/src/range_buf.rs
+++ b/quiche/src/range_buf.rs
@@ -1,0 +1,190 @@
+use std::cmp;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// Buffer holding data at a specific offset.
+///
+/// The data is stored in a `Vec<u8>` in such a way that it can be shared
+/// between multiple `RangeBuf` objects.
+///
+/// Each `RangeBuf` will have its own view of that buffer, where the `start`
+/// value indicates the initial offset within the `Vec`, and `len` indicates the
+/// number of bytes, starting from `start` that are included.
+///
+/// In addition, `pos` indicates the current offset within the `Vec`, starting
+/// from the very beginning of the `Vec`.
+///
+/// Finally, `off` is the starting offset for the specific `RangeBuf` within the
+/// stream the buffer belongs to.
+#[derive(Clone, Debug, Default)]
+pub struct RangeBuf<F = DefaultBufFactory>
+where
+    F: BufFactory,
+{
+    /// The internal buffer holding the data.
+    ///
+    /// To avoid needless allocations when a RangeBuf is split, this field
+    /// should be reference-counted so it can be shared between multiple
+    /// RangeBuf objects, and sliced using the `start` and `len` values.
+    pub(crate) data: F::Buf,
+
+    /// The initial offset within the internal buffer.
+    pub(crate) start: usize,
+
+    /// The current offset within the internal buffer.
+    pub(crate) pos: usize,
+
+    /// The number of bytes in the buffer, from the initial offset.
+    pub(crate) len: usize,
+
+    /// The offset of the buffer within a stream.
+    pub(crate) off: u64,
+
+    /// Whether this contains the final byte in the stream.
+    pub(crate) fin: bool,
+
+    _bf: PhantomData<F>,
+}
+
+/// A trait for providing internal storage buffers for [`RangeBuf`].
+/// The associated type [`Buf`] can be any type that dereferences to
+/// a slice, but should be fast to clone, eg. by wrapping it into an
+/// [`Arc`].
+pub trait BufFactory: Clone + Default + Debug {
+    /// The type of the generated buffer.
+    type Buf: Clone + Debug + AsRef<[u8]>;
+
+    /// Generate a new buffer from a given slice, the buffer must contain the
+    /// same data as the original slice.
+    fn buf_from_slice(buf: &[u8]) -> Self::Buf;
+}
+
+/// The default [`BufFactory`] allocates buffers on the heap on demand.
+#[derive(Debug, Clone, Default)]
+pub struct DefaultBufFactory;
+
+/// The default [`BufFactory::Buf`] is a boxes slices wrapped in an [`Arc`].
+#[derive(Debug, Clone, Default)]
+pub struct DefaultBuf(Arc<Box<[u8]>>);
+
+impl BufFactory for DefaultBufFactory {
+    type Buf = DefaultBuf;
+
+    fn buf_from_slice(buf: &[u8]) -> Self::Buf {
+        DefaultBuf(Arc::new(buf.into()))
+    }
+}
+
+impl AsRef<[u8]> for DefaultBuf {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl<F: BufFactory> RangeBuf<F>
+where
+    F::Buf: Clone,
+{
+    /// Creates a new `RangeBuf` from the given slice.
+    pub fn from(buf: &[u8], off: u64, fin: bool) -> RangeBuf<F> {
+        RangeBuf {
+            data: F::buf_from_slice(buf),
+            start: 0,
+            pos: 0,
+            len: buf.len(),
+            off,
+            fin,
+            _bf: Default::default(),
+        }
+    }
+
+    /// Returns whether `self` holds the final offset in the stream.
+    pub fn fin(&self) -> bool {
+        self.fin
+    }
+
+    /// Returns the starting offset of `self`.
+    pub fn off(&self) -> u64 {
+        (self.off - self.start as u64) + self.pos as u64
+    }
+
+    /// Returns the final offset of `self`.
+    pub fn max_off(&self) -> u64 {
+        self.off() + self.len() as u64
+    }
+
+    /// Returns the length of `self`.
+    pub fn len(&self) -> usize {
+        self.len - (self.pos - self.start)
+    }
+
+    /// Returns true if `self` has a length of zero bytes.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Consumes the starting `count` bytes of `self`.
+    pub fn consume(&mut self, count: usize) {
+        self.pos += count;
+    }
+
+    /// Splits the buffer into two at the given index.
+    pub fn split_off(&mut self, at: usize) -> RangeBuf<F>
+    where
+        F::Buf: Clone + AsRef<[u8]>,
+    {
+        assert!(
+            at <= self.len,
+            "`at` split index (is {}) should be <= len (is {})",
+            at,
+            self.len
+        );
+
+        let buf = RangeBuf {
+            data: self.data.clone(),
+            start: self.start + at,
+            pos: cmp::max(self.pos, self.start + at),
+            len: self.len - at,
+            off: self.off + at as u64,
+            _bf: Default::default(),
+            fin: self.fin,
+        };
+
+        self.pos = cmp::min(self.pos, self.start + at);
+        self.len = at;
+        self.fin = false;
+
+        buf
+    }
+}
+
+impl<F: BufFactory> Deref for RangeBuf<F> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.data.as_ref()[self.pos..self.start + self.len]
+    }
+}
+
+impl<F: BufFactory> Ord for RangeBuf<F> {
+    fn cmp(&self, other: &RangeBuf<F>) -> cmp::Ordering {
+        // Invert ordering to implement min-heap.
+        self.off.cmp(&other.off).reverse()
+    }
+}
+
+impl<F: BufFactory> PartialOrd for RangeBuf<F> {
+    fn partial_cmp(&self, other: &RangeBuf<F>) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<F: BufFactory> Eq for RangeBuf<F> {}
+
+impl<F: BufFactory> PartialEq for RangeBuf<F> {
+    fn eq(&self, other: &RangeBuf<F>) -> bool {
+        self.off == other.off
+    }
+}

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -39,6 +39,8 @@ use intrusive_collections::RBTreeAtomicLink;
 
 use smallvec::SmallVec;
 
+use crate::range_buf::DefaultBufFactory;
+use crate::BufFactory;
 use crate::Error;
 use crate::Result;
 
@@ -85,9 +87,9 @@ pub type StreamIdHashSet = HashSet<u64, BuildStreamIdHasher>;
 
 /// Keeps track of QUIC streams and enforces stream limits.
 #[derive(Default)]
-pub struct StreamMap {
+pub struct StreamMap<F: BufFactory = DefaultBufFactory> {
     /// Map of streams indexed by stream ID.
-    streams: StreamIdHashMap<Stream>,
+    streams: StreamIdHashMap<Stream<F>>,
 
     /// Set of streams that were completed and garbage collected.
     ///
@@ -163,10 +165,10 @@ pub struct StreamMap {
     max_stream_window: u64,
 }
 
-impl StreamMap {
+impl<F: BufFactory> StreamMap<F> {
     pub fn new(
         max_streams_bidi: u64, max_streams_uni: u64, max_stream_window: u64,
-    ) -> StreamMap {
+    ) -> Self {
         StreamMap {
             local_max_streams_bidi: max_streams_bidi,
             local_max_streams_bidi_next: max_streams_bidi,
@@ -181,12 +183,12 @@ impl StreamMap {
     }
 
     /// Returns the stream with the given ID if it exists.
-    pub fn get(&self, id: u64) -> Option<&Stream> {
+    pub fn get(&self, id: u64) -> Option<&Stream<F>> {
         self.streams.get(&id)
     }
 
     /// Returns the mutable stream with the given ID if it exists.
-    pub fn get_mut(&mut self, id: u64) -> Option<&mut Stream> {
+    pub fn get_mut(&mut self, id: u64) -> Option<&mut Stream<F>> {
         self.streams.get_mut(&id)
     }
 
@@ -205,7 +207,7 @@ impl StreamMap {
     pub(crate) fn get_or_create(
         &mut self, id: u64, local_params: &crate::TransportParams,
         peer_params: &crate::TransportParams, local: bool, is_server: bool,
-    ) -> Result<&mut Stream> {
+    ) -> Result<&mut Stream<F>> {
         let (stream, is_new_and_writable) = match self.streams.entry(id) {
             hash_map::Entry::Vacant(v) => {
                 // Stream has already been closed and garbage collected.
@@ -647,12 +649,12 @@ impl StreamMap {
 }
 
 /// A QUIC stream.
-pub struct Stream {
+pub struct Stream<F: BufFactory = DefaultBufFactory> {
     /// Receive-side stream buffer.
     pub recv: recv_buf::RecvBuf,
 
     /// Send-side stream buffer.
-    pub send: send_buf::SendBuf,
+    pub send: send_buf::SendBuf<F>,
 
     pub send_lowat: usize,
 
@@ -671,12 +673,12 @@ pub struct Stream {
     pub priority_key: Arc<StreamPriorityKey>,
 }
 
-impl Stream {
+impl<F: BufFactory> Stream<F> {
     /// Creates a new stream with the given flow control limits.
     pub fn new(
         id: u64, max_rx_data: u64, max_tx_data: u64, bidi: bool, local: bool,
         max_window: u64,
-    ) -> Stream {
+    ) -> Self {
         let priority_key = Arc::new(StreamPriorityKey {
             id,
             ..Default::default()
@@ -889,148 +891,16 @@ impl ExactSizeIterator for StreamIter {
     }
 }
 
-/// Buffer holding data at a specific offset.
-///
-/// The data is stored in a `Vec<u8>` in such a way that it can be shared
-/// between multiple `RangeBuf` objects.
-///
-/// Each `RangeBuf` will have its own view of that buffer, where the `start`
-/// value indicates the initial offset within the `Vec`, and `len` indicates the
-/// number of bytes, starting from `start` that are included.
-///
-/// In addition, `pos` indicates the current offset within the `Vec`, starting
-/// from the very beginning of the `Vec`.
-///
-/// Finally, `off` is the starting offset for the specific `RangeBuf` within the
-/// stream the buffer belongs to.
-#[derive(Clone, Debug, Default, Eq)]
-pub struct RangeBuf {
-    /// The internal buffer holding the data.
-    ///
-    /// To avoid needless allocations when a RangeBuf is split, this field is
-    /// reference-counted and can be shared between multiple RangeBuf objects,
-    /// and sliced using the `start` and `len` values.
-    data: Arc<Vec<u8>>,
-
-    /// The initial offset within the internal buffer.
-    start: usize,
-
-    /// The current offset within the internal buffer.
-    pos: usize,
-
-    /// The number of bytes in the buffer, from the initial offset.
-    len: usize,
-
-    /// The offset of the buffer within a stream.
-    off: u64,
-
-    /// Whether this contains the final byte in the stream.
-    fin: bool,
-}
-
-impl RangeBuf {
-    /// Creates a new `RangeBuf` from the given slice.
-    pub fn from(buf: &[u8], off: u64, fin: bool) -> RangeBuf {
-        RangeBuf {
-            data: Arc::new(Vec::from(buf)),
-            start: 0,
-            pos: 0,
-            len: buf.len(),
-            off,
-            fin,
-        }
-    }
-
-    /// Returns whether `self` holds the final offset in the stream.
-    pub fn fin(&self) -> bool {
-        self.fin
-    }
-
-    /// Returns the starting offset of `self`.
-    pub fn off(&self) -> u64 {
-        (self.off - self.start as u64) + self.pos as u64
-    }
-
-    /// Returns the final offset of `self`.
-    pub fn max_off(&self) -> u64 {
-        self.off() + self.len() as u64
-    }
-
-    /// Returns the length of `self`.
-    pub fn len(&self) -> usize {
-        self.len - (self.pos - self.start)
-    }
-
-    /// Returns true if `self` has a length of zero bytes.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Consumes the starting `count` bytes of `self`.
-    pub fn consume(&mut self, count: usize) {
-        self.pos += count;
-    }
-
-    /// Splits the buffer into two at the given index.
-    pub fn split_off(&mut self, at: usize) -> RangeBuf {
-        assert!(
-            at <= self.len,
-            "`at` split index (is {}) should be <= len (is {})",
-            at,
-            self.len
-        );
-
-        let buf = RangeBuf {
-            data: self.data.clone(),
-            start: self.start + at,
-            pos: cmp::max(self.pos, self.start + at),
-            len: self.len - at,
-            off: self.off + at as u64,
-            fin: self.fin,
-        };
-
-        self.pos = cmp::min(self.pos, self.start + at);
-        self.len = at;
-        self.fin = false;
-
-        buf
-    }
-}
-
-impl std::ops::Deref for RangeBuf {
-    type Target = [u8];
-
-    fn deref(&self) -> &[u8] {
-        &self.data[self.pos..self.start + self.len]
-    }
-}
-
-impl Ord for RangeBuf {
-    fn cmp(&self, other: &RangeBuf) -> cmp::Ordering {
-        // Invert ordering to implement min-heap.
-        self.off.cmp(&other.off).reverse()
-    }
-}
-
-impl PartialOrd for RangeBuf {
-    fn partial_cmp(&self, other: &RangeBuf) -> Option<cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl PartialEq for RangeBuf {
-    fn eq(&self, other: &RangeBuf) -> bool {
-        self.off == other.off
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use crate::range_buf::RangeBuf;
+
     use super::*;
 
     #[test]
     fn recv_flow_control() {
-        let mut stream = Stream::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
         assert!(!stream.recv.almost_full());
 
         let mut buf = [0; 32];
@@ -1061,7 +931,8 @@ mod tests {
 
     #[test]
     fn recv_past_fin() {
-        let mut stream = Stream::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
         assert!(!stream.recv.almost_full());
 
         let first = RangeBuf::from(b"hello", 0, true);
@@ -1073,7 +944,8 @@ mod tests {
 
     #[test]
     fn recv_fin_dup() {
-        let mut stream = Stream::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
         assert!(!stream.recv.almost_full());
 
         let first = RangeBuf::from(b"hello", 0, true);
@@ -1091,7 +963,8 @@ mod tests {
 
     #[test]
     fn recv_fin_change() {
-        let mut stream = Stream::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
         assert!(!stream.recv.almost_full());
 
         let first = RangeBuf::from(b"hello", 0, true);
@@ -1103,7 +976,8 @@ mod tests {
 
     #[test]
     fn recv_fin_lower_than_received() {
-        let mut stream = Stream::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
         assert!(!stream.recv.almost_full());
 
         let first = RangeBuf::from(b"hello", 0, true);
@@ -1115,7 +989,8 @@ mod tests {
 
     #[test]
     fn recv_fin_flow_control() {
-        let mut stream = Stream::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
         assert!(!stream.recv.almost_full());
 
         let mut buf = [0; 32];
@@ -1135,7 +1010,8 @@ mod tests {
 
     #[test]
     fn recv_fin_reset_mismatch() {
-        let mut stream = Stream::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
         assert!(!stream.recv.almost_full());
 
         let first = RangeBuf::from(b"hello", 0, true);
@@ -1146,7 +1022,8 @@ mod tests {
 
     #[test]
     fn recv_reset_dup() {
-        let mut stream = Stream::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
         assert!(!stream.recv.almost_full());
 
         let first = RangeBuf::from(b"hello", 0, false);
@@ -1158,7 +1035,8 @@ mod tests {
 
     #[test]
     fn recv_reset_change() {
-        let mut stream = Stream::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
         assert!(!stream.recv.almost_full());
 
         let first = RangeBuf::from(b"hello", 0, false);
@@ -1170,7 +1048,8 @@ mod tests {
 
     #[test]
     fn recv_reset_lower_than_received() {
-        let mut stream = Stream::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
         assert!(!stream.recv.almost_full());
 
         let first = RangeBuf::from(b"hello", 0, false);
@@ -1183,7 +1062,8 @@ mod tests {
     fn send_flow_control() {
         let mut buf = [0; 25];
 
-        let mut stream = Stream::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
 
         let first = b"hello";
         let second = b"world";
@@ -1226,7 +1106,8 @@ mod tests {
 
     #[test]
     fn send_past_fin() {
-        let mut stream = Stream::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
 
         let first = b"hello";
         let second = b"world";
@@ -1242,7 +1123,8 @@ mod tests {
 
     #[test]
     fn send_fin_dup() {
-        let mut stream = Stream::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
 
         assert_eq!(stream.send.write(b"hello", true), Ok(5));
         assert!(stream.send.is_fin());
@@ -1253,7 +1135,8 @@ mod tests {
 
     #[test]
     fn send_undo_fin() {
-        let mut stream = Stream::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
 
         assert_eq!(stream.send.write(b"hello", true), Ok(5));
         assert!(stream.send.is_fin());
@@ -1268,7 +1151,8 @@ mod tests {
     fn send_fin_max_data_match() {
         let mut buf = [0; 15];
 
-        let mut stream = Stream::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
 
         let slice = b"hellohellohello";
 
@@ -1284,7 +1168,8 @@ mod tests {
     fn send_fin_zero_length() {
         let mut buf = [0; 5];
 
-        let mut stream = Stream::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
 
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
         assert_eq!(stream.send.write(b"", true), Ok(0));
@@ -1300,7 +1185,8 @@ mod tests {
     fn send_ack() {
         let mut buf = [0; 5];
 
-        let mut stream = Stream::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
 
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
         assert_eq!(stream.send.write(b"world", false), Ok(5));
@@ -1330,7 +1216,8 @@ mod tests {
     fn send_ack_reordering() {
         let mut buf = [0; 5];
 
-        let mut stream = Stream::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
 
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
         assert_eq!(stream.send.write(b"world", false), Ok(5));
@@ -1367,7 +1254,8 @@ mod tests {
 
     #[test]
     fn recv_data_below_off() {
-        let mut stream = Stream::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 15, 0, true, true, DEFAULT_STREAM_WINDOW);
 
         let first = RangeBuf::from(b"hello", 0, false);
 
@@ -1390,7 +1278,7 @@ mod tests {
     #[test]
     fn stream_complete() {
         let mut stream =
-            Stream::new(0, 30, 30, true, true, DEFAULT_STREAM_WINDOW);
+            <Stream>::new(0, 30, 30, true, true, DEFAULT_STREAM_WINDOW);
 
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
         assert_eq!(stream.send.write(b"world", false), Ok(5));
@@ -1433,7 +1321,8 @@ mod tests {
     fn send_fin_zero_length_output() {
         let mut buf = [0; 5];
 
-        let mut stream = Stream::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 15, true, true, DEFAULT_STREAM_WINDOW);
 
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
         assert_eq!(stream.send.off_front(), 0);
@@ -1458,7 +1347,8 @@ mod tests {
     fn send_emit() {
         let mut buf = [0; 5];
 
-        let mut stream = Stream::new(0, 0, 20, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 20, true, true, DEFAULT_STREAM_WINDOW);
 
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
         assert_eq!(stream.send.write(b"world", false), Ok(5));
@@ -1510,7 +1400,8 @@ mod tests {
     fn send_emit_ack() {
         let mut buf = [0; 5];
 
-        let mut stream = Stream::new(0, 0, 20, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 20, true, true, DEFAULT_STREAM_WINDOW);
 
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
         assert_eq!(stream.send.write(b"world", false), Ok(5));
@@ -1577,7 +1468,8 @@ mod tests {
     fn send_emit_retransmit() {
         let mut buf = [0; 5];
 
-        let mut stream = Stream::new(0, 0, 20, true, true, DEFAULT_STREAM_WINDOW);
+        let mut stream =
+            <Stream>::new(0, 0, 20, true, true, DEFAULT_STREAM_WINDOW);
 
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
         assert_eq!(stream.send.write(b"world", false), Ok(5));
@@ -1687,7 +1579,7 @@ mod tests {
 
     #[test]
     fn rangebuf_split_off() {
-        let mut buf = RangeBuf::from(b"helloworld", 5, true);
+        let mut buf = <RangeBuf>::from(b"helloworld", 5, true);
         assert_eq!(buf.start, 0);
         assert_eq!(buf.pos, 0);
         assert_eq!(buf.len, 10);
@@ -1807,7 +1699,7 @@ mod tests {
         let local_tp = crate::TransportParams::default();
         let peer_tp = crate::TransportParams::default();
 
-        let mut streams = StreamMap::new(5, 5, 5);
+        let mut streams = <StreamMap>::new(5, 5, 5);
 
         let stream_id = 500;
         assert!(!is_local(stream_id, true), "stream id is peer initiated");
@@ -1828,7 +1720,7 @@ mod tests {
         let local_tp = crate::TransportParams::default();
         let peer_tp = crate::TransportParams::default();
 
-        let mut streams = StreamMap::new(5, 5, 5);
+        let mut streams = <StreamMap>::new(5, 5, 5);
 
         for stream_id in [8, 12, 4] {
             assert!(is_local(stream_id, false), "stream id is client initiated");
@@ -1845,7 +1737,7 @@ mod tests {
         let local_tp = crate::TransportParams::default();
         let peer_tp = crate::TransportParams::default();
 
-        let mut streams = StreamMap::new(3, 3, 3);
+        let mut streams = <StreamMap>::new(3, 3, 3);
 
         // Highest permitted
         let stream_id = 8;
@@ -1948,7 +1840,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut streams = StreamMap::new(100, 100, 100);
+        let mut streams = <StreamMap>::new(100, 100, 100);
 
         // Streams where the urgency descends (becomes more important). No stream
         // shares an urgency.

--- a/quiche/src/stream/recv_buf.rs
+++ b/quiche/src/stream/recv_buf.rs
@@ -35,7 +35,8 @@ use crate::Result;
 
 use crate::flowcontrol;
 
-use super::RangeBuf;
+use crate::range_buf::RangeBuf;
+
 use super::DEFAULT_STREAM_WINDOW;
 
 /// Receive-side stream buffer.

--- a/quiche/src/stream/send_buf.rs
+++ b/quiche/src/stream/send_buf.rs
@@ -28,12 +28,13 @@ use std::cmp;
 
 use std::collections::VecDeque;
 
+use crate::range_buf::RangeBuf;
+use crate::BufFactory;
 use crate::Error;
 use crate::Result;
 
+use crate::range_buf::DefaultBufFactory;
 use crate::ranges;
-
-use super::RangeBuf;
 
 #[cfg(test)]
 const SEND_BUFFER_SIZE: usize = 5;
@@ -51,9 +52,12 @@ const SEND_BUFFER_SIZE: usize = 4096;
 /// inserted at the start of the buffer (this is to allow data that needs to be
 /// retransmitted to be re-buffered).
 #[derive(Debug, Default)]
-pub struct SendBuf {
+pub struct SendBuf<F = DefaultBufFactory>
+where
+    F: BufFactory,
+{
     /// Chunks of data to be sent, ordered by offset.
-    data: VecDeque<RangeBuf>,
+    data: VecDeque<RangeBuf<F>>,
 
     /// The index of the buffer that needs to be sent next.
     pos: usize,
@@ -87,9 +91,9 @@ pub struct SendBuf {
     error: Option<u64>,
 }
 
-impl SendBuf {
+impl<F: BufFactory> SendBuf<F> {
     /// Creates a new send buffer.
-    pub fn new(max_data: u64) -> SendBuf {
+    pub fn new(max_data: u64) -> SendBuf<F> {
         SendBuf {
             max_data,
             ..SendBuf::default()
@@ -489,7 +493,7 @@ mod tests {
     fn empty_write() {
         let mut buf = [0; 5];
 
-        let mut send = SendBuf::new(u64::MAX);
+        let mut send = <SendBuf>::new(u64::MAX);
         assert_eq!(send.len, 0);
 
         let (written, fin) = send.emit(&mut buf).unwrap();
@@ -501,7 +505,7 @@ mod tests {
     fn multi_write() {
         let mut buf = [0; 128];
 
-        let mut send = SendBuf::new(u64::MAX);
+        let mut send = <SendBuf>::new(u64::MAX);
         assert_eq!(send.len, 0);
 
         let first = b"something";
@@ -524,7 +528,7 @@ mod tests {
     fn split_write() {
         let mut buf = [0; 10];
 
-        let mut send = SendBuf::new(u64::MAX);
+        let mut send = <SendBuf>::new(u64::MAX);
         assert_eq!(send.len, 0);
 
         let first = b"something";
@@ -567,7 +571,7 @@ mod tests {
     fn resend() {
         let mut buf = [0; 15];
 
-        let mut send = SendBuf::new(u64::MAX);
+        let mut send = <SendBuf>::new(u64::MAX);
         assert_eq!(send.len, 0);
         assert_eq!(send.off_front(), 0);
 
@@ -630,7 +634,7 @@ mod tests {
     fn write_blocked_by_off() {
         let mut buf = [0; 10];
 
-        let mut send = SendBuf::default();
+        let mut send = <SendBuf>::default();
         assert_eq!(send.len, 0);
 
         let first = b"something";
@@ -700,7 +704,7 @@ mod tests {
     fn zero_len_write() {
         let mut buf = [0; 10];
 
-        let mut send = SendBuf::new(u64::MAX);
+        let mut send = <SendBuf>::new(u64::MAX);
         assert_eq!(send.len, 0);
 
         let first = b"something";
@@ -725,7 +729,7 @@ mod tests {
     fn send_buf_len_on_retransmit() {
         let mut buf = [0; 15];
 
-        let mut send = SendBuf::new(u64::MAX);
+        let mut send = <SendBuf>::new(u64::MAX);
         assert_eq!(send.len, 0);
         assert_eq!(send.off_front(), 0);
 
@@ -751,7 +755,7 @@ mod tests {
     #[test]
     fn send_buf_final_size_retransmit() {
         let mut buf = [0; 50];
-        let mut send = SendBuf::new(u64::MAX);
+        let mut send = <SendBuf>::new(u64::MAX);
 
         send.write(&buf, false).unwrap();
         assert_eq!(send.off_front(), 0);


### PR DESCRIPTION
A BufFactory can override the generic buffer generation method with a custom method, eg. getting a buffer from a pool buffer.