### PR TITLE
remove per-stream application data

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -475,19 +475,6 @@ bool quiche_conn_local_error(const quiche_conn *conn,
                              const uint8_t **reason,
                              size_t *reason_len);
 
-// Initializes the stream's application data.
-//
-// Stream data can only be initialized once. Additional calls to this method
-// will fail.
-//
-// Note that the application is responsible for freeing the data.
-int quiche_conn_stream_init_application_data(quiche_conn *conn,
-                                             uint64_t stream_id,
-                                             void *data);
-
-// Returns the stream's application data, if any was initialized.
-void *quiche_conn_stream_application_data(quiche_conn *conn, uint64_t stream_id);
-
 // Fetches the next stream from the given iterator. Returns false if there are
 // no more elements in the iterator.
 bool quiche_stream_iter_next(quiche_stream_iter *iter, uint64_t *stream_id);

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -887,32 +887,6 @@ pub extern fn quiche_conn_is_readable(conn: &Connection) -> bool {
     conn.is_readable()
 }
 
-struct AppData(*mut c_void);
-unsafe impl Send for AppData {}
-unsafe impl Sync for AppData {}
-
-#[no_mangle]
-pub extern fn quiche_conn_stream_init_application_data(
-    conn: &mut Connection, stream_id: u64, data: *mut c_void,
-) -> c_int {
-    match conn.stream_init_application_data(stream_id, AppData(data)) {
-        Ok(_) => 0,
-
-        Err(e) => e.to_c() as c_int,
-    }
-}
-
-#[no_mangle]
-pub extern fn quiche_conn_stream_application_data(
-    conn: &mut Connection, stream_id: u64,
-) -> *mut c_void {
-    match conn.stream_application_data(stream_id) {
-        Some(v) => v.downcast_mut::<AppData>().unwrap().0,
-
-        None => ptr::null_mut(),
-    }
-}
-
 #[no_mangle]
 pub extern fn quiche_conn_close(
     conn: &mut Connection, app: bool, err: u64, reason: *const u8,

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4975,53 +4975,6 @@ impl Connection {
         self.streams.peer_streams_left_uni()
     }
 
-    /// Initializes the stream's application data.
-    ///
-    /// This can be used by applications to store per-stream information without
-    /// having to maintain their own stream map.
-    ///
-    /// Stream data can only be initialized once. Additional calls to this
-    /// method will return [`Done`].
-    ///
-    /// [`Done`]: enum.Error.html#variant.Done
-    pub fn stream_init_application_data<T>(
-        &mut self, stream_id: u64, data: T,
-    ) -> Result<()>
-    where
-        T: std::any::Any + Send + Sync,
-    {
-        // Get existing stream.
-        let stream = self.streams.get_mut(stream_id).ok_or(Error::Done)?;
-
-        if stream.data.is_some() {
-            return Err(Error::Done);
-        }
-
-        stream.data = Some(Box::new(data));
-
-        Ok(())
-    }
-
-    /// Returns the stream's application data, if any was initialized.
-    ///
-    /// This returns a reference to the application data that was initialized
-    /// by calling [`stream_init_application_data()`].
-    ///
-    /// [`stream_init_application_data()`]:
-    /// struct.Connection.html#method.stream_init_application_data
-    pub fn stream_application_data(
-        &mut self, stream_id: u64,
-    ) -> Option<&mut dyn std::any::Any> {
-        // Get existing stream.
-        let stream = self.streams.get_mut(stream_id)?;
-
-        if let Some(ref mut stream_data) = stream.data {
-            return Some(stream_data.as_mut());
-        }
-
-        None
-    }
-
     /// Returns an iterator over streams that have outstanding data to read.
     ///
     /// Note that the iterator will only include streams that were readable at

--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -657,9 +657,6 @@ pub struct Stream {
     /// Whether the stream was created by the local endpoint.
     pub local: bool,
 
-    /// Application data.
-    pub data: Option<Box<dyn std::any::Any + Send + Sync>>,
-
     /// The stream's urgency (lower is better). Default is `DEFAULT_URGENCY`.
     pub urgency: u8,
 
@@ -679,7 +676,6 @@ impl Stream {
             send_lowat: 1,
             bidi,
             local,
-            data: None,
             urgency: DEFAULT_URGENCY,
             incremental: true,
         }


### PR DESCRIPTION
This was originally added for curl, but it was never used. The Rust API is also hard to use, because the app data reference borrows the whole connection object.