### PR TITLE
Fix BBRv1 idle_restart flag

### DIFF
--- a/quiche/src/recovery/bbr/mod.rs
+++ b/quiche/src/recovery/bbr/mod.rs
@@ -290,9 +290,9 @@ fn reset(r: &mut Recovery) {
 }
 
 fn on_packet_sent(r: &mut Recovery, sent_bytes: usize, _now: Instant) {
-    r.bytes_in_flight += sent_bytes;
-
     per_transmit::bbr_on_transmit(r);
+
+    r.bytes_in_flight += sent_bytes;
 }
 
 fn on_packets_acked(


### PR DESCRIPTION
For Web traffic which is sending packets for short duration and then idle for some duration, we should not enter probe RTT phase when idle. This leads to unnecessary reduction in cwnd and sometimes stalls.

When probe RTT timer has expired, idle_restart flag decides whether to enter probe RTT or not. In quiche we reduce the inflight after updating the BBR model and state, this leads to inflight not being zero. Since inflight is not zero we do not set idle_restart flag and we always enter probe RTT phase for web kind of traffic.

Here we check if inflight is less than 4 packets and if app_limited flag is also set, we set idle_restart flag. The idea being since inflight is low we would have already captured min_rtt and dont need probe RTT phase.