### PR TITLE
Pin Nix to v0.26.3

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -30,7 +30,7 @@ octets = { version = "0.2", path = "../octets" }
 ring = "0.16"
 quiche = { path = "../quiche" }
 libc = "0.2"
-nix = "0"
+nix = "0.26.3"
 
 [lib]
 crate-type = ["lib"]

--- a/quiche/src/ranges.rs
+++ b/quiche/src/ranges.rs
@@ -95,7 +95,7 @@ impl RangeSet {
             RangeSet::BTree(set) if set.inner.len() <= MIN_TO_INLINE => {
                 let old_inner = std::mem::take(&mut set.inner);
                 *self = RangeSet::Inline(InlineRangeSet {
-                    inner: SmallVec::from_iter(old_inner.into_iter()),
+                    inner: SmallVec::from_iter(old_inner),
                     capacity: set.capacity,
                 })
             },


### PR DESCRIPTION
This PR pins Nix to v0.26.3. Nix's [v0.27.0](https://github.com/nix-rust/nix/blob/master/CHANGELOG.md#0270---2023-08-28) release removed features by default, which in turn breaks [this line](https://github.com/cloudflare/quiche/blob/master/apps/src/sendto.rs#L38). `socket` is [feature-gated](https://github.com/nix-rust/nix/blob/master/Cargo.toml#L65) so we need to include that in `apps/Cargo.toml`, but there are a couple other changes that have to be made. It's quicker to simply pin Nix to v0.26.3 and unblock downstream services.

I've got an item in my backlog to update our code to be compliant with their v0.27 release.