### PR TITLE
qlog: add length and payload_length fields to QUCI frames

### DIFF
--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -384,30 +384,43 @@ pub enum QuicFrameTypeName {
 // ensure it goes out on the wire. This means that deserialization of frames
 // also works automatically.
 pub enum QuicFrame {
-    Padding,
+    Padding {
+        length: Option<u32>,
+        payload_length: u32,
+    },
 
-    Ping,
+    Ping {
+        length: Option<u32>,
+        payload_length: Option<u32>,
+    },
 
     Ack {
         ack_delay: Option<f32>,
         acked_ranges: Option<AckedRanges>,
 
         ect1: Option<u64>,
-
         ect0: Option<u64>,
-
         ce: Option<u64>,
+
+        length: Option<u32>,
+        payload_length: Option<u32>,
     },
 
     ResetStream {
         stream_id: u64,
         error_code: u64,
         final_size: u64,
+
+        length: Option<u32>,
+        payload_length: Option<u32>,
     },
 
     StopSending {
         stream_id: u64,
         error_code: u64,
+
+        length: Option<u32>,
+        payload_length: Option<u32>,
     },
 
     Crypto {

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -332,8 +332,14 @@
 //!     Some(&dcid),
 //! );
 //!
-//! let ping = qlog::events::quic::QuicFrame::Ping;
-//! let padding = qlog::events::quic::QuicFrame::Padding;
+//! let ping = qlog::events::quic::QuicFrame::Ping {
+//!     length: None,
+//!     payload_length: None,
+//! };
+//! let padding = qlog::events::quic::QuicFrame::Padding {
+//!     length: None,
+//!     payload_length: 1234,
+//! };
 //!
 //! let event_data =
 //!     qlog::events::EventData::PacketSent(qlog::events::quic::PacketSent {
@@ -790,7 +796,8 @@ mod tests {
     },
     "frames": [
       {
-        "frame_type": "padding"
+        "frame_type": "padding",
+        "payload_length": 1234
       },
       {
         "frame_type": "ping"
@@ -808,14 +815,23 @@ mod tests {
 
         let pkt_hdr = make_pkt_hdr(PacketType::Initial);
 
-        let frames =
-            vec![QuicFrame::Padding, QuicFrame::Ping, QuicFrame::Stream {
+        let frames = vec![
+            QuicFrame::Padding {
+                payload_length: 1234,
+                length: None,
+            },
+            QuicFrame::Ping {
+                payload_length: None,
+                length: None,
+            },
+            QuicFrame::Stream {
                 stream_id: 0,
                 offset: 0,
                 length: 100,
                 fin: Some(true),
                 raw: None,
-            }];
+            },
+        ];
 
         let ev_data = EventData::PacketSent(PacketSent {
             header: pkt_hdr,

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -835,9 +835,15 @@ impl Frame {
     #[cfg(feature = "qlog")]
     pub fn to_qlog(&self) -> QuicFrame {
         match self {
-            Frame::Padding { .. } => QuicFrame::Padding,
+            Frame::Padding { len } => QuicFrame::Padding {
+                length: None,
+                payload_length: *len as u32,
+            },
 
-            Frame::Ping { .. } => QuicFrame::Ping,
+            Frame::Ping { .. } => QuicFrame::Ping {
+                length: None,
+                payload_length: None,
+            },
 
             Frame::ACK {
                 ack_delay,
@@ -864,6 +870,8 @@ impl Frame {
                     ect1,
                     ect0,
                     ce,
+                    length: None,
+                    payload_length: None,
                 }
             },
 
@@ -875,6 +883,8 @@ impl Frame {
                 stream_id: *stream_id,
                 error_code: *error_code,
                 final_size: *final_size,
+                length: None,
+                payload_length: None,
             },
 
             Frame::StopSending {
@@ -883,6 +893,8 @@ impl Frame {
             } => QuicFrame::StopSending {
                 stream_id: *stream_id,
                 error_code: *error_code,
+                length: None,
+                payload_length: None,
             },
 
             Frame::Crypto { data } => QuicFrame::Crypto {


### PR DESCRIPTION
The qlog spec includes these fields and we didn't; see https://quicwg.org/qlog/draft-ietf-quic-qlog-quic-events.html#name-quic-frames