### PR TITLE
lib: properly tidy up reset streams that are read

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -9869,6 +9869,92 @@ mod tests {
     }
 
     #[test]
+    fn stream_left_reset_bidi() {
+        let mut buf = [0; 65535];
+
+        let mut pipe = testing::Pipe::new().unwrap();
+        assert_eq!(pipe.handshake(), Ok(()));
+
+        assert_eq!(3, pipe.client.peer_streams_left_bidi());
+        assert_eq!(3, pipe.server.peer_streams_left_bidi());
+
+        pipe.client.stream_send(0, b"a", false).ok();
+        assert_eq!(2, pipe.client.peer_streams_left_bidi());
+        pipe.client.stream_send(4, b"a", false).ok();
+        assert_eq!(1, pipe.client.peer_streams_left_bidi());
+        pipe.client.stream_send(8, b"a", false).ok();
+        assert_eq!(0, pipe.client.peer_streams_left_bidi());
+
+        // Client resets the stream.
+        pipe.client
+            .stream_shutdown(0, Shutdown::Write, 1001)
+            .unwrap();
+        pipe.advance().unwrap();
+
+        assert_eq!(0, pipe.client.peer_streams_left_bidi());
+        let mut r = pipe.server.readable();
+        assert_eq!(Some(0), r.next());
+        assert_eq!(Some(4), r.next());
+        assert_eq!(Some(8), r.next());
+        assert_eq!(None, r.next());
+
+        assert_eq!(
+            pipe.server.stream_recv(0, &mut buf),
+            Err(Error::StreamReset(1001))
+        );
+
+        let mut r = pipe.server.readable();
+        assert_eq!(Some(4), r.next());
+        assert_eq!(Some(8), r.next());
+        assert_eq!(None, r.next());
+
+        // Server resets the stream in reaction.
+        pipe.server
+            .stream_shutdown(0, Shutdown::Write, 1001)
+            .unwrap();
+        pipe.advance().unwrap();
+
+        assert_eq!(1, pipe.client.peer_streams_left_bidi());
+
+        // Repeat for the other 2 streams
+        pipe.client
+            .stream_shutdown(4, Shutdown::Write, 1001)
+            .unwrap();
+        pipe.client
+            .stream_shutdown(8, Shutdown::Write, 1001)
+            .unwrap();
+        pipe.advance().unwrap();
+
+        let mut r = pipe.server.readable();
+        assert_eq!(Some(4), r.next());
+        assert_eq!(Some(8), r.next());
+        assert_eq!(None, r.next());
+
+        assert_eq!(
+            pipe.server.stream_recv(4, &mut buf),
+            Err(Error::StreamReset(1001))
+        );
+
+        assert_eq!(
+            pipe.server.stream_recv(8, &mut buf),
+            Err(Error::StreamReset(1001))
+        );
+
+        let mut r = pipe.server.readable();
+        assert_eq!(None, r.next());
+
+        pipe.server
+            .stream_shutdown(4, Shutdown::Write, 1001)
+            .unwrap();
+        pipe.server
+            .stream_shutdown(8, Shutdown::Write, 1001)
+            .unwrap();
+        pipe.advance().unwrap();
+
+        assert_eq!(3, pipe.client.peer_streams_left_bidi());
+    }
+
+    #[test]
     fn streams_blocked_max_bidi() {
         let mut buf = [0; 65535];
 

--- a/quiche/src/stream/recv_buf.rs
+++ b/quiche/src/stream/recv_buf.rs
@@ -209,8 +209,10 @@ impl RecvBuf {
             return Err(Error::Done);
         }
 
-        // The stream was reset, so return the error code instead.
+        // The stream was reset, so clear its data and return the error code
+        // instead.
         if let Some(e) = self.error {
+            self.data.clear();
             return Err(Error::StreamReset(e));
         }
 


### PR DESCRIPTION
When a peer resets their send side, quiche clears received data and inserts a a zero-length buffer
at the final size offset to ensure that the next stream_recv() call will return an Error to
indicate the reset.

Previously, when a reset error was returned, the zero-length buffer was not cleared, making it appear
that the stream was readable when everything else said it wasn't. This would confuse quiche's stream
limit accounting and lead to it not sending a MAX_STREAMS frame when it should have. This could lead
the peer running out of stream credits unexpectedly.

This change ensures the data is cleared in the terminal read state, and that MAX_STREAMS are emitted
once a stream has been fully handled.
