### PR TITLE
ci: uthash from homebrew, fix Apple Silicon macOS example build

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -95,8 +95,7 @@ jobs:
 
       - name: Build C examples
         run: |
-          brew install libev
-          curl -o quiche/examples/uthash.h https://raw.githubusercontent.com/troydhanson/uthash/master/src/uthash.h
+          brew install libev uthash
           make -C quiche/examples
 
   quiche_ios:

--- a/quiche/examples/Makefile
+++ b/quiche/examples/Makefile
@@ -8,14 +8,20 @@ INCLUDE_DIR = ../include
 INCS = -I$(INCLUDE_DIR)
 CFLAGS = -I. -Wall -Werror -pedantic -fsanitize=address -g
 
-ifeq ($(OS), Darwin)
-CFLAGS += -framework Security
-endif
-
 LIBCRYPTO_DIR = $(dir $(shell find ${BUILD_DIR} -name libcrypto.a))
 LIBSSL_DIR = $(dir $(shell find ${BUILD_DIR} -name libssl.a))
 
 LDFLAGS = -L$(LIBCRYPTO_DIR) -L$(LIBSSL_DIR) -L$(LIB_DIR)
+
+ifeq ($(OS), Darwin)
+# Default prefix of Apple Silicon macOS homebrew.
+# Intel will use /usr/local which is included by default.
+BREW_INC_DIR = /opt/homebrew/include/
+BREW_LIB_DIR = /opt/homebrew/lib/
+
+CFLAGS += -framework Security -I$(BREW_INC_DIR)
+LDFLAGS += -L$(BREW_LIB_DIR)
+endif
 
 LIBS = $(LIB_DIR)/libquiche.a -lev -ldl -pthread -lm
 


### PR DESCRIPTION
- ci: uthash is now available from homebrew
- Apple Silicon macOS: homebrew will install header and libraries in /opt/homebrew, not /usr/local.

CI doesn't have Apple Silicon yet, but it would be helpful for Apple Silicon macOS users.