### PR TITLE
WIP: lib: Add writable_prioritized()

### DIFF
--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -442,6 +442,7 @@ Options:
   --qpack-blocked-streams STREAMS   Limit of streams that can be blocked while decoding. Any value other that 0 is currently unsupported.
   --disable-gso               Disable GSO (linux only).
   --disable-pacing            Disable pacing (linux only).
+  --writable_prioritized      Use writable_prioritized StreamIter.
   -h --help                   Show this screen.
 ";
 
@@ -455,6 +456,7 @@ pub struct ServerArgs {
     pub key: String,
     pub disable_gso: bool,
     pub disable_pacing: bool,
+    pub writable_prioritized: bool,
 }
 
 impl Args for ServerArgs {
@@ -469,6 +471,7 @@ impl Args for ServerArgs {
         let key = args.get_str("--key").to_string();
         let disable_gso = args.get_bool("--disable-gso");
         let disable_pacing = args.get_bool("--disable-pacing");
+        let writable_prioritized = args.get_bool("--writable_prioritized");
 
         ServerArgs {
             listen,
@@ -479,6 +482,7 @@ impl Args for ServerArgs {
             key,
             disable_gso,
             disable_pacing,
+            writable_prioritized,
         }
     }
 }

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -478,8 +478,23 @@ fn main() {
                 let http_conn = client.http_conn.as_mut().unwrap();
                 let partial_responses = &mut client.partial_responses;
 
-                // Handle writable streams.
+                // TODO LP print prioritized streams
+                for stream_id in conn.writable_prioritized() {
+                    trace!("prioritized stream ID={}", stream_id);
+                }
+
                 for stream_id in conn.writable() {
+                    trace!("writable stream ID={}", stream_id);
+                }
+
+                let writable = if args.writable_prioritized {
+                    conn.writable_prioritized()
+                } else {
+                    conn.writable()
+                };
+
+                // Handle writable streams.
+                for stream_id in writable {
                     http_conn.handle_writable(conn, partial_responses, stream_id);
                 }
 

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -63,6 +63,7 @@ lazy_static = "1"
 octets = { version = "0.2", path = "../octets" }
 boring = { version = "2.0.0", optional = true }
 foreign-types-shared = { version = "0.3.0", optional = true }
+intrusive-collections = "0.9.5"
 qlog = { version = "0.9", path = "../qlog", optional = true }
 sfv = { version = "0.9", optional = true }
 smallvec = { version = "1.10", features = ["serde", "union"] }

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -910,6 +910,7 @@ impl PktNumSpace {
                 true,
                 true,
                 stream::MAX_STREAM_WINDOW,
+                0, // dummy
             ),
         }
     }
@@ -921,6 +922,7 @@ impl PktNumSpace {
             true,
             true,
             stream::MAX_STREAM_WINDOW,
+            0, // dummy
         );
 
         self.ack_elicited = false;

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -1051,7 +1051,14 @@ extern fn add_handshake_data(
             &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
     };
 
-    if space.crypto_stream.send.write(buf, false).is_err() {
+    if space
+        .crypto_stream
+        .send
+        .lock()
+        .unwrap()
+        .write(buf, false)
+        .is_err()
+    {
         return 0;
     }
 


### PR DESCRIPTION
This change adds a new writable_prioritized() stream iterator that better respects the ordering expected from RFC 9218.