### PR TITLE
lib: stricter NEW_TOKEN frame checks

### DIFF
--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -221,8 +221,15 @@ impl Frame {
                 Frame::Crypto { data }
             },
 
-            0x07 => Frame::NewToken {
-                token: b.get_bytes_with_varint_length()?.to_vec(),
+            0x07 => {
+                let len = b.get_varint()?;
+                if len == 0 {
+                    return Err(Error::InvalidFrame);
+                }
+
+                Frame::NewToken {
+                    token: b.get_bytes(len as usize)?.to_vec(),
+                }
             },
 
             0x08..=0x0f => parse_stream_frame(frame_type, b)?,
@@ -1058,8 +1065,8 @@ impl std::fmt::Debug for Frame {
                 write!(f, "CRYPTO off={offset} len={length}")?;
             },
 
-            Frame::NewToken { .. } => {
-                write!(f, "NEW_TOKEN (TODO)")?;
+            Frame::NewToken { token } => {
+                write!(f, "NEW_TOKEN len={}", token.len())?;
             },
 
             Frame::Stream { stream_id, data } => {


### PR DESCRIPTION
RFC 9000 has some low-level requirements for who is allowed to send
a NEW_TOKEN frame, and what the token value can be.

This change adds stricter NEW_TOKEN frame checks. It leaves any
more advanced handling of the Retry mechanism as continuing TODO.
