### PR TITLE
lib: progress through StreamIter from front to back

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -15649,30 +15649,31 @@ mod tests {
         // Server iterators are populated
         let mut r = pipe.server.readable();
         assert_eq!(r.len(), 10);
-        assert_eq!(r.next(), Some(28));
-        assert_eq!(r.next(), Some(12));
-        assert_eq!(r.next(), Some(24));
-        assert_eq!(r.next(), Some(8));
-        assert_eq!(r.next(), Some(36));
-        assert_eq!(r.next(), Some(20));
-        assert_eq!(r.next(), Some(4));
-        assert_eq!(r.next(), Some(32));
-        assert_eq!(r.next(), Some(16));
         assert_eq!(r.next(), Some(0));
+        assert_eq!(r.next(), Some(16));
+        assert_eq!(r.next(), Some(32));
+        assert_eq!(r.next(), Some(4));
+        assert_eq!(r.next(), Some(20));
+        assert_eq!(r.next(), Some(36));
+        assert_eq!(r.next(), Some(8));
+        assert_eq!(r.next(), Some(24));
+        assert_eq!(r.next(), Some(12));
+        assert_eq!(r.next(), Some(28));
+
         assert_eq!(r.next(), None);
 
         let mut w = pipe.server.writable();
         assert_eq!(w.len(), 10);
-        assert_eq!(w.next(), Some(28));
-        assert_eq!(w.next(), Some(12));
-        assert_eq!(w.next(), Some(24));
-        assert_eq!(w.next(), Some(8));
-        assert_eq!(w.next(), Some(36));
-        assert_eq!(w.next(), Some(20));
-        assert_eq!(w.next(), Some(4));
-        assert_eq!(w.next(), Some(32));
-        assert_eq!(w.next(), Some(16));
         assert_eq!(w.next(), Some(0));
+        assert_eq!(w.next(), Some(16));
+        assert_eq!(w.next(), Some(32));
+        assert_eq!(w.next(), Some(4));
+        assert_eq!(w.next(), Some(20));
+        assert_eq!(w.next(), Some(36));
+        assert_eq!(w.next(), Some(8));
+        assert_eq!(w.next(), Some(24));
+        assert_eq!(w.next(), Some(12));
+        assert_eq!(w.next(), Some(28));
         assert_eq!(w.next(), None);
 
         // Read one stream

--- a/quiche/src/stream.rs
+++ b/quiche/src/stream.rs
@@ -745,6 +745,7 @@ pub fn is_bidi(stream_id: u64) -> bool {
 #[derive(Default)]
 pub struct StreamIter {
     streams: SmallVec<[u64; 8]>,
+    index: usize,
 }
 
 impl StreamIter {
@@ -752,6 +753,7 @@ impl StreamIter {
     fn from(streams: &StreamIdHashSet) -> Self {
         StreamIter {
             streams: streams.iter().copied().collect(),
+            index: 0,
         }
     }
 }
@@ -761,14 +763,16 @@ impl Iterator for StreamIter {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.streams.pop()
+        let v = self.streams.get(self.index)?;
+        self.index += 1;
+        Some(*v)
     }
 }
 
 impl ExactSizeIterator for StreamIter {
     #[inline]
     fn len(&self) -> usize {
-        self.streams.len()
+        self.streams.len() - self.index
     }
 }
 


### PR DESCRIPTION
Previously, StreamIter next() would pop() the last stream ID and return
it, leading to a back-to-front progression.

Since we're stuck with SmallVec for internal data for performance reasons
we can't pop_front(). So instead, this change skips mutating the
StreamIter's internal data and instead uses a simple tracking index that
lets us move front-to-back.

This change helps to avoid cases where we had a correctly ordered
SmallVec of streams, and would need to reverse it before constructing a
StreamIter, just so that the iteration would make logical progressions.
It also addresses cases where we missed doing any reversal preparation.
