### PR TITLE
FFI: Add missing quiche_conn_is_dgram_send_queue_full(...) and quiche…

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -701,7 +701,6 @@ bool quiche_conn_is_dgram_send_queue_full(const quiche_conn *conn);
 // Returns whether or not the DATAGRAM recv queue is full.
 bool quiche_conn_is_dgram_recv_queue_full(const quiche_conn *conn);
 
-
 // Schedule an ack-eliciting packet on the active path.
 ssize_t quiche_conn_send_ack_eliciting(quiche_conn *conn);
 

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -695,6 +695,13 @@ ssize_t quiche_conn_dgram_send(quiche_conn *conn, const uint8_t *buf,
 void quiche_conn_dgram_purge_outgoing(quiche_conn *conn,
                                       bool (*f)(uint8_t *, size_t));
 
+// Returns whether or not the DATAGRAM send queue is full.
+bool quiche_conn_is_dgram_send_queue_full(const quiche_conn *conn);
+
+// Returns whether or not the DATAGRAM recv queue is full.
+bool quiche_conn_is_dgram_recv_queue_full(const quiche_conn *conn);
+
+
 // Schedule an ack-eliciting packet on the active path.
 ssize_t quiche_conn_send_ack_eliciting(quiche_conn *conn);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1385,6 +1385,16 @@ pub extern fn quiche_conn_dgram_purge_outgoing(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_is_dgram_send_queue_full(conn: &Connection) -> bool {
+    conn.is_dgram_send_queue_full()
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_is_dgram_recv_queue_full(conn: &Connection) -> bool {
+    conn.is_dgram_recv_queue_full()
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_send_ack_eliciting(conn: &mut Connection) -> ssize_t {
     match conn.send_ack_eliciting() {
         Ok(()) => 0,


### PR DESCRIPTION
…_conn_is_dgram_recv_queue_full(...) methods

Motivation:

quiche_conn_is_dgram_send_queue_full(...) and quiche_conn_is_dgram_recv_queue_full(...) is missing in the c API

Modifications:

Add functions to C header / add FFI impl

Result:

Missing functions added