### PR TITLE
lib: add getter for qlog streamer

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2061,6 +2061,13 @@ impl Connection {
         self.qlog.streamer = Some(streamer);
     }
 
+    /// Returns a mutable reference to the QlogStreamer, if it exists.
+    #[cfg(feature = "qlog")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "qlog")))]
+    pub fn qlog_streamer(&mut self) -> Option<&mut qlog::streamer::QlogStreamer> {
+        self.qlog.streamer.as_mut()
+    }
+
     /// Configures the given session for resumption.
     ///
     /// On the client, this can be used to offer the given serialized session,


### PR DESCRIPTION
If a quiche connection is configured to log using qlog (via set_qlog()
or set_qlog_with_level()) internally it creates a qlog streamer object
and using that to write out events.

This change adds a getter for the streamer, which allows library users
to also write their own events.
