### PR TITLE
qlog: Update ConnectionClose with CryptoError

### DIFF
--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -31,6 +31,7 @@ use smallvec::SmallVec;
 
 use super::connectivity::TransportOwner;
 use super::Bytes;
+use super::CryptoError;
 use super::DataRecipient;
 use super::RawInfo;
 use super::Token;
@@ -478,8 +479,7 @@ pub enum QuicFrame {
 
     ConnectionClose {
         error_space: Option<ErrorSpace>,
-        error_code: Option<u64>,
-        error_code_value: Option<u64>,
+        error_code: Option<ConnectionCloseErrorCode>,
         reason: Option<String>,
 
         trigger_frame_type: Option<u64>,
@@ -785,6 +785,13 @@ pub struct PacketLost {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct MarkedForRetransmit {
     pub frames: Vec<QuicFrame>,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[serde(untagged)]
+pub enum ConnectionCloseErrorCode {
+    CryptoError(CryptoError),
+    Numeric(u64),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This makes the qlog crate fit the specification laid out in https://github.com/quicwg/qlog/pull/392. 

This yields the following `ConnectionClose` frame:
```
{"time":5.063584,"name":"transport:packet_sent","data":{"header":{"packet_type":"1RTT","packet_number":5},"raw":{"length":49,"payload_length":11},"send_at_time":5.063584,"frames":[{"frame_type":"connection_close","error_space":"application_error","error_code":256,"reason":"kthxbye"}]}}
```

We won't be able to log `CryptoError`s without a larger change that pushes detection of connection establishment into the qlog crate. We could also explore logging one of two different `ConnectionClose` events on close, one each for pre- and post-establishment, but that seemed messy. I can implement that if we do want to go down that route.