### PR TITLE
Disable unused features from serde_with

### DIFF
--- a/qlog/Cargo.toml
+++ b/qlog/Cargo.toml
@@ -14,5 +14,5 @@ license = "BSD-2-Clause"
 serde = { version = "1.0.139", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_derive = "1.0"
-serde_with = "3.0.0"
+serde_with = { version = "3.0.0", default-features = false, features = ["macros"] }
 smallvec = { version = "1.10", features = ["serde"] }


### PR DESCRIPTION
Because of https://github.com/rust-lang/cargo/issues/10801, the default features from serde_with pull in a lot of unused cruft.