### PR TITLE
Expose functions related to client side connection migration via c API

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -727,6 +727,21 @@ int quiche_conn_new_scid(quiche_conn *conn,
                            const uint8_t *scid, size_t scid_len,
                            const uint8_t *reset_token, bool retire_if_needed, uint64_t *scid_seq);
 
+// Requests the stack to perform path validation of the proposed 4-tuple.
+int quiche_conn_probe_path(quiche_conn *conn,
+                                const struct sockaddr *local, socklen_t local_len,
+                                const struct sockaddr *peer, socklen_t peer_len, uint64_t *seq);
+
+// Migrates the connection to a new local address.
+int quiche_conn_migrate_source(quiche_conn *conn, const struct sockaddr *local, socklen_t local_len, uint64_t *seq);
+
+// Migrates the connection over the given network path between "local"
+// and "peer".
+int quiche_conn_migrate(quiche_conn *conn,
+                             const struct sockaddr *local, socklen_t local_len,
+                             const struct sockaddr *peer, socklen_t peer_len,
+                             uint64_t *seq);
+
 enum quiche_path_event_type {
     QUICHE_PATH_EVENT_NEW,
     QUICHE_PATH_EVENT_VALIDATED,

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1547,6 +1547,52 @@ pub extern fn quiche_conn_is_path_validated(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_probe_path(
+    conn: &mut Connection, local: &sockaddr, local_len: socklen_t,
+    peer: &sockaddr, peer_len: socklen_t, seq: *mut u64,
+) -> c_int {
+    let local = std_addr_from_c(local, local_len);
+    let peer = std_addr_from_c(peer, peer_len);
+    match conn.probe_path(local, peer) {
+        Ok(v) => {
+            unsafe { *seq = v }
+            0
+        },
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_migrate_source(
+    conn: &mut Connection, local: &sockaddr, local_len: socklen_t, seq: *mut u64,
+) -> c_int {
+    let local = std_addr_from_c(local, local_len);
+    match conn.migrate_source(local) {
+        Ok(v) => {
+            unsafe { *seq = v }
+            0
+        },
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_migrate(
+    conn: &mut Connection, local: &sockaddr, local_len: socklen_t,
+    peer: &sockaddr, peer_len: socklen_t, seq: *mut u64,
+) -> c_int {
+    let local = std_addr_from_c(local, local_len);
+    let peer = std_addr_from_c(peer, peer_len);
+    match conn.migrate(local, peer) {
+        Ok(v) => {
+            unsafe { *seq = v }
+            0
+        },
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_path_event_next(
     conn: &mut Connection,
 ) -> *const PathEvent {


### PR DESCRIPTION
Motivation:

Quiche didnt expose all methods via c functions that are required to start connection migration.

Modifications:

Add missing ffi implementatins and add functions to c header file.

Result:

Be able to do connection migration on the client side.