### PR TITLE
Update url dependency

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -77,7 +77,7 @@ winapi = { version = "0.3", features = ["wincrypt", "ws2def", "ws2ipdef", "ws2tc
 
 [dev-dependencies]
 mio = { version = "0.8", features = ["net", "os-poll"] }
-url = "1"
+url = "2.5"
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/quiche/examples/client.rs
+++ b/quiche/examples/client.rs
@@ -27,8 +27,6 @@
 #[macro_use]
 extern crate log;
 
-use std::net::ToSocketAddrs;
-
 use ring::rand::*;
 
 const MAX_DATAGRAM_SIZE: usize = 1350;
@@ -56,7 +54,7 @@ fn main() {
     let mut events = mio::Events::with_capacity(1024);
 
     // Resolve server address.
-    let peer_addr = url.to_socket_addrs().unwrap().next().unwrap();
+    let peer_addr = url.socket_addrs(|| None).unwrap()[0];
 
     // Bind to INADDR_ANY or IN6ADDR_ANY depending on the IP family of the
     // server address. This is needed on macOS and BSD variants that don't

--- a/quiche/examples/http3-client.rs
+++ b/quiche/examples/http3-client.rs
@@ -27,8 +27,6 @@
 #[macro_use]
 extern crate log;
 
-use std::net::ToSocketAddrs;
-
 use quiche::h3::NameValue;
 
 use ring::rand::*;
@@ -56,7 +54,7 @@ fn main() {
     let mut events = mio::Events::with_capacity(1024);
 
     // Resolve server address.
-    let peer_addr = url.to_socket_addrs().unwrap().next().unwrap();
+    let peer_addr = url.socket_addrs(|| None).unwrap()[0];
 
     // Bind to INADDR_ANY or IN6ADDR_ANY depending on the IP family of the
     // server address. This is needed on macOS and BSD variants that don't


### PR DESCRIPTION
This updates the dev-dependency url to the current version v2.5 and revises
the url parsing in the examples client and http3-client.
