### PR TITLE
lib: with_tls doesn't require a mutable Config

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -294,7 +294,7 @@ quiche_conn *quiche_conn_new_with_tls(const uint8_t *scid, size_t scid_len,
                                       const uint8_t *odcid, size_t odcid_len,
                                       const struct sockaddr *local, size_t local_len,
                                       const struct sockaddr *peer, size_t peer_len,
-                                      quiche_config *config, void *ssl,
+                                      const quiche_config *config, void *ssl,
                                       bool is_server);
 
 // Enables keylog to the specified file path. Returns true on success.

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -562,7 +562,7 @@ pub extern fn quiche_retry(
 pub extern fn quiche_conn_new_with_tls(
     scid: *const u8, scid_len: size_t, odcid: *const u8, odcid_len: size_t,
     local: &sockaddr, local_len: socklen_t, peer: &sockaddr, peer_len: socklen_t,
-    config: &mut Config, ssl: *mut c_void, is_server: bool,
+    config: &Config, ssl: *mut c_void, is_server: bool,
 ) -> *mut Connection {
     let scid = unsafe { slice::from_raw_parts(scid, scid_len) };
     let scid = ConnectionId::from_ref(scid);

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1671,8 +1671,7 @@ impl Connection {
 
     fn with_tls(
         scid: &ConnectionId, odcid: Option<&ConnectionId>, local: SocketAddr,
-        peer: SocketAddr, config: &mut Config, tls: tls::Handshake,
-        is_server: bool,
+        peer: SocketAddr, config: &Config, tls: tls::Handshake, is_server: bool,
     ) -> Result<Connection> {
         let max_rx_data = config.local_transport_params.initial_max_data;
 


### PR DESCRIPTION
Connection::new() takes several parameters and does a lot of heavy
lifting for callers. In particular it creates a TLS Handshake from the
Config's tls_ctx object, which requires mutability.

In contrast, Connection::with_tls() doesn't require any Config
mutability. So let's remove that.

Fixes #1593
