### PR TITLE
CI: macOS M1 architecture

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -87,7 +87,12 @@ jobs:
           make -C quiche/examples
 
   quiche_macos:
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        target:
+          - "macos-latest" # Intel (x86_64)
+          - "macos-14"     # Apple Silicon (M1)
+    runs-on: ${{ matrix.target }}
     # Only run on "pull_request" event for external PRs. This is to avoid
     # duplicate builds for PRs created from internal branches.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
Add `macos-latest-xlarge` target for building on Apple Sillicon macOS.