### PR TITLE
Add ability to convert errors to wire_error_code via C API

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -132,6 +132,10 @@ enum quiche_error {
 // Returns a human readable string with the quiche version number.
 const char *quiche_version(void);
 
+// Returns the wire error code for the given error as defined in RFC9000 Section 20. Error Codes.
+// The given error must be a valid quiche_error.
+uint64_t quiche_error_to_wire_error_code(ssize_t error);
+
 // Enables logging. |cb| will be called with log messages
 int quiche_enable_debug_logging(void (*cb)(const char *line, void *argp),
                                 void *argp);

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -105,6 +105,11 @@ pub extern fn quiche_version() -> *const u8 {
     VERSION.as_ptr()
 }
 
+#[no_mangle]
+pub extern fn quiche_error_to_wire_error_code(error: ssize_t) -> u64 {
+    Error::from_c(error).to_wire()
+}
+
 struct Logger {
     cb: extern fn(line: *const u8, argp: *mut c_void),
     argp: std::sync::atomic::AtomicPtr<c_void>,

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -687,6 +687,39 @@ impl Error {
             Error::CryptoBufferExceeded => -20,
         }
     }
+
+    #[cfg(feature = "ffi")]
+    fn from_c(error: libc::ssize_t) -> Error {
+        match error {
+            -1 => Error::Done,
+            -2 => Error::BufferTooShort,
+            -3 => Error::UnknownVersion,
+            -4 => Error::InvalidFrame,
+            -5 => Error::InvalidPacket,
+            -6 => Error::InvalidState,
+            // Let's use a value of 0 as a placeholder as we only use it in the
+            // FFI code and so don't care about it.
+            -7 => Error::InvalidStreamState(0),
+            -8 => Error::InvalidTransportParam,
+            -9 => Error::CryptoFail,
+            -10 => Error::TlsFail,
+            -11 => Error::FlowControl,
+            -12 => Error::StreamLimit,
+            -13 => Error::FinalSize,
+            -14 => Error::CongestionControl,
+            // Let's use a value of 0 as a placeholder as we only use it in the
+            // FFI code and so don't care about it.
+            -15 => Error::StreamStopped(0),
+            // Let's use a value of 0 as a placeholder as we only use it in the
+            // FFI code and so don't care about it.
+            -16 => Error::StreamReset(0),
+            -17 => Error::IdLimit,
+            -18 => Error::OutOfIdentifiers,
+            -19 => Error::KeyUpdate,
+            -20 => Error::CryptoBufferExceeded,
+            _ => panic!("expected error {:?}", error),
+        }
+    }
 }
 
 impl std::fmt::Display for Error {


### PR DESCRIPTION
Motivation:

https://github.com/cloudflare/quiche/commit/1d00ee1bb2256dfd99ba0cb2dfac72fe1e59407f added the ability to retrieve the wire error code for a given error but did not add the same functionallity to the C API.

Modifications:

Expose functions to convert errors to wire_error_code via C

Result:

More complete C API