### PR TITLE
Expose quiche_conn_retire_dcid(...)

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -702,6 +702,10 @@ uint64_t quiche_conn_new_scid(quiche_conn *conn,
                            const uint8_t *scid, size_t scid_len,
                            const uint8_t *reset_token, bool retire_if_needed);
 
+// Requests the retirement of the destination Connection ID used by the
+// host to reach its peer.
+int quiche_conn_retire_dcid(quiche_conn *conn, uint64_t dcid_seq);
+
 // Frees the connection object.
 void quiche_conn_free(quiche_conn *conn);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1384,6 +1384,16 @@ pub extern fn quiche_conn_new_scid(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_retire_dcid(
+    conn: &mut Connection, dcid_seq: u64,
+) -> c_int {
+    match conn.retire_dcid(dcid_seq) {
+        Ok(_) => 0,
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_available_dcids(conn: &Connection) -> size_t {
     conn.available_dcids() as size_t
 }


### PR DESCRIPTION
Motivation:

At the moment its impossible to call retire_dcid(...) via the C API.

Modifications:

Add quiche_conn_retire_dcid to header file and also add the implementation to ffi.

Result:

Be able to retire destination connection id