### PR TITLE
ffi: remove spurious `paths` field from Stats

### DIFF
--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1091,7 +1091,6 @@ pub struct Stats {
     lost_bytes: u64,
     stream_retrans_bytes: u64,
     paths_count: usize,
-    paths: [PathStats; 8],
 }
 
 pub struct TransportParams {


### PR DESCRIPTION
This should have been removed in 21af572b4ae1ce906fbac7b3048409c935e59662.