### PR TITLE
backstage: update ctaalog entry

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -19,4 +19,5 @@ spec:
   type: "library"
   lifecycle: "Active"
   owner: "teams/fl-protocols"
-  system: "system:default/protocols"
+  dependsOn:
+    - component:default/boringssl


### PR DESCRIPTION
The system key is not mandatory, and add BoringSSL to dependencies while at it.