### PR TITLE
Update README.md to mention that pacing is required for BBR (e.g., on Linux use fq instead of fq_codel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ the network.
 Applications can use these hints by artificially delaying the sending of
 packets through platform-specific mechanisms (such as the [`SO_TXTIME`]
 socket option on Linux), or custom methods (for example by using user-space
-timers).
+timers). Pacing is required for [BBR](quiche/src/recovery) (e.g., on Linux use `fq` instead of `fq_codel`).
 
 [pace]: https://datatracker.ietf.org/doc/html/rfc9002#section-7.7
 [`SO_TXTIME`]: https://man7.org/linux/man-pages/man8/tc-etf.8.html

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ the network.
 Applications can use these hints by artificially delaying the sending of
 packets through platform-specific mechanisms (such as the [`SO_TXTIME`]
 socket option on Linux), or custom methods (for example by using user-space
-timers). Pacing is required for [BBR](quiche/src/recovery) (e.g., on Linux use `fq` instead of `fq_codel`).
+timers). Pacing is required for [BBR](quiche/src/recovery) (e.g., on Linux
+use `fq` instead of `fq_codel`).
 
 [pace]: https://datatracker.ietf.org/doc/html/rfc9002#section-7.7
 [`SO_TXTIME`]: https://man7.org/linux/man-pages/man8/tc-etf.8.html


### PR DESCRIPTION
It is mentioned in #1180 but could be stated explicitly in my opinion. Also see #1513.

Or maybe add a note to the [argument parser](https://github.com/cloudflare/quiche/blob/c8d10d26db8994b96b475d85dfd557dddb3d7c6b/apps/src/args.rs#L278) but this seems wrong because it's not limited to that specific app.

Checking if `SO_TXTIME` is provided by the socket would be nice but I don't know if this is possible.