### PR TITLE
h3: better estimate QPACK encoded output size

### DIFF
--- a/fuzz/src/qpack_decode.rs
+++ b/fuzz/src/qpack_decode.rs
@@ -20,9 +20,14 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
         Ok(hdrs) => hdrs,
     };
+    let lookups: Vec<quiche::h3::qpack::encoder::StaticLookup> = hdrs
+        .iter()
+        .map(|h| quiche::h3::qpack::encoder::lookup_static(h))
+        .collect();
 
     let mut encoded_hdrs = vec![0; data.len() * 10 + 1000];
-    let encoded_size = encoder.encode(&hdrs, &mut encoded_hdrs).unwrap();
+    let encoded_size =
+        encoder.encode(&hdrs, &lookups, &mut encoded_hdrs).unwrap();
 
     let decoded_hdrs = decoder
         .decode(&encoded_hdrs[..encoded_size], std::u64::MAX)


### PR DESCRIPTION
The HTTP/3 and QPACK encoding process relies the HTTP/3 layer creating
an output buffer and passing this to the QPACK layer for it to encode
into. Previously, the calculation of the buffer size used a simple
approach for estimating the correct size of the buffer. In some cases
this estimate could be wrong, for instance when Huffman-encoding a
literal value in the low or extended ASCII ranges. This could lead to an
underestimation of the buffer size, which cause the QPACK encode to fail
leading to an h3::InternalError that would bubble up to an application
attempting to send requests or responses.

With this change, we move the check of a header's static representation
type earlier in the encode process, and use the type to provide a better
estimate of the required buffer sizes. The additional upshot is that
fully-indexed types (where the name and value are both in the static table)
require less storage and we no longer over estimate.
