### PR TITLE
Add `dgram` crate

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -104,7 +104,7 @@ jobs:
     # duplicate builds for PRs created from internal branches.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     env:
-      IPHONEOS_DEPLOYMENT_TARGET: "10.0"
+      IPHONEOS_DEPLOYMENT_TARGET: "17.5"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "apps", "h3i", "octets", "qlog", "quiche" ]
+members = [ "apps", "dgram", "h3i", "octets", "qlog", "quiche" ]
 exclude = [ "fuzz", "tools/http3_test" ]
 
 [profile.bench]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY apps/ ./apps/
 COPY octets/ ./octets/
 COPY qlog/ ./qlog/
 COPY quiche/ ./quiche/
+COPY dgram ./dgram/
 
 RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -21,6 +21,7 @@ sfv = ["quiche/sfv"]
 default = ["qlog", "sfv"]
 
 [dependencies]
+dgram = { path = "../dgram" }
 docopt = "1"
 env_logger = "0.10"
 mio = { version = "0.8", features = ["net", "os-poll"] }

--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -461,6 +461,7 @@ Options:
   --max-field-section-size BYTES    Max size of uncompressed HTTP/3 field section. Default is unlimited.
   --qpack-max-table-capacity BYTES  Max capacity of QPACK dynamic table decoding. Any value other that 0 is currently unsupported.
   --qpack-blocked-streams STREAMS   Limit of streams that can be blocked while decoding. Any value other that 0 is currently unsupported.
+  --disable-gro               Disable GRO (linux only).
   --disable-gso               Disable GSO (linux only).
   --disable-pacing            Disable pacing (linux only).
   --initial-cwnd-packets PACKETS      The initial congestion window size in terms of packet count [default: 10].
@@ -476,6 +477,7 @@ pub struct ServerArgs {
     pub cert: String,
     pub key: String,
     pub disable_gso: bool,
+    pub disable_gro: bool,
     pub disable_pacing: bool,
     pub enable_pmtud: bool,
 }
@@ -490,6 +492,7 @@ impl Args for ServerArgs {
         let index = args.get_str("--index").to_string();
         let cert = args.get_str("--cert").to_string();
         let key = args.get_str("--key").to_string();
+        let disable_gro = args.get_bool("--disable-gro");
         let disable_gso = args.get_bool("--disable-gso");
         let disable_pacing = args.get_bool("--disable-pacing");
         let enable_pmtud = args.get_bool("--enable-pmtud");
@@ -502,6 +505,7 @@ impl Args for ServerArgs {
             cert,
             key,
             disable_gso,
+            disable_gro,
             disable_pacing,
             enable_pmtud,
         }

--- a/apps/src/lib.rs
+++ b/apps/src/lib.rs
@@ -30,4 +30,5 @@ extern crate log;
 pub mod args;
 pub mod client;
 pub mod common;
+pub mod recvfrom;
 pub mod sendto;

--- a/apps/src/recvfrom.rs
+++ b/apps/src/recvfrom.rs
@@ -1,0 +1,63 @@
+use dgram::RecvData;
+
+#[cfg(target_os = "linux")]
+use std::io;
+
+/// For Linux, try to detect if GRO is available. If it is, the
+/// [`UdpGroSegment`] socket option will be set on the passed socket.
+///
+/// [`UdpGroSegment`]: https://docs.rs/nix/latest/nix/sys/socket/sockopt/struct.UdpGroSegment.html
+#[cfg(target_os = "linux")]
+pub fn detect_gro(socket: &mio::net::UdpSocket) -> bool {
+    use nix::sys::socket::setsockopt;
+    use nix::sys::socket::sockopt::UdpGroSegment;
+    use std::os::unix::io::AsRawFd;
+
+    // mio::net::UdpSocket doesn't implement AsFd (yet?).
+    let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(socket.as_raw_fd()) };
+
+    match setsockopt(&fd, UdpGroSegment, &true) {
+        Ok(_) => {
+            debug!("Successfully set UDP_GRO socket option");
+            true
+        },
+        Err(e) => {
+            debug!("Setting UDP_GRO failed: {:?}", e);
+            false
+        },
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn detect_gro(_socket: &mio::net::UdpSocket) -> bool {
+    false
+}
+
+#[cfg(target_os = "linux")]
+pub fn recv_from(
+    socket: &mio::net::UdpSocket, buf: &mut [u8],
+) -> io::Result<RecvData> {
+    use dgram::RecvMsgSettings;
+    use std::os::unix::io::AsRawFd;
+
+    let mut recvmsg_cmsg_settings = RecvMsgSettings {
+        store_cmsgs: false,
+        cmsg_space: &mut vec![],
+    };
+    socket.try_io(|| {
+        let fd =
+            unsafe { std::os::fd::BorrowedFd::borrow_raw(socket.as_raw_fd()) };
+
+        dgram::sync::recv_from(&fd, buf, &mut recvmsg_cmsg_settings)
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn recv_from(
+    socket: &mio::net::UdpSocket, buf: &mut [u8],
+) -> std::io::Result<RecvData> {
+    match socket.recv_from(buf) {
+        Ok((read, from)) => Ok(RecvData::new(Some(from), read, 0)),
+        Err(e) => Err(e),
+    }
+}

--- a/apps/src/sendto.rs
+++ b/apps/src/sendto.rs
@@ -38,7 +38,16 @@ pub fn detect_gso(socket: &mio::net::UdpSocket, segment_size: usize) -> bool {
     // mio::net::UdpSocket doesn't implement AsFd (yet?).
     let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(socket.as_raw_fd()) };
 
-    setsockopt(&fd, UdpGsoSegment, &(segment_size as i32)).is_ok()
+    match setsockopt(&fd, UdpGsoSegment, &(segment_size as i32)) {
+        Ok(_) => {
+            debug!("Successfully set UDP_SEGMENT socket option");
+            true
+        },
+        Err(e) => {
+            debug!("Setting UDP_SEGMENT failed: {:?}", e);
+            false
+        },
+    }
 }
 
 /// For non-Linux, there is no GSO support.
@@ -53,35 +62,25 @@ fn send_to_gso_pacing(
     socket: &mio::net::UdpSocket, buf: &[u8], send_info: &quiche::SendInfo,
     segment_size: usize,
 ) -> io::Result<usize> {
-    use nix::sys::socket::sendmsg;
-    use nix::sys::socket::ControlMessage;
-    use nix::sys::socket::MsgFlags;
-    use nix::sys::socket::SockaddrStorage;
-    use std::io::IoSlice;
+    use dgram::SendMsgSettings;
     use std::os::unix::io::AsRawFd;
 
-    let iov = [IoSlice::new(buf)];
-    let segment_size = segment_size as u16;
-    let dst = SockaddrStorage::from(send_info.to);
-    let sockfd = socket.as_raw_fd();
+    let sendmsg_settings = SendMsgSettings {
+        segment_size: Some(segment_size as u16),
+        tx_time: Some(send_info.at),
+        dst: Some(send_info.to),
+        ..Default::default()
+    };
 
-    // GSO option.
-    let cmsg_gso = ControlMessage::UdpGsoSegments(&segment_size);
+    // Important to use try_io so events keep coming even if we see
+    // EAGAIN/EWOULDBLOCK
+    socket.try_io(|| {
+        // mio::net::UdpSocket doesn't implement AsFd (yet?).
+        let fd =
+            unsafe { std::os::fd::BorrowedFd::borrow_raw(socket.as_raw_fd()) };
 
-    // Pacing option.
-    let send_time = std_time_to_u64(&send_info.at);
-    let cmsg_txtime = ControlMessage::TxTime(&send_time);
-
-    match sendmsg(
-        sockfd,
-        &iov,
-        &[cmsg_gso, cmsg_txtime],
-        MsgFlags::empty(),
-        Some(&dst),
-    ) {
-        Ok(v) => Ok(v),
-        Err(e) => Err(e.into()),
-    }
+        dgram::sync::send_to(&fd, buf, sendmsg_settings)
+    })
 }
 
 /// For non-Linux platforms.
@@ -90,7 +89,7 @@ fn send_to_gso_pacing(
     _socket: &mio::net::UdpSocket, _buf: &[u8], _send_info: &quiche::SendInfo,
     _segment_size: usize,
 ) -> io::Result<usize> {
-    panic!("send_to_gso() should not be called on non-linux platforms");
+    panic!("send_to_gso_pacing() should not be called on non-linux platforms");
 }
 
 /// A wrapper function of send_to().
@@ -131,19 +130,4 @@ pub fn send_to(
     }
 
     Ok(written)
-}
-
-#[cfg(target_os = "linux")]
-fn std_time_to_u64(time: &std::time::Instant) -> u64 {
-    const NANOS_PER_SEC: u64 = 1_000_000_000;
-
-    const INSTANT_ZERO: std::time::Instant =
-        unsafe { std::mem::transmute(std::time::UNIX_EPOCH) };
-
-    let raw_time = time.duration_since(INSTANT_ZERO);
-
-    let sec = raw_time.as_secs();
-    let nsec = raw_time.subsec_nanos();
-
-    sec * NANOS_PER_SEC + nsec as u64
 }

--- a/dgram/Cargo.toml
+++ b/dgram/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "dgram"
+version = "0.1.0"
+edition = "2021"
+
+ [features]
+ async = ["dep:tokio"]
+
+[dependencies]
+libc = "0.2.76"
+nix = { version = "0.27", features = ["net", "socket", "uio"] }
+smallvec = { version = "1.10", features = ["union"] }
+tokio = { version = "1.29", features = ["full", "test-util"], optional = true }

--- a/dgram/src/lib.rs
+++ b/dgram/src/lib.rs
@@ -1,0 +1,170 @@
+pub mod socket_setup;
+#[cfg(target_os = "linux")]
+pub mod sync;
+mod syscalls;
+#[cfg(feature = "async")]
+pub mod tokio;
+
+use std::net::SocketAddr;
+#[cfg(target_os = "linux")]
+use std::time::Instant;
+use std::time::SystemTime;
+
+use libc::in6_pktinfo;
+use libc::in_pktinfo;
+use libc::sockaddr_in;
+use libc::sockaddr_in6;
+use nix::sys::socket::ControlMessageOwned;
+
+/// Settings for handling control messages when sending data.
+#[cfg(target_os = "linux")]
+#[derive(Default, Copy, Clone)]
+pub struct SendMsgSettings {
+    /// Segment sized used in a UDP_SEGMENT control message
+    pub segment_size: Option<u16>,
+    /// Send time used in a TX_TIME control message
+    pub tx_time: Option<Instant>,
+    /// Destination socket address
+    pub dst: Option<SocketAddr>,
+    /// Packet info used in an IP_PKTINFO control message
+    pub pkt_info: Option<IpPktInfo>,
+}
+
+/// Settings for handling control messages when receiving data.
+#[cfg(target_os = "linux")]
+pub struct RecvMsgSettings<'c> {
+    /// If cmsgs should be stored when receiving a message. If set, cmsgs will
+    /// be stored in the [`RecvData`]'s `cmsgs` field.
+    pub store_cmsgs: bool,
+    /// The vector where cmsgs will be stored, if store_cmsgs is set.
+    ///
+    /// It is the caller's responsibility to create and clear the vector. The
+    /// `nix` crate recommends that the space be created with the
+    /// [`cmsg_space`] macro.
+    ///
+    /// [`cmsg_space`]: https://docs.rs/nix/latest/nix/macro.cmsg_space.html
+    pub cmsg_space: &'c mut Vec<u8>,
+}
+
+#[cfg(target_os = "linux")]
+impl<'c> RecvMsgSettings<'c> {
+    // Convenience to avoid forcing a specific version of nix
+    pub fn new(store_cmsgs: bool, cmsg_space: &'c mut Vec<u8>) -> Self {
+        Self {
+            store_cmsgs,
+            cmsg_space,
+        }
+    }
+}
+
+/// Output of a `recvmsg` call.
+#[derive(Debug, Default)]
+pub struct RecvData {
+    /// The number of bytes returned by `recvmsg`.
+    pub bytes: usize,
+    /// The peer address for this message.
+    pub peer_addr: Option<SocketAddr>,
+    /// Metrics for this `recvmsg` call.
+    ///
+    /// If no valid metrics exist - for example, when the RXQOVFL sockopt is not
+    /// set - this will be `None`.
+    pub metrics: Option<RecvMetrics>,
+    /// The `UDP_GRO_SEGMENTS` control message data from the result of
+    /// `recvmsg`, if it exist.
+    pub gro: Option<u16>,
+    /// The `RX_TIME` control message data from the result of `recvmsg`, if it
+    /// exists.
+    pub rx_time: Option<SystemTime>,
+    /// The original IP destination address for the message.
+    ///
+    /// This can be either an IPv4 or IPv6 address, depending on whether
+    /// `IPV4_ORIGDSTADDR` or `IPV6_ORIGDSTADDR` was received.
+    pub original_addr: Option<IpOrigDstAddr>,
+    cmsgs: Vec<ControlMessageOwned>,
+}
+
+impl RecvData {
+    pub fn new(
+        peer_addr: Option<SocketAddr>, bytes: usize, cmsg_space_len: usize,
+    ) -> Self {
+        Self {
+            peer_addr,
+            bytes,
+            metrics: None,
+            gro: None,
+            rx_time: None,
+            original_addr: None,
+            cmsgs: Vec::with_capacity(cmsg_space_len),
+        }
+    }
+
+    /// A constructor which only sets the `bytes` field.
+    pub fn with_bytes(bytes: usize) -> Self {
+        Self {
+            bytes,
+            ..Default::default()
+        }
+    }
+
+    /// Returns the list of cmsgs which were returned from calling `recvmsg`. If
+    /// `recvmsg` was called with its [`RecvMsgCmsgSettings::store_cmsgs`]
+    /// field set to to `false`, this will return an empty slice.
+    pub fn cmsgs(&self) -> &[ControlMessageOwned] {
+        &self.cmsgs
+    }
+}
+
+/// Metrics for `recvmsg` calls.
+#[derive(Debug, Default)]
+pub struct RecvMetrics {
+    /// The number of packets dropped between the last received packet and this
+    /// one.
+    ///
+    /// See SO_RXQOVFL for more.
+    pub udp_packets_dropped: u64,
+}
+
+#[derive(Debug)]
+pub enum IpOrigDstAddr {
+    V4(sockaddr_in),
+    V6(sockaddr_in6),
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum IpPktInfo {
+    V4(in_pktinfo),
+    V6(in6_pktinfo),
+}
+
+#[cfg(target_os = "linux")]
+mod linux_imports {
+    pub(super) use crate::syscalls::recv_msg;
+    pub(super) use crate::syscalls::send_msg;
+    pub(super) use crate::RecvData;
+    pub(super) use crate::RecvMetrics;
+    pub(super) use crate::RecvMsgSettings;
+    pub(super) use crate::SendMsgSettings;
+    pub(super) use nix::errno::Errno;
+    pub(super) use nix::sys::socket::getsockopt;
+    pub(super) use nix::sys::socket::recvmsg;
+    pub(super) use nix::sys::socket::sendmsg;
+    pub(super) use nix::sys::socket::setsockopt;
+    pub(super) use nix::sys::socket::sockopt::ReceiveTimestampns;
+    pub(super) use nix::sys::socket::sockopt::RxqOvfl;
+    pub(super) use nix::sys::socket::sockopt::TxTime;
+    pub(super) use nix::sys::socket::sockopt::UdpGroSegment;
+    pub(super) use nix::sys::socket::sockopt::UdpGsoSegment;
+    pub(super) use nix::sys::socket::AddressFamily;
+    pub(super) use nix::sys::socket::ControlMessage;
+    pub(super) use nix::sys::socket::ControlMessageOwned;
+    pub(super) use nix::sys::socket::MsgFlags;
+    pub(super) use nix::sys::socket::SetSockOpt;
+    pub(super) use nix::sys::socket::SockaddrLike;
+    pub(super) use nix::sys::socket::SockaddrStorage;
+    pub(super) use smallvec::SmallVec;
+    pub(super) use std::io::IoSlice;
+    pub(super) use std::io::IoSliceMut;
+    pub(super) use std::net::SocketAddrV4;
+    pub(super) use std::net::SocketAddrV6;
+    pub(super) use std::os::fd::AsRawFd;
+}

--- a/dgram/src/socket_setup.rs
+++ b/dgram/src/socket_setup.rs
@@ -1,0 +1,111 @@
+use std::io;
+use std::os::fd::AsFd;
+
+#[cfg(target_os = "linux")]
+use super::linux_imports::*;
+
+/// Indicators of settings applied to a socket. These settings aren't "applied"
+/// to a socket. Rather, the same (maximal) settings are always applied to a
+/// socket, and this struct indicates which of those settings were successfully
+/// applied to a socket.
+#[derive(Default)]
+pub struct SocketCapabilities {
+    /// Indicates if the socket has "Generic Segmentation Offload" enabled.
+    pub has_gso: bool,
+
+    /// Indicates if the socket has "SO_RXQ_OVFL" set.
+    pub check_udp_drop: bool,
+
+    /// Indicates if the monotonic clock is set for transimssion timestamps.
+    pub has_txtime: bool,
+
+    /// Indicates if the monotonic clock is set for receiving timestamps.
+    pub has_rxtime: bool,
+
+    /// Indicates if the socket has "Generic Receive Offload" enabled.
+    pub has_gro: bool,
+}
+
+impl SocketCapabilities {
+    /// Try applying maximal settings to a socket and returns indicators of
+    /// which settings were successfully applied.
+    #[cfg(unix)]
+    pub fn apply_all_and_get_compatibility(
+        socket: &impl AsFd, max_send_udp_payload_size: usize,
+    ) -> Self {
+        let fd = socket.as_fd();
+
+        Self {
+            has_gso: set_gso_segment(&fd, max_send_udp_payload_size).is_ok(),
+            check_udp_drop: set_udp_rxq_ovfl(&fd).is_ok(),
+            has_txtime: set_tx_time(&fd).is_ok(),
+            has_rxtime: set_rx_time(&fd).is_ok(),
+            has_gro: set_gro(&fd).is_ok(),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn set_gso_segment(sock: &impl AsFd, segment: usize) -> io::Result<()> {
+    setsockopt(sock, UdpGsoSegment, &(segment as i32))?;
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn set_gso_segment(_: &impl AsFd, _: usize) -> io::Result<()> {
+    Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+}
+
+#[cfg(target_os = "linux")]
+pub fn set_gro(sock: &impl AsFd) -> io::Result<()> {
+    UdpGroSegment.set(sock, &true)?;
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn set_gro(_: &impl AsFd) -> io::Result<()> {
+    Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+}
+
+#[cfg(target_os = "linux")]
+fn set_udp_rxq_ovfl(sock: &impl AsFd) -> io::Result<()> {
+    setsockopt(sock, RxqOvfl, &1)?;
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn set_udp_rxq_ovfl(_: &impl AsFd) -> io::Result<()> {
+    Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+}
+
+#[cfg(target_os = "linux")]
+pub fn set_tx_time(sock: &impl AsFd) -> io::Result<()> {
+    let cfg = libc::sock_txtime {
+        clockid: libc::CLOCK_MONOTONIC,
+        flags: 0,
+    };
+
+    setsockopt(sock, TxTime, &cfg)?;
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn set_tx_time(_: &impl AsFd) -> io::Result<()> {
+    Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+}
+
+#[cfg(target_os = "linux")]
+pub fn set_rx_time(sock: &impl AsFd) -> io::Result<()> {
+    setsockopt(sock, ReceiveTimestampns, &true)?;
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn set_rx_time(_: &impl AsFd) -> io::Result<()> {
+    Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+}

--- a/dgram/src/socket_setup.rs
+++ b/dgram/src/socket_setup.rs
@@ -1,8 +1,11 @@
-use std::io;
-use std::os::fd::AsFd;
-
 #[cfg(target_os = "linux")]
 use super::linux_imports::*;
+
+#[cfg(unix)]
+mod unix {
+    pub(super) use std::io;
+    pub(super) use std::os::fd::AsFd;
+}
 
 /// Indicators of settings applied to a socket. These settings aren't "applied"
 /// to a socket. Rather, the same (maximal) settings are always applied to a
@@ -31,7 +34,7 @@ impl SocketCapabilities {
     /// which settings were successfully applied.
     #[cfg(unix)]
     pub fn apply_all_and_get_compatibility(
-        socket: &impl AsFd, max_send_udp_payload_size: usize,
+        socket: &impl unix::AsFd, max_send_udp_payload_size: usize,
     ) -> Self {
         let fd = socket.as_fd();
 
@@ -52,8 +55,8 @@ pub fn set_gso_segment(sock: &impl AsFd, segment: usize) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(not(target_os = "linux"))]
-pub fn set_gso_segment(_: &impl AsFd, _: usize) -> io::Result<()> {
+#[cfg(all(not(target_os = "linux"), unix))]
+pub fn set_gso_segment(_: &impl unix::AsFd, _: usize) -> unix::io::Result<()> {
     Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
 }
 
@@ -65,7 +68,8 @@ pub fn set_gro(sock: &impl AsFd) -> io::Result<()> {
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn set_gro(_: &impl AsFd) -> io::Result<()> {
+#[cfg(all(not(target_os = "linux"), unix))]
+pub fn set_gro(_: &impl unix::AsFd) -> unix::io::Result<()> {
     Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
 }
 
@@ -76,8 +80,8 @@ fn set_udp_rxq_ovfl(sock: &impl AsFd) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(not(target_os = "linux"))]
-fn set_udp_rxq_ovfl(_: &impl AsFd) -> io::Result<()> {
+#[cfg(all(not(target_os = "linux"), unix))]
+fn set_udp_rxq_ovfl(_: &impl unix::AsFd) -> unix::io::Result<()> {
     Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
 }
 
@@ -93,8 +97,8 @@ pub fn set_tx_time(sock: &impl AsFd) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(not(target_os = "linux"))]
-pub fn set_tx_time(_: &impl AsFd) -> io::Result<()> {
+#[cfg(all(not(target_os = "linux"), unix))]
+pub fn set_tx_time(_: &impl unix::AsFd) -> unix::io::Result<()> {
     Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
 }
 
@@ -105,7 +109,7 @@ pub fn set_rx_time(sock: &impl AsFd) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(not(target_os = "linux"))]
-pub fn set_rx_time(_: &impl AsFd) -> io::Result<()> {
+#[cfg(all(not(target_os = "linux"), unix))]
+pub fn set_rx_time(_: &impl unix::AsFd) -> unix::io::Result<()> {
     Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
 }

--- a/dgram/src/sync.rs
+++ b/dgram/src/sync.rs
@@ -1,0 +1,37 @@
+use crate::RecvData;
+use crate::RecvMsgSettings;
+use crate::SendMsgSettings;
+use std::io::Result;
+use std::os::fd::AsFd;
+
+#[cfg(target_os = "linux")]
+use super::linux_imports::*;
+
+#[cfg(target_os = "linux")]
+pub fn send_to(
+    fd: &impl AsFd, send_buf: &[u8], sendmsg_settings: SendMsgSettings,
+) -> Result<usize> {
+    // TODO: separate mio module that uses try_io? This works for stateless
+    // polling e.g. epoll/kqueue, but stateful polling (select(), poll()) will
+    // require re-registering the socket after an event. try_io() does that for us
+    let sent = send_msg(fd, send_buf, sendmsg_settings);
+
+    match sent {
+        Ok(s) => Ok(s),
+        Err(Errno::EAGAIN) => Err(std::io::Error::last_os_error()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn recv_from(
+    fd: &impl AsFd, read_buf: &mut [u8], recvmsg_settings: &mut RecvMsgSettings,
+) -> Result<RecvData> {
+    let recvd = recv_msg(fd, read_buf, recvmsg_settings);
+
+    match recvd {
+        Ok(r) => Ok(r),
+        Err(Errno::EAGAIN) => Err(std::io::Error::last_os_error()),
+        Err(e) => Err(e.into()),
+    }
+}

--- a/dgram/src/syscalls.rs
+++ b/dgram/src/syscalls.rs
@@ -1,0 +1,340 @@
+#[cfg(target_os = "linux")]
+mod linux {
+    pub(super) use super::super::linux_imports::*;
+    pub(super) use std::os::fd::AsFd;
+    pub(super) use std::time::Instant;
+    pub(super) use std::time::SystemTime;
+
+    pub(crate) type SyscallResult<T> = std::result::Result<T, Errno>;
+
+    // An instant with the value of zero, since [`Instant`] is backed by a version
+    // of timespec this allows to extract raw values from an [`Instant`]
+    pub(super) const INSTANT_ZERO: Instant =
+        unsafe { std::mem::transmute(std::time::UNIX_EPOCH) };
+}
+
+#[cfg(target_os = "linux")]
+use linux::*;
+
+#[cfg(target_os = "linux")]
+fn raw_send_to(
+    fd: &impl AsFd, send_buf: &[u8], cmsgs: &[ControlMessage],
+    msg_flags: MsgFlags, client_addr: Option<SockaddrStorage>,
+) -> SyscallResult<usize> {
+    let iov = [IoSlice::new(send_buf)];
+    let borrowed = fd.as_fd();
+
+    sendmsg(
+        borrowed.as_raw_fd(),
+        &iov,
+        cmsgs,
+        msg_flags,
+        client_addr.as_ref(),
+    )
+}
+
+/// GSO-compatible convenience wrapper for the `sendmsg` syscall.
+///
+/// It is the caller's responsibility to set any relevant socket options.
+#[cfg(target_os = "linux")]
+pub fn send_msg(
+    fd: impl AsFd, send_buf: &[u8], send_msg_settings: SendMsgSettings,
+) -> SyscallResult<usize> {
+    use crate::IpPktInfo;
+
+    let SendMsgSettings {
+        ref segment_size,
+        tx_time,
+        dst,
+        pkt_info,
+    } = send_msg_settings;
+
+    let raw_time = tx_time
+        .map(|t| t.duration_since(INSTANT_ZERO).as_nanos() as u64)
+        .unwrap_or(0);
+
+    let mut cmsgs: SmallVec<[ControlMessage; 3]> = SmallVec::new();
+
+    if let Some(ss) = segment_size {
+        // Create cmsg for UDP_SEGMENT.
+        cmsgs.push(ControlMessage::UdpGsoSegments(ss));
+    }
+
+    if tx_time.filter(|t| *t > Instant::now()).is_some() {
+        // Create cmsg for TXTIME.
+        cmsgs.push(ControlMessage::TxTime(&raw_time));
+    }
+
+    if let Some(pkt_info) = pkt_info.as_ref() {
+        // Create cmsg for IP_PKTINFO.
+        match pkt_info {
+            IpPktInfo::V4(pi) => cmsgs.push(ControlMessage::Ipv4PacketInfo(pi)),
+            IpPktInfo::V6(pi) => cmsgs.push(ControlMessage::Ipv6PacketInfo(pi)),
+        }
+    }
+
+    let client_addr = dst.map(SockaddrStorage::from);
+    raw_send_to(
+        &fd.as_fd(),
+        send_buf,
+        &cmsgs,
+        MsgFlags::empty(),
+        client_addr,
+    )
+}
+
+/// Receive a message via `recvmsg`. The returned `RecvData` will contain data
+/// from supported cmsgs regardless of if the passed [`StoreCmsgSettings`]
+/// indicates that we should store the cmsgs.
+///
+/// # Note
+///
+/// It is the caller's responsibility to create and clear the cmsg space.`nix`
+/// recommends that the space be created via the `cmsg_space!()` macro. Calling
+/// this function will clear the cmsg buffer. It is also the caller's
+/// responsibility to set any relevant socket options.
+#[cfg(target_os = "linux")]
+pub fn recv_msg(
+    fd: impl AsFd, read_buf: &mut [u8], recvmsg_settings: &mut RecvMsgSettings,
+) -> SyscallResult<RecvData> {
+    use crate::IpOrigDstAddr;
+
+    let RecvMsgSettings {
+        store_cmsgs,
+        ref mut cmsg_space,
+    } = recvmsg_settings;
+
+    cmsg_space.clear();
+
+    let iov_s = &mut [IoSliceMut::new(read_buf)];
+    let cmsg_space_len = cmsg_space.len();
+
+    let borrowed = fd.as_fd();
+    match recvmsg::<SockaddrStorage>(
+        borrowed.as_raw_fd(),
+        iov_s,
+        Some(cmsg_space),
+        MsgFlags::empty(),
+    ) {
+        Ok(r) => {
+            let bytes = r.bytes;
+
+            let address = match r.address {
+                Some(a) => a,
+                _ => return Err(Errno::EINVAL),
+            };
+
+            let peer_addr = match address.family() {
+                Some(AddressFamily::Inet) => Some(
+                    SocketAddrV4::from(*address.as_sockaddr_in().unwrap()).into(),
+                ),
+                Some(AddressFamily::Inet6) => Some(
+                    SocketAddrV6::from(*address.as_sockaddr_in6().unwrap())
+                        .into(),
+                ),
+                _ => None,
+            };
+
+            let mut recv_data = RecvData::new(peer_addr, bytes, cmsg_space_len);
+            for msg in r.cmsgs() {
+                match msg {
+                    ControlMessageOwned::ScmTimestampns(time) =>
+                        recv_data.rx_time =
+                            SystemTime::UNIX_EPOCH.checked_add(time.into()),
+                    ControlMessageOwned::UdpGroSegments(gro) =>
+                        recv_data.gro = Some(gro),
+                    ControlMessageOwned::RxqOvfl(c) => {
+                        if let Ok(1) = getsockopt(&borrowed, RxqOvfl) {
+                            recv_data.metrics = Some(RecvMetrics {
+                                udp_packets_dropped: c as u64,
+                            });
+                        }
+                    },
+                    ControlMessageOwned::Ipv4OrigDstAddr(addr) =>
+                        recv_data.original_addr = Some(IpOrigDstAddr::V4(addr)),
+                    ControlMessageOwned::Ipv6OrigDstAddr(addr) =>
+                        recv_data.original_addr = Some(IpOrigDstAddr::V6(addr)),
+                    _ => return Err(Errno::EINVAL),
+                }
+
+                if *store_cmsgs {
+                    recv_data.cmsgs.push(msg);
+                }
+            }
+
+            Ok(recv_data)
+        },
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(all(test, target_os = "linux", not(target_os = "android")))]
+mod tests {
+    use nix::cmsg_space;
+    use nix::sys::socket::sockopt::ReceiveTimestampns;
+    use nix::sys::socket::sockopt::UdpGroSegment;
+    use nix::sys::socket::*;
+    use nix::sys::time::TimeVal;
+    use std::io::IoSliceMut;
+    use std::io::Result;
+    use std::net::SocketAddr;
+    use std::os::fd::OwnedFd;
+    use std::str::FromStr;
+
+    use super::*;
+
+    fn new_sockets() -> Result<(OwnedFd, OwnedFd)> {
+        let recv = socket(
+            AddressFamily::Inet,
+            SockType::Datagram,
+            SockFlag::empty(),
+            None,
+        )
+        .unwrap();
+        let recv_addr = SockaddrIn::from_str("127.0.0.1:0").unwrap();
+        bind(recv.as_raw_fd(), &recv_addr).unwrap();
+
+        let send = socket(
+            AddressFamily::Inet,
+            SockType::Datagram,
+            SockFlag::empty(),
+            None,
+        )
+        .unwrap();
+        connect(send.as_raw_fd(), &recv_addr).unwrap();
+
+        Ok((send, recv))
+    }
+
+    fn fd_to_socket_addr(fd: &impl AsRawFd) -> Option<SocketAddrV4> {
+        SocketAddrV4::from_str(
+            &getsockname::<SockaddrStorage>(fd.as_raw_fd())
+                .unwrap()
+                .to_string(),
+        )
+        .ok()
+    }
+
+    #[test]
+    fn send_msg_simple() -> Result<()> {
+        let (send, recv) = new_sockets()?;
+        let send_buf = b"njd";
+        let addr = fd_to_socket_addr(&recv);
+
+        let sent = send_msg(send, send_buf, SendMsgSettings {
+            segment_size: None,
+            tx_time: None,
+            dst: Some(SocketAddr::V4(addr.unwrap())),
+            pkt_info: None,
+        })?;
+        assert_eq!(sent, send_buf.len());
+
+        let mut buf = [0; 3];
+        let mut read_buf = [IoSliceMut::new(&mut buf)];
+        let recv = recvmsg::<()>(
+            recv.as_raw_fd(),
+            &mut read_buf,
+            None,
+            MsgFlags::empty(),
+        )
+        .unwrap();
+
+        assert_eq!(recv.bytes, 3);
+        assert_eq!(
+            String::from_utf8(buf.to_vec()).unwrap().as_bytes(),
+            send_buf
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn recv_msg_simple() -> Result<()> {
+        let (send, recv) = new_sockets()?;
+        let addr = getsockname::<SockaddrStorage>(recv.as_raw_fd()).unwrap();
+
+        let send_buf = b"jets";
+        let iov = [IoSlice::new(send_buf)];
+        sendmsg(send.as_raw_fd(), &iov, &[], MsgFlags::empty(), Some(&addr))?;
+
+        let mut read_buf = [0; 4];
+        let recv_data = recv_msg(recv, &mut read_buf, &mut RecvMsgSettings {
+            store_cmsgs: false,
+            cmsg_space: &mut vec![],
+        })?;
+
+        assert_eq!(recv_data.bytes, 4);
+        assert_eq!(&read_buf, b"jets");
+        assert!(recv_data.cmsgs().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn send_to_multiple_segments() -> Result<()> {
+        let (send, recv) = new_sockets()?;
+        // TODO: determine why this has to be set before sendmsg
+        setsockopt(&recv, UdpGroSegment, &true).expect("couldn't set UDP_GRO");
+
+        let addr = fd_to_socket_addr(&recv);
+        let send_buf = b"devils";
+        let sent = send_msg(send, send_buf, SendMsgSettings {
+            segment_size: Some(1),
+            tx_time: None,
+            dst: Some(SocketAddr::V4(addr.unwrap())),
+            pkt_info: None,
+        })?;
+        assert_eq!(sent, send_buf.len());
+
+        let mut buf = [0; 6];
+        let mut read_buf = [IoSliceMut::new(&mut buf)];
+        let mut cmsgs = cmsg_space!(i32);
+        let recv = recvmsg::<SockaddrStorage>(
+            recv.as_raw_fd(),
+            &mut read_buf,
+            Some(&mut cmsgs),
+            MsgFlags::empty(),
+        )
+        .unwrap();
+        assert_eq!(recv.bytes, 6);
+        assert_eq!(
+            String::from_utf8(buf.to_vec()).unwrap().as_bytes(),
+            send_buf
+        );
+        // TODO: determine why no cmsg shows up
+        assert!(cmsgs.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn recvfrom_cmsgs() -> Result<()> {
+        let (send, recv) = new_sockets()?;
+        setsockopt(&recv, ReceiveTimestampns, &true)?;
+
+        let addr = getsockname::<SockaddrStorage>(recv.as_raw_fd()).unwrap();
+        let send_buf = b"jets";
+        let iov = [IoSlice::new(send_buf)];
+        sendmsg(send.as_raw_fd(), &iov, &[], MsgFlags::empty(), Some(&addr))?;
+
+        let mut cmsg_space = cmsg_space!(TimeVal);
+        let mut recvmsg_settings = RecvMsgSettings {
+            store_cmsgs: true,
+            cmsg_space: &mut cmsg_space,
+        };
+
+        let mut read_buf = [0; 4];
+        let recv_data = recv_msg(recv, &mut read_buf, &mut recvmsg_settings)?;
+
+        assert_eq!(recv_data.bytes, 4);
+        assert_eq!(&read_buf, b"jets");
+
+        assert_eq!(recv_data.cmsgs().len(), 1);
+        match recv_data.cmsgs()[0] {
+            ControlMessageOwned::ScmTimestampns(_) => {},
+            _ => panic!("invalid cmsg received"),
+        };
+
+        Ok(())
+    }
+}

--- a/dgram/src/syscalls.rs
+++ b/dgram/src/syscalls.rs
@@ -17,7 +17,7 @@ mod linux {
 use linux::*;
 
 #[cfg(target_os = "linux")]
-fn raw_send_to(
+fn raw_send(
     fd: &impl AsFd, send_buf: &[u8], cmsgs: &[ControlMessage],
     msg_flags: MsgFlags, client_addr: Option<SockaddrStorage>,
 ) -> SyscallResult<usize> {
@@ -74,7 +74,7 @@ pub fn send_msg(
     }
 
     let client_addr = dst.map(SockaddrStorage::from);
-    raw_send_to(
+    raw_send(
         &fd.as_fd(),
         send_buf,
         &cmsgs,

--- a/dgram/src/tokio.rs
+++ b/dgram/src/tokio.rs
@@ -1,0 +1,90 @@
+use crate::RecvData;
+use std::io::ErrorKind;
+use std::io::Result;
+use std::task::Context;
+use std::task::Poll;
+
+use tokio::io::Interest;
+use tokio::net::UdpSocket;
+
+#[cfg(target_os = "linux")]
+mod linux {
+    pub(super) use super::super::linux_imports::*;
+    pub(super) use std::os::fd::AsFd;
+}
+
+#[cfg(target_os = "linux")]
+use linux::*;
+
+#[cfg(target_os = "linux")]
+pub fn poll_send_to(
+    socket: &UdpSocket, ctx: &mut Context<'_>, send_buf: &[u8],
+    sendmsg_settings: SendMsgSettings,
+) -> Poll<Result<usize>> {
+    loop {
+        match socket.poll_send_ready(ctx) {
+            Poll::Ready(Ok(())) => {
+                // Important to use try_io so that Tokio can clear the socket's
+                // readiness flag
+                match socket.try_io(Interest::WRITABLE, || {
+                    let fd = socket.as_fd();
+                    send_msg(fd, send_buf, sendmsg_settings).map_err(Into::into)
+                }) {
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => {},
+                    io_res => break Poll::Ready(io_res),
+                }
+            },
+            Poll::Ready(Err(e)) => break Poll::Ready(Err(e)),
+            Poll::Pending => break Poll::Pending,
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub async fn send_to(
+    socket: &UdpSocket, send_buf: &[u8], sendmsg_settings: SendMsgSettings,
+) -> Result<usize> {
+    std::future::poll_fn(|mut cx| {
+        poll_send_to(socket, &mut cx, send_buf, sendmsg_settings)
+    })
+    .await
+}
+
+#[cfg(target_os = "linux")]
+pub fn poll_recv_from(
+    socket: &UdpSocket, ctx: &mut Context<'_>, recv_buf: &mut [u8],
+    recvmsg_settings: &mut RecvMsgSettings,
+) -> Poll<Result<RecvData>> {
+    loop {
+        match socket.poll_recv_ready(ctx) {
+            Poll::Ready(Ok(())) => {
+                // Important to use try_io so that Tokio can clear the socket's
+                // readiness flag
+                match socket.try_io(Interest::READABLE, || {
+                    let fd = socket.as_fd();
+                    recv_msg(fd, recv_buf, recvmsg_settings).map_err(Into::into)
+                }) {
+                    // The `poll_recv_ready` future registers the ctx with Tokio.
+                    // We can only return Pending when that
+                    // future is Pending or we won't wake the
+                    // runtime properly
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => {},
+                    io_res => break Poll::Ready(io_res),
+                }
+            },
+            Poll::Ready(Err(e)) => break Poll::Ready(Err(e)),
+            Poll::Pending => break Poll::Pending,
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub async fn recv_from(
+    socket: &UdpSocket, recv_buf: &mut [u8],
+    recvmsg_settings: &mut RecvMsgSettings<'_>,
+) -> Result<RecvData> {
+    std::future::poll_fn(|mut ctx| {
+        poll_recv_from(socket, &mut ctx, recv_buf, recvmsg_settings)
+    })
+    .await
+}


### PR DESCRIPTION
## Overview
This PR adds a new crate for abstracting away UDP socket syscalls. It currently only contains implementations for Unix systems, but we can add multi-platform support when required. Async variants are provided with the `async` feature

## Tasks
- [x] Rerun tests one final time hitting relevant server(s)
- [x] Ensure build works on non-Linux (e.g. import errors in `syscalls`). I ended up just making the vast majority of the calls Linux-only, but ensured that quiche-server still works.
- [ ] Testing on remote metal

## Notes
`MsgFlags` currently aren't supported since we don't have a use case for them, and trying to implement them was causing crate conflicts. If this is a blocker, I can add support.

## Testing
Unit tests exist for basic functionality, but should probably be more robust. One per syscall would be nice. I also tested with a basic `quiche-server`/`quiche-client` setup on both Linux and MacOS. 

I plan on testing on a remote metal to double-check the GSO/GRO implementation, since that apparently doesn't work on loopback.

### QUIC Interop Runner results
```
Run took 3:48:53.496406
+----------+---------------------------------------------------+
|          |                       quiche                      |
+----------+---------------------------------------------------+
| quic-go  |        ✓(H,DC,LR,C20,M,S,R,Z,3,B,U,L2,C2,6)       |
|          |                  ?(E,A,L1,C1,V2)                  |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
|  ngtcp2  |       ✓(H,DC,LR,C20,M,S,R,Z,3,B,U,A,L2,C2,6)      |
|          |                   ?(E,L1,C1,V2)                   |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
|  mvfst   |              ✓(H,DC,LR,M,3,B,L2,C2,6)             |
|          |            ?(C20,S,R,Z,U,E,A,L1,C1,V2)            |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
|  quiche  |          ✓(H,DC,LR,M,S,R,Z,3,B,A,L2,C2,6)         |
|          |                   ?(C20,U,E,V2)                   |
|          |                      ✕(L1,C1)                     |
+----------+---------------------------------------------------+
|   kwik   |       ✓(H,DC,LR,C20,M,S,R,Z,3,B,U,A,L2,C2,6)      |
|          |                   ?(E,L1,C1,V2)                   |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
| picoquic |       ✓(H,DC,LR,C20,M,S,R,Z,3,B,U,A,L2,C2,6)      |
|          |                   ?(E,L1,C1,V2)                   |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
| aioquic  |        ✓(H,DC,LR,C20,M,S,R,Z,3,B,A,L2,C2,6)       |
|          |                  ?(U,E,L1,C1,V2)                  |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
|   neqo   |       ✓(H,DC,LR,C20,M,S,R,Z,3,B,U,A,L2,C2,6)      |
|          |                   ?(E,L1,C1,V2)                   |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
|  msquic  |          ✓(H,DC,LR,C20,M,S,R,B,U,L2,C2,6)         |
|          |                ?(Z,3,E,A,L1,C1,V2)                |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
|  chrome  |                        ✓()                        |
|          | ?(H,DC,LR,C20,M,S,R,Z,3,B,U,E,A,L1,L2,C1,C2,6,V2) |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
|  xquic   |                        ✓()                        |
|          |                        ?()                        |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
|  lsquic  |           ✓(H,DC,LR,M,S,R,3,B,A,L2,C2,6)          |
|          |               ?(C20,Z,U,E,L1,C1,V2)               |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
|  quinn   |        ✓(H,DC,LR,C20,M,S,R,3,B,U,A,L2,C2,6)       |
|          |                  ?(Z,E,L1,C1,V2)                  |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
| s2n-quic |                        ✓()                        |
|          |                        ?()                        |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
| go-x-net |              ✓(H,DC,LR,M,B,U,L2,C2,6)             |
|          |            ?(C20,S,R,Z,3,E,A,L1,C1,V2)            |
|          |                        ✕()                        |
+----------+---------------------------------------------------+
+----------+----------------------+
|          |        quiche        |
+----------+----------------------+
| quic-go  | G: 9451 (± 12) kbps  |
|          | C: 7914 (± 76) kbps  |
+----------+----------------------+
|  ngtcp2  | G: 9333 (± 14) kbps  |
|          | C: 7832 (± 106) kbps |
+----------+----------------------+
|  mvfst   | G: 9356 (± 18) kbps  |
|          | C: 7037 (± 266) kbps |
+----------+----------------------+
|  quiche  | G: 9195 (± 47) kbps  |
|          | C: 6845 (± 92) kbps  |
+----------+----------------------+
|   kwik   |  G: 9387 (± 6) kbps  |
|          | C: 7491 (± 293) kbps |
+----------+----------------------+
| picoquic | G: 9363 (± 62) kbps  |
|          | C: 7345 (± 517) kbps |
+----------+----------------------+
| aioquic  | G: 9363 (± 71) kbps  |
|          |          C           |
+----------+----------------------+
|   neqo   | G: 8414 (± 614) kbps |
|          | C: 7468 (± 182) kbps |
+----------+----------------------+
|  msquic  | G: 9443 (± 19) kbps  |
|          | C: 7507 (± 98) kbps  |
+----------+----------------------+
|  chrome  |          G           |
|          |          C           |
+----------+----------------------+
|  xquic   |                      |
+----------+----------------------+
|  lsquic  | G: 9408 (± 17) kbps  |
|          | C: 7387 (± 371) kbps |
+----------+----------------------+
|  quinn   | G: 9291 (± 109) kbps |
|          | C: 6973 (± 287) kbps |
+----------+----------------------+
| s2n-quic |                      |
+----------+----------------------+
| go-x-net | G: 9306 (± 118) kbps |
|          | C: 6157 (± 273) kbps |
+----------+----------------------+
```

### GSO/GRO Testing