### PR TITLE
avoid reacting to non-PMTUD PING losses

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3495,7 +3495,7 @@ impl Connection {
                         self.ids.mark_retire_dcid_seq(seq_num, true);
                     },
 
-                    frame::Frame::Ping { .. } => {
+                    frame::Frame::Ping { mtu_probe } if mtu_probe.is_some() => {
                         p.pmtud.pmtu_probe_lost();
                     },
 


### PR DESCRIPTION
Currently we treat any PING frame loss as a PMTUD signal, but PING frames are used for many other things (including PTO probes), so the PMTUD logic should not react to PING losses unconditionally.