### PR TITLE
WIP: add edge-triggered variant of StreamIter APIs

### DIFF
--- a/nginx/nginx-1.16.patch
+++ b/nginx/nginx-1.16.patch
@@ -1935,7 +1935,7 @@ index 000000000..1a05d4e01
 +    ngx_http_v3_stream_t      *stream;
 +    uint64_t                   stream_id;
 +
-+    writable = quiche_conn_writable(h3c->connection->quic->conn);
++    writable = quiche_conn_writable_drain(h3c->connection->quic->conn);
 +
 +    while (quiche_stream_iter_next(writable, &stream_id)) {
 +        stream = ngx_http_v3_stream_lookup(h3c, stream_id);

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -374,8 +374,14 @@ typedef struct quiche_stream_iter quiche_stream_iter;
 // Returns an iterator over streams that have outstanding data to read.
 quiche_stream_iter *quiche_conn_readable(const quiche_conn *conn);
 
+// Returns an iterator over streams that have outstanding data to read.
+quiche_stream_iter *quiche_conn_readable_drain(quiche_conn *conn);
+
 // Returns an iterator over streams that can be written to.
 quiche_stream_iter *quiche_conn_writable(const quiche_conn *conn);
+
+// Returns an iterator over streams that can be written to.
+quiche_stream_iter *quiche_conn_writable_drain(quiche_conn *conn);
 
 // Returns the maximum possible size of egress UDP payloads.
 size_t quiche_conn_max_send_udp_payload_size(const quiche_conn *conn);

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -858,8 +858,22 @@ pub extern fn quiche_conn_readable(conn: &Connection) -> *mut StreamIter {
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_readable_drain(
+    conn: &mut Connection,
+) -> *mut StreamIter {
+    Box::into_raw(Box::new(conn.readable_drain()))
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_writable(conn: &Connection) -> *mut StreamIter {
     Box::into_raw(Box::new(conn.writable()))
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_writable_drain(
+    conn: &mut Connection,
+) -> *mut StreamIter {
+    Box::into_raw(Box::new(conn.writable_drain()))
 }
 
 #[no_mangle]

--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -549,9 +549,21 @@ impl StreamMap {
         StreamIter::from(&self.readable)
     }
 
+    /// Creates an iterator over streams that have outstanding data to read, and
+    /// clears the readable streams set.
+    pub fn readable_drain(&mut self) -> StreamIter {
+        StreamIter::drain(&mut self.readable)
+    }
+
     /// Creates an iterator over streams that can be written to.
     pub fn writable(&self) -> StreamIter {
         StreamIter::from(&self.writable)
+    }
+
+    /// Creates an iterator over streams that can be written to, and clears the
+    /// writable streams set.
+    pub fn writable_drain(&mut self) -> StreamIter {
+        StreamIter::drain(&mut self.writable)
     }
 
     /// Creates an iterator over streams that need to send MAX_STREAM_DATA.
@@ -746,6 +758,13 @@ impl StreamIter {
     fn from(streams: &StreamIdHashSet) -> Self {
         StreamIter {
             streams: streams.iter().copied().collect(),
+        }
+    }
+
+    #[inline]
+    fn drain(streams: &mut StreamIdHashSet) -> Self {
+        StreamIter {
+            streams: streams.drain().collect(),
         }
     }
 }


### PR DESCRIPTION
Instead of simply cloning the list of streams, the `*_drain()` APIs will also drain the internal lists, so that streams are only reported once each time they become flushable/writable/readable/...