### PR TITLE
apps: remove siduck

### DIFF
--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -103,9 +103,6 @@ impl Args for CommonArgs {
                 false,
             ),
 
-            // SiDuck is it's own application protocol.
-            (_, "siduck") => (alpns::SIDUCK.to_vec(), true),
-
             (..) => panic!("Unsupported HTTP version and DATAGRAM protocol."),
         };
 

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -379,7 +379,6 @@ fn main() {
                     client_id,
                     partial_requests: HashMap::new(),
                     partial_responses: HashMap::new(),
-                    siduck_conn: None,
                     app_proto_selected: false,
                     max_datagram_size,
                     loss_rate: 0.0,
@@ -467,13 +466,6 @@ fn main() {
                     };
 
                     client.app_proto_selected = true;
-                } else if alpns::SIDUCK.contains(&app_proto) {
-                    client.siduck_conn = Some(SiDuckConn::new(
-                        conn_args.dgram_count,
-                        conn_args.dgram_data.clone(),
-                    ));
-
-                    client.app_proto_selected = true;
                 }
 
                 // Update max_datagram_size after connection established.
@@ -502,16 +494,6 @@ fn main() {
                     )
                     .is_err()
                 {
-                    continue 'read;
-                }
-            }
-
-            // If we have a siduck connection, handle the quacks.
-            if client.siduck_conn.is_some() {
-                let conn = &mut client.conn;
-                let si_conn = client.siduck_conn.as_mut().unwrap();
-
-                if si_conn.handle_quacks(conn, &mut buf).is_err() {
                     continue 'read;
                 }
             }

--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -64,7 +64,6 @@ pub mod alpns {
     pub const HTTP_09: [&[u8]; 5] =
         [b"hq-interop", b"hq-29", b"hq-28", b"hq-27", b"http/0.9"];
     pub const HTTP_3: [&[u8]; 4] = [b"h3", b"h3-29", b"h3-28", b"h3-27"];
-    pub const SIDUCK: [&[u8]; 2] = [b"siduck", b"siduck-00"];
 }
 
 pub struct PartialRequest {
@@ -88,8 +87,6 @@ pub struct Client {
     pub http_conn: Option<Box<dyn HttpConn>>,
 
     pub client_id: ClientId,
-
-    pub siduck_conn: Option<SiDuckConn>,
 
     pub app_proto_selected: bool,
 
@@ -340,161 +337,6 @@ pub trait HttpConn {
         &mut self, conn: &mut quiche::Connection,
         partial_responses: &mut HashMap<u64, PartialResponse>, stream_id: u64,
     );
-}
-
-pub struct SiDuckConn {
-    quacks_to_make: u64,
-    quack_contents: String,
-    quacks_sent: u64,
-    quacks_acked: u64,
-}
-
-impl SiDuckConn {
-    pub fn new(quacks_to_make: u64, quack_contents: String) -> Self {
-        Self {
-            quacks_to_make,
-            quack_contents,
-            quacks_sent: 0,
-            quacks_acked: 0,
-        }
-    }
-
-    pub fn send_quacks(&mut self, conn: &mut quiche::Connection) {
-        trace!("sending quacks");
-        let mut quacks_done = 0;
-
-        for _ in self.quacks_sent..self.quacks_to_make {
-            info!("sending QUIC DATAGRAM with data {:?}", self.quack_contents);
-
-            match conn.dgram_send(self.quack_contents.as_bytes()) {
-                Ok(v) => v,
-
-                Err(e) => {
-                    error!("failed to send dgram {:?}", e);
-
-                    break;
-                },
-            }
-
-            quacks_done += 1;
-        }
-
-        self.quacks_sent += quacks_done;
-    }
-
-    pub fn handle_quacks(
-        &mut self, conn: &mut quiche::Connection, buf: &mut [u8],
-    ) -> quiche::h3::Result<()> {
-        loop {
-            match conn.dgram_recv(buf) {
-                Ok(len) => {
-                    let data =
-                        unsafe { std::str::from_utf8_unchecked(&buf[..len]) };
-                    info!("Received DATAGRAM data {:?}", data);
-
-                    // TODO
-                    if data != "quack" {
-                        match conn.close(true, 0x101, b"only quacks echo") {
-                            // Already closed.
-                            Ok(_) | Err(quiche::Error::Done) => (),
-
-                            Err(e) => panic!("error closing conn: {:?}", e),
-                        }
-
-                        break;
-                    }
-
-                    match conn.dgram_send(format!("{data}-ack").as_bytes()) {
-                        Ok(v) => v,
-
-                        Err(quiche::Error::Done) => (),
-
-                        Err(e) => {
-                            error!("failed to send quack ack {e:?}");
-                            return Err(From::from(e));
-                        },
-                    }
-                },
-
-                Err(quiche::Error::Done) => break,
-
-                Err(e) => {
-                    error!("failure receiving DATAGRAM failure {:?}", e);
-
-                    return Err(From::from(e));
-                },
-            }
-        }
-
-        Ok(())
-    }
-
-    pub fn handle_quack_acks(
-        &mut self, conn: &mut quiche::Connection, buf: &mut [u8],
-        start: &std::time::Instant,
-    ) {
-        trace!("handle_quack_acks");
-
-        loop {
-            match conn.dgram_recv(buf) {
-                Ok(len) => {
-                    let data =
-                        unsafe { std::str::from_utf8_unchecked(&buf[..len]) };
-
-                    info!("Received DATAGRAM data {:?}", data);
-                    self.quacks_acked += 1;
-
-                    debug!(
-                        "{}/{} quacks acked",
-                        self.quacks_acked, self.quacks_to_make
-                    );
-
-                    if self.quacks_acked == self.quacks_to_make {
-                        info!(
-                            "{}/{} dgrams(s) received in {:?}, closing...",
-                            self.quacks_acked,
-                            self.quacks_to_make,
-                            start.elapsed()
-                        );
-
-                        match conn.close(true, 0x00, b"kthxbye") {
-                            // Already closed.
-                            Ok(_) | Err(quiche::Error::Done) => (),
-
-                            Err(e) => panic!("error closing conn: {:?}", e),
-                        }
-
-                        break;
-                    }
-                },
-
-                Err(quiche::Error::Done) => {
-                    break;
-                },
-
-                Err(e) => {
-                    error!("failure receiving DATAGRAM failure {:?}", e);
-
-                    break;
-                },
-            }
-        }
-    }
-
-    pub fn report_incomplete(&self, start: &std::time::Instant) -> bool {
-        if self.quacks_acked != self.quacks_to_make {
-            error!(
-                "connection timed out after {:?} and only received {}/{} quack-acks",
-                start.elapsed(),
-                self.quacks_acked,
-                self.quacks_to_make
-            );
-
-            return true;
-        }
-
-        false
-    }
 }
 
 /// Represents an HTTP/0.9 formatted request.


### PR DESCRIPTION
SiDuck was an early attempt to promote interop of QUIC datagrams.
In the meantime, both QUIC datagrams and HTTP datagrams have been
published as RFCs. Furthermore, UDP and IP proxying use cases have
acheived good interop in the wider community.

This change removes SiDuck from the apps.
