### PR TITLE
path: progress through SocketAddrIter from front to back

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -5897,6 +5897,8 @@ impl Connection {
                 .filter(|(_, p)| p.local_addr() == from)
                 .map(|(_, p)| p.peer_addr())
                 .collect(),
+
+            index: 0,
         }
     }
 

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -30,6 +30,8 @@ use std::collections::BTreeMap;
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 
+use smallvec::SmallVec;
+
 use slab::Slab;
 
 use crate::Error;
@@ -467,7 +469,8 @@ impl Path {
 /// An iterator over SocketAddr.
 #[derive(Default)]
 pub struct SocketAddrIter {
-    pub(crate) sockaddrs: Vec<SocketAddr>,
+    pub(crate) sockaddrs: SmallVec<[SocketAddr; 8]>,
+    pub(crate) index: usize,
 }
 
 impl Iterator for SocketAddrIter {
@@ -475,14 +478,16 @@ impl Iterator for SocketAddrIter {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.sockaddrs.pop()
+        let v = self.sockaddrs.get(self.index)?;
+        self.index += 1;
+        Some(*v)
     }
 }
 
 impl ExactSizeIterator for SocketAddrIter {
     #[inline]
     fn len(&self) -> usize {
-        self.sockaddrs.len()
+        self.sockaddrs.len() - self.index
     }
 }
 


### PR DESCRIPTION
Also use smallvec. Similar to 0f22ab5f.