### PR TITLE
lib: fix resetting of streams with buffered but unsent data

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -11060,11 +11060,7 @@ mod tests {
         assert_eq!(r.next(), Some(0));
         assert_eq!(r.next(), None);
 
-        loop {
-            if pipe.server.stream_send(0, b"world", false) == Err(Error::Done) {
-                break;
-            }
-
+        while pipe.server.stream_send(0, b"world", false) != Err(Error::Done) {
             assert_eq!(pipe.advance(), Ok(()));
         }
 
@@ -12115,6 +12111,157 @@ mod tests {
         assert_eq!(pipe.handshake(), Ok(()));
 
         assert_eq!(pipe.server_recv(&mut buf[..0]), Err(Error::BufferTooShort));
+    }
+
+    #[test]
+    fn stop_sending_before_flushed_packets() {
+        let mut b = [0; 15];
+
+        let mut buf = [0; 65535];
+
+        let mut pipe = testing::Pipe::new().unwrap();
+        assert_eq!(pipe.handshake(), Ok(()));
+
+        // Client sends some data, and closes stream.
+        assert_eq!(pipe.client.stream_send(0, b"hello", true), Ok(5));
+        assert_eq!(pipe.advance(), Ok(()));
+
+        // Server gets data.
+        let mut r = pipe.server.readable();
+        assert_eq!(r.next(), Some(0));
+        assert_eq!(r.next(), None);
+
+        assert_eq!(pipe.server.stream_recv(0, &mut b), Ok((5, true)));
+        assert!(pipe.server.stream_finished(0));
+
+        let mut r = pipe.server.readable();
+        assert_eq!(r.next(), None);
+
+        // Server sends data, until blocked.
+        let mut r = pipe.server.writable();
+        assert_eq!(r.next(), Some(0));
+        assert_eq!(r.next(), None);
+
+        while pipe.server.stream_send(0, b"world", false) != Err(Error::Done) {}
+
+        let mut r = pipe.server.writable();
+        assert_eq!(r.next(), None);
+
+        // Client sends STOP_SENDING.
+        let frames = [frame::Frame::StopSending {
+            stream_id: 0,
+            error_code: 42,
+        }];
+
+        let pkt_type = packet::Type::Short;
+        let len = pipe
+            .send_pkt_to_server(pkt_type, &frames, &mut buf)
+            .unwrap();
+
+        // Server sent a RESET_STREAM frame in response.
+        let frames =
+            testing::decode_pkt(&mut pipe.client, &mut buf[..len]).unwrap();
+
+        let mut iter = frames.iter();
+
+        // Skip ACK frame.
+        iter.next();
+
+        assert_eq!(
+            iter.next(),
+            Some(&frame::Frame::ResetStream {
+                stream_id: 0,
+                error_code: 42,
+                final_size: 0,
+            })
+        );
+
+        // Stream is writable, but writing returns an error.
+        let mut r = pipe.server.writable();
+        assert_eq!(r.next(), Some(0));
+        assert_eq!(r.next(), None);
+
+        assert_eq!(
+            pipe.server.stream_send(0, b"world", true),
+            Err(Error::StreamStopped(42)),
+        );
+
+        assert_eq!(pipe.server.streams.len(), 1);
+
+        // Client acks RESET_STREAM frame.
+        let mut ranges = ranges::RangeSet::default();
+        ranges.insert(0..6);
+
+        let frames = [frame::Frame::ACK {
+            ack_delay: 15,
+            ranges,
+            ecn_counts: None,
+        }];
+
+        assert_eq!(pipe.send_pkt_to_server(pkt_type, &frames, &mut buf), Ok(0));
+
+        // Client has ACK'd the RESET_STREAM so the stream is collected.
+        assert_eq!(pipe.server.streams.len(), 0);
+    }
+
+    #[test]
+    fn reset_before_flushed_packets() {
+        let mut b = [0; 15];
+
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config
+            .set_application_protos(&[b"proto1", b"proto2"])
+            .unwrap();
+        config.set_initial_max_data(30);
+        config.set_initial_max_stream_data_bidi_local(5);
+        config.set_initial_max_stream_data_bidi_remote(15);
+        config.set_initial_max_streams_bidi(3);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
+        assert_eq!(pipe.handshake(), Ok(()));
+
+        // Client sends some data, and closes stream.
+        assert_eq!(pipe.client.stream_send(0, b"hello", true), Ok(5));
+        assert_eq!(pipe.advance(), Ok(()));
+
+        // Server gets data.
+        let mut r = pipe.server.readable();
+        assert_eq!(r.next(), Some(0));
+        assert_eq!(r.next(), None);
+
+        assert_eq!(pipe.server.stream_recv(0, &mut b), Ok((5, true)));
+        assert!(pipe.server.stream_finished(0));
+
+        let mut r = pipe.server.readable();
+        assert_eq!(r.next(), None);
+
+        // Server sends data and is blocked by small stream flow control.
+        let mut r = pipe.server.writable();
+        assert_eq!(r.next(), Some(0));
+        assert_eq!(r.next(), None);
+
+        assert_eq!(pipe.server.stream_send(0, b"helloworld", false), Ok(5));
+        assert_eq!(pipe.advance(), Ok(()));
+
+        // Client reads to give flow control back.
+        assert_eq!(pipe.client.stream_recv(0, &mut b), Ok((5, false)));
+        assert_eq!(pipe.advance(), Ok(()));
+
+        // Server writes stream data and resets the stream before sending a
+        // packet.
+        assert_eq!(pipe.server.stream_send(0, b"world", false), Ok(5));
+        pipe.server.stream_shutdown(0, Shutdown::Write, 42).unwrap();
+        assert_eq!(pipe.advance(), Ok(()));
+
+        // Client has ACK'd the RESET_STREAM so the stream is collected.
+        assert_eq!(pipe.server.streams.len(), 0);
     }
 
     #[test]
@@ -16834,11 +16981,7 @@ mod tests {
         assert_eq!(pipe.server.stream_writable(0, 0), Ok(true));
 
         // Server sends data on stream 0, until blocked.
-        loop {
-            if pipe.server.stream_send(0, b"world", false) == Err(Error::Done) {
-                break;
-            }
-
+        while pipe.server.stream_send(0, b"world", false) != Err(Error::Done) {
             assert_eq!(pipe.advance(), Ok(()));
         }
 

--- a/quiche/src/stream/send_buf.rs
+++ b/quiche/src/stream/send_buf.rs
@@ -356,12 +356,12 @@ impl SendBuf {
         // Drop all buffered data.
         self.data.clear();
 
-        // Mark all data as acked.
+        // Mark relevant data as acked.
+        self.off = unsent_off;
         self.ack(0, self.off as usize);
 
         self.pos = 0;
         self.len = 0;
-        self.off = unsent_off;
 
         (self.emit_off, unsent_len)
     }


### PR DESCRIPTION
An application can buffer stream data but not have the opportunity to prepare
the packets that would send that data. Within this window of time, the stream
might get reset either in reaction to receiving a STOP_SENDING frame, or due to
the application resetting the stream themselves via stream_shutdown(). Once this
occurs, no stream data will be sent. Instead, a RESET_STREAM will be emitted
when packets are next prepared that contains a final size of whatever bytes
_had_ been sent.

Quiche needs to keep a reference to such a stream for as long as it is "active".
For a bidi stream, that means that the receive side has been finished, and the
send side closure (RESET_STREAM) has been acknowledged and validated. Only when
both these conditions are true will the stream be collected. Stream collection
is used in stream credit accounting, which is used to for determining when to
emit a MAX_STREAMS frame.

Prior to this change, resetting a stream with buffered but unsent data would
lead to some internal checks failing when processing RESET_STREAM
acknowledgement. That led to not collecting the stream and not updating
MAX_STREAMS when it was expected.