### PR TITLE
Bump serde_with to 2.3.1

### DIFF
--- a/qlog/Cargo.toml
+++ b/qlog/Cargo.toml
@@ -11,8 +11,8 @@ categories = ["network-programming"]
 license = "BSD-2-Clause"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.139", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_derive = "1.0"
-serde_with = "1.3.1"
-smallvec = { version = "1.10", features = ["serde" ] }
+serde_with = "2.3.1"
+smallvec = { version = "1.10", features = ["serde"] }


### PR DESCRIPTION
We also bump serde to 1.0.139 to address a semver bug in serde_with.

https://github.com/jonasbb/serde_with/pull/588