### PR TITLE
Clippy Fixes

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -3124,10 +3124,7 @@ mod tests {
         let (len, _) = pipe.client.send(&mut buf).unwrap();
 
         // Now an H3 connection can be created.
-        assert!(matches!(
-            Connection::with_transport(&mut pipe.client, &h3_config),
-            Ok(_)
-        ));
+        assert!(Connection::with_transport(&mut pipe.client, &h3_config).is_ok());
         assert_eq!(pipe.server_recv(&mut buf[..len]), Ok(len));
 
         // Client sends 0-RTT packet.
@@ -5865,7 +5862,7 @@ mod tests {
     #[test]
     /// Tests that the Data event is properly re-armed.
     fn data_event_rearm() {
-        let bytes = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let bytes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
         let mut s = Session::new().unwrap();
         s.handshake().unwrap();

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -15990,7 +15990,7 @@ mod tests {
             payload_len,
             payload_offset,
             None,
-            &aead,
+            aead,
         )
         .expect("packet encrypt");
         space.next_pkt_num += 1;

--- a/quiche/src/ranges.rs
+++ b/quiche/src/ranges.rs
@@ -95,7 +95,7 @@ impl RangeSet {
             RangeSet::BTree(set) if set.inner.len() <= MIN_TO_INLINE => {
                 let old_inner = std::mem::take(&mut set.inner);
                 *self = RangeSet::Inline(InlineRangeSet {
-                    inner: SmallVec::from_iter(old_inner.into_iter()),
+                    inner: SmallVec::from_iter(old_inner),
                     capacity: set.capacity,
                 })
             },


### PR DESCRIPTION
Fixes the following lints that were enabled in 1.72.0:
https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec
https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow