### PR TITLE
ffi: Fix const-correctness for quiche_h3_send_* functions

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -1061,23 +1061,23 @@ typedef struct {
 
 // Sends an HTTP/3 request.
 int64_t quiche_h3_send_request(quiche_h3_conn *conn, quiche_conn *quic_conn,
-                               quiche_h3_header *headers, size_t headers_len,
+                               const quiche_h3_header *headers, size_t headers_len,
                                bool fin);
 
 // Sends an HTTP/3 response on the specified stream with default priority.
 int quiche_h3_send_response(quiche_h3_conn *conn, quiche_conn *quic_conn,
-                            uint64_t stream_id, quiche_h3_header *headers,
+                            uint64_t stream_id, const quiche_h3_header *headers,
                             size_t headers_len, bool fin);
 
 // Sends an HTTP/3 response on the specified stream with specified priority.
 int quiche_h3_send_response_with_priority(quiche_h3_conn *conn,
                             quiche_conn *quic_conn, uint64_t stream_id,
-                            quiche_h3_header *headers, size_t headers_len,
+                            const quiche_h3_header *headers, size_t headers_len,
                             quiche_h3_priority *priority, bool fin);
 
 // Sends an HTTP/3 body chunk on the given stream.
 ssize_t quiche_h3_send_body(quiche_h3_conn *conn, quiche_conn *quic_conn,
-                            uint64_t stream_id, uint8_t *body, size_t body_len,
+                            uint64_t stream_id, const uint8_t *body, size_t body_len,
                             bool fin);
 
 // Reads request or response body data into the provided buffer.


### PR DESCRIPTION
Hi!

Unless I'm mistaken, these parameters are not mutable in the FFI Rust code and thus can be made `const` in the C/C++ header.