### PR TITLE
fix(qlog): update serde rename of `PacketsAcked`

### DIFF
--- a/qlog/src/events/mod.rs
+++ b/qlog/src/events/mod.rs
@@ -526,7 +526,7 @@ pub enum EventData {
     #[serde(rename = "transport:packet_buffered")]
     PacketBuffered(quic::PacketBuffered),
 
-    #[serde(rename = "transport:version_information")]
+    #[serde(rename = "transport:packets_acked")]
     PacketsAcked(quic::PacketsAcked),
 
     #[serde(rename = "transport:stream_state_updated")]


### PR DESCRIPTION
Fixes a copy&paste error in the serde rename attribute of the `EventData::PacketsAcked` `enum` variant.