### PR TITLE
add method to expose all source CIDs

### DIFF
--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -615,12 +615,15 @@ fn main() {
                     c.conn.stats(),
                     c.conn.path_stats().collect::<Vec<quiche::PathStats>>()
                 );
+
+                for id in c.conn.source_ids() {
+                    let id_owned = id.clone().into_owned();
+                    clients_ids.remove(&id_owned);
+                }
             }
 
             !c.conn.is_closed()
         });
-
-        clients_ids.retain(|_, client_id| clients.contains_key(client_id));
     }
 }
 

--- a/quiche/src/cid.rs
+++ b/quiche/src/cid.rs
@@ -585,6 +585,11 @@ impl ConnectionIdentifiers {
         Ok(e.path_id)
     }
 
+    /// Returns an iterator over the source connection IDs.
+    pub fn scids_iter(&self) -> impl Iterator<Item = &ConnectionId> {
+        self.scids.iter().map(|e| &e.cid)
+    }
+
     /// Updates the Source Connection ID entry with the provided sequence number
     /// to indicate that it is now linked to the provided path ID.
     pub fn link_scid_to_path_id(

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6069,6 +6069,9 @@ impl Connection {
 
     /// Returns the source connection ID.
     ///
+    /// When there are multiple IDs, and if there is an active path, the ID used
+    /// on that path is returned. Otherwise the oldest ID is returned.
+    ///
     /// Note that the value returned can change throughout the connection's
     /// lifetime.
     #[inline]
@@ -6083,6 +6086,15 @@ impl Connection {
 
         let e = self.ids.oldest_scid();
         ConnectionId::from_ref(e.cid.as_ref())
+    }
+
+    /// Returns all active source connection IDs.
+    ///
+    /// An iterator is returned for all active IDs (i.e. ones that have not
+    /// been explicitly retired yet).
+    #[inline]
+    pub fn source_ids(&self) -> impl Iterator<Item = &ConnectionId> {
+        self.ids.scids_iter()
     }
 
     /// Returns the destination connection ID.


### PR DESCRIPTION
An application can track these on its own, but quiche already has this information, so it can easily be exposed.