### PR TITLE
h3: fix event type conversion to FFI enum

### DIFF
--- a/quiche/src/h3/ffi.rs
+++ b/quiche/src/h3/ffi.rs
@@ -143,11 +143,11 @@ pub extern fn quiche_h3_event_type(ev: &h3::Event) -> u32 {
 
         h3::Event::Finished { .. } => 2,
 
-        h3::Event::GoAway { .. } => 4,
+        h3::Event::GoAway { .. } => 3,
 
-        h3::Event::Reset { .. } => 5,
+        h3::Event::Reset { .. } => 4,
 
-        h3::Event::PriorityUpdate { .. } => 6,
+        h3::Event::PriorityUpdate { .. } => 5,
     }
 }
 


### PR DESCRIPTION
An event was removed in 48aac48a1882631ecaf1c04c06235102631bfcf1 but the enum wasn't renumbered, so the Rust values didn't match the C ones anymore.

Fixes #1650