### PR TITLE
qlog: add stream_type_value for unknown streams

### DIFF
--- a/qlog/src/events/h3.rs
+++ b/qlog/src/events/h3.rs
@@ -209,9 +209,8 @@ pub struct H3ParametersRestored {
 pub struct H3StreamTypeSet {
     pub owner: Option<H3Owner>,
     pub stream_id: u64,
-
     pub stream_type: H3StreamType,
-
+    pub stream_type_value: Option<u64>,
     pub associated_push_id: Option<u64>,
 }
 


### PR DESCRIPTION
Adds a missing field, see See https://quicwg.org/qlog/draft-ietf-quic-qlog-h3-events.html#name-stream_type_set