### PR TITLE
Reuse the same Vec for newly_acked

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1394,6 +1394,9 @@ pub struct Connection {
     /// Whether the connection should prevent from reusing destination
     /// Connection IDs when the peer migrates.
     disable_dcid_reuse: bool,
+
+    /// A resusable buffer used by Recovery
+    newly_acked: Vec<recovery::Acked>,
 }
 
 /// Creates a new server-side connection.
@@ -1832,6 +1835,8 @@ impl Connection {
             emit_dgram: true,
 
             disable_dcid_reuse: config.disable_dcid_reuse,
+
+            newly_acked: Vec::new(),
         };
 
         if let Some(odcid) = odcid {
@@ -6608,6 +6613,7 @@ impl Connection {
                         handshake_status,
                         now,
                         &self.trace_id,
+                        &mut self.newly_acked,
                     )?;
 
                     self.lost_count += lost_packets;

--- a/quiche/src/recovery/delivery_rate.rs
+++ b/quiche/src/recovery/delivery_rate.rs
@@ -358,6 +358,7 @@ mod tests {
                 HandshakeStatus::default(),
                 now,
                 "",
+                &mut Vec::new(),
             ),
             Ok((0, 0)),
         );

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -60,10 +60,11 @@ pub fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
 }
 
 fn on_packets_acked(
-    r: &mut Recovery, packets: &[Acked], epoch: packet::Epoch, now: Instant,
+    r: &mut Recovery, packets: &mut Vec<Acked>, epoch: packet::Epoch,
+    now: Instant,
 ) {
-    for pkt in packets {
-        on_packet_acked(r, pkt, epoch, now);
+    for pkt in packets.drain(..) {
+        on_packet_acked(r, &pkt, epoch, now);
     }
 }
 
@@ -223,7 +224,7 @@ mod tests {
 
         let cwnd_prev = r.cwnd();
 
-        let acked = vec![Acked {
+        let mut acked = vec![Acked {
             pkt_num: p.pkt_num,
             time_sent: p.time_sent,
             size: p.size,
@@ -234,7 +235,7 @@ mod tests {
             rtt: Duration::ZERO,
         }];
 
-        r.on_packets_acked(acked, packet::Epoch::Application, now);
+        r.on_packets_acked(&mut acked, packet::Epoch::Application, now);
 
         // Check if cwnd increased by packet size (slow start).
         assert_eq!(r.cwnd(), cwnd_prev + p.size);
@@ -272,7 +273,7 @@ mod tests {
 
         let cwnd_prev = r.cwnd();
 
-        let acked = vec![
+        let mut acked = vec![
             Acked {
                 pkt_num: p.pkt_num,
                 time_sent: p.time_sent,
@@ -305,7 +306,7 @@ mod tests {
             },
         ];
 
-        r.on_packets_acked(acked, packet::Epoch::Application, now);
+        r.on_packets_acked(&mut acked, packet::Epoch::Application, now);
 
         // Acked 3 packets.
         assert_eq!(r.cwnd(), cwnd_prev + p.size * 3);
@@ -360,7 +361,7 @@ mod tests {
 
         let rtt = Duration::from_millis(100);
 
-        let acked = vec![Acked {
+        let mut acked = vec![Acked {
             pkt_num: 0,
             // To exit from recovery
             time_sent: now + rtt,
@@ -375,7 +376,7 @@ mod tests {
 
         // Ack more than cwnd bytes with rtt=100ms
         r.update_rtt(rtt, Duration::from_millis(0), now);
-        r.on_packets_acked(acked, packet::Epoch::Application, now + rtt * 2);
+        r.on_packets_acked(&mut acked, packet::Epoch::Application, now + rtt * 2);
 
         // After acking more than cwnd, expect cwnd increased by MSS
         assert_eq!(r.cwnd(), cur_cwnd + r.max_datagram_size);


### PR DESCRIPTION
Currently every time an ack arrives quiche allocates a new Vec to hold the newly acked packet descriptors. This is rather expensive, and can be avoided by reusing the same Vec. Sadly due to the way Recovery interface is implemented it can't be integrated in Recovery without significant rewrite, and has to be provided externally. Still the performance benefits are pretty significant.