### PR TITLE
h3: allow applications to set additional settings

### DIFF
--- a/quiche/src/h3/frame.rs
+++ b/quiche/src/h3/frame.rs
@@ -70,6 +70,7 @@ pub enum Frame {
         connect_protocol_enabled: Option<u64>,
         h3_datagram: Option<u64>,
         grease: Option<(u64, u64)>,
+        additional_settings: Option<Vec<(u64, u64)>>,
         raw: Option<Vec<(u64, u64)>>,
     },
 
@@ -181,6 +182,7 @@ impl Frame {
                 connect_protocol_enabled,
                 h3_datagram,
                 grease,
+                additional_settings,
                 ..
             } => {
                 let mut len = 0;
@@ -217,6 +219,13 @@ impl Frame {
                     len += octets::varint_len(val.1);
                 }
 
+                if let Some(vals) = additional_settings {
+                    for val in vals {
+                        len += octets::varint_len(val.0);
+                        len += octets::varint_len(val.1);
+                    }
+                }
+
                 b.put_varint(SETTINGS_FRAME_TYPE_ID)?;
                 b.put_varint(len as u64)?;
 
@@ -250,6 +259,13 @@ impl Frame {
                 if let Some(val) = grease {
                     b.put_varint(val.0)?;
                     b.put_varint(val.1)?;
+                }
+
+                if let Some(vals) = additional_settings {
+                    for val in vals {
+                        b.put_varint(val.0)?;
+                        b.put_varint(val.1)?;
+                    }
                 }
             },
 
@@ -457,10 +473,11 @@ impl std::fmt::Debug for Frame {
                 max_field_section_size,
                 qpack_max_table_capacity,
                 qpack_blocked_streams,
+                additional_settings,
                 raw,
                 ..
             } => {
-                write!(f, "SETTINGS max_field_section={max_field_section_size:?}, qpack_max_table={qpack_max_table_capacity:?}, qpack_blocked={qpack_blocked_streams:?} raw={raw:?}")?;
+                write!(f, "SETTINGS max_field_section={max_field_section_size:?}, qpack_max_table={qpack_max_table_capacity:?}, qpack_blocked={qpack_blocked_streams:?} raw={raw:?}, additional_settings={additional_settings:?}")?;
             },
 
             Frame::PushPromise {
@@ -525,6 +542,7 @@ fn parse_settings_frame(
     let mut connect_protocol_enabled = None;
     let mut h3_datagram = None;
     let mut raw = Vec::new();
+    let mut additional_settings: Option<Vec<(u64, u64)>> = None;
 
     // Reject SETTINGS frames that are too long.
     if settings_length > MAX_SETTINGS_PAYLOAD_SIZE {
@@ -572,8 +590,11 @@ fn parse_settings_frame(
             0x0 | 0x2 | 0x3 | 0x4 | 0x5 =>
                 return Err(super::Error::SettingsError),
 
-            // Unknown Settings parameters must be ignored.
-            _ => (),
+            // Unknown Settings parameters go into additional_settings.
+            _ => match &mut additional_settings {
+                Some(s) => s.push((identifier, value)),
+                None => additional_settings = Some(vec![(identifier, value)]),
+            },
         }
     }
 
@@ -585,6 +606,7 @@ fn parse_settings_frame(
         h3_datagram,
         grease: None,
         raw: Some(raw),
+        additional_settings,
     })
 }
 
@@ -734,6 +756,7 @@ mod tests {
             h3_datagram: Some(0),
             grease: None,
             raw: Some(raw_settings),
+            additional_settings: None,
         };
 
         let frame_payload_len = 13;
@@ -769,6 +792,7 @@ mod tests {
             h3_datagram: Some(0),
             grease: Some((33, 33)),
             raw: Default::default(),
+            additional_settings: None,
         };
 
         let raw_settings = vec![
@@ -791,6 +815,7 @@ mod tests {
             h3_datagram: Some(0),
             grease: None,
             raw: Some(raw_settings),
+            additional_settings: Some(vec![(33, 33)]),
         };
 
         let frame_payload_len = 15;
@@ -828,6 +853,7 @@ mod tests {
             h3_datagram: None,
             grease: None,
             raw: Some(raw_settings),
+            additional_settings: None,
         };
 
         let frame_payload_len = 3;
@@ -865,6 +891,7 @@ mod tests {
             h3_datagram: None,
             grease: None,
             raw: Some(raw_settings),
+            additional_settings: None,
         };
 
         let frame_payload_len = 2;
@@ -902,6 +929,7 @@ mod tests {
             h3_datagram: None,
             grease: None,
             raw: Some(raw_settings),
+            additional_settings: None,
         };
 
         let frame_payload_len = 2;
@@ -939,6 +967,7 @@ mod tests {
             h3_datagram: Some(1),
             grease: None,
             raw: Some(raw_settings),
+            additional_settings: None,
         };
 
         let frame_payload_len = 5;
@@ -974,6 +1003,7 @@ mod tests {
             h3_datagram: Some(5),
             grease: None,
             raw: Default::default(),
+            additional_settings: None,
         };
 
         let frame_payload_len = 5;
@@ -1013,6 +1043,7 @@ mod tests {
             h3_datagram: None,
             grease: None,
             raw: Some(raw_settings),
+            additional_settings: None,
         };
 
         let frame_payload_len = 4;

--- a/quiche/src/h3/frame.rs
+++ b/quiche/src/h3/frame.rs
@@ -351,6 +351,7 @@ impl Frame {
                 connect_protocol_enabled,
                 h3_datagram,
                 grease,
+                additional_settings,
                 ..
             } => {
                 let mut settings = vec![];
@@ -395,6 +396,15 @@ impl Frame {
                         name: k.to_string(),
                         value: *v,
                     });
+                }
+
+                if let Some(additional_settings) = additional_settings {
+                    for (k, v) in additional_settings {
+                        settings.push(qlog::events::h3::Setting {
+                            name: k.to_string(),
+                            value: *v,
+                        });
+                    }
                 }
 
                 qlog::events::h3::Http3Frame::Settings { settings }

--- a/quiche/src/h3/frame.rs
+++ b/quiche/src/h3/frame.rs
@@ -591,9 +591,10 @@ fn parse_settings_frame(
                 return Err(super::Error::SettingsError),
 
             // Unknown Settings parameters go into additional_settings.
-            _ => match &mut additional_settings {
-                Some(s) => s.push((identifier, value)),
-                None => additional_settings = Some(vec![(identifier, value)]),
+            _ => {
+                let s: &mut Vec<(u64, u64)> =
+                    additional_settings.get_or_insert(vec![]);
+                s.push((identifier, value));
             },
         }
     }

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -566,7 +566,7 @@ impl Config {
         }
     }
 
-    /// Sets H3 additional settings.
+    /// Sets additional HTTP/3 settings.
     ///
     /// The default value is no additional settings.
     /// The `additional_settings` parameter must not contain settings already

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -595,6 +595,7 @@ impl Config {
             frame::SETTINGS_QPACK_BLOCKED_STREAMS,
             frame::SETTINGS_ENABLE_CONNECT_PROTOCOL,
             frame::SETTINGS_H3_DATAGRAM,
+            frame::SETTINGS_H3_DATAGRAM_00,
         ]);
 
         let dedup_settings: HashSet<u64> =

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -569,8 +569,15 @@ impl Config {
     /// Sets additional HTTP/3 settings.
     ///
     /// The default value is no additional settings.
-    /// The `additional_settings` parameter must not contain settings already
-    /// handled by default in this library.
+    /// The `additional_settings` parameter must not the following
+    /// settings as they are already handled by this library:
+    ///
+    /// - SETTINGS_QPACK_MAX_TABLE_CAPACITY
+    /// - SETTINGS_MAX_FIELD_SECTION_SIZE
+    /// - SETTINGS_QPACK_BLOCKED_STREAMS
+    /// - SETTINGS_ENABLE_CONNECT_PROTOCOL
+    /// - SETTINGS_H3_DATAGRAM
+    ///
     /// If such a setting is present in the `additional_settings`,
     /// the method will return the [`Error::SettingsError`] error.
     ///

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -575,7 +575,9 @@ impl Config {
     /// the method will return the [`Error::SettingsError`] error.
     ///
     /// [`Error::SettingsError`]: enum.Error.html#variant.SettingsError
-    pub fn set_additional_settings(&mut self, additional_settings: Vec<(u64, u64)>) -> Result<()> {
+    pub fn set_additional_settings(
+        &mut self, additional_settings: Vec<(u64, u64)>,
+    ) -> Result<()> {
         let explicit_settings = vec![
             frame::SETTINGS_QPACK_MAX_TABLE_CAPACITY,
             frame::SETTINGS_MAX_FIELD_SECTION_SIZE,
@@ -583,7 +585,10 @@ impl Config {
             frame::SETTINGS_ENABLE_CONNECT_PROTOCOL,
             frame::SETTINGS_H3_DATAGRAM,
         ];
-        if additional_settings.iter().any(|(identifier, _)| explicit_settings.contains(identifier)) {
+        if additional_settings
+            .iter()
+            .any(|(identifier, _)| explicit_settings.contains(identifier))
+        {
             return Err(Error::SettingsError);
         }
         self.additional_settings = Some(additional_settings);
@@ -5507,11 +5512,39 @@ mod tests {
     /// Tests that setting SETTINGS with prohibited values generates an error.
     fn set_prohibited_additional_settings() {
         let mut h3_config = Config::new().unwrap();
-        assert_eq!(h3_config.set_additional_settings(vec![(frame::SETTINGS_QPACK_MAX_TABLE_CAPACITY, 43)]), Err(Error::SettingsError));
-        assert_eq!(h3_config.set_additional_settings(vec![(frame::SETTINGS_MAX_FIELD_SECTION_SIZE, 43)]), Err(Error::SettingsError));
-        assert_eq!(h3_config.set_additional_settings(vec![(frame::SETTINGS_QPACK_BLOCKED_STREAMS, 43)]), Err(Error::SettingsError));
-        assert_eq!(h3_config.set_additional_settings(vec![(frame::SETTINGS_ENABLE_CONNECT_PROTOCOL, 43)]), Err(Error::SettingsError));
-        assert_eq!(h3_config.set_additional_settings(vec![(frame::SETTINGS_H3_DATAGRAM, 43)]), Err(Error::SettingsError));
+        assert_eq!(
+            h3_config.set_additional_settings(vec![(
+                frame::SETTINGS_QPACK_MAX_TABLE_CAPACITY,
+                43
+            )]),
+            Err(Error::SettingsError)
+        );
+        assert_eq!(
+            h3_config.set_additional_settings(vec![(
+                frame::SETTINGS_MAX_FIELD_SECTION_SIZE,
+                43
+            )]),
+            Err(Error::SettingsError)
+        );
+        assert_eq!(
+            h3_config.set_additional_settings(vec![(
+                frame::SETTINGS_QPACK_BLOCKED_STREAMS,
+                43
+            )]),
+            Err(Error::SettingsError)
+        );
+        assert_eq!(
+            h3_config.set_additional_settings(vec![(
+                frame::SETTINGS_ENABLE_CONNECT_PROTOCOL,
+                43
+            )]),
+            Err(Error::SettingsError)
+        );
+        assert_eq!(
+            h3_config
+                .set_additional_settings(vec![(frame::SETTINGS_H3_DATAGRAM, 43)]),
+            Err(Error::SettingsError)
+        );
     }
 
     #[test]
@@ -5535,7 +5568,9 @@ mod tests {
         config.grease(false);
 
         let mut h3_config = Config::new().unwrap();
-        h3_config.set_additional_settings(vec![(42, 43), (44, 45)]).unwrap();
+        h3_config
+            .set_additional_settings(vec![(42, 43), (44, 45)])
+            .unwrap();
 
         let mut s = Session::with_configs(&mut config, &h3_config).unwrap();
         assert_eq!(s.pipe.handshake(), Ok(()));
@@ -5550,8 +5585,14 @@ mod tests {
         assert_eq!(s.pipe.advance(), Ok(()));
         assert_eq!(s.client.poll(&mut s.pipe.client), Err(Error::Done));
 
-        assert_eq!(s.server.peer_settings_raw(), Some(&[(42, 43), (44, 45)][..]));
-        assert_eq!(s.client.peer_settings_raw(), Some(&[(42, 43), (44, 45)][..]));
+        assert_eq!(
+            s.server.peer_settings_raw(),
+            Some(&[(42, 43), (44, 45)][..])
+        );
+        assert_eq!(
+            s.client.peer_settings_raw(),
+            Some(&[(42, 43), (44, 45)][..])
+        );
     }
 
     #[test]

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -511,6 +511,9 @@ pub struct Config {
     qpack_max_table_capacity: Option<u64>,
     qpack_blocked_streams: Option<u64>,
     connect_protocol_enabled: Option<u64>,
+    /// additional settings are settings that are not part of the H3
+    /// settings explicitly handled above
+    additional_settings: Option<Vec<(u64, u64)>>,
 }
 
 impl Config {
@@ -521,6 +524,7 @@ impl Config {
             qpack_max_table_capacity: None,
             qpack_blocked_streams: None,
             connect_protocol_enabled: None,
+            additional_settings: None,
         })
     }
 
@@ -560,6 +564,30 @@ impl Config {
         } else {
             self.connect_protocol_enabled = None;
         }
+    }
+
+    /// Sets H3 additional settings.
+    ///
+    /// The default value is no additional settings.
+    /// The `additional_settings` parameter must not contain settings already
+    /// handled by default in this library.
+    /// If such a setting is present in the `additional_settings`,
+    /// the method will return the [`Error::SettingsError`] error.
+    ///
+    /// [`Error::SettingsError`]: enum.Error.html#variant.SettingsError
+    pub fn set_additional_settings(&mut self, additional_settings: Vec<(u64, u64)>) -> Result<()> {
+        let explicit_settings = vec![
+            frame::SETTINGS_QPACK_MAX_TABLE_CAPACITY,
+            frame::SETTINGS_MAX_FIELD_SECTION_SIZE,
+            frame::SETTINGS_QPACK_BLOCKED_STREAMS,
+            frame::SETTINGS_ENABLE_CONNECT_PROTOCOL,
+            frame::SETTINGS_H3_DATAGRAM,
+        ];
+        if additional_settings.iter().any(|(identifier, _)| explicit_settings.contains(identifier)) {
+            return Err(Error::SettingsError);
+        }
+        self.additional_settings = Some(additional_settings);
+        Ok(())
     }
 }
 
@@ -804,6 +832,7 @@ struct ConnectionSettings {
     pub qpack_blocked_streams: Option<u64>,
     pub connect_protocol_enabled: Option<u64>,
     pub h3_datagram: Option<u64>,
+    pub additional_settings: Option<Vec<(u64, u64)>>,
     pub raw: Option<Vec<(u64, u64)>>,
 }
 
@@ -865,6 +894,7 @@ impl Connection {
                 qpack_blocked_streams: config.qpack_blocked_streams,
                 connect_protocol_enabled: config.connect_protocol_enabled,
                 h3_datagram,
+                additional_settings: config.additional_settings.clone(),
                 raw: Default::default(),
             },
 
@@ -874,6 +904,7 @@ impl Connection {
                 qpack_blocked_streams: None,
                 h3_datagram: None,
                 connect_protocol_enabled: None,
+                additional_settings: Default::default(),
                 raw: Default::default(),
             },
 
@@ -1961,6 +1992,7 @@ impl Connection {
                 .connect_protocol_enabled,
             h3_datagram: self.local_settings.h3_datagram,
             grease,
+            additional_settings: self.local_settings.additional_settings.clone(),
             raw: Default::default(),
         };
 
@@ -2379,6 +2411,7 @@ impl Connection {
                 qpack_blocked_streams,
                 connect_protocol_enabled,
                 h3_datagram,
+                additional_settings,
                 raw,
                 ..
             } => {
@@ -2388,6 +2421,7 @@ impl Connection {
                     qpack_blocked_streams,
                     connect_protocol_enabled,
                     h3_datagram,
+                    additional_settings,
                     raw,
                 };
 
@@ -5386,6 +5420,7 @@ mod tests {
             connect_protocol_enabled: None,
             h3_datagram: Some(1),
             grease: None,
+            additional_settings: Default::default(),
             raw: Default::default(),
         };
 
@@ -5466,6 +5501,57 @@ mod tests {
         assert_eq!(s.server.poll(&mut s.pipe.server), Err(Error::SettingsError));
 
         assert_eq!(s.client.poll(&mut s.pipe.client), Err(Error::SettingsError));
+    }
+
+    #[test]
+    /// Tests that setting SETTINGS with prohibited values generates an error.
+    fn set_prohibited_additional_settings() {
+        let mut h3_config = Config::new().unwrap();
+        assert_eq!(h3_config.set_additional_settings(vec![(frame::SETTINGS_QPACK_MAX_TABLE_CAPACITY, 43)]), Err(Error::SettingsError));
+        assert_eq!(h3_config.set_additional_settings(vec![(frame::SETTINGS_MAX_FIELD_SECTION_SIZE, 43)]), Err(Error::SettingsError));
+        assert_eq!(h3_config.set_additional_settings(vec![(frame::SETTINGS_QPACK_BLOCKED_STREAMS, 43)]), Err(Error::SettingsError));
+        assert_eq!(h3_config.set_additional_settings(vec![(frame::SETTINGS_ENABLE_CONNECT_PROTOCOL, 43)]), Err(Error::SettingsError));
+        assert_eq!(h3_config.set_additional_settings(vec![(frame::SETTINGS_H3_DATAGRAM, 43)]), Err(Error::SettingsError));
+    }
+
+    #[test]
+    /// Tests additional settings are actually exchanged by the peers.
+    fn set_additional_settings() {
+        let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
+        config.set_initial_max_data(70);
+        config.set_initial_max_stream_data_bidi_local(150);
+        config.set_initial_max_stream_data_bidi_remote(150);
+        config.set_initial_max_stream_data_uni(150);
+        config.set_initial_max_streams_bidi(100);
+        config.set_initial_max_streams_uni(5);
+        config.verify_peer(false);
+        config.grease(false);
+
+        let mut h3_config = Config::new().unwrap();
+        h3_config.set_additional_settings(vec![(42, 43), (44, 45)]).unwrap();
+
+        let mut s = Session::with_configs(&mut config, &h3_config).unwrap();
+        assert_eq!(s.pipe.handshake(), Ok(()));
+
+        assert_eq!(s.pipe.advance(), Ok(()));
+
+        s.client.send_settings(&mut s.pipe.client).unwrap();
+        assert_eq!(s.pipe.advance(), Ok(()));
+        assert_eq!(s.server.poll(&mut s.pipe.server), Err(Error::Done));
+
+        s.server.send_settings(&mut s.pipe.server).unwrap();
+        assert_eq!(s.pipe.advance(), Ok(()));
+        assert_eq!(s.client.poll(&mut s.pipe.client), Err(Error::Done));
+
+        assert_eq!(s.server.peer_settings_raw(), Some(&[(42, 43), (44, 45)][..]));
+        assert_eq!(s.client.peer_settings_raw(), Some(&[(42, 43), (44, 45)][..]));
     }
 
     #[test]

--- a/quiche/src/h3/stream.rs
+++ b/quiche/src/h3/stream.rs
@@ -702,6 +702,7 @@ mod tests {
             connect_protocol_enabled: None,
             h3_datagram: None,
             grease: None,
+            additional_settings: None,
             raw: Some(raw_settings),
         };
 
@@ -751,6 +752,7 @@ mod tests {
             connect_protocol_enabled: None,
             h3_datagram: None,
             grease: None,
+            additional_settings: None,
             raw: Some(vec![]),
         };
 
@@ -806,6 +808,7 @@ mod tests {
             connect_protocol_enabled: None,
             h3_datagram: None,
             grease: None,
+            additional_settings: None,
             raw: Some(raw_settings),
         };
 
@@ -870,6 +873,7 @@ mod tests {
             connect_protocol_enabled: None,
             h3_datagram: None,
             grease: None,
+            additional_settings: None,
             raw: Some(raw_settings),
         };
 
@@ -913,6 +917,7 @@ mod tests {
             connect_protocol_enabled: None,
             h3_datagram: None,
             grease: None,
+            additional_settings: None,
             raw: Some(raw_settings),
         };
 
@@ -1170,6 +1175,7 @@ mod tests {
             connect_protocol_enabled: None,
             h3_datagram: None,
             grease: None,
+            additional_settings: None,
             raw: Some(vec![]),
         };
 
@@ -1250,6 +1256,7 @@ mod tests {
             connect_protocol_enabled: None,
             h3_datagram: None,
             grease: None,
+            additional_settings: None,
             raw: Some(vec![]),
         };
 
@@ -1297,6 +1304,7 @@ mod tests {
             connect_protocol_enabled: None,
             h3_datagram: None,
             grease: None,
+            additional_settings: None,
             raw: Some(vec![]),
         };
 


### PR DESCRIPTION
Using additional settings, an application can configure and set H3 settings that are not explicitly handled by quiche.

This can be useful to develop some apps atop quiche's h3 without needing quiche to explicitly support it.

For instance, I use it in my webtransport implementation atop quiche: https://github.com/francoismichel/webtransport-quiche/blob/269d8fcba3e874c1984ec65c6dfd653cce4c15eb/src/lib.rs#L97C13-L97C13

Let me know your thoughts and comments.

Cheers,

François