### PR TITLE
handle peer-initiated key update

### DIFF
--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -859,6 +859,22 @@ fn compute_retry_integrity_tag(
         .map_err(|_| Error::CryptoFail)
 }
 
+pub struct KeyUpdate {
+    /// 1-RTT key used prior to a key update.
+    pub crypto_open: crypto::Open,
+
+    /// The packet number triggered the latest key-update.
+    ///
+    /// Incoming packets with lower pn should use this (prev) crypto key.
+    pub pn_on_update: u64,
+
+    /// Whether ACK frame for key-update has been sent.
+    pub update_acked: bool,
+
+    /// When the old key should be discarded.
+    pub timer: time::Instant,
+}
+
 pub struct PktNumSpace {
     pub largest_rx_pkt_num: u64,
 
@@ -873,6 +889,8 @@ pub struct PktNumSpace {
     pub recv_pkt_num: PktNumWindow,
 
     pub ack_elicited: bool,
+
+    pub key_update: Option<KeyUpdate>,
 
     pub crypto_open: Option<crypto::Open>,
     pub crypto_seal: Option<crypto::Seal>,
@@ -899,6 +917,8 @@ impl PktNumSpace {
             recv_pkt_num: PktNumWindow::default(),
 
             ack_elicited: false,
+
+            key_update: None,
 
             crypto_open: None,
             crypto_seal: None,


### PR DESCRIPTION
This adds support for handling key update initiated by a peer. Based on the changes from #1121 with some additional modifications.

In addition to the included test case, this was also tested using the QUIC interop runner.

Fixes #1115, #1273, #1121.