### PR TITLE
quiche.h: add missing pointer

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -677,7 +677,7 @@ int quiche_put_varint(uint8_t *buf, size_t buf_len,
 // Reads an unsigned variable-length integer in network byte-order from
 // the provided buffer and returns the wire length.
 ssize_t quiche_get_varint(const uint8_t *buf, size_t buf_len,
-                          uint64_t val);
+                          uint64_t *val);
 
 // HTTP/3 API
 //


### PR DESCRIPTION
The last argument of `quiche_get_varint` in [ffi.rs (line 1365)](https://github.com/cloudflare/quiche/blob/83d9168ab6f76302ae846cb068cc8991f2b06479/quiche/src/ffi.rs#L1365C15-L1365C32) writes the read value to the last argument. However, the argument in the respective C function in [quiche.h (line 679)](https://github.com/cloudflare/quiche/blob/83d9168ab6f76302ae846cb068cc8991f2b06479/quiche/include/quiche.h#L679) accepts the last argument as a value and not as a pointer.