### PR TITLE
quic: add peer_transport_params()

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -516,7 +516,6 @@ typedef struct {
 
     // The number of known paths for the connection.
     size_t paths_count;
-
 } quiche_stats;
 
 // Collects and returns statistics about the connection.
@@ -563,6 +562,8 @@ typedef struct {
     ssize_t peer_max_datagram_frame_size;
 } quiche_transport_params;
 
+// Returns the peer's transport parameters in |out|. Returns false if we have
+// not yet processed the peer's transport parameters.
 bool quiche_conn_peer_transport_params(const quiche_conn *conn, quiche_transport_params *out);
 
 typedef struct {

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -517,6 +517,12 @@ typedef struct {
     // The number of known paths for the connection.
     size_t paths_count;
 
+} quiche_stats;
+
+// Collects and returns statistics about the connection.
+void quiche_conn_stats(const quiche_conn *conn, quiche_stats *out);
+
+typedef struct {
     // The maximum idle timeout.
     uint64_t peer_max_idle_timeout;
 
@@ -555,10 +561,9 @@ typedef struct {
 
     // DATAGRAM frame extension parameter, if any.
     ssize_t peer_max_datagram_frame_size;
-} quiche_stats;
+} quiche_transport_params;
 
-// Collects and returns statistics about the connection.
-void quiche_conn_stats(const quiche_conn *conn, quiche_stats *out);
+void quiche_conn_peer_transport_params(const quiche_conn *conn, quiche_transport_params *out);
 
 typedef struct {
     // The local address used by this path.

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -563,7 +563,7 @@ typedef struct {
     ssize_t peer_max_datagram_frame_size;
 } quiche_transport_params;
 
-void quiche_conn_peer_transport_params(const quiche_conn *conn, quiche_transport_params *out);
+bool quiche_conn_peer_transport_params(const quiche_conn *conn, quiche_transport_params *out);
 
 typedef struct {
     // The local address used by this path.

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1091,20 +1091,23 @@ pub struct Stats {
     lost_bytes: u64,
     stream_retrans_bytes: u64,
     paths_count: usize,
-    peer_max_idle_timeout: u64,
-    peer_max_udp_payload_size: u64,
-    peer_initial_max_data: u64,
-    peer_initial_max_stream_data_bidi_local: u64,
-    peer_initial_max_stream_data_bidi_remote: u64,
-    peer_initial_max_stream_data_uni: u64,
-    peer_initial_max_streams_bidi: u64,
-    peer_initial_max_streams_uni: u64,
-    peer_ack_delay_exponent: u64,
-    peer_max_ack_delay: u64,
-    peer_disable_active_migration: bool,
-    peer_active_conn_id_limit: u64,
-    peer_max_datagram_frame_size: ssize_t,
     paths: [PathStats; 8],
+}
+
+pub struct TransportParams {
+    max_idle_timeout: u64,
+    max_udp_payload_size: u64,
+    initial_max_data: u64,
+    initial_max_stream_data_bidi_local: u64,
+    initial_max_stream_data_bidi_remote: u64,
+    initial_max_stream_data_uni: u64,
+    initial_max_streams_bidi: u64,
+    initial_max_streams_uni: u64,
+    ack_delay_exponent: u64,
+    max_ack_delay: u64,
+    disable_active_migration: bool,
+    active_conn_id_limit: u64,
+    max_datagram_frame_size: ssize_t,
 }
 
 #[no_mangle]
@@ -1120,25 +1123,38 @@ pub extern fn quiche_conn_stats(conn: &Connection, out: &mut Stats) {
     out.lost_bytes = stats.lost_bytes;
     out.stream_retrans_bytes = stats.stream_retrans_bytes;
     out.paths_count = stats.paths_count;
-    out.peer_max_idle_timeout = stats.peer_max_idle_timeout;
-    out.peer_max_udp_payload_size = stats.peer_max_udp_payload_size;
-    out.peer_initial_max_data = stats.peer_initial_max_data;
-    out.peer_initial_max_stream_data_bidi_local =
-        stats.peer_initial_max_stream_data_bidi_local;
-    out.peer_initial_max_stream_data_bidi_remote =
-        stats.peer_initial_max_stream_data_bidi_remote;
-    out.peer_initial_max_stream_data_uni = stats.peer_initial_max_stream_data_uni;
-    out.peer_initial_max_streams_bidi = stats.peer_initial_max_streams_bidi;
-    out.peer_initial_max_streams_uni = stats.peer_initial_max_streams_uni;
-    out.peer_ack_delay_exponent = stats.peer_ack_delay_exponent;
-    out.peer_max_ack_delay = stats.peer_max_ack_delay;
-    out.peer_disable_active_migration = stats.peer_disable_active_migration;
-    out.peer_active_conn_id_limit = stats.peer_active_conn_id_limit;
-    out.peer_max_datagram_frame_size = match stats.peer_max_datagram_frame_size {
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_peer_transport_params(
+    conn: &Connection, out: &mut TransportParams,
+) -> bool {
+    let tps = match conn.peer_transport_params() {
+        Some(v) => v,
+        None => return false,
+    };
+
+    out.max_idle_timeout = tps.max_idle_timeout;
+    out.max_udp_payload_size = tps.max_udp_payload_size;
+    out.initial_max_data = tps.initial_max_data;
+    out.initial_max_stream_data_bidi_local =
+        tps.initial_max_stream_data_bidi_local;
+    out.initial_max_stream_data_bidi_remote =
+        tps.initial_max_stream_data_bidi_remote;
+    out.initial_max_stream_data_uni = tps.initial_max_stream_data_uni;
+    out.initial_max_streams_bidi = tps.initial_max_streams_bidi;
+    out.initial_max_streams_uni = tps.initial_max_streams_uni;
+    out.ack_delay_exponent = tps.ack_delay_exponent;
+    out.max_ack_delay = tps.max_ack_delay;
+    out.disable_active_migration = tps.disable_active_migration;
+    out.active_conn_id_limit = tps.active_conn_id_limit;
+    out.max_datagram_frame_size = match tps.max_datagram_frame_size {
         None => Error::Done.to_c(),
 
         Some(v) => v as ssize_t,
     };
+
+    true
 }
 
 #[repr(C)]

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6248,7 +6248,7 @@ impl Connection {
     }
 
     /// Returns reference to peer's transport parameters. Returns `None` if we
-    /// have not yet processed the peer's transport parameters
+    /// have not yet processed the peer's transport parameters.
     pub fn peer_transport_params(&self) -> Option<&TransportParams> {
         if !self.parsed_peer_transport_params {
             return None;

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6244,40 +6244,17 @@ impl Connection {
             lost_bytes: self.lost_bytes,
             stream_retrans_bytes: self.stream_retrans_bytes,
             paths_count: self.paths.len(),
-            peer_max_idle_timeout: self.peer_transport_params.max_idle_timeout,
-            peer_max_udp_payload_size: self
-                .peer_transport_params
-                .max_udp_payload_size,
-            peer_initial_max_data: self.peer_transport_params.initial_max_data,
-            peer_initial_max_stream_data_bidi_local: self
-                .peer_transport_params
-                .initial_max_stream_data_bidi_local,
-            peer_initial_max_stream_data_bidi_remote: self
-                .peer_transport_params
-                .initial_max_stream_data_bidi_remote,
-            peer_initial_max_stream_data_uni: self
-                .peer_transport_params
-                .initial_max_stream_data_uni,
-            peer_initial_max_streams_bidi: self
-                .peer_transport_params
-                .initial_max_streams_bidi,
-            peer_initial_max_streams_uni: self
-                .peer_transport_params
-                .initial_max_streams_uni,
-            peer_ack_delay_exponent: self
-                .peer_transport_params
-                .ack_delay_exponent,
-            peer_max_ack_delay: self.peer_transport_params.max_ack_delay,
-            peer_disable_active_migration: self
-                .peer_transport_params
-                .disable_active_migration,
-            peer_active_conn_id_limit: self
-                .peer_transport_params
-                .active_conn_id_limit,
-            peer_max_datagram_frame_size: self
-                .peer_transport_params
-                .max_datagram_frame_size,
         }
+    }
+
+    /// Returns reference to peer's transport parameters. Returns `None` if we
+    /// have not yet processed the peer's transport parameters
+    pub fn peer_transport_params(&self) -> Option<&TransportParams> {
+        if !self.parsed_peer_transport_params {
+            return None;
+        }
+
+        Some(&self.peer_transport_params)
     }
 
     /// Collects and returns statistics about each known path for the
@@ -7494,45 +7471,6 @@ pub struct Stats {
 
     /// The number of known paths for the connection.
     pub paths_count: usize,
-
-    /// The maximum idle timeout.
-    pub peer_max_idle_timeout: u64,
-
-    /// The maximum UDP payload size.
-    pub peer_max_udp_payload_size: u64,
-
-    /// The initial flow control maximum data for the connection.
-    pub peer_initial_max_data: u64,
-
-    /// The initial flow control maximum data for local bidirectional streams.
-    pub peer_initial_max_stream_data_bidi_local: u64,
-
-    /// The initial flow control maximum data for remote bidirectional streams.
-    pub peer_initial_max_stream_data_bidi_remote: u64,
-
-    /// The initial flow control maximum data for unidirectional streams.
-    pub peer_initial_max_stream_data_uni: u64,
-
-    /// The initial maximum bidirectional streams.
-    pub peer_initial_max_streams_bidi: u64,
-
-    /// The initial maximum unidirectional streams.
-    pub peer_initial_max_streams_uni: u64,
-
-    /// The ACK delay exponent.
-    pub peer_ack_delay_exponent: u64,
-
-    /// The max ACK delay.
-    pub peer_max_ack_delay: u64,
-
-    /// Whether active migration is disabled.
-    pub peer_disable_active_migration: bool,
-
-    /// The active connection ID limit.
-    pub peer_active_conn_id_limit: u64,
-
-    /// DATAGRAM frame extension parameter, if any.
-    pub peer_max_datagram_frame_size: Option<u64>,
 }
 
 impl std::fmt::Debug for Stats {
@@ -7550,94 +7488,50 @@ impl std::fmt::Debug for Stats {
             self.sent_bytes, self.recv_bytes, self.lost_bytes,
         )?;
 
-        write!(f, " peer_tps={{")?;
-
-        write!(f, " max_idle_timeout={},", self.peer_max_idle_timeout)?;
-
-        write!(
-            f,
-            " max_udp_payload_size={},",
-            self.peer_max_udp_payload_size,
-        )?;
-
-        write!(f, " initial_max_data={},", self.peer_initial_max_data)?;
-
-        write!(
-            f,
-            " initial_max_stream_data_bidi_local={},",
-            self.peer_initial_max_stream_data_bidi_local,
-        )?;
-
-        write!(
-            f,
-            " initial_max_stream_data_bidi_remote={},",
-            self.peer_initial_max_stream_data_bidi_remote,
-        )?;
-
-        write!(
-            f,
-            " initial_max_stream_data_uni={},",
-            self.peer_initial_max_stream_data_uni,
-        )?;
-
-        write!(
-            f,
-            " initial_max_streams_bidi={},",
-            self.peer_initial_max_streams_bidi,
-        )?;
-
-        write!(
-            f,
-            " initial_max_streams_uni={},",
-            self.peer_initial_max_streams_uni,
-        )?;
-
-        write!(f, " ack_delay_exponent={},", self.peer_ack_delay_exponent)?;
-
-        write!(f, " max_ack_delay={},", self.peer_max_ack_delay)?;
-
-        write!(
-            f,
-            " disable_active_migration={},",
-            self.peer_disable_active_migration,
-        )?;
-
-        write!(
-            f,
-            " active_conn_id_limit={},",
-            self.peer_active_conn_id_limit,
-        )?;
-
-        write!(
-            f,
-            " max_datagram_frame_size={:?}",
-            self.peer_max_datagram_frame_size,
-        )?;
-
-        write!(f, "}}")
+        Ok(())
     }
 }
 
+/// QUIC Transport Parameters
 #[derive(Clone, Debug, PartialEq)]
-struct TransportParams {
+pub struct TransportParams {
+    /// Value of Destination CID field from first Initial packet sent by client
     pub original_destination_connection_id: Option<ConnectionId<'static>>,
+    /// The maximum idle timeout.
     pub max_idle_timeout: u64,
+    /// Token used for verifying stateless resets
     pub stateless_reset_token: Option<u128>,
+    /// The maximum UDP payload size.
     pub max_udp_payload_size: u64,
+    /// The initial flow control maximum data for the connection.
     pub initial_max_data: u64,
+    /// The initial flow control maximum data for local bidirectional streams.
     pub initial_max_stream_data_bidi_local: u64,
+    /// The initial flow control maximum data for remote bidirectional streams.
     pub initial_max_stream_data_bidi_remote: u64,
+    /// The initial flow control maximum data for unidirectional streams.
     pub initial_max_stream_data_uni: u64,
+    /// The initial maximum bidirectional streams.
     pub initial_max_streams_bidi: u64,
+    /// The initial maximum unidirectional streams.
     pub initial_max_streams_uni: u64,
+    /// The ACK delay exponent.
     pub ack_delay_exponent: u64,
+    /// The max ACK delay.
     pub max_ack_delay: u64,
+    /// Whether active migration is disabled.
     pub disable_active_migration: bool,
-    // pub preferred_address: ...,
+    /// The active connection ID limit.
     pub active_conn_id_limit: u64,
+    /// The value that the endpoint included in the Source CID field of a Retry
+    /// Packet.
     pub initial_source_connection_id: Option<ConnectionId<'static>>,
+    /// The value that the server included in the Source CID field of a Retry
+    /// Packet.
     pub retry_source_connection_id: Option<ConnectionId<'static>>,
+    /// DATAGRAM frame extension parameter, if any.
     pub max_datagram_frame_size: Option<u64>,
+    // pub preferred_address: ...,
 }
 
 impl Default for TransportParams {


### PR DESCRIPTION
Currently, transport parameters are available through `stats()`. APIs that used to offer access to certain transport parameters have been removed in favor of using `stats()`. While this does work, it's wasteful to return such a large structure when you may only care about a single TP. This change makes `TransportParameters` public, adds a method `peer_transport_params()` that returns a reference, and removes transport parameter fields from `Stats`.