### PR TITLE
generate packet numbers from a single sequence

### DIFF
--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -852,8 +852,6 @@ pub struct PktNumSpace {
 
     pub largest_rx_non_probing_pkt_num: u64,
 
-    pub next_pkt_num: u64,
-
     pub recv_pkt_need_ack: ranges::RangeSet,
 
     pub recv_pkt_num: PktNumWindow,
@@ -878,8 +876,6 @@ impl PktNumSpace {
             largest_rx_pkt_time: time::Instant::now(),
 
             largest_rx_non_probing_pkt_num: 0,
-
-            next_pkt_num: 0,
 
             recv_pkt_need_ack: ranges::RangeSet::new(crate::MAX_ACK_RANGES),
 


### PR DESCRIPTION
Instead of keeping separate sequences for each packet number space, use the same sequence.

This is needed to make it easier to support FIPS. This is because FIPS mandates that the crypto module (e.g. BoringCrypto) has to validate that the AEAD counter (which in QUIC corresponds to the packet number) is stricly monotonically increasing (so that counters are not reused).

Because BoringCrypto saves the counter inside its own AEAD context, and because new paths currently require starting from packet number 0 again, the FIPS requirement would require us to maintain separate AEAD contexts for each path, which we currently don't do (and would probably be messy to implement).

This reverts commit 40e2433300d5bf57e3046a09e81974effb4697d7.