### PR TITLE
Fix broken send_on_path_test

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -5940,15 +5940,9 @@ impl Connection {
             sockaddrs: self
                 .paths
                 .iter()
-                .filter_map(|(_, p)| {
-                    if (p.usable() || p.validation_requested()) &&
-                        p.local_addr() == from
-                    {
-                        Some(p.peer_addr())
-                    } else {
-                        None
-                    }
-                })
+                .filter(|(_, p)| p.usable() || p.probing_required())
+                .filter(|(_, p)| p.local_addr() == from)
+                .map(|(_, p)| p.peer_addr())
                 .collect(),
 
             index: 0,


### PR DESCRIPTION
The function declaration of `sort()` is `fn sort(&mut self) -> ()` and so these tests were simply asserting `() == ()`. After correcting them they failed and so a change to `paths_iter()` is needed.