### PR TITLE
apps: add option to disable pacing on the server

### DIFF
--- a/apps/run_endpoint.sh
+++ b/apps/run_endpoint.sh
@@ -16,7 +16,7 @@ QUICHE_CLIENT=quiche-client
 QUICHE_SERVER=quiche-server
 QUICHE_CLIENT_OPT="--no-verify --dump-responses ${DOWNLOAD_DIR} --wire-version 00000001"
 # interop container has tso off. need to disable gso as well.
-QUICHE_SERVER_OPT_COMMON="--listen [::]:443 --root $WWW_DIR --cert /certs/cert.pem --key /certs/priv.key --disable-gso"
+QUICHE_SERVER_OPT_COMMON="--listen [::]:443 --root $WWW_DIR --cert /certs/cert.pem --key /certs/priv.key --disable-gso --disable-pacing"
 QUICHE_SERVER_OPT="$QUICHE_SERVER_OPT_COMMON --no-retry "
 LOG_DIR=/logs
 LOG=$LOG_DIR/log.txt

--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -444,6 +444,7 @@ Options:
   --qpack-max-table-capacity BYTES  Max capacity of QPACK dynamic table decoding. Any value other that 0 is currently unsupported.
   --qpack-blocked-streams STREAMS   Limit of streams that can be blocked while decoding. Any value other that 0 is currently unsupported.
   --disable-gso               Disable GSO (linux only).
+  --disable-pacing            Disable pacing (linux only).
   -h --help                   Show this screen.
 ";
 
@@ -456,6 +457,7 @@ pub struct ServerArgs {
     pub cert: String,
     pub key: String,
     pub disable_gso: bool,
+    pub disable_pacing: bool,
 }
 
 impl Args for ServerArgs {
@@ -469,6 +471,7 @@ impl Args for ServerArgs {
         let cert = args.get_str("--cert").to_string();
         let key = args.get_str("--key").to_string();
         let disable_gso = args.get_bool("--disable-gso");
+        let disable_pacing = args.get_bool("--disable-pacing");
 
         ServerArgs {
             listen,
@@ -478,6 +481,7 @@ impl Args for ServerArgs {
             cert,
             key,
             disable_gso,
+            disable_pacing,
         }
     }
 }

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -75,13 +75,15 @@ fn main() {
 
     // Set SO_TXTIME socket option on the listening UDP socket for pacing
     // outgoing packets.
-    match set_txtime_sockopt(&socket) {
-        Ok(_) => {
-            pacing = true;
-            debug!("successfully set SO_TXTIME socket option");
-        },
-        Err(e) => debug!("setsockopt failed {:?}", e),
-    };
+    if !args.disable_pacing {
+        match set_txtime_sockopt(&socket) {
+            Ok(_) => {
+                pacing = true;
+                debug!("successfully set SO_TXTIME socket option");
+            },
+            Err(e) => debug!("setsockopt failed {:?}", e),
+        };
+    }
 
     info!("listening on {:}", socket.local_addr().unwrap());
 
@@ -120,6 +122,8 @@ fn main() {
 
     config.set_max_connection_window(conn_args.max_window);
     config.set_max_stream_window(conn_args.max_stream_window);
+
+    config.enable_pacing(pacing);
 
     let mut keylog = None;
 


### PR DESCRIPTION
Pacing is enabled by default if SO_TXTIME is available, but it can be useful to disable it completely (e.g. for testing purposes).