### PR TITLE
Update env_logger to mitigate RUSTSEC-2021-0145

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -22,7 +22,7 @@ default = ["qlog", "sfv"]
 
 [dependencies]
 docopt = "1"
-env_logger = "0.6"
+env_logger = "0.10"
 mio = { version = "0.8", features = ["net", "os-poll"] }
 url = "1"
 log = "0.4"

--- a/apps/src/bin/quiche-client.rs
+++ b/apps/src/bin/quiche-client.rs
@@ -31,9 +31,7 @@ use quiche_apps::common::*;
 use quiche_apps::client::*;
 
 fn main() {
-    env_logger::builder()
-        .default_format_timestamp_nanos(true)
-        .init();
+    env_logger::builder().format_timestamp_nanos().init();
 
     // Parse CLI parameters.
     let docopt = docopt::Docopt::new(CLIENT_USAGE).unwrap();

--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -58,9 +58,7 @@ fn main() {
     let mut out = [0; MAX_BUF_SIZE];
     let mut pacing = false;
 
-    env_logger::builder()
-        .default_format_timestamp_nanos(true)
-        .init();
+    env_logger::builder().format_timestamp_nanos().init();
 
     // Parse CLI parameters.
     let docopt = docopt::Docopt::new(SERVER_USAGE).unwrap();

--- a/tools/http3_test/Cargo.toml
+++ b/tools/http3_test/Cargo.toml
@@ -10,7 +10,7 @@ test_resets = []
 
 [dependencies]
 docopt = "1"
-env_logger = "0.6"
+env_logger = "0.10"
 mio = { version = "0.8", features = ["net", "os-poll"] }
 url = "1"
 log = "0.4"

--- a/tools/http3_test/tests/httpbin_tests.rs
+++ b/tools/http3_test/tests/httpbin_tests.rs
@@ -181,11 +181,7 @@ mod httpbin_tests {
     fn do_test(
         reqs: Vec<Http3Req>, assert: Http3Assert, concurrent: bool,
     ) -> std::result::Result<(), Http3TestError> {
-        INIT.call_once(|| {
-            env_logger::builder()
-                .default_format_timestamp_nanos(true)
-                .init()
-        });
+        INIT.call_once(|| env_logger::builder().format_timestamp_nanos().init());
 
         let mut test = Http3Test::new(endpoint(None), reqs, assert, concurrent);
         runner::run(
@@ -203,11 +199,7 @@ mod httpbin_tests {
         reqs: Vec<Http3Req>, stream_data: Vec<ArbitraryStreamData>,
         assert: Http3Assert, concurrent: bool,
     ) -> std::result::Result<(), Http3TestError> {
-        INIT.call_once(|| {
-            env_logger::builder()
-                .default_format_timestamp_nanos(true)
-                .init()
-        });
+        INIT.call_once(|| env_logger::builder().format_timestamp_nanos().init());
 
         let mut test = Http3Test::with_stream_data(
             endpoint(None),


### PR DESCRIPTION
This dependency update removes usage of the unmaintained and unsound `atty` crate.