### PR TITLE
FFI: Expose the peer cert chain

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -467,6 +467,12 @@ void quiche_conn_application_proto(const quiche_conn *conn, const uint8_t **out,
 // Returns the peer's leaf certificate (if any) as a DER-encoded buffer.
 void quiche_conn_peer_cert(const quiche_conn *conn, const uint8_t **out, size_t *out_len);
 
+// Returns the nth certificate of the peer's leaf certificate (if any) as a DER-encoded buffer.
+void quiche_conn_peer_cert_chain_index(const quiche_conn *conn, size_t index, const uint8_t **out, size_t *out_len);
+
+// Returns the length of the peer's leaf certificate.
+size_t quiche_conn_peer_cert_chain_len(const quiche_conn *conn);
+
 // Returns the serialized cryptographic session for the connection.
 void quiche_conn_session(const quiche_conn *conn, const uint8_t **out, size_t *out_len);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1078,6 +1078,27 @@ pub extern fn quiche_conn_peer_cert(
 }
 
 #[no_mangle]
+pub extern fn quiche_conn_peer_cert_chain_index(
+    conn: &Connection, index: size_t, out: &mut *const u8, out_len: &mut size_t,
+) {
+    match conn.peer_cert_chain_index(index) {
+        Some(peer_cert) => {
+            *out = peer_cert.as_ptr();
+            *out_len = peer_cert.len();
+        },
+
+        None => *out_len = 0,
+    }
+}
+
+#[no_mangle]
+pub extern fn quiche_conn_peer_cert_chain_len(
+    conn: &Connection
+) -> size_t {
+    conn.peer_cert_chain_len()
+}
+
+#[no_mangle]
 pub extern fn quiche_conn_session(
     conn: &Connection, out: &mut *const u8, out_len: &mut size_t,
 ) {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6124,6 +6124,25 @@ impl Connection {
         self.handshake.peer_cert_chain()
     }
 
+    /// Returns the peer's certificate chain length.
+    ///
+    /// This function supports FFI, enabling reading the certificate chain
+    /// without extra allocations.
+    #[inline]
+    pub(crate) fn peer_cert_chain_len(&self) -> usize {
+        self.handshake.peer_cert_chain_len()
+    }
+
+    /// Returns the nth certificate of the peer's certificate chain as a
+    /// DER-encoded buffer.
+    ///
+    /// This function supports FFI, enabling reading the certificate chain
+    /// without extra allocations.
+    #[inline]
+    pub(crate) fn peer_cert_chain_index(&self, index: usize) -> Option<&[u8]> {
+        self.handshake.peer_cert_chain_index(index)
+    }
+
     /// Returns the serialized cryptographic session for the connection.
     ///
     /// This can be used by a client to cache a connection's session, and resume


### PR DESCRIPTION
Just wanted to use Connection::peer_cert_chain() and realized it's not actually exposed via FFI.

The vector cannot be trivially returned by FFI, except by translating the vector to a `&[Certificate]` with a `struct Certificate { *mut u8; size_t; }`, and then adding a free-function for this.

I think directly fetching the values one by one is a superior approach for FFI purposes in terms of usability and complexity, hence this PR proposes this.