### PR TITLE
apps: queue response body writes for better scheduling

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -1484,35 +1484,14 @@ impl HttpConn for Http3Conn {
                         },
                     }
 
-                    let written = match self
-                        .h3_conn
-                        .send_body(conn, stream_id, &body, true)
-                    {
-                        Ok(v) => v,
-
-                        Err(quiche::h3::Error::Done) => 0,
-
-                        Err(e) => {
-                            error!(
-                                "{} stream send failed {:?}",
-                                conn.trace_id(),
-                                e
-                            );
-
-                            break;
-                        },
+                    let response = PartialResponse {
+                        headers: None,
+                        priority: None,
+                        body,
+                        written: 0,
                     };
 
-                    if written < body.len() {
-                        let response = PartialResponse {
-                            headers: None,
-                            priority: None,
-                            body,
-                            written,
-                        };
-
-                        partial_responses.insert(stream_id, response);
-                    }
+                    partial_responses.insert(stream_id, response);
                 },
 
                 Ok((stream_id, quiche::h3::Event::Data)) => {


### PR DESCRIPTION
Previously, as soon as a server received a request, it would try to emit
headers and body during the same cycle. When then body was too large to
send (e.g., due to congestion window) the response would be queued up
for later rounds of writing. This initial send always happened
regardless of a stream's selected priority.

The later rounds of writing explicitly use a writable iterator to step
through the streams. When switching to an iterator that better supports
priority scheduling, streams that are queued are more likely to respect
the selected priority.

With this change, we no longer attempt to write body immediately.
Instead, it is added to the dispatch queue that will be drained in
accordance with the writable iterator.
.
