### PR TITLE
Getting rid of the sleep function

### DIFF
--- a/apps/run_endpoint.sh
+++ b/apps/run_endpoint.sh
@@ -70,9 +70,8 @@ check_testcase () {
 }
 
 run_quiche_client_tests () {
-    # TODO: https://github.com/marten-seemann/quic-interop-runner/issues/61
-    # remove this sleep when the issue above is resolved.
-    sleep 3
+
+    #sleep 3
 
     case $1 in
         multiconnect | resumption | zerortt )


### PR DESCRIPTION
I noticed that this [https://github.com/quic-interop/quic-interop-runner/issues/61](bug) and thought it'd be better to remove the sleep function. I'm open to all suggestions,thanks in advance.