### PR TITLE
ranges: simplify removing first element of list

### DIFF
--- a/quiche/src/ranges.rs
+++ b/quiche/src/ranges.rs
@@ -82,9 +82,7 @@ impl RangeSet {
         }
 
         if self.inner.len() >= self.capacity {
-            if let Some(first) = self.inner.keys().next().copied() {
-                self.inner.remove(&first);
-            }
+            self.inner.pop_first();
         }
 
         self.inner.insert(start, end);


### PR DESCRIPTION
This API used to require an unstable feature, but it's now been stabilized.