### PR TITLE
stream: delete unreachable logic

### DIFF
--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -845,12 +845,6 @@ impl RecvBuf {
             return Ok(());
         }
 
-        // No need to process an empty buffer with the fin flag, if we already
-        // know the final size.
-        if buf.fin() && buf.is_empty() && self.fin_off.is_some() {
-            return Ok(());
-        }
-
         if buf.fin() {
             self.fin_off = Some(buf.max_off());
         }


### PR DESCRIPTION
if buf.fin() && buf.is_empty() && self.fin_off.is_some() true, then self.fin_off.is_some() && buf.is_empty() MUST be true, which means that we should return Ok(()) before this command.