### PR TITLE
h3: make grease_value() public

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -2716,7 +2716,7 @@ impl Connection {
 }
 
 /// Generates an HTTP/3 GREASE variable length integer.
-fn grease_value() -> u64 {
+pub fn grease_value() -> u64 {
     let n = super::rand::rand_u64_uniform(148_764_065_110_560_899);
     31 * n + 33
 }


### PR DESCRIPTION
grease_value() generates an HTTP/3 GREASE value. Applications can
find this useful, so make it public.
