### PR TITLE
make path and cid maps infallible

### DIFF
--- a/quiche/src/cid.rs
+++ b/quiche/src/cid.rs
@@ -326,15 +326,15 @@ impl ConnectionIdentifiers {
     /// Gets the destination Connection ID associated with the provided sequence
     /// number.
     #[inline]
-    pub fn get_dcid(&self, seq_num: u64) -> Result<&ConnectionIdEntry> {
-        self.dcids.get(seq_num).ok_or(Error::InvalidState)
+    pub fn get_dcid(&self, seq_num: u64) -> Option<&ConnectionIdEntry> {
+        self.dcids.get(seq_num)
     }
 
     /// Gets the source Connection ID associated with the provided sequence
     /// number.
     #[inline]
-    pub fn get_scid(&self, seq_num: u64) -> Result<&ConnectionIdEntry> {
-        self.scids.get(seq_num).ok_or(Error::InvalidState)
+    pub fn get_scid(&self, seq_num: u64) -> Option<&ConnectionIdEntry> {
+        self.scids.get(seq_num)
     }
 
     /// Adds a new source identifier, and indicates whether it should be

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -531,24 +531,16 @@ impl PathMap {
         }
     }
 
-    /// Gets an immutable reference to the path identified by `path_id`. If the
-    /// provided `path_id` does not identify any current `Path`, returns an
-    /// [`InvalidState`].
-    ///
-    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    /// Gets an immutable reference to the path identified by `path_id`.
     #[inline]
-    pub fn get(&self, path_id: usize) -> Result<&Path> {
-        self.paths.get(path_id).ok_or(Error::InvalidState)
+    pub fn get(&self, path_id: usize) -> Option<&Path> {
+        self.paths.get(path_id)
     }
 
-    /// Gets a mutable reference to the path identified by `path_id`. If the
-    /// provided `path_id` does not identify any current `Path`, returns an
-    /// [`InvalidState`].
-    ///
-    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    /// Gets a mutable reference to the path identified by `path_id`.
     #[inline]
-    pub fn get_mut(&mut self, path_id: usize) -> Result<&mut Path> {
-        self.paths.get_mut(path_id).ok_or(Error::InvalidState)
+    pub fn get_mut(&mut self, path_id: usize) -> Option<&mut Path> {
+        self.paths.get_mut(path_id)
     }
 
     #[inline]
@@ -559,38 +551,22 @@ impl PathMap {
     }
 
     /// Gets an immutable reference to the active path with the lowest
-    /// identifier. If there is no active path, returns an [`InvalidState`].
-    ///
-    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    /// identifier.
     #[inline]
-    pub fn get_active(&self) -> Result<&Path> {
-        self.get_active_with_pid()
-            .map(|(_, p)| p)
-            .ok_or(Error::InvalidState)
+    pub fn get_active(&self) -> Option<&Path> {
+        self.get_active_with_pid().map(|(_, p)| p)
     }
 
-    /// Gets the lowest active path identifier. If there is no active path,
-    /// returns an [`InvalidState`].
-    ///
-    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    /// Gets the lowest active path identifier
     #[inline]
-    pub fn get_active_path_id(&self) -> Result<usize> {
-        self.get_active_with_pid()
-            .map(|(pid, _)| pid)
-            .ok_or(Error::InvalidState)
+    pub fn get_active_path_id(&self) -> Option<usize> {
+        self.get_active_with_pid().map(|(pid, _)| pid)
     }
 
     /// Gets an mutable reference to the active path with the lowest identifier.
-    /// If there is no active path, returns an [`InvalidState`].
-    ///
-    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
     #[inline]
-    pub fn get_active_mut(&mut self) -> Result<&mut Path> {
-        self.paths
-            .iter_mut()
-            .map(|(_, p)| p)
-            .find(|p| p.active())
-            .ok_or(Error::InvalidState)
+    pub fn get_active_mut(&mut self) -> Option<&mut Path> {
+        self.paths.iter_mut().map(|(_, p)| p).find(|p| p.active())
     }
 
     /// Returns an iterator over all existing paths.
@@ -709,7 +685,7 @@ impl PathMap {
 
     /// Handles incoming PATH_RESPONSE data.
     pub fn on_response_received(&mut self, data: [u8; 8]) -> Result<()> {
-        let active_pid = self.get_active_path_id()?;
+        let active_pid = self.get_active_path_id().ok_or(Error::InvalidState)?;
 
         let challenge_pending =
             self.iter_mut().find(|(_, p)| p.has_pending_challenge(data));
@@ -750,11 +726,11 @@ impl PathMap {
     pub fn set_active_path(&mut self, path_id: usize) -> Result<()> {
         let is_server = self.is_server;
 
-        if let Ok(old_active_path) = self.get_active_mut() {
+        if let Some(old_active_path) = self.get_active_mut() {
             old_active_path.active = false;
         }
 
-        let new_active_path = self.get_mut(path_id)?;
+        let new_active_path = self.get_mut(path_id).ok_or(Error::InvalidState)?;
         new_active_path.active = true;
 
         if is_server {
@@ -780,7 +756,8 @@ impl PathMap {
     pub fn on_peer_migrated(
         &mut self, new_pid: usize, disable_dcid_reuse: bool,
     ) -> Result<()> {
-        let active_path_id = self.get_active_path_id()?;
+        let active_path_id =
+            self.get_active_path_id().ok_or(Error::InvalidState)?;
 
         if active_path_id == new_pid {
             return Ok(());
@@ -788,11 +765,19 @@ impl PathMap {
 
         self.set_active_path(new_pid)?;
 
-        let no_spare_dcid = self.get_mut(new_pid)?.active_dcid_seq.is_none();
+        let no_spare_dcid = self
+            .get_mut(new_pid)
+            .ok_or(Error::InvalidState)?
+            .active_dcid_seq
+            .is_none();
 
         if no_spare_dcid && !disable_dcid_reuse {
-            self.get_mut(new_pid)?.active_dcid_seq =
-                self.get_mut(active_path_id)?.active_dcid_seq;
+            self.get_mut(new_pid)
+                .ok_or(Error::InvalidState)?
+                .active_dcid_seq = self
+                .get_mut(active_path_id)
+                .ok_or(Error::InvalidState)?
+                .active_dcid_seq;
         }
 
         Ok(())


### PR DESCRIPTION
No functional change. Changes path and cid maps to return Option instead of Result with InvalidState. This is more consistent with the streams map, pushes the error case higher up in the call stack, and better reflects what is being returned. For cases where you want to simply check the existence of a path or cid, an Option is more natural because there are only two variants: Some or None. When a Result is returned, any error _could_ be returned. While in most instances, doc comments indicate that the only Error is InvalidState, this seems like an unnecessary mental burden.