### PR TITLE
lib: skip dgram frame size calc when none to send

### DIFF
--- a/quiche/src/dgram.rs
+++ b/quiche/src/dgram.rs
@@ -103,6 +103,10 @@ impl DatagramQueue {
         self.len() == self.queue_max_len
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn len(&self) -> usize {
         self.queue.as_ref().map(|q| q.len()).unwrap_or(0)
     }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3263,7 +3263,11 @@ impl Connection {
 
         let pkt_type = self.write_pkt_type(send_pid)?;
 
-        let max_dgram_len = self.dgram_max_writable_len();
+        let max_dgram_len = if !self.dgram_send_queue.is_empty() {
+            self.dgram_max_writable_len()
+        } else {
+            None
+        };
 
         let epoch = pkt_type.to_epoch()?;
         let pkt_space = &mut self.pkt_num_spaces[epoch];


### PR DESCRIPTION
Previously, we calculated the value of the largest DATAGRAM frame that
could be sent every time we wanted to send a packet. The calculation is
controlled by peer TPs, which can be sent even if the peer doesn't
really want us to use the DATAGRAM on the connection (e.g. conventional
HTTP/3 serving).

We only need the DATAGRAM size when we have datagrams to actually send.
This change implements a check of the internal DATAGRAM send queue to
avoid the calculation.
