### PR TITLE
apps: keep sending packets when a small packet is generated

### DIFF
--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -588,6 +588,7 @@ fn main() {
                 let _ = dst_info.get_or_insert(send_info);
 
                 if write < client.max_datagram_size {
+                    continue_write = true;
                     break;
                 }
             }


### PR DESCRIPTION
When small packets are generated, the server only sends a single packet per RTT, which is not verry efficient.