### PR TITLE
tls: use once_cell instead of lazy_static

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -60,7 +60,7 @@ libc = "0.2"
 libm = "0.2"
 ring = "0.16"
 slab = "0.4"
-lazy_static = "1"
+once_cell = "1"
 octets = { version = "0.2", path = "../octets" }
 boring = { version = "2.0.0", optional = true }
 foreign-types-shared = { version = "0.3.0", optional = true }

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -30,6 +30,8 @@ use std::slice;
 
 use std::io::Write;
 
+use once_cell::sync::Lazy;
+
 use libc::c_char;
 use libc::c_int;
 use libc::c_long;
@@ -181,12 +183,12 @@ struct SSL_PRIVATE_KEY_METHOD {
     >,
 }
 
-lazy_static::lazy_static! {
-    /// BoringSSL Extra Data Index for Quiche Connections
-    pub static ref QUICHE_EX_DATA_INDEX: c_int = unsafe {
-        SSL_get_ex_new_index(0, ptr::null(), ptr::null(), ptr::null(), ptr::null())
-    };
-}
+/// BoringSSL ex_data index for quiche connections.
+///
+/// TODO: replace with `std::sync::LazyLock` when stable.
+pub static QUICHE_EX_DATA_INDEX: Lazy<c_int> = Lazy::new(|| unsafe {
+    SSL_get_ex_new_index(0, ptr::null(), ptr::null(), ptr::null(), ptr::null())
+});
 
 static QUICHE_STREAM_METHOD: SSL_QUIC_METHOD = SSL_QUIC_METHOD {
     set_read_secret: Some(set_read_secret),


### PR DESCRIPTION
It's already in our dependency tree, and will be easier to replace with std API once it's stabilized.