### PR TITLE
Consider only data in the network, not data buffered in host due to pacing at lower layers

### DIFF
--- a/quiche/src/recovery/bbr/mod.rs
+++ b/quiche/src/recovery/bbr/mod.rs
@@ -605,7 +605,7 @@ mod tests {
         }
 
         // Stop at right before filled_pipe=true.
-        for _ in 0..5 {
+        for _ in 0..6 {
             let pkt = Sent {
                 pkt_num: pn,
                 frames: smallvec![],
@@ -640,9 +640,9 @@ mod tests {
 
         let mut acked = ranges::RangeSet::default();
 
-        // We sent 5 packets, but ack only one, to stay
+        // We sent 6 packets, but ack only one, to stay
         // in Drain state.
-        acked.insert(0..pn - 4);
+        acked.insert(0..pn - 5);
 
         assert_eq!(
             r.on_ack_received(

--- a/quiche/src/recovery/bbr/per_ack.rs
+++ b/quiche/src/recovery/bbr/per_ack.rs
@@ -257,11 +257,18 @@ fn bbr_check_drain(r: &mut Recovery, now: Instant) {
     }
 
     if r.bbr_state.state == BBRStateMachine::Drain &&
-        r.bytes_in_flight <= bbr_inflight(r, 1.0)
+        bbr_bytes_in_net(r, now) <= bbr_inflight(r, 1.0)
     {
         // we estimate queue is drained
         bbr_enter_probe_bw(r, now);
     }
+}
+
+fn bbr_bytes_in_net(r: &mut Recovery, now: Instant) -> usize {
+    let buffered = r.get_host_buffered(now);
+    let in_flight = r.bytes_in_flight;
+
+    in_flight.saturating_sub(buffered)
 }
 
 // 4.3.4.3.  Gain Cycling Algorithm


### PR DESCRIPTION
When using packet pacing at the lower layers there can be less data in the network than in_flight data. This is due to buffering the packets at lower layers until the sent time of the packet. When using BBR as the CC algorithm and when we are checking the condition to exit the drain phase we need to consider only the data which is in the network and not the data buffered in the host. If we consider the inflight(host buffered
+ in the network) data then we exit the drain phase later than expected leading to low throughput.