### PR TITLE
qlog: Added MtuUpdated event missing from EventImportance implementation

### DIFF
--- a/qlog/src/events/mod.rs
+++ b/qlog/src/events/mod.rs
@@ -169,6 +169,9 @@ impl From<EventType> for EventImportance {
             EventType::ConnectivityEventType(
                 ConnectivityEventType::ConnectionStateUpdated,
             ) => EventImportance::Base,
+            EventType::ConnectivityEventType(
+                ConnectivityEventType::MtuUpdated,
+            ) => EventImportance::Extra,
 
             EventType::SecurityEventType(SecurityEventType::KeyUpdated) =>
                 EventImportance::Base,


### PR DESCRIPTION
Related to #1643 