### PR TITLE
qpack: when huffman inflates use raw literals

### DIFF
--- a/quiche/src/h3/qpack/huffman/mod.rs
+++ b/quiche/src/h3/qpack/huffman/mod.rs
@@ -101,6 +101,10 @@ pub fn encode_output_length(src: &[u8], low: bool) -> Result<usize> {
         len += 1;
     }
 
+    if len > src.len() {
+        return Err(Error::InflatedHuffmanEncoding);
+    }
+
     Ok(len)
 }
 


### PR DESCRIPTION
Huffman encoding is optimised for the regular ASCII range that HTTP
field values use. Characters in the lower or extended ASCII ranges can
use more bits via huffman than they might normally do otherwise.

The HTTP/3 layer estimates a generous buffer size for qpack encoding
based on name and value lengths. However, prior to this change,
certain combinations of characters could result in length inflation
beyond that which could bit in the reserved buffer. In turn, that would
cause the QPACK encode to fail and bubble up an h3::InternalError
to an application attempting to send requests or responses.

With this change, we add an early check the of huffman encoding
length prediction. If that huffman would produce a string larger
than the the literal unencoded string, we simply just use the raw
string. Because this check is done in the QPACK layer, which is less
opinionated about valid characters than true HTTP, we run the check for
both field names and values.