### PR TITLE
Flush qlog streamer before closing the connection

### DIFF
--- a/qlog/src/streamer.rs
+++ b/qlog/src/streamer.rs
@@ -229,6 +229,12 @@ impl QlogStreamer {
     }
 }
 
+impl Drop for QlogStreamer {
+    fn drop(&mut self) {
+        let _ = self.finish_log();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1625,21 +1625,6 @@ macro_rules! push_frame_to_pkt {
     }};
 }
 
-/// Conditional qlog actions.
-///
-/// Executes the provided body if the qlog feature is enabled and quiche
-/// has been configured with a log writer.
-macro_rules! qlog_with {
-    ($qlog:expr, $qlog_streamer_ref:ident, $body:block) => {{
-        #[cfg(feature = "qlog")]
-        {
-            if let Some($qlog_streamer_ref) = &mut $qlog.streamer {
-                $body
-            }
-        }
-    }};
-}
-
 /// Executes the provided body if the qlog feature is enabled, quiche has been
 /// configured with a log writer, the event's importance is within the
 /// configured level.
@@ -7433,9 +7418,10 @@ impl Connection {
 
     // Marks the connection as closed and does any related tidyup.
     fn mark_closed(&mut self) {
-        qlog_with!(self.qlog, q, {
-            q = None;
-        });
+        #[cfg(feature = "qlog")]
+        {
+            self.qlog.streamer = None;
+        }
         self.closed = true;
     }
 }


### PR DESCRIPTION
# Motivation
I was debugging some connection problems and enabled qlog; however, often I did not get output. My use-case is going through the FFI layer which instantiates a `BufferedWriter` for the file. After looking through the code a bit it appears that the `QLogStreamer` is not flushed on all close paths which can lead to missing logs.

# Modification
Make sure that on every close path the streamer is flushed and closed as well.