### PR TITLE
implement edge-triggered stream pseudo-iterators

### DIFF
--- a/nginx/nginx-1.16.patch
+++ b/nginx/nginx-1.16.patch
@@ -1618,7 +1618,7 @@ new file mode 100644
 index 000000000..1a05d4e01
 --- /dev/null
 +++ b/src/http/v3/ngx_http_v3.c
-@@ -0,0 +1,2234 @@
+@@ -0,0 +1,2230 @@
 +
 +/*
 + * Copyright (C) Cloudflare, Inc.
@@ -1931,13 +1931,11 @@ index 000000000..1a05d4e01
 +ngx_http_v3_process_blocked_streams(ngx_http_v3_connection_t *h3c)
 +{
 +    ngx_event_t               *wev;
-+    quiche_stream_iter        *writable;
 +    ngx_http_v3_stream_t      *stream;
-+    uint64_t                   stream_id;
++    ngx_quic_connection_t     *quic = h3c->connection->quic;
++    int64_t                    stream_id;
 +
-+    writable = quiche_conn_writable(h3c->connection->quic->conn);
-+
-+    while (quiche_stream_iter_next(writable, &stream_id)) {
++    while ((stream_id = quiche_conn_stream_writable_next(quic->conn)) >= 0) {
 +        stream = ngx_http_v3_stream_lookup(h3c, stream_id);
 +
 +        if (stream == NULL) {
@@ -1966,8 +1964,6 @@ index 000000000..1a05d4e01
 +            wev->handler(wev);
 +        }
 +    }
-+
-+    quiche_stream_iter_free(writable);
 +}
 +
 +

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -361,10 +361,18 @@ ssize_t quiche_conn_stream_capacity(const quiche_conn *conn, uint64_t stream_id)
 // Returns true if the stream has data that can be read.
 bool quiche_conn_stream_readable(const quiche_conn *conn, uint64_t stream_id);
 
+// Returns the next stream that has data to read, or -1 if no such stream is
+// available.
+int64_t quiche_conn_stream_readable_next(quiche_conn *conn);
+
 // Returns true if the stream has enough send capacity.
 //
 // On error a value lower than 0 is returned.
 int quiche_conn_stream_writable(quiche_conn *conn, uint64_t stream_id, size_t len);
+
+// Returns the next stream that can be written to, or -1 if no such stream is
+// available.
+int64_t quiche_conn_stream_writable_next(quiche_conn *conn);
 
 // Returns true if all the data has been read from the specified stream.
 bool quiche_conn_stream_finished(const quiche_conn *conn, uint64_t stream_id);

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -833,6 +833,11 @@ pub extern fn quiche_conn_stream_readable(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_stream_readable_next(conn: &mut Connection) -> i64 {
+    conn.stream_readable_next().map(|v| v as i64).unwrap_or(-1)
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_stream_writable(
     conn: &mut Connection, stream_id: u64, len: usize,
 ) -> c_int {
@@ -843,6 +848,11 @@ pub extern fn quiche_conn_stream_writable(
 
         Err(e) => e.to_c() as c_int,
     }
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_stream_writable_next(conn: &mut Connection) -> i64 {
+    conn.stream_writable_next().map(|v| v as i64).unwrap_or(-1)
 }
 
 #[no_mangle]


### PR DESCRIPTION
Instead of cloning and returning a list of readable/writable streams, the new `stream_readable_next()` and `stream_writable_next()` return the first stream in the corresponding readable or writable queue, and remove it from said queue.

The end result is that each stream is only reported once, rather than being continuously reported until it becomes unreadable or unwritable, and as a consequence, applications will need to track partial read or written streams on their own.

In addition, a "low send watermark" is implemented through the existing `stream_writable()` method. When calling `stream_writable()`, if the stream doesn't at that time have enough capacity for the specified amount of bytes (i.e. `Ok(false)` is returned), then that stream will only be marked as writable again once its capacity grows enough to accomodate the amount of bytes requested.

This can be used in conjuction with `stream_writable_next()` to prevent streams from constantly being reported as writable, even though they don't have enough useful capacity. This is done automatically by the HTTP/3 implementation for example to ensure that request streams aren't constantly reported as writable until they have enough capacity for sending a HEADERS frame atomically.