### PR TITLE
Make BBR less aggresive

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2964,6 +2964,10 @@ impl Connection {
 
         self.ack_eliciting_sent = false;
 
+        // Reset pacer and start a new burst when a valid
+        // packet is received.
+        self.paths.get_mut(recv_pid)?.recovery.pacer.reset(now);
+
         Ok(read)
     }
 

--- a/quiche/src/recovery/bbr/per_ack.rs
+++ b/quiche/src/recovery/bbr/per_ack.rs
@@ -270,7 +270,7 @@ fn bbr_enter_probe_bw(r: &mut Recovery, now: Instant) {
 
     bbr.state = BBRStateMachine::ProbeBW;
     bbr.pacing_gain = 1.0;
-    bbr.cwnd_gain = 2.0;
+    bbr.cwnd_gain = 1.25;
 
     // cycle_index will be one of (1, 2, 3, 4, 5, 6, 7). Since
     // bbr_advance_cycle_phase() is called right next and it will

--- a/quiche/src/recovery/pacer.rs
+++ b/quiche/src/recovery/pacer.rs
@@ -143,7 +143,7 @@ impl Pacer {
     }
 
     /// Resets the pacer for the next burst.
-    fn reset(&mut self, now: Instant) {
+    pub fn reset(&mut self, now: Instant) {
         self.used = 0;
 
         self.last_update = now;


### PR DESCRIPTION
This changes does two things,
1. Avoids pacer skew that might show up when cwnd restricts us to clear pacer.used.
2. Make BBR less aggressive. In probe_bw phase instead of keeping inflight two times the BDP, we keep 1.25 times BDP. This has been tested in different RTT (<1ms, 8msec, 45msec) environments. And this greatly redcues BBR aggressiveness and retransmissions.