### PR TITLE
ffi: explicitly drop Box in _free methods

### DIFF
--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -388,7 +388,7 @@ pub extern fn quiche_config_set_stateless_reset_token(
 
 #[no_mangle]
 pub extern fn quiche_config_free(config: *mut Config) {
-    unsafe { drop(Box::from_raw(config)) };
+    drop(unsafe { Box::from_raw(config) });
 }
 
 #[no_mangle]
@@ -1070,7 +1070,7 @@ pub extern fn quiche_stream_iter_next(
 
 #[no_mangle]
 pub extern fn quiche_stream_iter_free(iter: *mut StreamIter) {
-    unsafe { drop(Box::from_raw(iter)) };
+    drop(unsafe { Box::from_raw(iter) });
 }
 
 #[repr(C)]
@@ -1303,7 +1303,7 @@ pub extern fn quiche_conn_send_ack_eliciting_on_path(
 
 #[no_mangle]
 pub extern fn quiche_conn_free(conn: *mut Connection) {
-    unsafe { drop(Box::from_raw(conn)) };
+    drop(unsafe { Box::from_raw(conn) });
 }
 
 #[no_mangle]

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -388,7 +388,7 @@ pub extern fn quiche_config_set_stateless_reset_token(
 
 #[no_mangle]
 pub extern fn quiche_config_free(config: *mut Config) {
-    unsafe { Box::from_raw(config) };
+    unsafe { drop(Box::from_raw(config)) };
 }
 
 #[no_mangle]
@@ -1070,7 +1070,7 @@ pub extern fn quiche_stream_iter_next(
 
 #[no_mangle]
 pub extern fn quiche_stream_iter_free(iter: *mut StreamIter) {
-    unsafe { Box::from_raw(iter) };
+    unsafe { drop(Box::from_raw(iter)) };
 }
 
 #[repr(C)]
@@ -1303,7 +1303,7 @@ pub extern fn quiche_conn_send_ack_eliciting_on_path(
 
 #[no_mangle]
 pub extern fn quiche_conn_free(conn: *mut Connection) {
-    unsafe { Box::from_raw(conn) };
+    unsafe { drop(Box::from_raw(conn)) };
 }
 
 #[no_mangle]

--- a/quiche/src/h3/ffi.rs
+++ b/quiche/src/h3/ffi.rs
@@ -79,7 +79,7 @@ pub extern fn quiche_h3_config_enable_extended_connect(
 
 #[no_mangle]
 pub extern fn quiche_h3_config_free(config: *mut h3::Config) {
-    unsafe { drop(Box::from_raw(config)) };
+    drop(unsafe { Box::from_raw(config) });
 }
 
 #[no_mangle]
@@ -207,7 +207,7 @@ pub extern fn quiche_h3_extended_connect_enabled_by_peer(
 
 #[no_mangle]
 pub extern fn quiche_h3_event_free(ev: *mut h3::Event) {
-    unsafe { drop(Box::from_raw(ev)) };
+    drop(unsafe { Box::from_raw(ev) });
 }
 
 #[repr(C)]
@@ -407,7 +407,7 @@ pub extern fn quiche_h3_recv_dgram(
 
 #[no_mangle]
 pub extern fn quiche_h3_conn_free(conn: *mut h3::Connection) {
-    unsafe { drop(Box::from_raw(conn)) };
+    drop(unsafe { Box::from_raw(conn) });
 }
 
 fn headers_from_ptr<'a>(

--- a/quiche/src/h3/ffi.rs
+++ b/quiche/src/h3/ffi.rs
@@ -79,7 +79,7 @@ pub extern fn quiche_h3_config_enable_extended_connect(
 
 #[no_mangle]
 pub extern fn quiche_h3_config_free(config: *mut h3::Config) {
-    unsafe { Box::from_raw(config) };
+    unsafe { drop(Box::from_raw(config)) };
 }
 
 #[no_mangle]
@@ -207,7 +207,7 @@ pub extern fn quiche_h3_extended_connect_enabled_by_peer(
 
 #[no_mangle]
 pub extern fn quiche_h3_event_free(ev: *mut h3::Event) {
-    unsafe { Box::from_raw(ev) };
+    unsafe { drop(Box::from_raw(ev)) };
 }
 
 #[repr(C)]
@@ -407,7 +407,7 @@ pub extern fn quiche_h3_recv_dgram(
 
 #[no_mangle]
 pub extern fn quiche_h3_conn_free(conn: *mut h3::Connection) {
-    unsafe { Box::from_raw(conn) };
+    unsafe { drop(Box::from_raw(conn)) };
 }
 
 fn headers_from_ptr<'a>(


### PR DESCRIPTION
nightly builds are failing without such a change.