### PR TITLE
Revert "constrain ring version to avoid Windows issues" and bump ring in http3_test

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -27,7 +27,7 @@ mio = { version = "0.8", features = ["net", "os-poll"] }
 url = "1"
 log = "0.4"
 octets = { version = "0.3", path = "../octets" }
-ring = "< 0.17.8"
+ring = "0.17"
 quiche = { path = "../quiche" }
 libc = "0.2"
 nix = { version = "0.27", features = ["net", "socket", "uio"] }

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -61,7 +61,7 @@ either = { version = "1.8", default-features = false }
 log = { version = "0.4", features = ["std"] }
 libc = "0.2"
 libm = "0.2"
-ring = "< 0.17.8"
+ring = "0.17"
 slab = "0.4"
 once_cell = "1"
 octets = { version = "0.3", path = "../octets" }

--- a/tools/http3_test/Cargo.toml
+++ b/tools/http3_test/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10"
 mio = { version = "0.8", features = ["net", "os-poll"] }
 url = "1"
 log = "0.4"
-ring = "< 0.17.8"
+ring = "0.16"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/tools/http3_test/Cargo.toml
+++ b/tools/http3_test/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10"
 mio = { version = "0.8", features = ["net", "os-poll"] }
 url = "1"
 log = "0.4"
-ring = "0.16"
+ring = "0.17"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
This reverts commit 45b59aa8f2d6f2e97c2af74f562848fcd0092062.

Dependabot stepped in seemed to have builds work on https://github.com/cloudflare/quiche/pull/1727, so maybe it was a transient issue, lets see how CI deals with it