### PR TITLE
WIP: qlog: move sent_at_time to extension field

### DIFF
--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -646,9 +646,16 @@ pub struct PacketSent {
 
     pub trigger: Option<PacketSentTrigger>,
 
-    pub send_at_time: Option<f32>,
+    #[serde(flatten)]
+    pub extension: PacketSentExtension,
 
     pub frames: Option<SmallVec<[QuicFrame; 1]>>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct PacketSentExtension {
+    pub send_at_time: Option<f32>,
 }
 
 #[serde_with::skip_serializing_none]

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -141,7 +141,9 @@
 //!         supported_versions: None,
 //!         raw: Some(raw),
 //!         datagram_id: None,
-//!         send_at_time: None,
+//!         extension: qlog::events::quic::PacketSentExtension {
+//!             send_at_time: None,
+//!         },
 //!         trigger: None,
 //!     });
 //!
@@ -345,7 +347,9 @@
 //!         supported_versions: None,
 //!         raw: None,
 //!         datagram_id: None,
-//!         send_at_time: None,
+//!         extension: qlog::events::quic::PacketSentExtension {
+//!             send_at_time: None,
+//!         },
 //!         trigger: None,
 //!     });
 //!
@@ -718,6 +722,7 @@ pub mod testing {
 mod tests {
     use super::*;
     use crate::events::quic::PacketSent;
+    use crate::events::quic::PacketSentExtension;
     use crate::events::quic::PacketType;
     use crate::events::quic::QuicFrame;
     use crate::events::EventData;
@@ -760,7 +765,7 @@ mod tests {
                 data: None,
             }),
             datagram_id: None,
-            send_at_time: None,
+            extension: PacketSentExtension { send_at_time: None },
             trigger: None,
         });
 
@@ -830,7 +835,7 @@ mod tests {
                 data: None,
             }),
             datagram_id: None,
-            send_at_time: None,
+            extension: PacketSentExtension { send_at_time: None },
             trigger: None,
         });
 
@@ -950,7 +955,7 @@ mod tests {
                 data: None,
             }),
             datagram_id: None,
-            send_at_time: None,
+            extension: PacketSentExtension { send_at_time: None },
             trigger: None,
         });
 

--- a/qlog/src/streamer.rs
+++ b/qlog/src/streamer.rs
@@ -265,6 +265,7 @@ mod tests {
 
     use super::*;
     use crate::events::quic;
+    use crate::events::quic::PacketSentExtension;
     use crate::events::quic::QuicFrame;
     use crate::events::RawInfo;
     use smallvec::smallvec;
@@ -303,7 +304,7 @@ mod tests {
             supported_versions: None,
             raw: raw.clone(),
             datagram_id: None,
-            send_at_time: None,
+            extension: PacketSentExtension { send_at_time: None },
             trigger: None,
         });
 
@@ -334,7 +335,7 @@ mod tests {
             supported_versions: None,
             raw: raw.clone(),
             datagram_id: None,
-            send_at_time: None,
+            extension: PacketSentExtension { send_at_time: None },
             trigger: None,
         });
 
@@ -349,7 +350,7 @@ mod tests {
             supported_versions: None,
             raw,
             datagram_id: None,
-            send_at_time: None,
+            extension: PacketSentExtension { send_at_time: None },
             trigger: None,
         });
 
@@ -478,7 +479,7 @@ mod tests {
             supported_versions: None,
             raw: raw.clone(),
             datagram_id: None,
-            send_at_time: None,
+            extension: PacketSentExtension { send_at_time: None },
             trigger: None,
         });
         let j1 = json!({"foo": "Bar", "hello": 123});
@@ -506,7 +507,7 @@ mod tests {
             supported_versions: None,
             raw: raw.clone(),
             datagram_id: None,
-            send_at_time: None,
+            extension: PacketSentExtension { send_at_time: None },
             trigger: None,
         });
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4456,7 +4456,10 @@ impl Connection {
                         supported_versions: None,
                         raw: Some(qlog_raw_info),
                         datagram_id: None,
-                        send_at_time: Some(send_at_time),
+                        extension: qlog::events::quic::PacketSentExtension {
+                            send_at_time: Some(send_at_time),
+                        },
+
                         trigger: None,
                     });
 


### PR DESCRIPTION
Previously, we added our own `send_at_time` field to packet_sent
events, in order to help analysis of pacing related code.

Recently, the qlog specs have been changed to allow for better
extensibility of individual events. Rather than have each extension field
defined at the same level as the base fields in specs, they are instead
put in an extension type that serialized as an "anonymous" field.

In this change, we move `send_at_time` to a new extension type and
use serde flatten to place them at the same level as base events in
serialized logs.