### PR TITLE
lib: set an aggressive draining timeout when closed before established

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -7272,7 +7272,13 @@ impl Connection {
                 });
 
                 let path = self.paths.get_active()?;
-                self.draining_timer = Some(now + (path.recovery.pto() * 3));
+
+                if self.is_established() {
+                    self.draining_timer = Some(now + (path.recovery.pto() * 3));
+                } else {
+                    // May as well tidy things up immediately.
+                    self.draining_timer = Some(now);
+                }
             },
 
             frame::Frame::ApplicationClose { error_code, reason } => {


### PR DESCRIPTION
It is possible that a server could close a connection without ever sending
an ACK frame. For example, when immeditaly closing a connection due to a
TLS-level reason.

Previously, we always would set the draining timer the same way when processing
CONNECTION_CLOSE frames, basing it on 3*PTO. In the situation where there
is no accurate RTT estimate, the PTO is based on the default initial RTT,
which comes out at 999ms. This leads to clients that honor the draining
period to have to wait 3 seconds for no real reason.

With this change, in the situation where a CONNECTION_CLOSE is received
before the connection is established, we'll just immediately timeout.