### PR TITLE
FFI: Add quiche_conn_is_resumed

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -467,6 +467,9 @@ void quiche_conn_session(const quiche_conn *conn, const uint8_t **out, size_t *o
 // Returns true if the connection handshake is complete.
 bool quiche_conn_is_established(const quiche_conn *conn);
 
+// Returns true if the connection is resumed.
+bool quiche_conn_is_resumed(const quiche_conn *conn);
+
 // Returns true if the connection has a pending handshake that has progressed
 // enough to send or receive early data.
 bool quiche_conn_is_in_early_data(const quiche_conn *conn);

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1080,6 +1080,11 @@ pub extern fn quiche_conn_is_established(conn: &Connection) -> bool {
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_is_resumed(conn: &Connection) -> bool {
+    conn.is_resumed()
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_is_in_early_data(conn: &Connection) -> bool {
     conn.is_in_early_data()
 }


### PR DESCRIPTION
Motivation:

Connection.is_resumed() is not exposed via FFI / C.

Modifications:

Add quiche_conn_is_resumed

Result:

Missing API added