### PR TITLE
Crate octets: Fix incorrect lifetime annotation

### DIFF
--- a/octets/src/lib.rs
+++ b/octets/src/lib.rs
@@ -251,7 +251,7 @@ impl<'a> Octets<'a> {
     }
 
     /// Returns a slice of `len` elements from the current offset.
-    pub fn slice(&'a self, len: usize) -> Result<&'a [u8]> {
+    pub fn slice(&self, len: usize) -> Result<&'a [u8]> {
         if len > self.cap() {
             return Err(BufferTooShortError);
         }
@@ -260,7 +260,7 @@ impl<'a> Octets<'a> {
     }
 
     /// Returns a slice of `len` elements from the end of the buffer.
-    pub fn slice_last(&'a self, len: usize) -> Result<&'a [u8]> {
+    pub fn slice_last(&self, len: usize) -> Result<&'a [u8]> {
         if len > self.cap() {
             return Err(BufferTooShortError);
         }


### PR DESCRIPTION
This pull request proposes a minor fix to the lifetime annotations in the octets crate.
The `slice` and `slice_last` methods defined for `Octets` return a subslice from a slice stored
inside the method's receiver. As such the returned reference should share the lifetime of the 
originating slice.
Due to the current lifetime annotations the returned lifetime is bounded by the method's receiver.
This has the implication that the returned slice can not be used after the receiver
used to produce the slice goes out of scope even though the returned reference to the underlying data
may still be valid.

## Example
```
struct Capsule<'a> {
    kind: u64,
    data: &'a [u8],
}

impl<'a> Capsule<'a> {
    fn from_bytes(buf: &'a [u8]) -> std::result::Result<Self, BufferTooShortError> {
        let mut octets = Octets::with_slice(buf);
        let kind = octets.get_varint()?;
        let len = octets.get_varint()? as usize;
        let data = octets.slice(len)?;
        Ok(Capsule { kind, data })
    }
}
```
This example creates a struct from a user supplied buffer and uses the `slice()` method to retrieve
the necessary data. The expectation would be that the returned lifetime is bounded by the user-supplied buffer,
which means that the code should be able to compile.
Currently the code above fails with this compile error:
```
error[E0515]: cannot return value referencing local variable `octets`
   --> octets\src\lib.rs:877:13
    |
876 |             let data = octets.slice(len)?;
    |                        ------ `octets` is borrowed here
877 |             Ok(Capsule { kind, data })
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ returns a value referencing data owned by the current function
```
By implementing the proposed changes this error can be eliminated.