### PR TITLE
apps: update to nix 0.27

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -30,7 +30,7 @@ octets = { version = "0.2", path = "../octets" }
 ring = "0.16"
 quiche = { path = "../quiche" }
 libc = "0.2"
-nix = "0"
+nix = { version = "0.27", features = ["net", "socket", "uio"] }
 
 [lib]
 crate-type = ["lib"]

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -772,7 +772,10 @@ fn set_txtime_sockopt(sock: &mio::net::UdpSocket) -> io::Result<()> {
         flags: 0,
     };
 
-    setsockopt(sock.as_raw_fd(), TxTime, &config)?;
+    // mio::net::UdpSocket doesn't implement AsFd (yet?).
+    let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(sock.as_raw_fd()) };
+
+    setsockopt(&fd, TxTime, &config)?;
 
     Ok(())
 }

--- a/apps/src/sendto.rs
+++ b/apps/src/sendto.rs
@@ -35,7 +35,10 @@ pub fn detect_gso(socket: &mio::net::UdpSocket, segment_size: usize) -> bool {
     use nix::sys::socket::sockopt::UdpGsoSegment;
     use std::os::unix::io::AsRawFd;
 
-    setsockopt(socket.as_raw_fd(), UdpGsoSegment, &(segment_size as i32)).is_ok()
+    // mio::net::UdpSocket doesn't implement AsFd (yet?).
+    let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(socket.as_raw_fd()) };
+
+    setsockopt(&fd, UdpGsoSegment, &(segment_size as i32)).is_ok()
 }
 
 /// For non-Linux, there is no GSO support.


### PR DESCRIPTION
One notable change is that functions like `setsockopt()` now require `AsFd` instead of the raw fd, but mio doesn't implement that, so we need to convert fds explicitly.