### PR TITLE
Trigger loss recovery as soon as connection migration is complete

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2933,11 +2933,7 @@ impl Connection {
                 recv_pid != active_path_id &&
                 self.pkt_num_spaces[epoch].largest_rx_non_probing_pkt_num == pn
             {
-                self.paths.on_peer_migrated(
-                    recv_pid,
-                    self.disable_dcid_reuse,
-                    &self.trace_id,
-                )?;
+                self.on_peer_migrated(recv_pid, self.disable_dcid_reuse, now)?;
             }
         }
 
@@ -5594,7 +5590,7 @@ impl Connection {
         if self.paths.get_active_path_id().is_err() {
             match self.paths.find_candidate_path() {
                 Some(pid) =>
-                    if self.paths.set_active_path(pid, &self.trace_id).is_err() {
+                    if self.set_active_path(pid, now).is_err() {
                         // The connection cannot continue.
                         self.closed = true;
                     },
@@ -5734,7 +5730,7 @@ impl Connection {
         };
 
         // Change the active path.
-        self.paths.set_active_path(pid, &self.trace_id)?;
+        self.set_active_path(pid, time::Instant::now())?;
 
         Ok(dcid_seq)
     }
@@ -7315,6 +7311,49 @@ impl Connection {
         };
 
         Err(Error::InvalidState)
+    }
+
+    /// Sets the path with identifier 'path_id' to be active.
+    fn set_active_path(
+        &mut self, path_id: usize, now: time::Instant,
+    ) -> Result<()> {
+        if let Ok(old_active_path) = self.paths.get_active_mut() {
+            for &e in packet::Epoch::epochs(
+                packet::Epoch::Initial..=packet::Epoch::Application,
+            ) {
+                let (lost_packets, lost_bytes) = old_active_path
+                    .recovery
+                    .on_path_change(e, now, &self.trace_id);
+
+                self.lost_count += lost_packets;
+                self.lost_bytes += lost_bytes as u64;
+            }
+        }
+
+        self.paths.set_active_path(path_id)
+    }
+
+    /// Handles potential connection migration.
+    fn on_peer_migrated(
+        &mut self, new_pid: usize, disable_dcid_reuse: bool, now: time::Instant,
+    ) -> Result<()> {
+        let active_path_id = self.paths.get_active_path_id()?;
+
+        if active_path_id == new_pid {
+            return Ok(());
+        }
+
+        self.set_active_path(new_pid, now)?;
+
+        let no_spare_dcid =
+            self.paths.get_mut(new_pid)?.active_dcid_seq.is_none();
+
+        if no_spare_dcid && !disable_dcid_reuse {
+            self.paths.get_mut(new_pid)?.active_dcid_seq =
+                self.paths.get_mut(active_path_id)?.active_dcid_seq;
+        }
+
+        Ok(())
     }
 
     /// Creates a new client-side path.

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2933,8 +2933,11 @@ impl Connection {
                 recv_pid != active_path_id &&
                 self.pkt_num_spaces[epoch].largest_rx_non_probing_pkt_num == pn
             {
-                self.paths
-                    .on_peer_migrated(recv_pid, self.disable_dcid_reuse)?;
+                self.paths.on_peer_migrated(
+                    recv_pid,
+                    self.disable_dcid_reuse,
+                    &self.trace_id,
+                )?;
             }
         }
 
@@ -5591,7 +5594,7 @@ impl Connection {
         if self.paths.get_active_path_id().is_err() {
             match self.paths.find_candidate_path() {
                 Some(pid) =>
-                    if self.paths.set_active_path(pid).is_err() {
+                    if self.paths.set_active_path(pid, &self.trace_id).is_err() {
                         // The connection cannot continue.
                         self.closed = true;
                     },
@@ -5731,7 +5734,7 @@ impl Connection {
         };
 
         // Change the active path.
-        self.paths.set_active_path(pid)?;
+        self.paths.set_active_path(pid, &self.trace_id)?;
 
         Ok(dcid_seq)
     }

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -765,7 +765,7 @@ impl PathMap {
             ) {
                 let (..) = old_active_path
                     .recovery
-                    .detect_lost_packets(e, now, trace_id);
+                    .recover_lost_packets(e, now, trace_id);
             }
         }
 

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -1,3 +1,4 @@
+// Copyright (C) 2022, Cloudflare, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -1,4 +1,3 @@
-// Copyright (C) 2022, Cloudflare, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -760,7 +759,7 @@ impl PathMap {
             old_active_path.active = false;
             let now = Instant::now();
 
-            /// Detect lost packets over all epochs
+            // Detect lost packets over all epochs
             for &e in packet::Epoch::epochs(
                 packet::Epoch::Initial..=packet::Epoch::Application,
             ) {

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -667,6 +667,12 @@ impl Recovery {
         self.set_loss_detection_timer(handshake_status, now);
     }
 
+    pub fn on_path_change(
+        &mut self, epoch: packet::Epoch, now: Instant, trace_id: &str,
+    ) -> (usize, usize) {
+        self.detect_lost_packets(epoch, now, trace_id)
+    }
+
     pub fn loss_detection_timer(&self) -> Option<Instant> {
         self.loss_detection_timer
     }
@@ -939,12 +945,6 @@ impl Recovery {
         self.drain_packets(epoch, now);
 
         (lost_packets, lost_bytes)
-    }
-
-    pub fn recover_lost_packets(
-        &mut self, epoch: packet::Epoch, now: Instant, trace_id: &str,
-    ) {
-        self.detect_lost_packets(epoch, now, trace_id);
     }
 
     fn drain_packets(&mut self, epoch: packet::Epoch, now: Instant) {

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -861,7 +861,7 @@ impl Recovery {
         self.loss_detection_timer = timeout;
     }
 
-    pub fn detect_lost_packets(
+    fn detect_lost_packets(
         &mut self, epoch: packet::Epoch, now: Instant, trace_id: &str,
     ) -> (usize, usize) {
         let largest_acked = self.largest_acked_pkt[epoch];
@@ -939,6 +939,12 @@ impl Recovery {
         self.drain_packets(epoch, now);
 
         (lost_packets, lost_bytes)
+    }
+
+    pub fn recover_lost_packets(
+        &mut self, epoch: packet::Epoch, now: Instant, trace_id: &str,
+    ) {
+        self.detect_lost_packets(epoch, now, trace_id);
     }
 
     fn drain_packets(&mut self, epoch: packet::Epoch, now: Instant) {

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -861,7 +861,7 @@ impl Recovery {
         self.loss_detection_timer = timeout;
     }
 
-    fn detect_lost_packets(
+    pub fn detect_lost_packets(
         &mut self, epoch: packet::Epoch, now: Instant, trace_id: &str,
     ) -> (usize, usize) {
         let largest_acked = self.largest_acked_pkt[epoch];


### PR DESCRIPTION
There is a bug where Quiche does not appropriately trigger loss recovery on connection migration. The main change introduced in this PR is to perform loss detection when connection migration is complete to allow for faster loss detection and retransmission on the current active path instead of the old, inactive path.