### PR TITLE
Introduce session_and_params methods

### DIFF
--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -200,6 +200,7 @@ pub fn connect(
 
     if let Some(session_file) = &args.session_file {
         if let Ok(session) = std::fs::read(session_file) {
+            #[allow(deprecated)]
             conn.set_session(&session).ok();
         }
     }
@@ -331,6 +332,7 @@ pub fn connect(
             }
 
             if let Some(session_file) = &args.session_file {
+                #[allow(deprecated)]
                 if let Some(session) = conn.session() {
                     std::fs::write(session_file, session).ok();
                 }
@@ -560,6 +562,7 @@ pub fn connect(
             }
 
             if let Some(session_file) = &args.session_file {
+                #[allow(deprecated)]
                 if let Some(session) = conn.session() {
                     std::fs::write(session_file, session).ok();
                 }

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -308,8 +308,11 @@ bool quiche_conn_set_qlog_path(quiche_conn *conn, const char *path,
 void quiche_conn_set_qlog_fd(quiche_conn *conn, int fd, const char *log_title,
                              const char *log_desc);
 
-// Configures the given session for resumption.
+// Configures the given session for resumption.This function is deprecated, use quiche_conn_set_session_and_params.
 int quiche_conn_set_session(quiche_conn *conn, const uint8_t *buf, size_t buf_len);
+
+// Configures the given session and params for resumption.
+int quiche_conn_set_session_and_params(quiche_conn *conn, const uint8_t *session_buf, size_t session_buf_len, const uint8_t *params_buf, size_t params_buf_len);
 
 typedef struct {
     // The remote address the packet was received from.
@@ -429,8 +432,11 @@ void quiche_conn_application_proto(const quiche_conn *conn, const uint8_t **out,
 // Returns the peer's leaf certificate (if any) as a DER-encoded buffer.
 void quiche_conn_peer_cert(const quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
-// Returns the serialized cryptographic session for the connection.
+// Returns the serialized cryptographic session for the connection. This function is deprecated, use quiche_conn_session_and_params.
 void quiche_conn_session(const quiche_conn *conn, const uint8_t **out, size_t *out_len);
+
+// Returns the serialized cryptographic session and params for the connection.
+void quiche_conn_session_and_params(const quiche_conn *conn, const uint8_t **session_out, size_t *session_out_len, const uint8_t **params_out, size_t *params_out_len);
 
 // Returns true if the connection handshake is complete.
 bool quiche_conn_is_established(const quiche_conn *conn);

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -3200,11 +3200,14 @@ mod tests {
         assert_eq!(pipe.handshake(), Ok(()));
 
         // Extract session,
-        let session = pipe.client.session().unwrap();
+        let session_and_params = pipe.client.session_and_params().unwrap();
 
         // Configure session on new connection.
         let mut pipe = crate::testing::Pipe::with_config(&mut config).unwrap();
-        assert_eq!(pipe.client.set_session(session), Ok(()));
+        assert_eq!(
+            pipe.client.set_session_and_params(session_and_params),
+            Ok(())
+        );
 
         // Can't create an H3 connection until the QUIC connection is determined
         // to have made sufficient early data progress.

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1236,11 +1236,18 @@ pub struct Connection {
     /// TLS handshake state.
     handshake: tls::Handshake,
 
-    /// Serialized TLS session buffer.
+    /// Serialized TLS session buffer that combines the session and transport
+    /// params.
     ///
     /// This field is populated when a new session ticket is processed on the
     /// client. On the server this is empty.
     session: Option<Vec<u8>>,
+
+    /// Serialized TLS session buffer.
+    ///
+    /// This field is populated when a new session ticket is processed on the
+    /// client. On the server this is empty.
+    session_and_params: Option<(Vec<u8>, Vec<u8>)>,
 
     /// The configuration for recovery.
     recovery_config: recovery::RecoveryConfig,
@@ -1738,6 +1745,8 @@ impl Connection {
 
             session: None,
 
+            session_and_params: None,
+
             recovery_config,
 
             paths,
@@ -1998,7 +2007,7 @@ impl Connection {
         self.qlog.streamer = Some(streamer);
     }
 
-    /// Configures the given session for resumption.
+    /// Configures the given session and transport params for resumption.
     ///
     /// On the client, this can be used to offer the given serialized session,
     /// as returned by [`session()`], for resumption.
@@ -2008,19 +2017,38 @@ impl Connection {
     ///
     /// [`session()`]: struct.Connection.html#method.session
     #[inline]
+    #[deprecated(note = "Use set_session_and_params()")]
     pub fn set_session(&mut self, session: &[u8]) -> Result<()> {
         let mut b = octets::Octets::with_slice(session);
 
         let session_len = b.get_u64()? as usize;
         let session_bytes = b.get_bytes(session_len)?;
 
-        self.handshake.set_session(session_bytes.as_ref())?;
-
         let raw_params_len = b.get_u64()? as usize;
         let raw_params_bytes = b.get_bytes(raw_params_len)?;
+        self.set_session_and_params((
+            session_bytes.as_ref(),
+            raw_params_bytes.as_ref(),
+        ))
+    }
+
+    /// Configures the given session and transport params for resumption.
+    ///
+    /// On the client, this can be used to offer the given serialized session,
+    /// as returned by [`session_and_params()`], for resumption.
+    ///
+    /// This must only be called immediately after creating a connection, that
+    /// is, before any packet is sent or received.
+    ///
+    /// [`session_and_params()`]: struct.Connection.html#method.session_and_params
+    #[inline]
+    pub fn set_session_and_params(
+        &mut self, session_and_params: (&[u8], &[u8]),
+    ) -> Result<()> {
+        self.handshake.set_session(session_and_params.0)?;
 
         let peer_params =
-            TransportParams::decode(raw_params_bytes.as_ref(), self.is_server)?;
+            TransportParams::decode(session_and_params.1, self.is_server)?;
 
         self.process_peer_transport_params(peer_params)?;
 
@@ -6063,8 +6091,24 @@ impl Connection {
     ///
     /// [`set_session()`]: struct.Connection.html#method.set_session
     #[inline]
+    #[deprecated(note = "Use session_and_params()")]
     pub fn session(&self) -> Option<&[u8]> {
         self.session.as_deref()
+    }
+
+    /// Returns the serialized cryptographic session and  transport params
+    /// for the connection.
+    ///
+    /// This can be used by a client to cache a connection's session and
+    /// transport params, and resume it later using the
+    /// [`set_session_and_params()`] method.
+    ///
+    /// [`set_session_and_params()`]: struct.Connection.html#method.set_session_and_params
+    #[inline]
+    pub fn session_and_params(&self) -> Option<(&[u8], &[u8])> {
+        self.session_and_params
+            .as_ref()
+            .map(|sp| (sp.0.as_slice(), sp.1.as_slice()))
     }
 
     /// Returns the source connection ID.
@@ -6390,6 +6434,8 @@ impl Connection {
             pkt_num_spaces: &mut self.pkt_num_spaces,
 
             session: &mut self.session,
+
+            session_and_params: &mut self.session_and_params,
 
             local_error: &mut self.local_error,
 
@@ -8814,7 +8860,7 @@ mod tests {
         assert!(!pipe.server.is_resumed());
 
         // Extract session,
-        let session = pipe.client.session().unwrap();
+        let session_and_params = pipe.client.session_and_params().unwrap();
 
         // Configure session on new connection and perform handshake.
         let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
@@ -8835,7 +8881,10 @@ mod tests {
 
         let mut pipe = testing::Pipe::with_server_config(&mut config).unwrap();
 
-        assert_eq!(pipe.client.set_session(session), Ok(()));
+        assert_eq!(
+            pipe.client.set_session_and_params(session_and_params),
+            Ok(())
+        );
         assert_eq!(pipe.handshake(), Ok(()));
 
         assert!(pipe.client.is_established());
@@ -8895,11 +8944,14 @@ mod tests {
         assert_eq!(pipe.handshake(), Ok(()));
 
         // Extract session,
-        let session = pipe.client.session().unwrap();
+        let session_and_params = pipe.client.session_and_params().unwrap();
 
         // Configure session on new connection.
         let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
-        assert_eq!(pipe.client.set_session(session), Ok(()));
+        assert_eq!(
+            pipe.client.set_session_and_params(session_and_params),
+            Ok(())
+        );
 
         // Client sends initial flight.
         let (len, _) = pipe.client.send(&mut buf).unwrap();
@@ -8956,11 +9008,14 @@ mod tests {
         assert_eq!(pipe.handshake(), Ok(()));
 
         // Extract session,
-        let session = pipe.client.session().unwrap();
+        let session_and_params = pipe.client.session_and_params().unwrap();
 
         // Configure session on new connection.
         let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
-        assert_eq!(pipe.client.set_session(session), Ok(()));
+        assert_eq!(
+            pipe.client.set_session_and_params(session_and_params),
+            Ok(())
+        );
 
         // Client sends initial flight.
         let (len, _) = pipe.client.send(&mut buf).unwrap();
@@ -9027,11 +9082,14 @@ mod tests {
         assert_eq!(pipe.handshake(), Ok(()));
 
         // Extract session,
-        let session = pipe.client.session().unwrap();
+        let session_and_params = pipe.client.session_and_params().unwrap();
 
         // Configure session on new connection.
         let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
-        assert_eq!(pipe.client.set_session(session), Ok(()));
+        assert_eq!(
+            pipe.client.set_session_and_params(session_and_params),
+            Ok(())
+        );
 
         // Client sends initial flight.
         pipe.client.send(&mut buf).unwrap();
@@ -9148,11 +9206,14 @@ mod tests {
         assert_eq!(pipe.handshake(), Ok(()));
 
         // Extract session,
-        let session = pipe.client.session().unwrap();
+        let session_and_params = pipe.client.session_and_params().unwrap();
 
         // Configure session on new connection.
         let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
-        assert_eq!(pipe.client.set_session(session), Ok(()));
+        assert_eq!(
+            pipe.client.set_session_and_params(session_and_params),
+            Ok(())
+        );
 
         // Client sends initial flight.
         let (len, _) = pipe.client.send(&mut buf).unwrap();

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -896,6 +896,8 @@ pub struct ExData<'a> {
 
     pub session: &'a mut Option<Vec<u8>>,
 
+    pub session_and_params: &'a mut Option<(Vec<u8>, Vec<u8>)>,
+
     pub local_error: &'a mut Option<super::ConnectionError>,
 
     pub keylog: Option<&'a mut Box<dyn std::io::Write + Send + Sync>>,
@@ -1213,6 +1215,7 @@ extern fn new_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int {
     }
 
     *ex_data.session = Some(buffer);
+    *ex_data.session_and_params = Some((session_bytes, peer_params.to_vec()));
 
     // Prevent handshake from being freed, as we still need it.
     std::mem::forget(handshake);

--- a/tools/http3_test/src/runner.rs
+++ b/tools/http3_test/src/runner.rs
@@ -127,6 +127,7 @@ pub fn run(
 
     if let Some(session_file) = &session_file {
         if let Ok(session) = std::fs::read(session_file) {
+            #[allow(deprecated)]
             conn.set_session(&session).ok();
         }
     }
@@ -223,6 +224,7 @@ pub fn run(
             }
 
             if let Some(session_file) = session_file {
+                #[allow(deprecated)]
                 if let Some(session) = conn.session() {
                     std::fs::write(session_file, session).ok();
                 }
@@ -421,6 +423,7 @@ pub fn run(
             }
 
             if let Some(session_file) = session_file {
+                #[allow(deprecated)]
                 if let Some(session) = conn.session() {
                     std::fs::write(session_file, session).ok();
                 }


### PR DESCRIPTION
Motivation:

At the moment the session and transport params are serialized into one buffer using their length as a prefix. While this works it would be better to keep them split for various reasons. One is that it doesnt make sense to encode them first into one just to split them again later. The other is that users might want to implement session re-use / caching themselves by using BoringSSL callbacks in which case they need to re-implement the encoding again which might break later as its an implementation details.

Modifications:

- Add session_and_params(...) and set_session_and_params(...) methods
- Deprecate the old methods

Result:

Improve API.