### PR TITLE
h3: allow the frame module to be public under a new feature

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -45,6 +45,9 @@ fuzzing = []
 # Build and expose the FFI API.
 ffi = []
 
+# Exposes internal APIs that have no stability guarantees across versions.
+internal = []
+
 [package.metadata.docs.rs]
 no-default-features = true
 features = ["boringssl-boring-crate", "qlog"]

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -6277,6 +6277,10 @@ mod tests {
 
 #[cfg(feature = "ffi")]
 mod ffi;
+#[cfg(feature = "internal")]
+#[doc(hidden)]
+pub mod frame;
+#[cfg(not(feature = "internal"))]
 mod frame;
 #[doc(hidden)]
 pub mod qpack;


### PR DESCRIPTION
The quiche::h3::frame module is by default private because low-level
details are abstracted behind higher-layer APIs. However, for some
situations, such as testing, it can be helpful to have direct access
to frame types and their serialization/deserialization code.

This change adds a new 'internal' feature that when enables makes
the frame module public. There are no guarantees of API stability
for things exposed in this way.
