### PR TITLE
FFI: Add missing API for config

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -251,6 +251,12 @@ void quiche_config_set_active_connection_id_limit(quiche_config *config, uint64_
 // Sets the initial stateless reset token. |v| must contain 16 bytes, otherwise the behaviour is undefined.
 void quiche_config_set_stateless_reset_token(quiche_config *config, const uint8_t *v);
 
+// Sets whether the QUIC connection should avoid reusing DCIDs over different paths.
+void quiche_config_set_disable_dcid_reuse(quiche_config *config, bool v);
+
+// Configures the session ticket key material.
+int quiche_config_set_ticket_key(quiche_config *config, const uint8_t *key, size_t key_len);
+
 // Frees the config object.
 void quiche_config_free(quiche_config *config);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -394,6 +394,24 @@ pub extern fn quiche_config_set_stateless_reset_token(
 }
 
 #[no_mangle]
+pub extern fn quiche_config_set_disable_dcid_reuse(config: &mut Config, v: bool) {
+    config.set_disable_dcid_reuse(v);
+}
+
+#[no_mangle]
+pub extern fn quiche_config_set_ticket_key(
+    config: &mut Config, key: *const u8, key_len: size_t,
+) -> c_int {
+    let key = unsafe { slice::from_raw_parts(key, key_len) };
+
+    match config.set_ticket_key(key) {
+        Ok(_) => 0,
+
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
 pub extern fn quiche_config_free(config: *mut Config) {
     drop(unsafe { Box::from_raw(config) });
 }


### PR DESCRIPTION
Motivation:

set_disable_dcid_reuse(...) and quiche_config_set_ticket_key(...) are not exposed via the c API.

Modifications:

Add FFI implementation and add functions to c header file.

Result:

Add missing config methods