### PR TITLE
quic: don't optimistically bundle ACK when ack-eliciting required

### DIFF
--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -74,7 +74,7 @@ const PACING_MULTIPLIER: f64 = 1.25;
 
 // How many non ACK eliciting packets we send before including a PING to solicit
 // an ACK.
-const MAX_OUTSTANDING_NON_ACK_ELICITING: usize = 24;
+pub(super) const MAX_OUTSTANDING_NON_ACK_ELICITING: usize = 24;
 
 pub struct Recovery {
     loss_detection_timer: Option<Instant>,


### PR DESCRIPTION
MAX_OUTSTANDING_NON_ACK_ELICITING was introduced to avoid the sent queue from getting too large and to solicit additional RTT samples. As part of that change, we optimistically bundled an ACK frame if we intended on including a PING if no other ACK-eliciting frame was included in the packet. This was "optimistic" because there was no check for whether or not the congestion window would be too full for the PING frame.

When ACK-only packets that ignore congestion window were introduced, the MAX_OUTSTANDING_NON_ACK_ELICITING case wasn't covered. If the number of outstanding non-ack-eliciting packets exceeded the maximum and the congestion window was full, the connection would produce ACK-only packets whenever `Connection::send` was called. If `Connection::send` is called until it returns `Error::Done`, it will be called forever. This may lead to packet send surges, massive sent queues, or even an infinite loop depending on the application.

#1312 and #1385 