### PR TITLE
Convert Instant to timespec in a more safer way 

### DIFF
--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1500,29 +1500,15 @@ fn std_addr_to_c(addr: &SocketAddr, out: &mut sockaddr_storage) -> socklen_t {
     }
 }
 
-#[cfg(all(
-    not(any(target_os = "macos", target_os = "ios", target_os = "windows")),
-    target_arch = "x86_64"
-))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "windows")))]
 fn std_time_to_c(time: &std::time::Instant, out: &mut timespec) {
-    const NANOS_PER_SEC: u128 = 1_000_000_000;
-
     const INSTANT_ZERO: std::time::Instant =
-        unsafe { std::mem::transmute(0u128) };
+        unsafe { std::mem::transmute(std::time::UNIX_EPOCH) };
 
-    let raw_time = time.duration_since(INSTANT_ZERO).as_nanos();
+    let raw_time = time.duration_since(INSTANT_ZERO);
 
-    out.tv_sec = (raw_time / NANOS_PER_SEC) as i64;
-    out.tv_nsec = (raw_time % NANOS_PER_SEC) as i64;
-}
-
-#[cfg(all(
-    not(any(target_os = "macos", target_os = "ios", target_os = "windows")),
-    not(target_arch = "x86_64")
-))]
-fn std_time_to_c(_time: &std::time::Instant, out: &mut timespec) {
-    out.tv_sec = 0;
-    out.tv_nsec = 0;
+    out.tv_sec = raw_time.as_secs() as libc::time_t;
+    out.tv_nsec = raw_time.subsec_nanos() as libc::c_long;
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows"))]


### PR DESCRIPTION
Different architectures have different sizes for timespec and Instant. ~~Here conversion is considered only for x86_64 architectures running linux. Not sure if other architectures are using paced time (because earlier conversion had problems and using it would have raised bug reports) . If any architecture is found using paced time then conversion for that arch should be added.~~ This diff covers all of them.