### PR TITLE
lib: minimise calls to SendBuf off_front() during emit()

### DIFF
--- a/quiche/src/stream/send_buf.rs
+++ b/quiche/src/stream/send_buf.rs
@@ -175,7 +175,7 @@ impl SendBuf {
         while out_len > 0 {
             let off_front = self.off_front();
 
-            if self.data.is_empty() ||
+            if self.is_empty() ||
                 off_front >= self.off ||
                 off_front != next_off ||
                 off_front >= self.max_data

--- a/quiche/src/stream/send_buf.rs
+++ b/quiche/src/stream/send_buf.rs
@@ -172,11 +172,17 @@ impl SendBuf {
 
         let mut next_off = out_off;
 
-        while out_len > 0 &&
-            self.ready() &&
-            self.off_front() == next_off &&
-            self.off_front() < self.max_data
-        {
+        while out_len > 0 {
+            let off_front = self.off_front();
+
+            if self.data.is_empty() ||
+                off_front >= self.off ||
+                off_front != next_off ||
+                off_front >= self.max_data
+            {
+                break;
+            }
+
             let buf = match self.data.get_mut(self.pos) {
                 Some(v) => v,
 
@@ -448,9 +454,9 @@ impl SendBuf {
         self.shutdown
     }
 
-    /// Returns true if there is data to be written.
-    pub fn ready(&self) -> bool {
-        !self.data.is_empty() && self.off_front() < self.off
+    /// Returns true if there is no data.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
     }
 
     /// Returns the highest contiguously acked offset.


### PR DESCRIPTION
lib: minimise calls to SendBuf off_front()

There were several places where off_front() would be called in rapid succession.
off_front() potentially has to iterate a large queue to find the "front" value.
In rapid succession, that value is identical, leading to wasted work.

This change removes the ready() function (which called off_front) and refactors
code to minimise off _front() calls.