### PR TITLE
Add soname to libquiche.so

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -46,7 +46,7 @@ pkg-config-meta = []
 fuzzing = []
 
 # Build and expose the FFI API.
-ffi = []
+ffi = ["dep:cdylib-link-lines"]
 
 # Exposes internal APIs that have no stability guarantees across versions.
 internal = []
@@ -59,6 +59,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [build-dependencies]
 cmake = "0.1"
 pkg-config = { version = "0.3", optional = true }
+cdylib-link-lines = { version = "0.1", optional = true }
 
 [dependencies]
 either = { version = "1.8", default-features = false }

--- a/quiche/src/build.rs
+++ b/quiche/src/build.rs
@@ -277,4 +277,9 @@ fn main() {
     if cfg!(feature = "pkg-config-meta") {
         write_pkg_config();
     }
+
+    #[cfg(feature = "ffi")]
+    if target_os != "windows" {
+        cdylib_link_lines::metabuild();
+    }
 }


### PR DESCRIPTION
Using cdylib-link-lines, add soname to the generated shlibs.

It will add the following to libquiche.so:

```
% readelf -d target/debug/libquiche.so
...
 0x000000000000000e (SONAME)             Library soname: [libquiche.so.0]
```

For linux, *bsd, android, ios and macos.

Fixes #598
Fixes #165