### PR TITLE
crypto: avoid unnecessary allocations when generating keys

### DIFF
--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -1514,7 +1514,7 @@ mod tests {
 
         let alg = crypto::Algorithm::ChaCha20_Poly1305;
 
-        let aead = crypto::Open::from_secret(alg, &secret).unwrap();
+        let aead = crypto::Open::from_secret(alg, secret.into()).unwrap();
 
         let mut hdr = Header::from_bytes(&mut b, 0).unwrap();
         assert_eq!(hdr.ty, Type::Short);
@@ -1882,7 +1882,7 @@ mod tests {
 
         let alg = crypto::Algorithm::ChaCha20_Poly1305;
 
-        let aead = crypto::Seal::from_secret(alg, &secret).unwrap();
+        let aead = crypto::Seal::from_secret(alg, secret.into()).unwrap();
 
         let pn = 654_360_564;
         let pn_len = 3;

--- a/quiche/src/tls.rs
+++ b/quiche/src/tls.rs
@@ -984,7 +984,7 @@ extern fn set_read_secret(
     if level != crypto::Level::ZeroRTT || ex_data.is_server {
         let secret = unsafe { slice::from_raw_parts(secret, secret_len) };
 
-        let open = match crypto::Open::from_secret(aead, secret) {
+        let open = match crypto::Open::from_secret(aead, secret.to_vec()) {
             Ok(v) => v,
 
             Err(_) => return 0,
@@ -1035,7 +1035,7 @@ extern fn set_write_secret(
     if level != crypto::Level::ZeroRTT || !ex_data.is_server {
         let secret = unsafe { slice::from_raw_parts(secret, secret_len) };
 
-        let seal = match crypto::Seal::from_secret(aead, secret) {
+        let seal = match crypto::Seal::from_secret(aead, secret.to_vec()) {
             Ok(v) => v,
 
             Err(_) => return 0,


### PR DESCRIPTION
In some cases we are turning Vec values into slices to pass them to functions that will then turn the slice back into a Vec.

Instead just pass `Vec`s around to avoid some unnecessary allocations.