### PR TITLE
Initial QPACK dynamic table decode

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -734,12 +734,11 @@ fn make_h3_config(
     }
 
     if let Some(v) = qpack_max_table_capacity {
-        // quiche doesn't support dynamic QPACK, so clamp to 0 for now.
-        config.set_qpack_max_table_capacity(v.clamp(0, 0));
+        config.set_qpack_max_table_capacity(v);
     }
 
     if let Some(v) = qpack_blocked_streams {
-        // quiche doesn't support dynamic QPACK, so clamp to 0 for now.
+        // quiche doesn't support dynamic QPACK blocking, so clamp to 0 for now.
         config.set_qpack_blocked_streams(v.clamp(0, 0));
     }
 

--- a/fuzz/src/qpack_decode.rs
+++ b/fuzz/src/qpack_decode.rs
@@ -13,10 +13,10 @@ use quiche::h3::NameValue;
 // input. However, that transformation is not guaranteed to be the identify
 // function, as there are multiple ways the same hdr list could be encoded.
 fuzz_target!(|data: &[u8]| {
-    let mut decoder = quiche::h3::qpack::Decoder::new();
+    let mut decoder = quiche::h3::qpack::Decoder::new(0);
     let mut encoder = quiche::h3::qpack::Encoder::new();
 
-    let hdrs = match decoder.decode(&mut data.to_vec(), u64::MAX) {
+    let hdrs = match decoder.decode(&mut data.to_vec(), u64::MAX, 0) {
         Err(_) => return,
         Ok(hdrs) => hdrs,
     };
@@ -25,7 +25,7 @@ fuzz_target!(|data: &[u8]| {
     let encoded_size = encoder.encode(&hdrs, &mut encoded_hdrs).unwrap();
 
     let decoded_hdrs = decoder
-        .decode(&encoded_hdrs[..encoded_size], u64::MAX)
+        .decode(&encoded_hdrs[..encoded_size], u64::MAX, 0)
         .unwrap();
 
     let mut expected_hdrs = Vec::new();
@@ -35,7 +35,7 @@ fuzz_target!(|data: &[u8]| {
     for h in &hdrs {
         let name = h.name().to_ascii_lowercase();
 
-        expected_hdrs.push(quiche::h3::Header::new(&name, h.value()));
+        expected_hdrs.push(quiche::h3::Header::new(name, h.value()));
     }
 
     assert_eq!(expected_hdrs, decoded_hdrs)

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["quic", "http3"]
 categories = ["network-programming"]
 license = "BSD-2-Clause"
-rust-version = "1.66"
+rust-version = "1.74"
 include = [
     "/*.md",
     "/*.toml",

--- a/quiche/examples/qpack-decode.rs
+++ b/quiche/examples/qpack-decode.rs
@@ -49,7 +49,7 @@ fn main() {
 
     let mut file = File::open(args.next().unwrap()).unwrap();
 
-    let mut dec = qpack::Decoder::new();
+    let mut dec = qpack::Decoder::new(0);
 
     loop {
         let mut stream_id: [u8; 8] = [0; 8];
@@ -72,11 +72,11 @@ fn main() {
         debug!("Got stream={} len={}", stream_id, len);
 
         if stream_id == 0 {
-            dec.control(&mut data[..len]).unwrap();
+            dec.control(&data[..len]).unwrap();
             continue;
         }
 
-        for hdr in dec.decode(&data[..len], u64::MAX).unwrap() {
+        for hdr in dec.decode(&data[..len], u64::MAX, 0).unwrap() {
             let name = std::str::from_utf8(hdr.name()).unwrap();
             let value = std::str::from_utf8(hdr.value()).unwrap();
             println!("{name}\t{value}");

--- a/quiche/src/h3/qpack/decoder.rs
+++ b/quiche/src/h3/qpack/decoder.rs
@@ -24,10 +24,18 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::borrow::Cow;
+use std::collections::VecDeque;
+
+use super::encoder::encode_int;
 use super::Error;
 use super::Result;
+use super::INSERT_WITH_LITERAL_NAME;
+use super::INSERT_WITH_NAME_REF;
+use super::SET_DYNAMIC_TABLE_CAPACITY;
 
 use crate::h3::Header;
+use crate::h3::NameValue;
 
 use super::INDEXED;
 use super::INDEXED_WITH_POST_BASE;
@@ -65,60 +73,348 @@ impl Representation {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum EncoderInstruction {
+    SetDynamicTableCapacity,
+    InsertWithNameRef,
+    InsertWithLiteralName,
+    Duplicate,
+}
+
+impl EncoderInstruction {
+    pub fn from_byte(b: u8) -> EncoderInstruction {
+        if b & INSERT_WITH_NAME_REF == INSERT_WITH_NAME_REF {
+            return EncoderInstruction::InsertWithNameRef;
+        }
+
+        if b & INSERT_WITH_LITERAL_NAME == INSERT_WITH_LITERAL_NAME {
+            return EncoderInstruction::InsertWithLiteralName;
+        }
+
+        if b & SET_DYNAMIC_TABLE_CAPACITY == SET_DYNAMIC_TABLE_CAPACITY {
+            return EncoderInstruction::SetDynamicTableCapacity;
+        }
+
+        EncoderInstruction::Duplicate
+    }
+}
+
 /// A QPACK decoder.
 #[derive(Default)]
-pub struct Decoder {}
+pub struct Decoder {
+    dynamic_table: VecDeque<(Cow<'static, [u8]>, Vec<u8>)>,
+    /// The number of insertions into the table
+    insert_cnt: u64,
+    /// The number of entries removed from the table
+    base: u64,
+    /// The computed size of the table as per rfc9204
+    tbl_sz: u64,
+    /// The current capacity requested by the peer
+    capacity: u64,
+    /// The capacity limit imposed by settings
+    max_capacity: u64,
+
+    /// The value of `insert_cnt` last time "Insert Count Increment" was emmited
+    last_acked_insert: u64,
+    /// A list of streams pending "Section Acknowledgment"
+    unacked_sections: VecDeque<u64>,
+    /// A list of streams pending "Stream Cancellation"
+    unacked_cancellations: VecDeque<u64>,
+
+    /// Internal buffer in case the decoder receives a partial buffer
+    inner_buffer: Vec<u8>,
+}
 
 impl Decoder {
     /// Creates a new QPACK decoder.
-    pub fn new() -> Decoder {
-        Decoder::default()
+    pub fn new(max_capacity: u64) -> Decoder {
+        Decoder {
+            max_capacity: max_capacity.min(u32::MAX as u64),
+            ..Decoder::default()
+        }
     }
 
-    /// Processes control instructions from the encoder.
-    pub fn control(&mut self, _buf: &mut [u8]) -> Result<()> {
-        // TODO: process control instructions
+    /// Check if the decoder wants to emit any instructions on the instruction
+    /// stream
+    pub fn has_instructions(&self) -> bool {
+        self.last_acked_insert != self.insert_cnt ||
+            !self.unacked_sections.is_empty() ||
+            !self.unacked_cancellations.is_empty()
+    }
+
+    /// Emit any pending instructions on the instruction stream, once emitted
+    /// the buffer must be fully sent to the peer, or else the encoder and
+    /// decoder may get out of sync.
+    pub fn emit_instructions(&mut self, buf: &mut [u8]) -> usize {
+        const INSERT_CNT_INC: u8 = 0x00;
+        const SECTION_ACK: u8 = 0x80;
+        const STREAM_CANCEL: u8 = 0x40;
+
+        let mut b = octets::OctetsMut::with_slice(buf);
+
+        let inc_req_count = self.insert_cnt - self.last_acked_insert;
+
+        if inc_req_count > 0 &&
+            encode_int(inc_req_count, INSERT_CNT_INC, 6, &mut b).is_ok()
+        {
+            self.last_acked_insert = self.insert_cnt;
+        }
+
+        while let Some(section) = self.unacked_sections.front() {
+            if encode_int(*section, SECTION_ACK, 7, &mut b).is_ok() {
+                self.unacked_sections.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        if self.capacity > 0 {
+            // Those notifications MAY be ommited if table size is 0, so omit them
+            while let Some(section) = self.unacked_cancellations.front() {
+                if encode_int(*section, STREAM_CANCEL, 6, &mut b).is_ok() {
+                    self.unacked_cancellations.pop_front();
+                } else {
+                    break;
+                }
+            }
+        } else {
+            self.unacked_cancellations.clear();
+        }
+
+        b.off()
+    }
+
+    pub fn cancel_stream(&mut self, stream: u64) {
+        self.unacked_cancellations.push_back(stream);
+    }
+
+    fn process_control(&mut self, b: &mut octets::Octets) -> Result<()> {
+        let first = b.peek_u8()?;
+
+        match EncoderInstruction::from_byte(first) {
+            EncoderInstruction::SetDynamicTableCapacity => {
+                let capacity = decode_int(b, 5)?;
+
+                trace!("SetDynamicTableCapacity size={capacity}");
+
+                self.resize_table(capacity)?;
+            },
+
+            EncoderInstruction::InsertWithNameRef => {
+                let is_static = first & 0x40 == 0x40;
+                let idx = decode_int(b, 6)?;
+
+                let value = decode_str(b, 7)?;
+
+                trace!("InsertWithNameRef index={idx} static={is_static} value={value:?}");
+
+                if is_static {
+                    let (name, _) = lookup_static(idx)?;
+                    self.insert((Cow::Borrowed(name), value))?;
+                } else {
+                    let (name, _) = self.lookup_dynamic(
+                        self.insert_cnt
+                            .checked_sub(idx + 1)
+                            .ok_or(Error::InvalidDynamicTableIndex)?,
+                    )?;
+                    self.insert((Cow::Owned(name.to_vec()), value))?;
+                }
+            },
+
+            EncoderInstruction::InsertWithLiteralName => {
+                let name = decode_str(b, 5)?;
+                let value = decode_str(b, 7)?;
+
+                trace!("InsertWithLiteralName name={name:?} value={value:?}");
+
+                self.insert((Cow::Owned(name), value))?;
+            },
+
+            EncoderInstruction::Duplicate => {
+                let idx = decode_int(b, 5)?;
+
+                trace!("Duplicate index={idx}");
+
+                let (name, value) = self.lookup_dynamic(
+                    self.insert_cnt
+                        .checked_sub(idx + 1)
+                        .ok_or(Error::InvalidDynamicTableIndex)?,
+                )?;
+
+                self.insert((Cow::Owned(name.to_vec()), value.to_vec()))?;
+            },
+        }
+
         Ok(())
     }
 
+    /// Processes control instructions from the encoder.
+    pub fn control(&mut self, buf: &[u8]) -> Result<()> {
+        let mut maybe_buf = Vec::new();
+
+        let mut b = if !self.inner_buffer.is_empty() {
+            // Have a buffered partial instruction, should concatenate the
+            // provided buffer and try again
+            std::mem::swap(&mut maybe_buf, &mut self.inner_buffer);
+            maybe_buf.extend_from_slice(buf);
+            octets::Octets::with_slice(maybe_buf.as_slice())
+        } else {
+            octets::Octets::with_slice(buf)
+        };
+
+        while b.cap() > 0 {
+            let pos = b.off();
+            match self.process_control(&mut b) {
+                Ok(_) => {},
+                Err(Error::BufferTooShort) => {
+                    // Have partial instruction, have to buffer it now
+                    self.inner_buffer.extend_from_slice(&b.buf()[pos..]);
+                    return Ok(());
+                },
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Evict the oldest entry in the table
+    fn evict_one(&mut self) -> Result<()> {
+        let entry = self
+            .dynamic_table
+            .pop_front()
+            .ok_or(Error::DynamicTableTooBig)?;
+
+        self.tbl_sz -= entry.qpack_cost();
+        self.base += 1;
+        Ok(())
+    }
+
+    fn insert(&mut self, entry: (Cow<'static, [u8]>, Vec<u8>)) -> Result<()> {
+        self.tbl_sz += entry.qpack_cost();
+
+        while self.tbl_sz > self.capacity {
+            self.evict_one()?;
+        }
+
+        self.dynamic_table.push_back(entry);
+        self.insert_cnt += 1;
+
+        trace!("Insert insert_cnt={} size={}", self.insert_cnt, self.tbl_sz);
+
+        Ok(())
+    }
+
+    fn resize_table(&mut self, new_capacity: u64) -> Result<()> {
+        if new_capacity > self.max_capacity {
+            return Err(Error::DynamicTableTooBig);
+        }
+
+        self.capacity = new_capacity;
+        while self.tbl_sz > self.capacity {
+            self.evict_one()?;
+        }
+
+        Ok(())
+    }
+
+    fn lookup_dynamic(&self, idx: u64) -> Result<(&[u8], &[u8])> {
+        let idx = idx
+            .checked_sub(self.base)
+            .ok_or(Error::InvalidDynamicTableIndex)?;
+
+        self.dynamic_table
+            .get(idx as usize)
+            .ok_or(Error::InvalidDynamicTableIndex)
+            .map(|(n, v)| (&n[..], &v[..]))
+    }
+
+    fn decode_insert_cnt_and_base(
+        &self, b: &mut octets::Octets,
+    ) -> Result<(u64, u64)> {
+        let mut req_insert_count = decode_int(b, 8)?;
+        if req_insert_count != 0 {
+            let max_entries = self.max_capacity / 32;
+            let full_range = max_entries * 2;
+            if req_insert_count > full_range {
+                return Err(Error::InvalidDynamicTableIndex);
+            }
+
+            let max_value = self.insert_cnt + max_entries;
+
+            let max_wrapped = (max_value / full_range) * full_range;
+
+            req_insert_count = max_wrapped + req_insert_count - 1;
+
+            // If req_insert_count exceeds max_value, the Encoder's value must
+            // have wrapped one fewer time
+            if req_insert_count > max_value {
+                if req_insert_count <= full_range {
+                    return Err(Error::InvalidDynamicTableIndex);
+                }
+                req_insert_count -= full_range;
+            }
+
+            // Value of 0 must be encoded as 0.
+            if req_insert_count == 0 {
+                return Err(Error::InvalidDynamicTableIndex);
+            }
+        }
+
+        let delta_negative = b.peek_u8()? & 0x80 == 0x80;
+        let delta = decode_int(b, 7)?;
+
+        let base = if delta_negative {
+            req_insert_count
+                .checked_sub(delta + 1)
+                .ok_or(Error::InvalidDynamicTableIndex)?
+        } else {
+            req_insert_count + delta
+        };
+
+        Ok((req_insert_count as u64, base as u64))
+    }
+
     /// Decodes a QPACK header block into a list of headers.
-    pub fn decode(&mut self, buf: &[u8], max_size: u64) -> Result<Vec<Header>> {
+    pub fn decode(
+        &mut self, buf: &[u8], max_size: u64, stream_id: u64,
+    ) -> Result<Vec<Header>> {
         let mut b = octets::Octets::with_slice(buf);
 
         let mut out = Vec::new();
 
         let mut left = max_size;
 
-        let req_insert_count = decode_int(&mut b, 8)?;
-        let base = decode_int(&mut b, 7)?;
+        let (req_insert_count, base) = self.decode_insert_cnt_and_base(&mut b)?;
 
         trace!("Header count={} base={}", req_insert_count, base);
+
+        if req_insert_count > self.insert_cnt {
+            return Err(Error::DynamicTableWouldBlock);
+        }
 
         while b.cap() > 0 {
             let first = b.peek_u8()?;
 
-            match Representation::from_byte(first) {
+            let hdr = match Representation::from_byte(first) {
                 Representation::Indexed => {
                     const STATIC: u8 = 0x40;
 
-                    let s = first & STATIC == STATIC;
+                    let is_static = first & STATIC == STATIC;
                     let index = decode_int(&mut b, 6)?;
 
-                    trace!("Indexed index={} static={}", index, s);
+                    trace!("Indexed index={} static={}", index, is_static);
 
-                    if !s {
-                        // TODO: implement dynamic table
-                        return Err(Error::InvalidHeaderValue);
-                    }
+                    let (name, value) = if !is_static {
+                        self.lookup_dynamic(
+                            base.checked_sub(index + 1)
+                                .ok_or(Error::InvalidDynamicTableIndex)?,
+                        )?
+                    } else {
+                        lookup_static(index)?
+                    };
 
-                    let (name, value) = lookup_static(index)?;
-
-                    left = left
-                        .checked_sub((name.len() + value.len()) as u64)
-                        .ok_or(Error::HeaderListTooLarge)?;
-
-                    let hdr = Header::new(name, value);
-                    out.push(hdr);
+                    Header::new(name, value)
                 },
 
                 Representation::IndexedWithPostBase => {
@@ -126,80 +422,64 @@ impl Decoder {
 
                     trace!("Indexed With Post Base index={}", index);
 
-                    // TODO: implement dynamic table
-                    return Err(Error::InvalidHeaderValue);
+                    let (name, value) = self.lookup_dynamic(base + index)?;
+
+                    Header::new(name, value)
                 },
 
                 Representation::Literal => {
-                    let name_huff = b.as_ref()[0] & 0x08 == 0x08;
-                    let name_len = decode_int(&mut b, 3)? as usize;
+                    let name = decode_str(&mut b, 3)?;
+                    let value = decode_str(&mut b, 7)?;
 
-                    let mut name = b.get_bytes(name_len)?;
+                    trace!("Literal Without Name Reference name={name:?} value={value:?}");
 
-                    let name = if name_huff {
-                        super::huffman::decode(&mut name)?
-                    } else {
-                        name.to_vec()
-                    };
-
-                    let name = name.to_vec();
-                    let value = decode_str(&mut b)?;
-
-                    trace!(
-                        "Literal Without Name Reference name={:?} value={:?}",
-                        name,
-                        value,
-                    );
-
-                    left = left
-                        .checked_sub((name.len() + value.len()) as u64)
-                        .ok_or(Error::HeaderListTooLarge)?;
-
-                    // Instead of calling Header::new(), create Header directly
-                    // from `name` and `value`, which are already String.
-                    let hdr = Header(name, value);
-                    out.push(hdr);
+                    Header::new(name, value)
                 },
 
                 Representation::LiteralWithNameRef => {
                     const STATIC: u8 = 0x10;
 
-                    let s = first & STATIC == STATIC;
+                    let is_static = first & STATIC == STATIC;
                     let name_idx = decode_int(&mut b, 4)?;
-                    let value = decode_str(&mut b)?;
+                    let value = decode_str(&mut b, 7)?;
 
-                    trace!(
-                        "Literal name_idx={} static={} value={:?}",
-                        name_idx,
-                        s,
-                        value
-                    );
+                    trace!("Literal name_idx={name_idx} static={is_static} value={value:?}");
 
-                    if !s {
-                        // TODO: implement dynamic table
-                        return Err(Error::InvalidHeaderValue);
-                    }
+                    let (name, _) = if !is_static {
+                        self.lookup_dynamic(
+                            base.checked_sub(name_idx + 1)
+                                .ok_or(Error::InvalidDynamicTableIndex)?,
+                        )?
+                    } else {
+                        lookup_static(name_idx)?
+                    };
 
-                    let (name, _) = lookup_static(name_idx)?;
-
-                    left = left
-                        .checked_sub((name.len() + value.len()) as u64)
-                        .ok_or(Error::HeaderListTooLarge)?;
-
-                    // Instead of calling Header::new(), create Header directly
-                    // from `value`, which is already String, but clone `name`
-                    // as it is just a reference.
-                    let hdr = Header(name.to_vec(), value);
-                    out.push(hdr);
+                    Header::new(name, value)
                 },
 
                 Representation::LiteralWithPostBase => {
-                    trace!("Literal With Post Base");
+                    let index = decode_int(&mut b, 3)?;
+                    let value = decode_str(&mut b, 7)?;
 
-                    // TODO: implement dynamic table
-                    return Err(Error::InvalidHeaderValue);
+                    trace!(
+                        "Literal With Post Base index={index} value={value:?}"
+                    );
+
+                    let (name, _) = self.lookup_dynamic(base + index)?;
+
+                    Header::new(name, value)
                 },
-            }
+            };
+
+            left = left
+                .checked_sub((hdr.0.len() + hdr.1.len()) as u64)
+                .ok_or(Error::HeaderListTooLarge)?;
+
+            out.push(hdr);
+        }
+
+        if req_insert_count > 0 {
+            self.unacked_sections.push_back(stream_id);
         }
 
         Ok(out)
@@ -245,12 +525,12 @@ fn decode_int(b: &mut octets::Octets, prefix: usize) -> Result<u64> {
     Err(Error::BufferTooShort)
 }
 
-fn decode_str(b: &mut octets::Octets) -> Result<Vec<u8>> {
+fn decode_str(b: &mut octets::Octets, prefix: usize) -> Result<Vec<u8>> {
     let first = b.peek_u8()?;
 
-    let huff = first & 0x80 == 0x80;
+    let huff = first & (1 << prefix) != 0;
 
-    let len = decode_int(b, 7)? as usize;
+    let len = decode_int(b, prefix)? as usize;
 
     let mut val = b.get_bytes(len)?;
 
@@ -289,5 +569,298 @@ mod tests {
         let mut b = octets::Octets::with_slice(&encoded);
 
         assert_eq!(decode_int(&mut b, 8), Ok(42));
+    }
+
+    #[test]
+    fn decode_dynamic1() {
+        let mut decoder = Decoder::new(300);
+        assert!(!decoder.has_instructions());
+
+        // Stream: Encoder
+        // 3fbd01              | Set Dynamic Table Capacity=220
+        // c00f 7777 772e 6578 | Insert With Name Reference
+        // 616d 706c 652e 636f | Static Table, Index=0
+        // 6d                  |  (:authority=www.example.com)
+        // c10c 2f73 616d 706c | Insert With Name Reference
+        // 652f 7061 7468      |  Static Table, Index=1
+        // |  (:path=/sample/path)
+        //
+        // Abs Ref Name        Value
+        // ^-- acknowledged --^
+        // 0   0  :authority  www.example.com
+        // 1   0  :path       /sample/path
+        // Size=106
+        //
+        // Stream: 4
+        // 0381                | Required Insert Count = 2, Base = 0
+        // 10                  | Indexed Field Line With Post-Base Index
+        // |  Absolute Index = Base(0) + Index(0) = 0
+        // |  (:authority=www.example.com)
+        // 11                  | Indexed Field Line With Post-Base Index
+        // |  Absolute Index = Base(0) + Index(1) = 1
+        // |  (:path=/sample/path)
+        //
+        // Abs Ref Name        Value
+        // ^-- acknowledged --^
+        // 0   1  :authority  www.example.com
+        // 1   1  :path       /sample/path
+        // Size=106
+        //
+        // Stream: Decoder
+        // 84                  | Section Acknowledgment (stream=4)
+        //
+        // Abs Ref Name        Value
+        // 0   0  :authority  www.example.com
+        // 1   0  :path       /sample/path
+        // ^-- acknowledged --^
+        // Size=106
+
+        let mut decoder_stream = [0u8; 16];
+        let encoder_stream = [
+            0x3f, 0xbd, 0x01, 0xc0, 0x0f, 0x77, 0x77, 0x77, 0x2e, 0x65, 0x78,
+            0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d, 0xc1, 0x0c,
+            0x2f, 0x73, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2f, 0x70, 0x61, 0x74,
+            0x68,
+        ];
+
+        decoder.control(&encoder_stream).unwrap();
+
+        assert_eq!(decoder.insert_cnt, 2);
+        assert_eq!(decoder.tbl_sz, 106);
+
+        let n = decoder.emit_instructions(&mut decoder_stream);
+
+        assert_eq!(n, 1);
+        assert_eq!(decoder_stream[0], 0x02);
+
+        let enc_headers = [0x03, 0x81, 0x10, 0x11];
+        let headers = decoder.decode(&enc_headers, u64::MAX, 4).unwrap();
+
+        assert_eq!(headers[0], Header::new(":authority", "www.example.com"));
+        assert_eq!(headers[1], Header::new(":path", "/sample/path"));
+        assert!(decoder.has_instructions());
+
+        let n = decoder.emit_instructions(&mut decoder_stream);
+
+        assert_eq!(n, 1);
+        assert_eq!(decoder_stream[0], 0x84);
+    }
+
+    #[test]
+    fn decode_dynamic2() {
+        let mut decoder = Decoder::new(300);
+        let mut decoder_stream = [0u8; 16];
+
+        let encoder_stream = [
+            0x3f, 0xbd, 0x01, 0xc0, 0x0f, 0x77, 0x77, 0x77, 0x2e, 0x65, 0x78,
+            0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d, 0xc1, 0x0c,
+            0x2f, 0x73, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2f, 0x70, 0x61, 0x74,
+            0x68,
+        ];
+
+        assert!(!decoder.has_instructions());
+        decoder.control(&encoder_stream).unwrap();
+        decoder.emit_instructions(&mut decoder_stream);
+
+        // Stream: Encoder
+        // 4a63 7573 746f 6d2d | Insert With Literal Name
+        // 6b65 790c 6375 7374 |  (custom-key=custom-value)
+        // 6f6d 2d76 616c 7565 |
+        //
+        // Abs Ref Name        Value
+        // 0   0  :authority  www.example.com
+        // 1   0  :path       /sample/path
+        // ^-- acknowledged --^
+        // 2   0  custom-key  custom-value
+        // Size=160
+        //
+        // Stream: Decoder
+        // 01                  | Insert Count Increment (1)
+        //
+        // Abs Ref Name        Value
+        // 0   0  :authority  www.example.com
+        // 1   0  :path       /sample/path
+        // 2   0  custom-key  custom-value
+        // ^-- acknowledged --^
+        // Size=160
+
+        let encoder_stream = [
+            0x4a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65, 0x79,
+            0x0c, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x76, 0x61, 0x6c,
+            0x75, 0x65,
+        ];
+        decoder.control(&encoder_stream).unwrap();
+
+        assert_eq!(decoder.insert_cnt, 3);
+        assert_eq!(decoder.tbl_sz, 160);
+
+        let n = decoder.emit_instructions(&mut decoder_stream);
+
+        assert_eq!(n, 1);
+        assert_eq!(decoder_stream[0], 0x01);
+
+        let chk_hdr = |idx: u64, n: &str, v: &str| -> bool {
+            let hdr = decoder.lookup_dynamic(idx).unwrap();
+            hdr.0 == n.as_bytes() && hdr.1 == v.as_bytes()
+        };
+
+        assert!(chk_hdr(0, ":authority", "www.example.com"));
+        assert!(chk_hdr(1, ":path", "/sample/path"));
+        assert!(chk_hdr(2, "custom-key", "custom-value"));
+    }
+
+    #[test]
+    fn decode_dynamic3() {
+        let mut decoder = Decoder::new(300);
+        let mut decoder_stream = [0u8; 16];
+
+        let encoder_stream = [
+            0x3f, 0xbd, 0x01, 0xc0, 0x0f, 0x77, 0x77, 0x77, 0x2e, 0x65, 0x78,
+            0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d, 0xc1, 0x0c,
+            0x2f, 0x73, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2f, 0x70, 0x61, 0x74,
+            0x68, 0x4a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65,
+            0x79, 0x0c, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x76, 0x61,
+            0x6c, 0x75, 0x65,
+        ];
+
+        assert!(!decoder.has_instructions());
+        decoder.control(&encoder_stream).unwrap();
+        decoder.emit_instructions(&mut decoder_stream);
+
+        // Stream: Encoder
+        // 02                  | Duplicate (Relative Index = 2)
+        // |  Absolute Index =
+        // |   Insert Count(3) - Index(2) - 1 = 0
+        //
+        // Abs Ref Name        Value
+        // 0   0  :authority  www.example.com
+        // 1   0  :path       /sample/path
+        // 2   0  custom-key  custom-value
+        // ^-- acknowledged --^
+        // 3   0  :authority  www.example.com
+        // Size=217
+        //
+        // Stream: 8
+        // 0500                | Required Insert Count = 4, Base = 4
+        // 80                  | Indexed Field Line, Dynamic Table
+        // |  Absolute Index = Base(4) - Index(0) - 1 = 3
+        // |  (:authority=www.example.com)
+        // c1                  | Indexed Field Line, Static Table Index = 1
+        // |  (:path=/)
+        // 81                  | Indexed Field Line, Dynamic Table
+        // |  Absolute Index = Base(4) - Index(1) - 1 = 2
+        // |  (custom-key=custom-value)
+        //
+        // Abs Ref Name        Value
+        // 0   0  :authority  www.example.com
+        // 1   0  :path       /sample/path
+        // 2   1  custom-key  custom-value
+        // ^-- acknowledged --^
+        // 3   1  :authority  www.example.com
+        // Size=217
+        //
+        // Stream: Decoder
+        // 48                  | Stream Cancellation (Stream=8)
+        //
+        // Abs Ref Name        Value
+        // 0   0  :authority  www.example.com
+        // 1   0  :path       /sample/path
+        // 2   0  custom-key  custom-value
+        // ^-- acknowledged --^
+        // 3   0  :authority  www.example.com
+        // Size=217
+
+        let encoder_stream = [0x02];
+        decoder.control(&encoder_stream).unwrap();
+        decoder.emit_instructions(&mut decoder_stream);
+
+        assert_eq!(decoder.insert_cnt, 4);
+        assert_eq!(decoder.tbl_sz, 217);
+
+        let chk_hdr = |idx: u64, n: &str, v: &str| -> bool {
+            let hdr = decoder.lookup_dynamic(idx).unwrap();
+            hdr.0 == n.as_bytes() && hdr.1 == v.as_bytes()
+        };
+
+        assert!(chk_hdr(3, ":authority", "www.example.com"));
+
+        let enc_headers = [0x05, 0x00, 0x80, 0xc1, 0x81];
+        let headers = decoder.decode(&enc_headers, u64::MAX, 8).unwrap();
+
+        assert_eq!(headers[0], Header::new(":authority", "www.example.com"));
+        assert_eq!(headers[1], Header::new(":path", "/"));
+        assert_eq!(headers[2], Header::new("custom-key", "custom-value"));
+
+        let n = decoder.emit_instructions(&mut decoder_stream);
+
+        assert_eq!(n, 1);
+        assert_eq!(decoder_stream[0], 0x88);
+
+        assert!(!decoder.has_instructions());
+        decoder.cancel_stream(8);
+        assert!(decoder.has_instructions());
+
+        let n = decoder.emit_instructions(&mut decoder_stream);
+
+        assert_eq!(n, 1);
+        assert_eq!(decoder_stream[0], 0x48);
+    }
+
+    #[test]
+    /// Test partial instructions are properly buffered
+    fn decode_dynamic4() {
+        let mut decoder = Decoder::new(300);
+
+        let encoder_stream = [
+            0x3f, 0xbd, 0x01, 0xc0, 0x0f, 0x77, 0x77, 0x77, 0x2e, 0x65, 0x78,
+            0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d, 0xc1, 0x0c,
+            0x2f, 0x73, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2f, 0x70, 0x61, 0x74,
+            0x68, 0x4a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65,
+            0x79, 0x0c, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x76, 0x61,
+            0x6c, 0x75, 0x65, 0x02,
+        ];
+
+        assert!(!decoder.has_instructions());
+        decoder.control(&encoder_stream[..7]).unwrap();
+        decoder.control(&encoder_stream[7..31]).unwrap();
+        decoder.control(&encoder_stream[31..]).unwrap();
+
+        let chk_hdr = |idx: u64, n: &str, v: &str| -> bool {
+            let hdr = decoder.lookup_dynamic(idx).unwrap();
+            hdr.0 == n.as_bytes() && hdr.1 == v.as_bytes()
+        };
+
+        assert!(chk_hdr(0, ":authority", "www.example.com"));
+        assert!(chk_hdr(1, ":path", "/sample/path"));
+        assert!(chk_hdr(2, "custom-key", "custom-value"));
+        assert!(chk_hdr(3, ":authority", "www.example.com"));
+    }
+
+    #[test]
+    /// Test entries are evicted
+    fn decode_dynamic5() {
+        let mut decoder = Decoder::new(200);
+
+        let encoder_stream = [
+            0x3f, 0xa9, 0x01, 0xc0, 0x0f, 0x77, 0x77, 0x77, 0x2e, 0x65, 0x78,
+            0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d, 0xc1, 0x0c,
+            0x2f, 0x73, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2f, 0x70, 0x61, 0x74,
+            0x68, 0x4a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65,
+            0x79, 0x0c, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x76, 0x61,
+            0x6c, 0x75, 0x65, 0x02,
+        ];
+
+        assert!(!decoder.has_instructions());
+        decoder.control(&encoder_stream).unwrap();
+        let chk_hdr = |idx: u64, n: &str, v: &str| -> bool {
+            let hdr = decoder.lookup_dynamic(idx).unwrap();
+            hdr.0 == n.as_bytes() && hdr.1 == v.as_bytes()
+        };
+
+        assert_eq!(decoder.tbl_sz, 160);
+        assert!(decoder.lookup_dynamic(0).is_err());
+        assert!(chk_hdr(1, ":path", "/sample/path"));
+        assert!(chk_hdr(2, "custom-key", "custom-value"));
+        assert!(chk_hdr(3, ":authority", "www.example.com"));
     }
 }

--- a/quiche/src/h3/qpack/encoder.rs
+++ b/quiche/src/h3/qpack/encoder.rs
@@ -117,7 +117,7 @@ fn lookup_static<T: NameValue>(h: &T) -> Option<(u64, bool)> {
     None
 }
 
-fn encode_int(
+pub(crate) fn encode_int(
     mut v: u64, first: u8, prefix: usize, b: &mut octets::OctetsMut,
 ) -> Result<()> {
     let mask = 2u64.pow(prefix as u32) - 1;

--- a/quiche/src/h3/stream.rs
+++ b/quiche/src/h3/stream.rs
@@ -80,8 +80,11 @@ pub enum State {
     /// Reading the push ID.
     PushId,
 
-    /// Reading a QPACK instruction.
-    QpackInstruction,
+    /// Reading a QPACK decoder instruction.
+    QpackDecoderInstruction,
+
+    /// Reading a QPACK encoder instruction.
+    QpackEncoderInstruction,
 
     /// Reading and discarding data.
     Drain,
@@ -218,10 +221,16 @@ impl Stream {
 
             Type::Push => State::PushId,
 
-            Type::QpackEncoder | Type::QpackDecoder => {
+            Type::QpackEncoder => {
                 self.remote_initialized = true;
 
-                State::QpackInstruction
+                State::QpackEncoderInstruction
+            },
+
+            Type::QpackDecoder => {
+                self.remote_initialized = true;
+
+                State::QpackDecoderInstruction
             },
 
             Type::Unknown => State::Drain,

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -784,7 +784,7 @@ impl Eq for StreamPriorityKey {}
 
 impl PartialOrd for StreamPriorityKey {
     // Priority ordering is complex, disable Clippy warning.
-    #[allow(clippy::incorrect_partial_ord_impl_on_ord_type)]
+    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         // Ignore priority if ID matches.
         if self.id == other.id {


### PR DESCRIPTION
This change adds a basic dynamic table support for QPACK decoder. It only implements the table without the blocking. Still in many cases it allows for much better compression than the static only table.