### PR TITLE
bbr: fix cwnd calculation when recovery starts

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2955,6 +2955,10 @@ impl Connection {
 
         self.ack_eliciting_sent = false;
 
+        // Reset pacer and start a new burst when a valid
+        // packet is received.
+        self.paths.get_mut(recv_pid)?.recovery.pacer.reset(now);
+
         Ok(read)
     }
 

--- a/quiche/src/recovery/bbr/mod.rs
+++ b/quiche/src/recovery/bbr/mod.rs
@@ -255,13 +255,12 @@ impl State {
 fn bbr_enter_recovery(r: &mut Recovery, now: Instant) {
     r.bbr_state.prior_cwnd = per_ack::bbr_save_cwnd(r);
 
-    r.congestion_window = r.bytes_in_flight.max(r.max_datagram_size);
+    r.congestion_window = r.bytes_in_flight +
+        r.bbr_state.newly_acked_bytes.max(r.max_datagram_size);
     r.congestion_recovery_start_time = Some(now);
 
     r.bbr_state.packet_conservation = true;
     r.bbr_state.in_recovery = true;
-
-    r.bbr_state.newly_lost_bytes = 0;
 
     // Start round now.
     r.bbr_state.next_round_delivered = r.delivery_rate.delivered();
@@ -311,7 +310,7 @@ fn on_packets_acked(
         });
 
     if let Some(pkt) = packets.last() {
-        if !r.in_congestion_recovery(pkt.time_sent) && r.bbr_state.in_recovery {
+        if !r.in_congestion_recovery(pkt.time_sent) {
             // Upon exiting loss recovery.
             bbr_exit_recovery(r);
         }

--- a/quiche/src/recovery/bbr/mod.rs
+++ b/quiche/src/recovery/bbr/mod.rs
@@ -252,12 +252,15 @@ impl State {
 }
 
 // When entering the recovery episode.
-fn bbr_enter_recovery(r: &mut Recovery, now: Instant) {
+fn bbr_enter_recovery(r: &mut Recovery) {
     r.bbr_state.prior_cwnd = per_ack::bbr_save_cwnd(r);
 
+    // Temporarily add lost bytes, because bytes_in_flight
+    // doesn't have lost bytes at this point. cwnd will be
+    // calculated again in bbr_modulate_cwnd_for_recovery().
     r.congestion_window = r.bytes_in_flight +
-        r.bbr_state.newly_acked_bytes.max(r.max_datagram_size);
-    r.congestion_recovery_start_time = Some(now);
+        r.bbr_state.newly_acked_bytes.max(r.max_datagram_size) +
+        r.bbr_state.newly_lost_bytes;
 
     r.bbr_state.packet_conservation = true;
     r.bbr_state.in_recovery = true;
@@ -309,9 +312,14 @@ fn on_packets_acked(
             acked_bytes + p.size
         });
 
+    // Upon entering Fast Recovery.
+    if r.congestion_recovery_start_time.is_some() && !r.bbr_state.in_recovery {
+        bbr_enter_recovery(r);
+    }
+
     if let Some(pkt) = packets.last() {
-        if !r.in_congestion_recovery(pkt.time_sent) {
-            // Upon exiting loss recovery.
+        // Upon exiting loss recovery.
+        if !r.in_congestion_recovery(pkt.time_sent) && r.bbr_state.in_recovery {
             bbr_exit_recovery(r);
         }
     }
@@ -327,10 +335,8 @@ fn congestion_event(
 ) {
     r.bbr_state.newly_lost_bytes = lost_bytes;
 
-    // Upon entering Fast Recovery.
     if !r.in_congestion_recovery(time_sent) {
-        // Upon entering Fast Recovery.
-        bbr_enter_recovery(r, now);
+        r.congestion_recovery_start_time = Some(now);
     }
 }
 
@@ -526,9 +532,13 @@ mod tests {
             Ok((2, 2400)),
         );
 
-        // Sent: 0, 1, 2, 3, 4, Acked 4.
-        assert_eq!(r.cwnd(), mss * 4);
-        // Stil in flight: 2, 3.
+        // Sent: 0, 1, 2, 3, 4
+        // Acked: [ 4 ]
+        // Detected Lost: 0, 1
+        //   2, 3 is still considered as in-flight due to lost detection threshold
+        // New cwnd: mss * (2 (in flight) + 1 (acked))
+        assert_eq!(r.cwnd(), mss * 3);
+        // Stil in flight: 2, 3
         assert_eq!(r.bytes_in_flight, mss * 2);
     }
 

--- a/quiche/src/recovery/bbr/per_ack.rs
+++ b/quiche/src/recovery/bbr/per_ack.rs
@@ -172,8 +172,9 @@ fn bbr_modulate_cwnd_for_recovery(r: &mut Recovery) {
     }
 
     if r.bbr_state.packet_conservation {
-        r.congestion_window =
-            r.congestion_window.max(r.bytes_in_flight + acked_bytes);
+        r.congestion_window = r
+            .congestion_window
+            .max(r.bytes_in_flight + acked_bytes.max(r.max_datagram_size));
     }
 }
 

--- a/quiche/src/recovery/pacer.rs
+++ b/quiche/src/recovery/pacer.rs
@@ -123,7 +123,7 @@ impl Pacer {
     }
 
     /// Resets the pacer for the next burst.
-    fn reset(&mut self, now: Instant) {
+    pub fn reset(&mut self, now: Instant) {
         self.used = 0;
 
         self.last_update = now;


### PR DESCRIPTION
Alternative to #1473. Also fixed the test which I believe it's correct.

Previously `bbr_enter_recovery()` used old `newly_acked_bytes` to set
a new cwnd when the recovery starts. To prevent this from happening,
`bbr_enter_recovery()` is called after `newly_acked_bytes` is updated
in a current ack processing. Also `bbr_modulate_cwnd_for_recovery()`
use the same cwnd calculation to match the same in `bbr_enter_recovery()`.

@lohith-bellad please feel free to take a look if it makes sense. I didn't test it much