### PR TITLE
qlog: switch to RawInfo where needed

### DIFF
--- a/qlog/src/events/h3.rs
+++ b/qlog/src/events/h3.rs
@@ -28,7 +28,6 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use super::RawInfo;
-use crate::Bytes;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -134,7 +133,7 @@ pub enum Http3FrameTypeName {
 // also works automatically.
 pub enum Http3Frame {
     Data {
-        raw: Option<Bytes>,
+        raw: Option<RawInfo>,
     },
 
     Headers {
@@ -173,9 +172,8 @@ pub enum Http3Frame {
     },
 
     Unknown {
-        raw_frame_type: u64,
-        raw_length: Option<u32>,
-        raw: Option<Bytes>,
+        frame_type_value: u64,
+        raw: Option<RawInfo>,
     },
 }
 

--- a/qlog/src/events/qpack.rs
+++ b/qlog/src/events/qpack.rs
@@ -28,7 +28,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use super::h3::HttpHeader;
-use super::Bytes;
+use super::RawInfo;
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -243,8 +243,7 @@ pub struct QpackHeadersEncoded {
     pub block_prefix: QpackHeaderBlockPrefix,
     pub header_block: Vec<QpackHeaderBlockRepresentation>,
 
-    pub length: Option<u32>,
-    pub raw: Option<Bytes>,
+    pub raw: Option<RawInfo>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -257,8 +256,7 @@ pub struct QpackHeadersDecoded {
     pub block_prefix: QpackHeaderBlockPrefix,
     pub header_block: Vec<QpackHeaderBlockRepresentation>,
 
-    pub length: Option<u32>,
-    pub raw: Option<Bytes>,
+    pub raw: Option<RawInfo>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -266,8 +264,7 @@ pub struct QpackHeadersDecoded {
 pub struct QpackInstructionCreated {
     pub instruction: QPackInstruction,
 
-    pub length: Option<u32>,
-    pub raw: Option<Bytes>,
+    pub raw: Option<RawInfo>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -275,6 +272,5 @@ pub struct QpackInstructionCreated {
 pub struct QpackInstructionParsed {
     pub instruction: QPackInstruction,
 
-    pub length: Option<u32>,
-    pub raw: Option<Bytes>,
+    pub raw: Option<RawInfo>,
 }

--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -428,7 +428,7 @@ pub enum QuicFrame {
         length: u64,
         fin: Option<bool>,
 
-        raw: Option<Bytes>,
+        raw: Option<RawInfo>,
     },
 
     MaxData {
@@ -482,7 +482,7 @@ pub enum QuicFrame {
     ConnectionClose {
         error_space: Option<ErrorSpace>,
         error_code: Option<u64>,
-        raw_error_code: Option<u64>,
+        error_code_value: Option<u64>,
         reason: Option<String>,
 
         trigger_frame_type: Option<u64>,
@@ -498,8 +498,8 @@ pub enum QuicFrame {
 
     Unknown {
         raw_frame_type: u64,
-        raw_length: Option<u32>,
-        raw: Option<Bytes>,
+        frame_type_value: Option<u64>,
+        raw: Option<RawInfo>,
     },
 }
 
@@ -713,7 +713,7 @@ pub struct DataMoved {
     pub from: Option<DataRecipient>,
     pub to: Option<DataRecipient>,
 
-    pub data: Option<Bytes>,
+    pub raw: Option<RawInfo>,
 }
 
 #[serde_with::skip_serializing_none]

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -623,10 +623,9 @@ pub struct Token {
     #[serde(rename(serialize = "type"))]
     pub ty: Option<TokenType>,
 
-    pub length: Option<u32>,
-    pub data: Option<Bytes>,
-
     pub details: Option<String>,
+
+    pub raw: Option<events::RawInfo>,
 }
 
 pub struct HexSlice<'a>(&'a [u8]);

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -875,8 +875,11 @@ impl Frame {
                 token: qlog::Token {
                     // TODO: pick the token type some how
                     ty: Some(qlog::TokenType::Retry),
-                    length: Some(token.len() as u32),
-                    data: qlog::HexSlice::maybe_string(Some(token)),
+                    raw: Some(qlog::events::RawInfo {
+                        data: qlog::HexSlice::maybe_string(Some(token)),
+                        length: Some(token.len() as u64),
+                        payload_length: None,
+                    }),
                     details: None,
                 },
             },
@@ -968,7 +971,7 @@ impl Frame {
             } => QuicFrame::ConnectionClose {
                 error_space: Some(ErrorSpace::TransportError),
                 error_code: Some(*error_code),
-                raw_error_code: None, // raw error is no different for us
+                error_code_value: None, // raw error is no different for us
                 reason: Some(String::from_utf8_lossy(reason).into_owned()),
                 trigger_frame_type: None, // don't know trigger type
             },
@@ -977,7 +980,7 @@ impl Frame {
                 QuicFrame::ConnectionClose {
                     error_space: Some(ErrorSpace::ApplicationError),
                     error_code: Some(*error_code),
-                    raw_error_code: None, // raw error is no different for us
+                    error_code_value: None, // raw error is no different for us
                     reason: Some(String::from_utf8_lossy(reason).into_owned()),
                     trigger_frame_type: None, // don't know trigger type
                 },

--- a/quiche/src/h3/frame.rs
+++ b/quiche/src/h3/frame.rs
@@ -310,6 +310,8 @@ impl Frame {
 
     #[cfg(feature = "qlog")]
     pub fn to_qlog(&self) -> Http3Frame {
+        use qlog::events::RawInfo;
+
         match self {
             Frame::Data { .. } => Http3Frame::Data { raw: None },
 
@@ -420,9 +422,12 @@ impl Frame {
                 raw_type,
                 payload_length,
             } => Http3Frame::Unknown {
-                raw_frame_type: *raw_type,
-                raw_length: Some(*payload_length as u32),
-                raw: None,
+                frame_type_value: *raw_type,
+                raw: Some(RawInfo {
+                    data: None,
+                    payload_length: Some(*payload_length),
+                    length: None,
+                }),
             },
         }
     }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2822,7 +2822,7 @@ impl Connection {
                                     length: Some(length as u64),
                                     from: Some(DataRecipient::Transport),
                                     to: Some(DataRecipient::Dropped),
-                                    data: None,
+                                    raw: None,
                                 },
                             );
 
@@ -4453,7 +4453,7 @@ impl Connection {
                 length: Some(read as u64),
                 from: Some(DataRecipient::Transport),
                 to: Some(DataRecipient::Application),
-                data: None,
+                raw: None,
             });
 
             let now = time::Instant::now();
@@ -4634,7 +4634,7 @@ impl Connection {
                 length: Some(sent as u64),
                 from: Some(DataRecipient::Application),
                 to: Some(DataRecipient::Transport),
-                data: None,
+                raw: None,
             });
 
             let now = time::Instant::now();


### PR DESCRIPTION
The specs updated to use the common RawInfo type in several places,
these changes just synchronise that.
