### PR TITLE
Add C api for methods that are required to handle connection migratio…

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -678,6 +678,30 @@ ssize_t quiche_conn_send_ack_eliciting_on_path(quiche_conn *conn,
                            const struct sockaddr *local, socklen_t local_len,
                            const struct sockaddr *peer, socklen_t peer_len);
 
+// Returns true if there are retired source connection ids and fill the parameters
+bool quiche_conn_retired_scid_next(const quiche_conn *conn, const uint8_t **out, size_t *out_len);
+
+// Returns the number of source Connection IDs that are retired.
+size_t quiche_conn_retired_scids(const quiche_conn *conn);
+
+// Returns the number of spare Destination Connection IDs, i.e.,
+// Destination Connection IDs that are still unused.
+size_t quiche_conn_available_dcids(const quiche_conn *conn);
+
+// Returns the number of source Connection IDs that should be provided
+// to the peer without exceeding the limit it advertised.
+size_t quiche_conn_source_cids_left(quiche_conn *conn);
+
+// Returns the number of source Connection IDs that are active. This is
+// only meaningful if the host uses non-zero length Source Connection IDs.
+size_t quiche_conn_active_source_cids(quiche_conn *conn);
+
+// Provides additional source Connection IDs that the peer can use to reach
+// this host.
+uint64_t quiche_conn_new_source_cid(quiche_conn *conn,
+                           const uint8_t *scid, size_t scid_len,
+                           const uint8_t *reset_token, bool retire_if_needed);
+
 // Frees the connection object.
 void quiche_conn_free(quiche_conn *conn);
 

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -690,15 +690,15 @@ size_t quiche_conn_available_dcids(const quiche_conn *conn);
 
 // Returns the number of source Connection IDs that should be provided
 // to the peer without exceeding the limit it advertised.
-size_t quiche_conn_source_cids_left(quiche_conn *conn);
+size_t quiche_conn_scids_left(quiche_conn *conn);
 
 // Returns the number of source Connection IDs that are active. This is
 // only meaningful if the host uses non-zero length Source Connection IDs.
-size_t quiche_conn_active_source_cids(quiche_conn *conn);
+size_t quiche_conn_active_scids(quiche_conn *conn);
 
 // Provides additional source Connection IDs that the peer can use to reach
 // this host.
-uint64_t quiche_conn_new_source_cid(quiche_conn *conn,
+uint64_t quiche_conn_new_scid(quiche_conn *conn,
                            const uint8_t *scid, size_t scid_len,
                            const uint8_t *reset_token, bool retire_if_needed);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1352,17 +1352,17 @@ pub extern fn quiche_conn_send_quantum(conn: &Connection) -> size_t {
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_active_source_cids(conn: &Connection) -> size_t {
-    conn.active_source_cids() as size_t
+pub extern fn quiche_conn_active_scids(conn: &Connection) -> size_t {
+    conn.active_scids() as size_t
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_source_cids_left(conn: &Connection) -> size_t {
-    conn.source_cids_left() as size_t
+pub extern fn quiche_conn_scids_left(conn: &Connection) -> size_t {
+    conn.scids_left() as size_t
 }
 
 #[no_mangle]
-pub extern fn quiche_conn_new_source_cid(
+pub extern fn quiche_conn_new_scid(
     conn: &mut Connection, scid: *const u8, scid_len: size_t,
     reset_token: *const u8, retire_if_needed: bool,
 ) -> u64 {
@@ -1376,7 +1376,7 @@ pub extern fn quiche_conn_new_source_cid(
     };
     let reset_token = u128::from_be_bytes(reset_token);
 
-    match conn.new_source_cid(&scid, reset_token, retire_if_needed) {
+    match conn.new_scid(&scid, reset_token, retire_if_needed) {
         Ok(c) => c,
 
         Err(e) => e.to_c() as u64,

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1352,6 +1352,64 @@ pub extern fn quiche_conn_send_quantum(conn: &Connection) -> size_t {
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_active_source_cids(conn: &Connection) -> size_t {
+    conn.active_source_cids() as size_t
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_source_cids_left(conn: &Connection) -> size_t {
+    conn.source_cids_left() as size_t
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_new_source_cid(
+    conn: &mut Connection, scid: *const u8, scid_len: size_t,
+    reset_token: *const u8, retire_if_needed: bool,
+) -> u64 {
+    let scid = unsafe { slice::from_raw_parts(scid, scid_len) };
+    let scid = ConnectionId::from_ref(scid);
+
+    let reset_token = unsafe { slice::from_raw_parts(reset_token, 16) };
+    let reset_token = match reset_token.try_into() {
+        Ok(rt) => rt,
+        Err(_) => unreachable!(),
+    };
+    let reset_token = u128::from_be_bytes(reset_token);
+
+    match conn.new_source_cid(&scid, reset_token, retire_if_needed) {
+        Ok(c) => c,
+
+        Err(e) => e.to_c() as u64,
+    }
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_available_dcids(conn: &Connection) -> size_t {
+    conn.available_dcids() as size_t
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_retired_scids(conn: &Connection) -> size_t {
+    conn.retired_scids() as size_t
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_retired_scid_next(
+    conn: &mut Connection, out: &mut *const u8, out_len: &mut size_t,
+) -> bool {
+    match conn.retired_scid_next() {
+        None => false,
+
+        Some(conn_id) => {
+            let id = conn_id.as_ref();
+            *out = id.as_ptr();
+            *out_len = id.len();
+            true
+        },
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_put_varint(
     buf: *mut u8, buf_len: size_t, val: u64,
 ) -> c_int {


### PR DESCRIPTION
…n on the server side.

Motivation:

We need to expose some methods via the C api to be able to over the remote peer connection ids that it can be used for migration

Modifications:

Add missing ffi

Result:

Be able to handle connection migrations