### PR TITLE
openssl/quictls support

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -14,6 +14,7 @@ jobs:
         tls-feature:
           - "" # default, boringssl-vendored
           - "boringssl-boring-crate"
+          - "openssl"
     # Only run on "pull_request" event for external PRs. This is to avoid
     # duplicate builds for PRs created from internal branches.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
@@ -30,6 +31,17 @@ jobs:
           toolchain: ${{ env.TOOLCHAIN }}
           components: clippy
           override: true
+
+      - name: Build OpenSSL
+        if: ${{ matrix.tls-feature == 'openssl' }}
+        run: |
+          git clone https://github.com/quictls/openssl
+          cd openssl
+          ./Configure --prefix="$PWD/install"
+          make -j"$(nproc)"
+          make install -j"$(nproc)"
+          echo "PKG_CONFIG_PATH=$PWD" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$PWD" >> "$GITHUB_ENV"
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/README.md
+++ b/README.md
@@ -345,7 +345,13 @@ the BoringSSL directory with the ``QUICHE_BSSL_PATH`` environment variable:
  $ QUICHE_BSSL_PATH="/path/to/boringssl" cargo build --examples
 ```
 
+Alternatively you can use [OpenSSL/quictls]. To enable quiche to use this vendor
+the ``openssl`` feature can be added to the ``--feature`` list. Be aware that
+``0-RTT`` is not supported if this vendor is used.
+
 [BoringSSL]: https://boringssl.googlesource.com/boringssl/
+
+[OpenSSL/quictls]: https://github.com/quictls/openssl
 
 ### Building for Android
 

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -36,6 +36,9 @@ boringssl-vendored = []
 # Use the BoringSSL library provided by the boring crate.
 boringssl-boring-crate = ["boring", "foreign-types-shared"]
 
+# Build quiche against OpenSSL instead of BoringSSL.
+openssl = ["pkg-config"]
+
 # Generate pkg-config metadata file for libquiche.
 pkg-config-meta = []
 
@@ -55,6 +58,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [build-dependencies]
 cmake = "0.1"
+pkg-config = { version = "0.3", optional = true }
 
 [dependencies]
 either = { version = "1.8", default-features = false }

--- a/quiche/src/build.rs
+++ b/quiche/src/build.rs
@@ -217,7 +217,8 @@ fn target_dir_path() -> std::path::PathBuf {
 
 fn main() {
     if cfg!(feature = "boringssl-vendored") &&
-        !cfg!(feature = "boringssl-boring-crate")
+        !cfg!(feature = "boringssl-boring-crate") &&
+        !cfg!(feature = "openssl")
     {
         let bssl_dir = std::env::var("QUICHE_BSSL_PATH").unwrap_or_else(|_| {
             let mut cfg = get_boringssl_cmake_config();
@@ -258,6 +259,19 @@ fn main() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     if target_os == "macos" {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-undefined,dynamic_lookup");
+    }
+
+    #[cfg(feature = "openssl")]
+    {
+        let pkgcfg = pkg_config::Config::new();
+
+        if pkgcfg.probe("libcrypto").is_err() {
+            panic!("no libcrypto found");
+        }
+
+        if pkgcfg.probe("libssl").is_err() {
+            panic!("no libssl found");
+        }
     }
 
     if cfg!(feature = "pkg-config-meta") {

--- a/quiche/src/crypto/boringssl.rs
+++ b/quiche/src/crypto/boringssl.rs
@@ -1,0 +1,206 @@
+use super::*;
+
+use std::mem::MaybeUninit;
+
+use libc::c_int;
+
+// NOTE: This structure is copied from <openssl/aead.h> in order to be able to
+// statically allocate it. While it is not often modified upstream, it needs to
+// be kept in sync.
+#[repr(C)]
+struct EVP_AEAD_CTX {
+    aead: libc::uintptr_t,
+    opaque: [u8; 580],
+    alignment: u64,
+    tag_len: u8,
+}
+
+impl Algorithm {
+    fn get_evp_aead(self) -> *const EVP_AEAD {
+        match self {
+            Algorithm::AES128_GCM => unsafe { EVP_aead_aes_128_gcm() },
+            Algorithm::AES256_GCM => unsafe { EVP_aead_aes_256_gcm() },
+            Algorithm::ChaCha20_Poly1305 => unsafe {
+                EVP_aead_chacha20_poly1305()
+            },
+        }
+    }
+}
+
+impl Open {
+    pub fn open_with_u64_counter(
+        &self, counter: u64, ad: &[u8], buf: &mut [u8],
+    ) -> Result<usize> {
+        if cfg!(feature = "fuzzing") {
+            return Ok(buf.len());
+        }
+
+        let tag_len = self.alg().tag_len();
+
+        let mut out_len = match buf.len().checked_sub(tag_len) {
+            Some(n) => n,
+            None => return Err(Error::CryptoFail),
+        };
+
+        let max_out_len = out_len;
+
+        let nonce = make_nonce(&self.packet.nonce, counter);
+
+        let rc = unsafe {
+            EVP_AEAD_CTX_open(
+                &self.packet.ctx,   // ctx
+                buf.as_mut_ptr(),   // out
+                &mut out_len,       // out_len
+                max_out_len,        // max_out_len
+                nonce[..].as_ptr(), // nonce
+                nonce.len(),        // nonce_len
+                buf.as_ptr(),       // inp
+                buf.len(),          // in_len
+                ad.as_ptr(),        // ad
+                ad.len(),           // ad_len
+            )
+        };
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+        Ok(out_len)
+    }
+}
+
+impl Seal {
+    pub fn seal_with_u64_counter(
+        &self, counter: u64, ad: &[u8], buf: &mut [u8], in_len: usize,
+        extra_in: Option<&[u8]>,
+    ) -> Result<usize> {
+        if cfg!(feature = "fuzzing") {
+            if let Some(extra) = extra_in {
+                buf[in_len..in_len + extra.len()].copy_from_slice(extra);
+                return Ok(in_len + extra.len());
+            }
+
+            return Ok(in_len);
+        }
+
+        let tag_len = self.alg().tag_len();
+
+        let mut out_tag_len = tag_len;
+
+        let (extra_in_ptr, extra_in_len) = match extra_in {
+            Some(v) => (v.as_ptr(), v.len()),
+
+            None => (std::ptr::null(), 0),
+        };
+
+        // Make sure all the outputs combined fit in the buffer.
+        if in_len + tag_len + extra_in_len > buf.len() {
+            return Err(Error::CryptoFail);
+        }
+
+        let nonce = make_nonce(&self.packet.nonce, counter);
+
+        let rc = unsafe {
+            EVP_AEAD_CTX_seal_scatter(
+                &self.packet.ctx,           // ctx
+                buf.as_mut_ptr(),           // out
+                buf[in_len..].as_mut_ptr(), // out_tag
+                &mut out_tag_len,           // out_tag_len
+                tag_len + extra_in_len,     // max_out_tag_len
+                nonce[..].as_ptr(),         // nonce
+                nonce.len(),                // nonce_len
+                buf.as_ptr(),               // inp
+                in_len,                     // in_len
+                extra_in_ptr,               // extra_in
+                extra_in_len,               // extra_in_len
+                ad.as_ptr(),                // ad
+                ad.len(),                   // ad_len
+            )
+        };
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        Ok(in_len + out_tag_len)
+    }
+}
+
+fn make_aead_ctx(alg: Algorithm, key: &[u8]) -> Result<EVP_AEAD_CTX> {
+    let mut ctx = MaybeUninit::uninit();
+
+    let ctx = unsafe {
+        let aead = alg.get_evp_aead();
+
+        let rc = EVP_AEAD_CTX_init(
+            ctx.as_mut_ptr(),
+            aead,
+            key.as_ptr(),
+            alg.key_len(),
+            alg.tag_len(),
+            std::ptr::null_mut(),
+        );
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        ctx.assume_init()
+    };
+
+    Ok(ctx)
+}
+
+pub(crate) struct PacketKey {
+    ctx: EVP_AEAD_CTX,
+    nonce: Vec<u8>,
+}
+
+impl PacketKey {
+    pub fn new(
+        alg: Algorithm, key: Vec<u8>, iv: Vec<u8>, _enc: u32,
+    ) -> Result<Self> {
+        Ok(Self {
+            ctx: make_aead_ctx(alg, &key)?,
+            nonce: iv,
+        })
+    }
+
+    pub fn from_secret(aead: Algorithm, secret: &[u8], enc: u32) -> Result<Self> {
+        let key_len = aead.key_len();
+        let nonce_len = aead.nonce_len();
+
+        let mut key = vec![0; key_len];
+        let mut iv = vec![0; nonce_len];
+
+        derive_pkt_key(aead, secret, &mut key)?;
+        derive_pkt_iv(aead, secret, &mut iv)?;
+
+        Self::new(aead, key, iv, enc)
+    }
+}
+
+extern {
+    fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
+
+    fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
+
+    fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
+
+    // EVP_AEAD_CTX
+    fn EVP_AEAD_CTX_init(
+        ctx: *mut EVP_AEAD_CTX, aead: *const EVP_AEAD, key: *const u8,
+        key_len: usize, tag_len: usize, engine: *mut c_void,
+    ) -> c_int;
+
+    fn EVP_AEAD_CTX_open(
+        ctx: *const EVP_AEAD_CTX, out: *mut u8, out_len: *mut usize,
+        max_out_len: usize, nonce: *const u8, nonce_len: usize, inp: *const u8,
+        in_len: usize, ad: *const u8, ad_len: usize,
+    ) -> c_int;
+
+    fn EVP_AEAD_CTX_seal_scatter(
+        ctx: *const EVP_AEAD_CTX, out: *mut u8, out_tag: *mut u8,
+        out_tag_len: *mut usize, max_out_tag_len: usize, nonce: *const u8,
+        nonce_len: usize, inp: *const u8, in_len: usize, extra_in: *const u8,
+        extra_in_len: usize, ad: *const u8, ad_len: usize,
+    ) -> c_int;
+}

--- a/quiche/src/crypto/openssl_quictls.rs
+++ b/quiche/src/crypto/openssl_quictls.rs
@@ -1,0 +1,362 @@
+use super::*;
+
+use libc::c_int;
+use libc::c_uchar;
+
+#[allow(non_camel_case_types)]
+#[repr(transparent)]
+struct EVP_CIPHER_CTX {
+    _unused: *mut EVP_CIPHER_CTX,
+}
+#[allow(non_camel_case_types)]
+#[repr(transparent)]
+struct OSSL_PARAM {
+    _unused: c_void,
+}
+
+impl Drop for EVP_CIPHER_CTX {
+    fn drop(&mut self) {
+        unsafe { EVP_CIPHER_CTX_free(self) }
+    }
+}
+
+impl Algorithm {
+    pub fn get_evp_aead(self) -> *const EVP_AEAD {
+        match self {
+            Algorithm::AES128_GCM => unsafe { EVP_aes_128_gcm() },
+            Algorithm::AES256_GCM => unsafe { EVP_aes_256_gcm() },
+            Algorithm::ChaCha20_Poly1305 => unsafe { EVP_chacha20_poly1305() },
+        }
+    }
+}
+
+impl Open {
+    pub fn open_with_u64_counter(
+        &self, counter: u64, ad: &[u8], buf: &mut [u8],
+    ) -> Result<usize> {
+        if cfg!(feature = "fuzzing") {
+            return Ok(buf.len());
+        }
+
+        let in_buf = buf.to_owned(); // very inefficient
+        let tag_len = self.alg().tag_len();
+
+        let mut cipher_len = buf.len();
+
+        let nonce = make_nonce(&self.packet.nonce, counter);
+
+        // Set the IV len.
+        const EVP_CTRL_AEAD_SET_IVLEN: i32 = 0x9;
+        let mut rc = unsafe {
+            EVP_CIPHER_CTX_ctrl(
+                self.packet.ctx,
+                EVP_CTRL_AEAD_SET_IVLEN,
+                nonce.len() as i32,
+                std::ptr::null_mut(),
+            )
+        };
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        rc = unsafe {
+            EVP_CipherInit_ex2(
+                self.packet.ctx,
+                std::ptr::null_mut(), // already set
+                self.packet.key.as_ptr(),
+                nonce[..].as_ptr(),
+                Self::DECRYPT as i32,
+                std::ptr::null(),
+            )
+        };
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        let mut olen: i32 = 0;
+
+        if !ad.is_empty() {
+            rc = unsafe {
+                EVP_CipherUpdate(
+                    self.packet.ctx,
+                    std::ptr::null_mut(),
+                    &mut olen,
+                    ad.as_ptr(),
+                    ad.len() as i32,
+                )
+            };
+
+            if rc != 1 {
+                return Err(Error::CryptoFail);
+            }
+        }
+
+        if cipher_len < tag_len {
+            return Err(Error::CryptoFail);
+        }
+
+        cipher_len -= tag_len;
+
+        rc = unsafe {
+            EVP_CipherUpdate(
+                self.packet.ctx,
+                buf.as_mut_ptr(),
+                &mut olen,
+                in_buf.as_ptr(),
+                cipher_len as i32,
+            )
+        };
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        let plaintext_len = olen as usize;
+
+        const EVP_CTRL_AEAD_SET_TAG: i32 = 0x11;
+        rc = unsafe {
+            EVP_CIPHER_CTX_ctrl(
+                self.packet.ctx,
+                EVP_CTRL_AEAD_SET_TAG,
+                tag_len as i32,
+                buf[cipher_len..].as_mut_ptr() as *mut c_void,
+            )
+        };
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        rc = unsafe {
+            EVP_CipherFinal_ex(
+                self.packet.ctx,
+                buf[plaintext_len..].as_mut_ptr(),
+                &mut olen,
+            )
+        };
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        Ok(plaintext_len + olen as usize)
+    }
+}
+
+impl Seal {
+    pub fn seal_with_u64_counter(
+        &self, counter: u64, ad: &[u8], buf: &mut [u8], in_len: usize,
+        extra_in: Option<&[u8]>,
+    ) -> Result<usize> {
+        if cfg!(feature = "fuzzing") {
+            if let Some(extra) = extra_in {
+                buf[in_len..in_len + extra.len()].copy_from_slice(extra);
+                return Ok(in_len + extra.len());
+            }
+
+            return Ok(in_len);
+        }
+        // very inefficient
+        let in_buf = buf.to_owned();
+
+        let nonce = make_nonce(&self.packet.nonce, counter);
+
+        // Set the IV len.
+        const EVP_CTRL_AEAD_SET_IVLEN: i32 = 0x9;
+        let mut rc = unsafe {
+            EVP_CIPHER_CTX_ctrl(
+                self.packet.ctx,
+                EVP_CTRL_AEAD_SET_IVLEN,
+                nonce.len() as i32,
+                std::ptr::null_mut(),
+            )
+        };
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        rc = unsafe {
+            EVP_CipherInit_ex2(
+                self.packet.ctx,
+                std::ptr::null_mut(), // already set
+                self.packet.key.as_ptr(),
+                nonce[..].as_ptr(),
+                Self::ENCRYPT as i32,
+                std::ptr::null(),
+            )
+        };
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        let tag_len = self.alg().tag_len();
+
+        let mut olen: i32 = 0;
+        let mut rc;
+
+        if !ad.is_empty() {
+            rc = unsafe {
+                EVP_CipherUpdate(
+                    self.packet.ctx,
+                    std::ptr::null_mut(),
+                    &mut olen,
+                    ad.as_ptr(),
+                    ad.len() as i32,
+                )
+            };
+
+            if rc != 1 {
+                // We had AD but we couldn't set it.
+                return Err(Error::CryptoFail);
+            }
+        }
+
+        let mut ciphertext_len: usize = 0;
+
+        rc = unsafe {
+            EVP_CipherUpdate(
+                self.packet.ctx,
+                buf.as_mut_ptr(),
+                &mut olen,
+                in_buf.as_ptr(),
+                in_len as i32,
+            )
+        };
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        };
+
+        ciphertext_len += olen as usize;
+
+        let len = olen as usize;
+        rc = unsafe {
+            EVP_CipherFinal_ex(
+                self.packet.ctx,
+                buf[len..].as_mut_ptr(),
+                &mut olen,
+            )
+        };
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        ciphertext_len += olen as usize;
+
+        const EVP_CTRL_AEAD_GET_TAG: i32 = 0x10;
+        rc = unsafe {
+            EVP_CIPHER_CTX_ctrl(
+                self.packet.ctx,
+                EVP_CTRL_AEAD_GET_TAG,
+                tag_len as i32,
+                buf[ciphertext_len..].as_mut_ptr() as *mut c_void,
+            )
+        };
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        Ok(in_len + tag_len)
+    }
+}
+
+fn make_evp_cipher_ctx_basic(
+    alg: Algorithm, enc: u32,
+) -> Result<*mut EVP_CIPHER_CTX> {
+    let ctx: *mut EVP_CIPHER_CTX = unsafe {
+        let cipher: *const EVP_AEAD = alg.get_evp_aead();
+
+        let ctx = EVP_CIPHER_CTX_new();
+        if ctx.is_null() {
+            return Err(Error::CryptoFail);
+        }
+
+        let rc = EVP_CipherInit_ex2(
+            ctx,
+            cipher,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            enc as c_int, // Following calls can use -1 once this is set.
+            std::ptr::null(),
+        );
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+        ctx
+    };
+    Ok(ctx)
+}
+
+pub(crate) struct PacketKey {
+    ctx: *mut EVP_CIPHER_CTX,
+    nonce: Vec<u8>,
+    // Note: We'd need the key for later use as it is needed by the openssl API.
+    // TODO: check if we can avoid this and get the key when needed and not
+    // have it stored here.
+    key: Vec<u8>,
+}
+
+impl PacketKey {
+    pub fn new(
+        algo: Algorithm, key: Vec<u8>, iv: Vec<u8>, enc: u32,
+    ) -> Result<Self> {
+        Ok(Self {
+            ctx: make_evp_cipher_ctx_basic(algo, enc)?,
+            nonce: iv,
+            key,
+        })
+    }
+
+    pub fn from_secret(aead: Algorithm, secret: &[u8], enc: u32) -> Result<Self> {
+        let key_len = aead.key_len();
+        let nonce_len = aead.nonce_len();
+
+        let mut key = vec![0; key_len];
+        let mut iv = vec![0; nonce_len];
+
+        derive_pkt_key(aead, secret, &mut key)?;
+        derive_pkt_iv(aead, secret, &mut iv)?;
+
+        Self::new(aead, key, iv, enc)
+    }
+}
+
+unsafe impl std::marker::Send for PacketKey {}
+unsafe impl std::marker::Sync for PacketKey {}
+
+extern {
+    // EVP
+    fn EVP_aes_128_gcm() -> *const EVP_AEAD;
+
+    fn EVP_aes_256_gcm() -> *const EVP_AEAD;
+
+    fn EVP_chacha20_poly1305() -> *const EVP_AEAD;
+
+    // EVP_CIPHER_CTX
+    fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
+
+    fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
+
+    fn EVP_CipherInit_ex2(
+        ctx: *mut EVP_CIPHER_CTX, cipher: *const EVP_AEAD, key: *const c_uchar,
+        iv: *const c_uchar, enc: c_int, params: *const OSSL_PARAM,
+    ) -> c_int;
+
+    fn EVP_CIPHER_CTX_ctrl(
+        ctx: *mut EVP_CIPHER_CTX, type_: i32, arg: i32, ptr: *mut c_void,
+    ) -> c_int;
+
+    fn EVP_CipherUpdate(
+        ctx: *mut EVP_CIPHER_CTX, out: *mut c_uchar, outl: *mut c_int,
+        in_: *const c_uchar, inl: i32,
+    ) -> c_int;
+
+    fn EVP_CipherFinal_ex(
+        ctx: *mut EVP_CIPHER_CTX, out: *mut c_uchar, outl: *mut c_int,
+    ) -> c_int;
+}

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -3089,6 +3089,7 @@ mod tests {
         assert!(grease_value() < 2u64.pow(62) - 1);
     }
 
+    #[cfg(not(feature = "openssl"))] // 0-RTT not supported when using openssl/quictls
     #[test]
     fn h3_handshake_0rtt() {
         let mut buf = [0; 65535];

--- a/quiche/src/tls/boringssl.rs
+++ b/quiche/src/tls/boringssl.rs
@@ -1,0 +1,363 @@
+use super::*;
+
+use libc::c_long;
+
+#[allow(non_camel_case_types)]
+#[repr(transparent)]
+struct CRYPTO_BUFFER {
+    _unused: c_void,
+}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub(super) struct SSL_QUIC_METHOD {
+    set_read_secret: Option<
+        unsafe extern fn(
+            ssl: *mut SSL,
+            level: crypto::Level,
+            cipher: *const SSL_CIPHER,
+            secret: *const u8,
+            secret_len: usize,
+        ) -> c_int,
+    >,
+
+    set_write_secret: Option<
+        unsafe extern fn(
+            ssl: *mut SSL,
+            level: crypto::Level,
+            cipher: *const SSL_CIPHER,
+            secret: *const u8,
+            secret_len: usize,
+        ) -> c_int,
+    >,
+
+    add_handshake_data: Option<
+        unsafe extern fn(
+            ssl: *mut SSL,
+            level: crypto::Level,
+            data: *const u8,
+            len: usize,
+        ) -> c_int,
+    >,
+
+    flush_flight: Option<extern fn(ssl: *mut SSL) -> c_int>,
+
+    send_alert: Option<
+        extern fn(ssl: *mut SSL, level: crypto::Level, alert: u8) -> c_int,
+    >,
+}
+
+#[cfg(test)]
+#[repr(C)]
+#[allow(non_camel_case_types)]
+struct SSL_PRIVATE_KEY_METHOD {
+    sign: Option<
+        unsafe extern fn(
+            ssl: *mut SSL,
+            out: *mut u8,
+            out_len: *mut usize,
+            max_out: usize,
+            signature_algorithm: u16,
+            r#in: *const u8,
+            in_len: usize,
+        ) -> ssl_private_key_result_t,
+    >,
+
+    decrypt: Option<
+        unsafe extern fn(
+            ssl: *mut SSL,
+            out: *mut u8,
+            out_len: *mut usize,
+            max_out: usize,
+            r#in: *const u8,
+            in_len: usize,
+        ) -> ssl_private_key_result_t,
+    >,
+
+    complete: Option<
+        unsafe extern fn(
+            ssl: *mut SSL,
+            out: *mut u8,
+            out_len: *mut usize,
+            max_out: usize,
+        ) -> ssl_private_key_result_t,
+    >,
+}
+
+pub(super) static QUICHE_STREAM_METHOD: SSL_QUIC_METHOD = SSL_QUIC_METHOD {
+    set_read_secret: Some(set_read_secret),
+    set_write_secret: Some(set_write_secret),
+    add_handshake_data: Some(add_handshake_data),
+    flush_flight: Some(flush_flight),
+    send_alert: Some(send_alert),
+};
+
+impl Context {
+    pub fn set_early_data_enabled(&mut self, _enabled: bool) {
+        unsafe {
+            SSL_CTX_set_early_data_enabled(
+                self.as_mut_ptr(),
+                i32::from(_enabled),
+            );
+        }
+    }
+}
+
+impl Handshake {
+    pub fn set_quic_early_data_context(&mut self, context: &[u8]) -> Result<()> {
+        map_result(unsafe {
+            SSL_set_quic_early_data_context(
+                self.as_mut_ptr(),
+                context.as_ptr(),
+                context.len(),
+            )
+        })
+    }
+
+    pub fn set_session(&mut self, session: &[u8]) -> Result<()> {
+        unsafe {
+            let ctx = SSL_get_SSL_CTX(self.as_ptr());
+
+            if ctx.is_null() {
+                return Err(Error::TlsFail);
+            }
+
+            let session =
+                SSL_SESSION_from_bytes(session.as_ptr(), session.len(), ctx);
+
+            if session.is_null() {
+                return Err(Error::TlsFail);
+            }
+
+            let rc = SSL_set_session(self.as_mut_ptr(), session);
+            SSL_SESSION_free(session);
+
+            map_result(rc)
+        }
+    }
+
+    pub fn reset_early_data_reject(&mut self) {
+        unsafe { SSL_reset_early_data_reject(self.as_mut_ptr()) };
+    }
+
+    pub fn curve(&self) -> Option<String> {
+        let curve = unsafe {
+            let curve_id = SSL_get_curve_id(self.as_ptr());
+            if curve_id == 0 {
+                return None;
+            }
+
+            let curve_name = SSL_get_curve_name(curve_id);
+            match ffi::CStr::from_ptr(curve_name).to_str() {
+                Ok(v) => v,
+
+                Err(_) => return None,
+            }
+        };
+
+        Some(curve.to_string())
+    }
+
+    pub fn sigalg(&self) -> Option<String> {
+        let sigalg = unsafe {
+            let sigalg_id = SSL_get_peer_signature_algorithm(self.as_ptr());
+            if sigalg_id == 0 {
+                return None;
+            }
+
+            let sigalg_name = SSL_get_signature_algorithm_name(sigalg_id, 1);
+            match ffi::CStr::from_ptr(sigalg_name).to_str() {
+                Ok(v) => v,
+
+                Err(_) => return None,
+            }
+        };
+
+        Some(sigalg.to_string())
+    }
+
+    pub fn peer_cert_chain(&self) -> Option<Vec<&[u8]>> {
+        let cert_chain = unsafe {
+            let chain =
+                map_result_ptr(SSL_get0_peer_certificates(self.as_ptr())).ok()?;
+
+            let num = sk_num(chain);
+            if num == 0 {
+                return None;
+            }
+
+            let mut cert_chain = vec![];
+            for i in 0..num {
+                let buffer =
+                    map_result_ptr(sk_value(chain, i) as *const CRYPTO_BUFFER)
+                        .ok()?;
+
+                let out_len = CRYPTO_BUFFER_len(buffer);
+                if out_len == 0 {
+                    return None;
+                }
+
+                let out = CRYPTO_BUFFER_data(buffer);
+                let slice = slice::from_raw_parts(out, out_len);
+
+                cert_chain.push(slice);
+            }
+
+            cert_chain
+        };
+
+        Some(cert_chain)
+    }
+
+    pub fn peer_cert(&self) -> Option<&[u8]> {
+        let peer_cert = unsafe {
+            let chain =
+                map_result_ptr(SSL_get0_peer_certificates(self.as_ptr())).ok()?;
+            if sk_num(chain) == 0 {
+                return None;
+            }
+
+            let buffer =
+                map_result_ptr(sk_value(chain, 0) as *const CRYPTO_BUFFER)
+                    .ok()?;
+
+            let out_len = CRYPTO_BUFFER_len(buffer);
+            if out_len == 0 {
+                return None;
+            }
+
+            let out = CRYPTO_BUFFER_data(buffer);
+            slice::from_raw_parts(out, out_len)
+        };
+
+        Some(peer_cert)
+    }
+
+    // Only used for testing handling of failure during key signing.
+    #[cfg(test)]
+    pub fn set_failing_private_key_method(&mut self) {
+        extern fn failing_sign(
+            _ssl: *mut SSL, _out: *mut u8, _out_len: *mut usize, _max_out: usize,
+            _signature_algorithm: u16, _in: *const u8, _in_len: usize,
+        ) -> ssl_private_key_result_t {
+            ssl_private_key_result_t::ssl_private_key_failure
+        }
+
+        extern fn failing_decrypt(
+            _ssl: *mut SSL, _out: *mut u8, _out_len: *mut usize, _max_out: usize,
+            _in: *const u8, _in_len: usize,
+        ) -> ssl_private_key_result_t {
+            ssl_private_key_result_t::ssl_private_key_failure
+        }
+
+        extern fn failing_complete(
+            _ssl: *mut SSL, _out: *mut u8, _out_len: *mut usize, _max_out: usize,
+        ) -> ssl_private_key_result_t {
+            ssl_private_key_result_t::ssl_private_key_failure
+        }
+
+        static QUICHE_PRIVATE_KEY_METHOD: SSL_PRIVATE_KEY_METHOD =
+            SSL_PRIVATE_KEY_METHOD {
+                decrypt: Some(failing_decrypt),
+                sign: Some(failing_sign),
+                complete: Some(failing_complete),
+            };
+
+        unsafe {
+            SSL_set_private_key_method(
+                self.as_mut_ptr(),
+                &QUICHE_PRIVATE_KEY_METHOD,
+            );
+        }
+    }
+
+    pub fn is_in_early_data(&self) -> bool {
+        unsafe { SSL_in_early_data(self.as_ptr()) == 1 }
+    }
+}
+
+pub(super) fn get_session_bytes(session: *mut SSL_SESSION) -> Result<Vec<u8>> {
+    let session_bytes = unsafe {
+        let mut out: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+
+        if SSL_SESSION_to_bytes(session, &mut out, &mut out_len) == 0 {
+            return Err(Error::TlsFail);
+        }
+        let session_bytes = std::slice::from_raw_parts(out, out_len).to_vec();
+        OPENSSL_free(out as *mut c_void);
+        session_bytes
+    };
+
+    Ok(session_bytes)
+}
+pub(super) const TLS_ERROR: c_int = 3;
+
+extern {
+    // SSL_METHOD specific for boringssl.
+    pub(super) fn SSL_CTX_set_tlsext_ticket_keys(
+        ctx: *mut SSL_CTX, key: *const u8, key_len: usize,
+    ) -> c_int;
+    fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: i32);
+
+    pub(super) fn SSL_CTX_set_session_cache_mode(
+        ctx: *mut SSL_CTX, mode: c_int,
+    ) -> c_int;
+    pub(super) fn SSL_get_ex_new_index(
+        argl: c_long, argp: *const c_void, unused: *const c_void,
+        dup_unused: *const c_void, free_func: *const c_void,
+    ) -> c_int;
+
+    fn SSL_get_curve_id(ssl: *const SSL) -> u16;
+    fn SSL_get_curve_name(curve: u16) -> *const c_char;
+
+    fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
+    fn SSL_get_signature_algorithm_name(
+        sigalg: u16, include_curve: i32,
+    ) -> *const c_char;
+
+    fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const STACK_OF;
+
+    pub(super) fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16)
+        -> c_int;
+
+    pub(super) fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16)
+        -> c_int;
+
+    pub(super) fn SSL_set_tlsext_host_name(
+        ssl: *mut SSL, name: *const c_char,
+    ) -> c_int;
+
+    fn SSL_set_quic_early_data_context(
+        ssl: *mut SSL, context: *const u8, context_len: usize,
+    ) -> c_int;
+
+    #[cfg(test)]
+    fn SSL_set_private_key_method(
+        ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD,
+    );
+
+    fn SSL_reset_early_data_reject(ssl: *mut SSL);
+
+    fn SSL_in_early_data(ssl: *const SSL) -> c_int;
+
+    fn SSL_SESSION_to_bytes(
+        session: *const SSL_SESSION, out: *mut *mut u8, out_len: *mut usize,
+    ) -> c_int;
+
+    fn SSL_SESSION_from_bytes(
+        input: *const u8, input_len: usize, ctx: *const SSL_CTX,
+    ) -> *mut SSL_SESSION;
+
+    // STACK_OF
+
+    fn sk_num(stack: *const STACK_OF) -> usize;
+
+    fn sk_value(stack: *const STACK_OF, idx: usize) -> *mut c_void;
+
+    // CRYPTO_BUFFER
+
+    fn CRYPTO_BUFFER_len(buffer: *const CRYPTO_BUFFER) -> usize;
+
+    fn CRYPTO_BUFFER_data(buffer: *const CRYPTO_BUFFER) -> *const u8;
+}

--- a/quiche/src/tls/openssl_quictls.rs
+++ b/quiche/src/tls/openssl_quictls.rs
@@ -1,0 +1,359 @@
+use super::*;
+
+use libc::c_long;
+use libc::c_uchar;
+
+#[allow(non_camel_case_types)]
+#[repr(transparent)]
+struct OPENSSL_STACK {
+    _unused: c_void,
+}
+
+#[allow(non_camel_case_types)]
+#[repr(transparent)]
+struct X509 {
+    _unused: c_void,
+}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub(super) struct SSL_QUIC_METHOD {
+    set_encryption_secrets: Option<
+        extern fn(
+            ssl: *mut SSL,
+            level: crypto::Level,
+            read_secret: *const u8,
+            write_secret: *const u8,
+            secret_len: usize,
+        ) -> c_int,
+    >,
+
+    add_handshake_data: Option<
+        unsafe extern fn(
+            ssl: *mut SSL,
+            level: crypto::Level,
+            data: *const u8,
+            len: usize,
+        ) -> c_int,
+    >,
+
+    flush_flight: Option<extern fn(ssl: *mut SSL) -> c_int>,
+
+    send_alert: Option<
+        extern fn(ssl: *mut SSL, level: crypto::Level, alert: u8) -> c_int,
+    >,
+}
+
+pub(super) static QUICHE_STREAM_METHOD: SSL_QUIC_METHOD = SSL_QUIC_METHOD {
+    set_encryption_secrets: Some(set_encryption_secrets),
+    add_handshake_data: Some(super::add_handshake_data),
+    flush_flight: Some(super::flush_flight),
+    send_alert: Some(super::send_alert),
+};
+
+impl Context {
+    pub fn set_early_data_enabled(&mut self, _enabled: bool) {
+        // not yet supported
+    }
+}
+
+impl Handshake {
+    pub fn set_quic_early_data_context(&mut self, _context: &[u8]) -> Result<()> {
+        // not supported for now.
+        map_result(1)
+    }
+
+    pub fn curve(&self) -> Option<String> {
+        let curve = unsafe {
+            let curve_id = SSL_get_negotiated_group(self.as_ptr());
+            if curve_id == 0 {
+                return None;
+            }
+
+            let curve_name = SSL_group_to_name(self.as_ptr(), curve_id);
+
+            match ffi::CStr::from_ptr(curve_name).to_str() {
+                Ok(v) => v,
+
+                Err(_) => return None,
+            }
+        };
+
+        Some(curve.to_string())
+    }
+
+    pub fn peer_cert_chain(&self) -> Option<Vec<&[u8]>> {
+        // If ssl is server then the leaf will not be included,
+        // SSL_get0_peer_certificate should be called.
+        let cert_chain = unsafe {
+            let chain =
+                map_result_ptr(SSL_get_peer_cert_chain(self.as_ptr())).ok()?;
+
+            let num = sk_X509_num(chain);
+            if num == 0 {
+                return None;
+            }
+
+            let mut cert_chain = vec![];
+            for i in 0..num {
+                let cert =
+                    map_result_ptr(sk_X509_value(chain, i) as *mut X509).ok()?;
+
+                let mut out: *mut u8 = std::ptr::null_mut();
+                let len = i2d_X509(cert, &mut out);
+                if len < 0 {
+                    return None;
+                }
+                cert_chain.push(slice::from_raw_parts(out, len as usize));
+            }
+
+            cert_chain
+        };
+
+        Some(cert_chain)
+    }
+
+    pub fn peer_cert(&self) -> Option<&[u8]> {
+        let peer_cert = unsafe {
+            // Important: Unit tests is disabled on this method.
+            // Although the client calls SSL_CTX_set_verify,  for some reason
+            // SSL_get0_peer_certificate seems not to return the peer's
+            // certificate as in bssl. SSL_peer_certificate does
+            // returns the object representing a certificate used as
+            // the local peer's identity.
+            let cert =
+                map_result_ptr(SSL_get0_peer_certificate(self.as_ptr())).ok()?;
+            let mut out: *mut u8 = std::ptr::null_mut();
+            let len = i2d_X509(cert, &mut out);
+            if len < 0 {
+                return None;
+            }
+            slice::from_raw_parts(out, len as usize)
+        };
+        Some(peer_cert)
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)] // for now, till we implement this using openssl
+    pub fn set_failing_private_key_method(&mut self) {}
+
+    pub fn is_in_early_data(&self) -> bool {
+        false
+    }
+
+    pub fn set_session(&mut self, session: &[u8]) -> Result<()> {
+        unsafe {
+            let ctx = SSL_get_SSL_CTX(self.as_ptr());
+
+            if ctx.is_null() {
+                return Err(Error::TlsFail);
+            }
+
+            let session = d2i_SSL_SESSION(
+                std::ptr::null_mut(),
+                &mut session.as_ptr(),
+                session.len() as c_long,
+            );
+
+            if session.is_null() {
+                return Err(Error::TlsFail);
+            }
+
+            let rc = SSL_set_session(self.as_mut_ptr(), session);
+            SSL_SESSION_free(session);
+
+            map_result(rc)
+        }
+    }
+
+    pub fn reset_early_data_reject(&mut self) {
+        // not yet supported
+    }
+
+    pub fn sigalg(&self) -> Option<String> {
+        let sigalg = "";
+
+        Some(sigalg.to_string())
+    }
+}
+
+extern fn set_encryption_secrets(
+    ssl: *mut SSL, level: crypto::Level, read_secret: *const u8,
+    write_secret: *const u8, secret_len: usize,
+) -> c_int {
+    let cipher = map_result_ptr(unsafe { SSL_get_current_cipher(ssl) });
+    let _write_ret =
+        set_write_secret(ssl, level, cipher.unwrap(), write_secret, secret_len);
+    let _read_ret =
+        set_read_secret(ssl, level, cipher.unwrap(), read_secret, secret_len);
+
+    1
+}
+
+// OpenSSL compatibility functions.
+//
+// These don't 100% follow the OpenSSL API (e.g. some arguments have slightly
+// different types) in order to make them compatible with the BoringSSL API.
+
+#[allow(non_snake_case)]
+unsafe fn sk_X509_num(stack: *const STACK_OF) -> usize {
+    OPENSSL_sk_num(stack as *const OPENSSL_STACK)
+}
+
+#[allow(non_snake_case)]
+unsafe fn sk_X509_value(stack: *const STACK_OF, idx: usize) -> *mut c_void {
+    OPENSSL_sk_value(stack as *const OPENSSL_STACK, idx)
+}
+
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_CTX_set_session_cache_mode(
+    ctx: *mut SSL_CTX, mode: c_int,
+) -> c_int {
+    const SSL_CTRL_SET_SESS_CACHE_MODE: c_int = 44;
+
+    SSL_CTX_ctrl(
+        ctx,
+        SSL_CTRL_SET_SESS_CACHE_MODE,
+        mode as c_long,
+        ptr::null_mut(),
+    ) as c_int
+}
+
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_CTX_set_tlsext_ticket_keys(
+    ctx: *mut SSL_CTX, key: *const u8, key_len: usize,
+) -> c_int {
+    const SSL_CTRL_SET_TLSEXT_TICKET_KEYS: c_int = 59;
+
+    SSL_CTX_ctrl(
+        ctx,
+        SSL_CTRL_SET_TLSEXT_TICKET_KEYS,
+        key_len as c_long,
+        key as *mut c_void,
+    ) as c_int
+}
+
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_set_min_proto_version(
+    s: *mut SSL, version: u16,
+) -> c_int {
+    const SSL_CTRL_SET_MIN_PROTO_VERSION: c_int = 123;
+
+    SSL_ctrl(
+        s,
+        SSL_CTRL_SET_MIN_PROTO_VERSION,
+        version as c_long,
+        ptr::null_mut(),
+    ) as c_int
+}
+
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_set_max_proto_version(
+    s: *mut SSL, version: u16,
+) -> c_int {
+    const SSL_CTRL_SET_MAX_PROTO_VERSION: c_int = 124;
+
+    SSL_ctrl(
+        s,
+        SSL_CTRL_SET_MAX_PROTO_VERSION,
+        version as c_long,
+        ptr::null_mut(),
+    ) as c_int
+}
+
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_set_tlsext_host_name(
+    s: *mut SSL, name: *const c_char,
+) -> c_int {
+    const SSL_CTRL_SET_TLSEXT_HOSTNAME: c_int = 55;
+
+    #[allow(non_upper_case_globals)]
+    const TLSEXT_NAMETYPE_host_name: c_long = 0;
+
+    SSL_ctrl(
+        s,
+        SSL_CTRL_SET_TLSEXT_HOSTNAME,
+        TLSEXT_NAMETYPE_host_name,
+        name as *mut c_void,
+    ) as c_int
+}
+
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_get_ex_new_index(
+    argl: c_long, argp: *const c_void, newf: *const c_void, dupf: *const c_void,
+    freef: *const c_void,
+) -> c_int {
+    const CRYPTO_EX_INDEX_SSL: c_int = 0;
+
+    CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL, argl, argp, newf, dupf, freef)
+}
+
+#[allow(non_snake_case)]
+unsafe fn SSL_get_negotiated_group(ssl: *const SSL) -> c_int {
+    const SSL_CTRL_GET_NEGOTIATED_GROUP: c_int = 134;
+    SSL_ctrl(
+        ssl,
+        SSL_CTRL_GET_NEGOTIATED_GROUP,
+        0 as c_long,
+        ptr::null_mut(),
+    ) as c_int
+}
+
+pub(super) fn get_session_bytes(session: *mut SSL_SESSION) -> Result<Vec<u8>> {
+    let session_bytes = unsafe {
+        // get session encoding length
+        let out_len = i2d_SSL_SESSION(session, std::ptr::null_mut());
+        if out_len == 0 {
+            return Err(Error::TlsFail);
+        }
+        let mut out: Vec<c_uchar> = Vec::with_capacity(out_len as usize);
+
+        let out_len = i2d_SSL_SESSION(session, &mut out.as_mut_ptr());
+        let session_bytes =
+            std::slice::from_raw_parts(out.as_mut_ptr(), out_len as usize)
+                .to_vec();
+        session_bytes
+    };
+
+    Ok(session_bytes)
+}
+pub(super) const TLS_ERROR: c_int = 2;
+
+extern {
+
+    fn SSL_CTX_ctrl(
+        ctx: *mut SSL_CTX, cmd: c_int, larg: c_long, parg: *mut c_void,
+    ) -> c_long;
+
+    fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut STACK_OF;
+
+    fn SSL_get0_peer_certificate(ssl: *const SSL) -> *mut X509;
+
+    fn SSL_ctrl(
+        ssl: *const SSL, cmd: c_int, larg: c_long, parg: *mut c_void,
+    ) -> c_long;
+
+    fn i2d_X509(px: *const X509, out: *mut *mut c_uchar) -> c_int;
+
+    fn OPENSSL_sk_num(stack: *const OPENSSL_STACK) -> usize;
+
+    fn OPENSSL_sk_value(stack: *const OPENSSL_STACK, idx: usize) -> *mut c_void;
+
+    // CRYPTO
+
+    fn CRYPTO_get_ex_new_index(
+        class_index: c_int, argl: c_long, argp: *const c_void,
+        new_func: *const c_void, dup_func: *const c_void,
+        free_func: *const c_void,
+    ) -> c_int;
+
+    fn d2i_SSL_SESSION(
+        a: *mut *mut SSL_SESSION, pp: *mut *const c_uchar, len: c_long,
+    ) -> *mut SSL_SESSION;
+
+    pub(super) fn i2d_SSL_SESSION(
+        in_: *mut SSL_SESSION, pp: *mut *mut c_uchar,
+    ) -> c_int;
+
+    fn SSL_group_to_name(ssl: *const SSL, id: c_int) -> *const c_char;
+}


### PR DESCRIPTION
Apache Traffic Server uses this library for handling the QUIC side of things of H3, as a part of this effort we plan to use quictls as the  cryptography  library, this is an effort(I work for Yahoo) to support that.

---

This PR includes  all the previous work  done in the [openssl](https://github.com/cloudflare/quiche/tree/openssl) branch.  

### Design Notes

As some of the API are different between vendors, I have added two sub-modules to handle the specifics, for both, tls and the crypto module. The specifics of course are coded inside each submodule:
BoringSSL:
- borinssl_crypto.rs
- borinssl_tls.rs

OpenSSL/quictls:
- openssl_quictls_crypto.rs
- openssl_quictls_tls.rs

Each sub-module will be compiled depending on the feature you use (```openssl``` or ```boringssl vendor```) from the main module(```tls```, ```crypto```).


### Features
```0-RTT``` Is not supported in this PR. It will be added afterwards. This is reflected in the README.

### CI
- we need to work around having openssl/quitls build and let quiche use it.
- pkg-config seems not to be installed as `build-dependency`


### Building notes for testing.

- Make sure you have the openssl library in your `LD_LIBRARY_PATH` and the right path inside the `PKG_CONFIG_PATH`
- Add `openssl` in the cargo `--features` list

**I am using openssl/quictls 3 for this implementation.**

