### PR TITLE
Add an inline version of RangeSet

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -54,6 +54,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 cmake = "0.1"
 
 [dependencies]
+either = { version = "1.8", default-features = false }
 log = { version = "0.4", features = ["std"] }
 libc = "0.2"
 libm = "0.2"


### PR DESCRIPTION
Currently the RangeSet is always backed by a BTreeMap, and the map is allocated every Ack packet. This change is not unlike SmallVec for Vec, where instead of allocating, a limited number of ranges can be stored inline. Because in practice Ack packets will rarely ack more than one or two ranges, this avoids a significant number of allocations.

RangeSet is also used by the SendBuf to track the numbers of acked packets. Although in this use case allocations are already rare, with inline RangeSet the insertion operation is now also significantly faster.