### PR TITLE
recovery: make initial_window_packets configurable

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -212,6 +212,9 @@ void quiche_config_set_disable_active_migration(quiche_config *config, bool v);
 // Sets the congestion control algorithm used by string.
 int quiche_config_set_cc_algorithm_name(quiche_config *config, const char *algo);
 
+// Sets the initial cwnd for the connection.
+void quiche_config_set_initial_window_packets(quiche_config *config, size_t window_packets);
+
 enum quiche_cc_algorithm {
     QUICHE_CC_RENO = 0,
     QUICHE_CC_CUBIC = 1,

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -325,6 +325,13 @@ pub extern fn quiche_config_set_cc_algorithm(
 }
 
 #[no_mangle]
+pub extern fn quiche_config_set_initial_window_packets(
+    config: &mut Config, initial_window_packets: size_t,
+) {
+    config.set_initial_window_packets(window_packets);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_enable_hystart(config: &mut Config, v: bool) {
     config.enable_hystart(v);
 }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -483,6 +483,9 @@ const CONNECTION_WINDOW_FACTOR: f64 = 1.5;
 // validation as failed.
 const MAX_PROBING_TIMEOUTS: usize = 3;
 
+// The default number of packets sent in the initial congestion window.
+const DEFAULT_INITIAL_WINDOW_PACKETS: usize = 10;
+
 /// A specialized [`Result`] type for quiche operations.
 ///
 /// This type is used throughout quiche's public API for any operation that
@@ -705,6 +708,7 @@ pub struct Config {
     grease: bool,
 
     cc_algorithm: CongestionControlAlgorithm,
+    initial_window_packets: usize,
 
     hystart: bool,
 
@@ -766,6 +770,7 @@ impl Config {
             application_protos: Vec::new(),
             grease: true,
             cc_algorithm: CongestionControlAlgorithm::CUBIC,
+            initial_window_packets: DEFAULT_INITIAL_WINDOW_PACKETS,
             hystart: true,
             pacing: true,
             max_pacing_rate: None,
@@ -1124,6 +1129,13 @@ impl Config {
         self.cc_algorithm = CongestionControlAlgorithm::from_str(name)?;
 
         Ok(())
+    }
+
+    /// Sets the number of packets to be sent in the initial congestion window.
+    ///
+    /// The default value is 10.
+    pub fn set_initial_window_packets(&mut self, window_packets: usize) {
+        self.initial_window_packets = window_packets;
     }
 
     /// Sets the congestion control algorithm used.

--- a/quiche/src/recovery/bbr/mod.rs
+++ b/quiche/src/recovery/bbr/mod.rs
@@ -380,7 +380,7 @@ mod tests {
         // called manually here.
         r.on_init();
 
-        assert_eq!(r.cwnd(), r.max_datagram_size * INITIAL_WINDOW_PACKETS);
+        assert_eq!(r.cwnd(), r.max_datagram_size * cfg.initial_window_packets);
         assert_eq!(r.bytes_in_flight, 0);
 
         assert_eq!(r.bbr_state.state, BBRStateMachine::Startup);

--- a/quiche/src/recovery/bbr/per_ack.rs
+++ b/quiche/src/recovery/bbr/per_ack.rs
@@ -132,7 +132,7 @@ fn bbr_inflight(r: &mut Recovery, gain: f64) -> usize {
     let bbr = &mut r.bbr_state;
 
     if bbr.rtprop == Duration::MAX {
-        return r.max_datagram_size * INITIAL_WINDOW_PACKETS;
+        return r.max_datagram_size * r.initial_window_packets;
     }
 
     let quanta = 3 * r.send_quantum;
@@ -199,7 +199,7 @@ fn bbr_set_cwnd(r: &mut Recovery) {
             )
         } else if r.congestion_window < r.bbr_state.target_cwnd ||
             r.delivery_rate.delivered() <
-                r.max_datagram_size * INITIAL_WINDOW_PACKETS
+                r.max_datagram_size * r.initial_window_packets
         {
             r.congestion_window += acked_bytes;
         }

--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -489,7 +489,7 @@ mod tests {
         };
 
         // Send initcwnd full MSS packets to become no longer app limited
-        for _ in 0..recovery::INITIAL_WINDOW_PACKETS {
+        for _ in 0..r.initial_window_packets {
             r.on_packet_sent_cc(p.size, now);
         }
 
@@ -537,7 +537,7 @@ mod tests {
         };
 
         // Send initcwnd full MSS packets to become no longer app limited
-        for _ in 0..recovery::INITIAL_WINDOW_PACKETS {
+        for _ in 0..r.initial_window_packets {
             r.on_packet_sent_cc(p.size, now);
         }
 
@@ -613,7 +613,7 @@ mod tests {
         let prev_cwnd = r.cwnd();
 
         // Send initcwnd full MSS packets to become no longer app limited
-        for _ in 0..recovery::INITIAL_WINDOW_PACKETS {
+        for _ in 0..r.initial_window_packets {
             r.on_packet_sent_cc(r.max_datagram_size, now);
         }
 
@@ -1007,7 +1007,7 @@ mod tests {
         let prev_cwnd = r.cwnd();
 
         // Send initcwnd full MSS packets to become no longer app limited
-        for _ in 0..recovery::INITIAL_WINDOW_PACKETS {
+        for _ in 0..r.initial_window_packets {
             r.on_packet_sent_cc(r.max_datagram_size, now);
         }
 
@@ -1103,7 +1103,7 @@ mod tests {
         let prev_cwnd = r.cwnd();
 
         // Send initcwnd full MSS packets to become no longer app limited
-        for _ in 0..recovery::INITIAL_WINDOW_PACKETS {
+        for _ in 0..r.initial_window_packets {
             r.on_packet_sent_cc(r.max_datagram_size, now);
         }
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -63,9 +63,6 @@ const RTT_WINDOW: Duration = Duration::from_secs(300);
 
 const MAX_PTO_PROBES_COUNT: usize = 2;
 
-// Congestion Control
-const INITIAL_WINDOW_PACKETS: usize = 10;
-
 const MINIMUM_WINDOW_PACKETS: usize = 2;
 
 const LOSS_REDUCTION_FACTOR: f64 = 0.5;
@@ -168,6 +165,9 @@ pub struct Recovery {
 
     /// How many non-ack-eliciting packets have been sent.
     outstanding_non_ack_eliciting: usize,
+
+    /// How many packets should be sent in the initial congestion window.
+    initial_window_packets: usize,
 }
 
 pub struct RecoveryConfig {
@@ -177,6 +177,7 @@ pub struct RecoveryConfig {
     hystart: bool,
     pacing: bool,
     max_pacing_rate: Option<u64>,
+    initial_window_packets: usize,
 }
 
 impl RecoveryConfig {
@@ -188,14 +189,15 @@ impl RecoveryConfig {
             hystart: config.hystart,
             pacing: config.pacing,
             max_pacing_rate: config.max_pacing_rate,
+            initial_window_packets: config.initial_window_packets,
         }
     }
 }
 
 impl Recovery {
     pub fn new_with_config(recovery_config: &RecoveryConfig) -> Self {
-        let initial_congestion_window =
-            recovery_config.max_send_udp_payload_size * INITIAL_WINDOW_PACKETS;
+        let initial_congestion_window = recovery_config.max_send_udp_payload_size *
+            recovery_config.initial_window_packets;
 
         Recovery {
             loss_detection_timer: None,
@@ -289,6 +291,8 @@ impl Recovery {
             bbr_state: bbr::State::new(),
 
             outstanding_non_ack_eliciting: 0,
+
+            initial_window_packets: recovery_config.initial_window_packets,
         }
     }
 
@@ -301,7 +305,8 @@ impl Recovery {
     }
 
     pub fn reset(&mut self) {
-        self.congestion_window = self.max_datagram_size * INITIAL_WINDOW_PACKETS;
+        self.congestion_window =
+            self.max_datagram_size * self.initial_window_packets;
         self.in_flight_count = [0; packet::Epoch::count()];
         self.congestion_recovery_start_time = None;
         self.ssthresh = usize::MAX;
@@ -407,8 +412,8 @@ impl Recovery {
 
         let is_app = epoch == packet::Epoch::Application;
 
-        let in_initcwnd =
-            self.bytes_sent < self.max_datagram_size * INITIAL_WINDOW_PACKETS;
+        let in_initcwnd = self.bytes_sent <
+            self.max_datagram_size * self.initial_window_packets;
 
         let sent_bytes = if !self.pacer.enabled() || !is_app || in_initcwnd {
             0
@@ -740,9 +745,10 @@ impl Recovery {
 
         // Update cwnd if it hasn't been updated yet.
         if self.congestion_window ==
-            self.max_datagram_size * INITIAL_WINDOW_PACKETS
+            self.max_datagram_size * self.initial_window_packets
         {
-            self.congestion_window = max_datagram_size * INITIAL_WINDOW_PACKETS;
+            self.congestion_window =
+                max_datagram_size * self.initial_window_packets;
         }
 
         self.pacer = pacer::Pacer::new(

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -218,7 +218,7 @@ mod tests {
         };
 
         // Send initcwnd full MSS packets to become no longer app limited
-        for _ in 0..recovery::INITIAL_WINDOW_PACKETS {
+        for _ in 0..r.initial_window_packets {
             r.on_packet_sent_cc(p.size, now);
         }
 
@@ -267,7 +267,7 @@ mod tests {
         };
 
         // Send initcwnd full MSS packets to become no longer app limited
-        for _ in 0..recovery::INITIAL_WINDOW_PACKETS {
+        for _ in 0..r.initial_window_packets {
             r.on_packet_sent_cc(p.size, now);
         }
 


### PR DESCRIPTION
This PR allows users to make their initial `cwnd` value configurable to allow for more fine-grained performance tuning.