### PR TITLE
replace deprecated number constants by built-in primitive type constants

### DIFF
--- a/fuzz/src/qpack_decode.rs
+++ b/fuzz/src/qpack_decode.rs
@@ -16,7 +16,7 @@ fuzz_target!(|data: &[u8]| {
     let mut decoder = quiche::h3::qpack::Decoder::new();
     let mut encoder = quiche::h3::qpack::Encoder::new();
 
-    let hdrs = match decoder.decode(&mut data.to_vec(), std::u64::MAX) {
+    let hdrs = match decoder.decode(&mut data.to_vec(), u64::MAX) {
         Err(_) => return,
         Ok(hdrs) => hdrs,
     };
@@ -25,7 +25,7 @@ fuzz_target!(|data: &[u8]| {
     let encoded_size = encoder.encode(&hdrs, &mut encoded_hdrs).unwrap();
 
     let decoded_hdrs = decoder
-        .decode(&encoded_hdrs[..encoded_size], std::u64::MAX)
+        .decode(&encoded_hdrs[..encoded_size], u64::MAX)
         .unwrap();
 
     let mut expected_hdrs = Vec::new();

--- a/octets/src/lib.rs
+++ b/octets/src/lib.rs
@@ -1023,7 +1023,7 @@ mod tests {
     fn varint_too_large() {
         let mut d = [0; 3];
         let mut b = OctetsMut::with_slice(&mut d);
-        assert!(b.put_varint(std::u64::MAX).is_err());
+        assert!(b.put_varint(u64::MAX).is_err());
     }
 
     #[test]

--- a/quiche/examples/qpack-decode.rs
+++ b/quiche/examples/qpack-decode.rs
@@ -76,7 +76,7 @@ fn main() {
             continue;
         }
 
-        for hdr in dec.decode(&data[..len], std::u64::MAX).unwrap() {
+        for hdr in dec.decode(&data[..len], u64::MAX).unwrap() {
             let name = std::str::from_utf8(hdr.name()).unwrap();
             let value = std::str::from_utf8(hdr.value()).unwrap();
             println!("{name}\t{value}");

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -927,7 +927,7 @@ pub extern fn quiche_conn_timeout_as_nanos(conn: &Connection) -> u64 {
     match conn.timeout() {
         Some(timeout) => timeout.as_nanos() as u64,
 
-        None => std::u64::MAX,
+        None => u64::MAX,
     }
 }
 
@@ -936,7 +936,7 @@ pub extern fn quiche_conn_timeout_as_millis(conn: &Connection) -> u64 {
     match conn.timeout() {
         Some(timeout) => timeout.as_millis() as u64,
 
-        None => std::u64::MAX,
+        None => u64::MAX,
     }
 }
 

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -2527,7 +2527,7 @@ impl Connection {
                 let max_size = self
                     .local_settings
                     .max_field_section_size
-                    .unwrap_or(std::u64::MAX);
+                    .unwrap_or(u64::MAX);
 
                 let headers = match self
                     .qpack_decoder

--- a/quiche/src/h3/qpack/mod.rs
+++ b/quiche/src/h3/qpack/mod.rs
@@ -105,7 +105,7 @@ mod tests {
         assert_eq!(enc.encode(&headers, &mut encoded), Ok(240));
 
         let mut dec = Decoder::new();
-        assert_eq!(dec.decode(&mut encoded, std::u64::MAX), Ok(headers));
+        assert_eq!(dec.decode(&mut encoded, u64::MAX), Ok(headers));
     }
 
     #[test]
@@ -133,7 +133,7 @@ mod tests {
         assert_eq!(enc.encode(&headers_in, &mut encoded), Ok(35));
 
         let mut dec = Decoder::new();
-        let headers_out = dec.decode(&mut encoded, std::u64::MAX).unwrap();
+        let headers_out = dec.decode(&mut encoded, u64::MAX).unwrap();
 
         assert_eq!(headers_expected, headers_out);
 
@@ -150,7 +150,7 @@ mod tests {
         assert_eq!(enc.encode(&headers_in, &mut encoded), Ok(35));
 
         let mut dec = Decoder::new();
-        let headers_out = dec.decode(&mut encoded, std::u64::MAX).unwrap();
+        let headers_out = dec.decode(&mut encoded, u64::MAX).unwrap();
 
         assert_eq!(headers_expected, headers_out);
     }

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -556,11 +556,11 @@ impl<'a> std::fmt::Debug for Header<'a> {
 }
 
 pub fn pkt_num_len(pn: u64) -> Result<usize> {
-    let len = if pn < u64::from(std::u8::MAX) {
+    let len = if pn < u64::from(u8::MAX) {
         1
-    } else if pn < u64::from(std::u16::MAX) {
+    } else if pn < u64::from(u16::MAX) {
         2
-    } else if pn < u64::from(std::u32::MAX) {
+    } else if pn < u64::from(u32::MAX) {
         4
     } else {
         return Err(Error::InvalidPacket);
@@ -907,8 +907,8 @@ impl PktNumSpace {
             crypto_0rtt_seal: None,
 
             crypto_stream: stream::Stream::new(
-                std::u64::MAX,
-                std::u64::MAX,
+                u64::MAX,
+                u64::MAX,
                 true,
                 true,
                 stream::MAX_STREAM_WINDOW,
@@ -918,8 +918,8 @@ impl PktNumSpace {
 
     pub fn clear(&mut self) {
         self.crypto_stream = stream::Stream::new(
-            std::u64::MAX,
-            std::u64::MAX,
+            u64::MAX,
+            u64::MAX,
             true,
             true,
             stream::MAX_STREAM_WINDOW,
@@ -1262,7 +1262,7 @@ mod tests {
         assert!(!win.contains(1025));
         assert!(!win.contains(1026));
 
-        win.insert(std::u64::MAX - 1);
+        win.insert(u64::MAX - 1);
         assert!(win.contains(0));
         assert!(win.contains(1));
         assert!(win.contains(2));
@@ -1284,8 +1284,8 @@ mod tests {
         assert!(win.contains(1024));
         assert!(win.contains(1025));
         assert!(win.contains(1026));
-        assert!(!win.contains(std::u64::MAX - 2));
-        assert!(win.contains(std::u64::MAX - 1));
+        assert!(!win.contains(u64::MAX - 2));
+        assert!(win.contains(u64::MAX - 1));
     }
 
     fn assert_decrypt_initial_pkt(

--- a/quiche/src/ranges.rs
+++ b/quiche/src/ranges.rs
@@ -152,7 +152,7 @@ impl RangeSet {
 
 impl Default for RangeSet {
     fn default() -> Self {
-        Self::new(std::usize::MAX)
+        Self::new(usize::MAX)
     }
 }
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -202,7 +202,7 @@ impl Recovery {
 
             time_of_last_sent_ack_eliciting_pkt: [None; packet::Epoch::count()],
 
-            largest_acked_pkt: [std::u64::MAX; packet::Epoch::count()],
+            largest_acked_pkt: [u64::MAX; packet::Epoch::count()],
 
             largest_sent_pkt: [0; packet::Epoch::count()],
 
@@ -245,7 +245,7 @@ impl Recovery {
 
             bytes_in_flight: 0,
 
-            ssthresh: std::usize::MAX,
+            ssthresh: usize::MAX,
 
             bytes_acked_sl: 0,
 
@@ -301,7 +301,7 @@ impl Recovery {
         self.congestion_window = self.max_datagram_size * INITIAL_WINDOW_PACKETS;
         self.in_flight_count = [0; packet::Epoch::count()];
         self.congestion_recovery_start_time = None;
-        self.ssthresh = std::usize::MAX;
+        self.ssthresh = usize::MAX;
         (self.cc_ops.reset)(self);
         self.hystart.reset();
         self.prr = prr::PRR::default();
@@ -430,7 +430,7 @@ impl Recovery {
         // a validating path, then receives an acknowledgment for that packet on
         // the active one.
 
-        if self.largest_acked_pkt[epoch] == std::u64::MAX {
+        if self.largest_acked_pkt[epoch] == u64::MAX {
             self.largest_acked_pkt[epoch] = largest_acked;
         } else {
             self.largest_acked_pkt[epoch] =
@@ -676,7 +676,7 @@ impl Recovery {
     pub fn cwnd_available(&self) -> usize {
         // Ignore cwnd when sending probe packets.
         if self.loss_probes.iter().any(|&x| x > 0) {
-            return std::usize::MAX;
+            return usize::MAX;
         }
 
         // Open more space (snd_cnt) for PRR when allowed.

--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -1662,7 +1662,7 @@ mod tests {
 
     #[test]
     fn empty_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1728,7 +1728,7 @@ mod tests {
 
     #[test]
     fn ordered_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1765,7 +1765,7 @@ mod tests {
 
     #[test]
     fn split_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1805,7 +1805,7 @@ mod tests {
 
     #[test]
     fn incomplete_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1833,7 +1833,7 @@ mod tests {
 
     #[test]
     fn zero_len_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1861,7 +1861,7 @@ mod tests {
 
     #[test]
     fn past_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1900,7 +1900,7 @@ mod tests {
 
     #[test]
     fn fully_overlapping_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1931,7 +1931,7 @@ mod tests {
 
     #[test]
     fn fully_overlapping_read2() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1962,7 +1962,7 @@ mod tests {
 
     #[test]
     fn fully_overlapping_read3() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -1993,7 +1993,7 @@ mod tests {
 
     #[test]
     fn fully_overlapping_read_multi() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -2030,7 +2030,7 @@ mod tests {
 
     #[test]
     fn overlapping_start_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -2060,7 +2060,7 @@ mod tests {
 
     #[test]
     fn overlapping_end_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -2090,7 +2090,7 @@ mod tests {
 
     #[test]
     fn overlapping_end_twice_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -2132,7 +2132,7 @@ mod tests {
 
     #[test]
     fn overlapping_end_twice_and_contained_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -2174,7 +2174,7 @@ mod tests {
 
     #[test]
     fn partially_multi_overlapping_reordered_read() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -2211,7 +2211,7 @@ mod tests {
 
     #[test]
     fn partially_multi_overlapping_reordered_read2() {
-        let mut recv = RecvBuf::new(std::u64::MAX, DEFAULT_STREAM_WINDOW);
+        let mut recv = RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW);
         assert_eq!(recv.len, 0);
 
         let mut buf = [0; 32];
@@ -2268,7 +2268,7 @@ mod tests {
     fn empty_write() {
         let mut buf = [0; 5];
 
-        let mut send = SendBuf::new(std::u64::MAX);
+        let mut send = SendBuf::new(u64::MAX);
         assert_eq!(send.len, 0);
 
         let (written, fin) = send.emit(&mut buf).unwrap();
@@ -2280,7 +2280,7 @@ mod tests {
     fn multi_write() {
         let mut buf = [0; 128];
 
-        let mut send = SendBuf::new(std::u64::MAX);
+        let mut send = SendBuf::new(u64::MAX);
         assert_eq!(send.len, 0);
 
         let first = b"something";
@@ -2303,7 +2303,7 @@ mod tests {
     fn split_write() {
         let mut buf = [0; 10];
 
-        let mut send = SendBuf::new(std::u64::MAX);
+        let mut send = SendBuf::new(u64::MAX);
         assert_eq!(send.len, 0);
 
         let first = b"something";
@@ -2346,7 +2346,7 @@ mod tests {
     fn resend() {
         let mut buf = [0; 15];
 
-        let mut send = SendBuf::new(std::u64::MAX);
+        let mut send = SendBuf::new(u64::MAX);
         assert_eq!(send.len, 0);
         assert_eq!(send.off_front(), 0);
 
@@ -2479,7 +2479,7 @@ mod tests {
     fn zero_len_write() {
         let mut buf = [0; 10];
 
-        let mut send = SendBuf::new(std::u64::MAX);
+        let mut send = SendBuf::new(u64::MAX);
         assert_eq!(send.len, 0);
 
         let first = b"something";
@@ -3338,7 +3338,7 @@ mod tests {
     fn send_buf_len_on_retransmit() {
         let mut buf = [0; 15];
 
-        let mut send = SendBuf::new(std::u64::MAX);
+        let mut send = SendBuf::new(u64::MAX);
         assert_eq!(send.len, 0);
         assert_eq!(send.off_front(), 0);
 


### PR DESCRIPTION
[std::u8](https://doc.rust-lang.org/stable/std/u8/index.html) has been deprecated in the standard library, as have [std::u16](https://doc.rust-lang.org/stable/std/u16/index.html), [std::u32](https://doc.rust-lang.org/stable/std/u32/index.html), [std::u64](https://doc.rust-lang.org/stable/std/u64/index.html), [std::usize](https://doc.rust-lang.org/stable/std/usize/index.html), etc. So I replaced these deprecated constants by built-in primitive type constants. Then these are all I can find, please add if there is something missing.