### PR TITLE
Add API to load certificate and private key from memory buffers

### DIFF
--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -150,6 +150,17 @@ pub extern fn quiche_config_new(version: u32) -> *mut Config {
 }
 
 #[no_mangle]
+pub extern fn quiche_config_load_cert(
+    config: &mut Config, cert: *const u8, cert_len: size_t,
+) -> c_int {
+    match config.load_cert(cert, cert_len) {
+        Ok(_) => 0,
+
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_config_load_cert_chain_from_pem_file(
     config: &mut Config, path: *const c_char,
 ) -> c_int {

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -163,6 +163,17 @@ pub extern fn quiche_config_load_cert_chain_from_pem_file(
 }
 
 #[no_mangle]
+pub extern fn quiche_config_load_priv_key(
+    config: &mut Config, key: *const u8, key_len: size_t,
+) -> c_int {
+    match config.load_priv_key(key, key_len) {
+        Ok(_) => 0,
+
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_config_load_priv_key_from_pem_file(
     config: &mut Config, path: *const c_char,
 ) -> c_int {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -800,6 +800,13 @@ impl Config {
         self.tls_ctx.use_certificate_chain_file(file)
     }
 
+    /// Configures the given certificate.
+    ///
+    /// The content of `cert` is a certificate encoded as ASN.1 DER.
+    pub fn load_cert(&mut self, cert: *const u8, cert_len: libc::size_t) -> Result<()> {
+        self.tls_ctx.use_cert(cert, cert_len)
+    }
+
     /// Configures the given private key.
     ///
     /// The content of `file` is parsed as a PEM-encoded private key.
@@ -817,7 +824,7 @@ impl Config {
 
     /// Configures the given private key.
     ///
-    /// The content of `key` is a binary private key.
+    /// The content of `key` is a private key encoded as PKCS-8 BER.
     pub fn load_priv_key(&mut self, key: *const u8, key_len: libc::size_t) -> Result<()> {
         self.tls_ctx.use_privkey(key, key_len)
     }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -815,6 +815,13 @@ impl Config {
         self.tls_ctx.use_privkey_file(file)
     }
 
+    /// Configures the given private key.
+    ///
+    /// The content of `key` is a binary private key.
+    pub fn load_priv_key(&mut self, key: *const u8, key_len: libc::size_t) -> Result<()> {
+        self.tls_ctx.use_privkey(key, key_len)
+    }
+
     /// Specifies a file where trusted CA certificates are stored for the
     /// purposes of certificate verification.
     ///

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -80,7 +80,6 @@ struct X509_STORE(c_void);
 
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
-#[cfg(windows)]
 struct X509(c_void);
 
 #[allow(non_camel_case_types)]
@@ -258,12 +257,29 @@ impl Context {
         })
     }
 
-
     pub fn use_privkey(&mut self, key: *const u8, key_len: libc::size_t) -> Result<()> {
         map_result(unsafe {
             let cbs = CBS {data: key, len: key_len};
-            let parsed = EVP_parse_private_key(&cbs);
-            SSL_CTX_use_PrivateKey(self.as_mut_ptr(), parsed)
+            let pkey = EVP_parse_private_key(&cbs);
+            let rc = SSL_CTX_use_PrivateKey(self.as_mut_ptr(), pkey);
+            EVP_PKEY_free(pkey);
+            rc
+        })
+    }
+
+    pub fn use_cert(&mut self, cert: *const u8, cert_len: libc::size_t) -> Result<()> {
+        map_result(unsafe {
+            let x = d2i_X509(
+                ptr::null_mut(),
+                &cert,
+                cert_len as i32,
+            );
+            if x.is_null() {
+                return Err(Error::TlsFail);
+            }
+            let rc = SSL_CTX_use_certificate(self.as_mut_ptr(), x);
+            X509_free(x);
+            rc
         })
     }
 
@@ -1276,6 +1292,10 @@ extern {
     fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
     fn SSL_CTX_free(ctx: *mut SSL_CTX);
 
+    fn SSL_CTX_use_certificate(
+        ctx: *mut SSL_CTX, key: *mut X509,
+    ) -> c_int;
+
     fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX, file: *const c_char,
     ) -> c_int;
@@ -1283,6 +1303,10 @@ extern {
     fn EVP_parse_private_key(
         cbs: *const CBS,
     ) -> *const u8;
+
+    fn EVP_PKEY_free(
+        pkey: *const u8,
+    );
 
     fn SSL_CTX_use_PrivateKey(
         ctx: *mut SSL_CTX, key: *const u8,
@@ -1457,9 +1481,7 @@ extern {
     fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> c_int;
 
     // X509
-    #[cfg(windows)]
     fn X509_free(x: *mut X509);
-    #[cfg(windows)]
     fn d2i_X509(px: *mut X509, input: *const *const u8, len: c_int) -> *mut X509;
 
     // STACK_OF


### PR DESCRIPTION
This exposes BoringSSL's  `SSL_CTX_use_certificate` and `SSL_CTX_use_PrivateKey` calls so that it's possible to pass Quiche a certificate and a private key via in-memory buffers instead of having to write files on disk containing their PEM representations.

Fixes #1511.