### PR TITLE
lib: add qlogging of connection close

### DIFF
--- a/qlog/src/events/mod.rs
+++ b/qlog/src/events/mod.rs
@@ -203,6 +203,9 @@ impl From<EventType> for EventImportance {
                 ConnectivityEventType::ConnectionStarted,
             ) => EventImportance::Base,
             EventType::ConnectivityEventType(
+                ConnectivityEventType::ConnectionClosed,
+            ) => EventImportance::Base,
+            EventType::ConnectivityEventType(
                 ConnectivityEventType::ConnectionIdUpdated,
             ) => EventImportance::Base,
             EventType::ConnectivityEventType(

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1698,6 +1698,10 @@ const QLOG_METRICS: EventType =
     EventType::RecoveryEventType(RecoveryEventType::MetricsUpdated);
 
 #[cfg(feature = "qlog")]
+const QLOG_CONNECTION_CLOSED: EventType =
+    EventType::ConnectivityEventType(ConnectivityEventType::ConnectionClosed);
+
+#[cfg(feature = "qlog")]
 struct QlogInfo {
     streamer: Option<qlog::streamer::QlogStreamer>,
     logged_peer_params: bool,
@@ -7666,6 +7670,74 @@ impl Connection {
     fn mark_closed(&mut self) {
         #[cfg(feature = "qlog")]
         {
+            let cc = match (self.is_established(), self.timed_out, &self.peer_error, &self.local_error) {
+                (false, _, _, _) => qlog::events::connectivity::ConnectionClosed {
+                    owner: Some(TransportOwner::Local),
+                    connection_code: None,
+                    application_code: None,
+                    internal_code: None,
+                    reason: Some("Failed to establish connection".to_string()),
+                    trigger: Some(qlog::events::connectivity::ConnectionClosedTrigger::HandshakeTimeout)
+                },
+
+                (true, true, _, _) => qlog::events::connectivity::ConnectionClosed {
+                    owner: Some(TransportOwner::Local),
+                    connection_code: None,
+                    application_code: None,
+                    internal_code: None,
+                    reason: Some("Idle timeout".to_string()),
+                    trigger: Some(qlog::events::connectivity::ConnectionClosedTrigger::IdleTimeout)
+                },
+
+                (true, false, Some(peer_error), None) => {
+                    let (connection_code, application_code) = if peer_error.is_app {
+                        (None, Some(qlog::events::ApplicationErrorCode::Value(peer_error.error_code)))
+                    } else {
+                        (Some(qlog::events::ConnectionErrorCode::Value(peer_error.error_code)), None)
+                    };
+
+                    qlog::events::connectivity::ConnectionClosed {
+                        owner: Some(TransportOwner::Remote),
+                        connection_code,
+                        application_code,
+                        internal_code: None,
+                        reason: Some(String::from_utf8_lossy(&peer_error.reason).to_string()),
+                        trigger: Some(qlog::events::connectivity::ConnectionClosedTrigger::Error),
+                    }
+                },
+
+                (true, false, None, Some(local_error)) => {
+                    let (connection_code, application_code) = if local_error.is_app {
+                        (None, Some(qlog::events::ApplicationErrorCode::Value(local_error.error_code)))
+                    } else {
+                        (Some(qlog::events::ConnectionErrorCode::Value(local_error.error_code)), None)
+                    };
+
+                    qlog::events::connectivity::ConnectionClosed {
+                        owner: Some(TransportOwner::Local),
+                        connection_code,
+                        application_code,
+                        internal_code: None,
+                        reason: Some(String::from_utf8_lossy(&local_error.reason).to_string()),
+                        trigger: Some(qlog::events::connectivity::ConnectionClosedTrigger::Error),
+                    }
+                },
+
+                _ => qlog::events::connectivity::ConnectionClosed {
+                    owner: None,
+                    connection_code: None,
+                    application_code: None,
+                    internal_code: None,
+                    reason: None,
+                    trigger: None,
+                },
+            };
+
+            qlog_with_type!(QLOG_CONNECTION_CLOSED, self.qlog, q, {
+                let ev_data = qlog::events::EventData::ConnectionClosed(cc);
+
+                q.add_event_data_now(ev_data).ok();
+            });
             self.qlog.streamer = None;
         }
         self.closed = true;


### PR DESCRIPTION
There are situations where connections are closed but no CONNECTION_CLOSE
frames were exchanged, for example handshake failures or idle timeouts.

This change adds the connectivity::connection_closed event to the mark_closed()
method, just before we blow away the qlog serializer.

I've chosen to have it log an event even if we did send or receive
CONNECTION_CLOSE frames, which is a minor duplication. My rationale is
that in future we might want to have filters that would omit detailed
frame information while key connection state changes are interesting.