### PR TITLE
Expose quiche_conn_retired_scids

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -666,6 +666,9 @@ ssize_t quiche_conn_send_ack_eliciting_on_path(quiche_conn *conn,
                            const struct sockaddr *local, size_t local_len,
                            const struct sockaddr *peer, size_t peer_len);
 
+// Returns the number of source Connection IDs that are retired.
+size_t quiche_conn_retired_scids(quiche_conn *conn);
+
 // Frees the connection object.
 void quiche_conn_free(quiche_conn *conn);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1347,6 +1347,11 @@ pub extern fn quiche_conn_send_quantum(conn: &Connection) -> size_t {
     conn.send_quantum() as size_t
 }
 
+#[no_mangle]
+pub extern fn quiche_conn_retired_scids(conn: &Connection) -> size_t {
+    conn.retired_scids() as size_t
+}
+
 fn std_addr_from_c(addr: &sockaddr, addr_len: socklen_t) -> SocketAddr {
     match addr.sa_family as i32 {
         AF_INET => {


### PR DESCRIPTION
Motivation:

https://github.com/cloudflare/quiche/commit/c484819eb2d047c730c0a7f7f215e6bec56d0b4c introduced retired_source_cids() but did miss to expose it via the C API.

Modifications:

Add ffi impl and c header definition

Result:

Expose method also via C