### PR TITLE
github: bump Android NDK version

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -288,7 +288,7 @@ jobs:
   android_ndk_lts:
     runs-on: ubuntu-latest
     env:
-      NDK_LTS_VER: "21"
+      NDK_LTS_VER: "23"
     strategy:
       matrix:
         target: ["aarch64-linux-android","armv7-linux-androideabi","x86_64-linux-android","i686-linux-android"]


### PR DESCRIPTION
This is now required to use Rust 1.68 and above:
https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html