### PR TITLE
ci: deprecate action-rs and other ci fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,17 +18,10 @@ jobs:
           submodules: 'recursive'
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Run cargo doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps --all-features
+        run: cargo doc --no-deps --all-features
 
       - name: Deploy to GitHub Pages
         uses: crazy-max/ghaction-github-pages@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,7 +5,7 @@ name: Nightly
 env:
   RUSTFLAGS: "-D warnings"
   RUSTDOCFLAGS: "--cfg docsrs"
-  TOOLCHAIN: "nightly"
+  RUSTTOOLCHAIN: "nightly"
 
 jobs:
   quiche:
@@ -20,44 +20,27 @@ jobs:
           submodules: 'recursive'
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}
+          toolchain: ${{ env.RUSTTOOLCHAIN }}
           components: rustfmt
-          override: true
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: cargo fmt -- --check
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --all-targets --features=ffi,qlog
+        run: cargo test --verbose --all-targets --features=ffi,qlog
 
       # Need to run doc tests separately.
       # (https://github.com/rust-lang/cargo/issues/6669)
       - name: Run cargo doc test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --doc --features=ffi,qlog
+        run: cargo test --verbose --doc --features=ffi,qlog
 
       - name: Run cargo package
-        uses: actions-rs/cargo@v1
-        with:
-          command: package
-          args: --verbose --workspace --exclude=quiche_apps --allow-dirty
+        run: cargo package --verbose --workspace --exclude=quiche_apps --allow-dirty
 
       - name: Run cargo doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps --all-features --document-private-items
+        run: cargo doc --no-deps --all-features --document-private-items
 
       - name: Build C examples
         run: |
@@ -76,39 +59,25 @@ jobs:
           submodules: 'recursive'
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}
+          toolchain: ${{ env.RUSTTOOLCHAIN }}
           components: rustfmt
-          override: true
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 
       - name: Run cargo fuzz for packet_recv_client
-        uses: actions-rs/cargo@v1
-        with:
-          command: fuzz
-          args: run packet_recv_client -- -runs=1
+        run: cargo fuzz run packet_recv_client -- -runs=1
 
       - name: Run cargo fuzz for packet_recv_server
-        uses: actions-rs/cargo@v1
-        with:
-          command: fuzz
-          args: run packet_recv_server -- -runs=1
+        run: cargo fuzz run packet_recv_server -- -runs=1
 
       - name: Run cargo fuzz for qpack_decode
-        uses: actions-rs/cargo@v1
-        with:
-          command: fuzz
-          args: run qpack_decode -- -runs=1
+        run: cargo fuzz run qpack_decode -- -runs=1
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path=fuzz/Cargo.toml -- --check
+        run: cargo fmt --manifest-path=fuzz/Cargo.toml -- --check
 
   http3_test:
     runs-on: ubuntu-latest
@@ -122,21 +91,13 @@ jobs:
           submodules: 'recursive'
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}
+          toolchain: ${{ env.RUSTTOOLCHAIN }}
           components: rustfmt
-          override: true
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-run --verbose --manifest-path=tools/http3_test/Cargo.toml
+        run: cargo test --no-run --verbose --manifest-path=tools/http3_test/Cargo.toml
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path=tools/http3_test/Cargo.toml -- --check
+        run: cargo fmt --manifest-path=tools/http3_test/Cargo.toml -- --check

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -54,7 +54,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -86,7 +86,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -78,7 +78,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -105,7 +105,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -132,7 +132,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -181,7 +181,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -206,7 +206,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -232,7 +232,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -271,7 +271,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -300,7 +300,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -70,8 +70,8 @@ jobs:
     strategy:
       matrix:
         target:
-          - "macos-latest" # Intel (x86_64)
-          - "macos-14"     # Apple Silicon (M1)
+          - "macos-13"     # Intel (x86_64)
+          - "macos-latest" # Apple Silicon (M1)
     runs-on: ${{ matrix.target }}
     # Only run on "pull_request" event for external PRs. This is to avoid
     # duplicate builds for PRs created from internal branches.

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -159,7 +159,7 @@ jobs:
           tag: 12.2.0-16.0.0-10.0.0-msvcrt-r5
 
       - name: Install dependencies
-        uses: crazy-max/ghaction-chocolatey@v2
+        uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: install nasm
 

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -4,7 +4,7 @@ name: Stable
 
 env:
   RUSTFLAGS: "-D warnings"
-  TOOLCHAIN: "stable"
+  RUSTTOOLCHAIN: "stable"
 
 jobs:
   quiche:
@@ -25,12 +25,10 @@ jobs:
           submodules: 'recursive'
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}
+          toolchain: ${{ env.RUSTTOOLCHAIN }}
           components: clippy
-          override: true
 
       - name: Build OpenSSL
         if: ${{ matrix.tls-feature == 'openssl' }}
@@ -44,42 +42,24 @@ jobs:
           echo "LD_LIBRARY_PATH=$PWD" >> "$GITHUB_ENV"
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --all-targets --features=ffi,qlog,${{ matrix.tls-feature }}
+        run: cargo test --verbose --all-targets --features=ffi,qlog,${{ matrix.tls-feature }}
 
       # Need to run doc tests separately.
       # (https://github.com/rust-lang/cargo/issues/6669)
       - name: Run cargo doc test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --doc --features=ffi,qlog,${{ matrix.tls-feature }}
+        run: cargo test --verbose --doc --features=ffi,qlog,${{ matrix.tls-feature }}
 
       - name: Run cargo package
-        uses: actions-rs/cargo@v1
-        with:
-          command: package
-          args: --verbose --workspace --exclude=quiche_apps --allow-dirty
+        run: cargo package --verbose --workspace --exclude=quiche_apps --allow-dirty
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features=ffi,qlog,${{ matrix.tls-feature }} -- -D warnings
+        run: cargo clippy --features=ffi,qlog,${{ matrix.tls-feature }} -- -D warnings
 
       - name: Run cargo clippy on examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --examples --features=ffi,qlog,${{ matrix.tls-feature }} -- -D warnings
+        run: cargo clippy --examples --features=ffi,qlog,${{ matrix.tls-feature }} -- -D warnings
 
       - name: Run cargo doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps --all-features --document-private-items
+        run: cargo doc --no-deps --all-features --document-private-items
 
       - name: Build C examples
         run: |
@@ -103,17 +83,12 @@ jobs:
           submodules: 'recursive'
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}
-          override: true
+          toolchain: ${{ env.RUSTTOOLCHAIN }}
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --all-targets --features ffi,qlog
+        run: cargo test --verbose --all-targets --features ffi,qlog
 
       - name: Build C examples
         run: |
@@ -135,22 +110,17 @@ jobs:
           submodules: 'recursive'
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}
-          target: ${{ matrix.target }}
-          override: true
+          toolchain: ${{ env.RUSTTOOLCHAIN }}
+          targets: ${{ matrix.target }}
 
       - name: Remove cdylib from iOS build
         run: |
           sed -i -e 's/, "cdylib"//g' quiche/Cargo.toml
 
       - name: Run cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ matrix.target }} --verbose
+        run: cargo build --target=${{ matrix.target }} --verbose
 
   quiche_windows:
     runs-on: windows-2019
@@ -167,12 +137,13 @@ jobs:
           submodules: 'recursive'
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}-${{ matrix.target }}
-          target: ${{ matrix.target }}
-          override: true
+          toolchain: ${{ env.RUSTTOOLCHAIN }}
+          targets: ${{ matrix.target }}
+
+      - name: Set default toolchain
+        run: rustup default ${{ env.RUSTTOOLCHAIN }}-${{ matrix.target }}
 
       - name: Set up MinGW for 64 bit
         if: matrix.target == 'x86_64-pc-windows-gnu'
@@ -194,17 +165,11 @@ jobs:
 
       - name: Run cargo build
         if: endsWith(matrix.target, '-gnu')
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ matrix.target }} --verbose --all-targets --features=ffi,qlog
+        run: cargo build --target=${{ matrix.target }} --verbose --all-targets --features=ffi,qlog
 
       - name: Run cargo test
         if: endsWith(matrix.target, '-msvc')
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target=${{ matrix.target }} --verbose --all-targets --features=ffi,qlog
+        run: cargo test --target=${{ matrix.target }} --verbose --all-targets --features=ffi,qlog
 
   quiche_multiarch:
     runs-on: ubuntu-latest
@@ -220,12 +185,19 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          command: test
-          args: --target=${{ matrix.target }} --verbose --all-targets --features=ffi,qlog
-          use-cross: true
+          toolchain: ${{ env.RUSTTOOLCHAIN }}
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install cross
+        run: cargo-binstall -y cross
+
+      - name: Run cargo test using cross
+        run: cross test --target=${{ matrix.target }} --verbose --all-targets --features=ffi,qlog
 
   http3_test:
     runs-on: ubuntu-latest
@@ -239,23 +211,16 @@ jobs:
           submodules: 'recursive'
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}
-          override: true
+          toolchain: ${{ env.RUSTTOOLCHAIN }}
+          components: clippy
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-run --verbose --manifest-path=tools/http3_test/Cargo.toml
+        run: cargo test --no-run --verbose --manifest-path=tools/http3_test/Cargo.toml
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path=tools/http3_test/Cargo.toml -- -D warnings
+        run: cargo clippy --manifest-path=tools/http3_test/Cargo.toml -- -D warnings
 
   nginx:
     runs-on: ubuntu-latest
@@ -272,11 +237,9 @@ jobs:
           submodules: 'recursive'
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}
-          override: true
+          toolchain: ${{ env.RUSTTOOLCHAIN }}
 
       - name: Install dependencies
         run: sudo apt-get install libpcre3-dev zlib1g-dev
@@ -291,7 +254,13 @@ jobs:
         run: |
           cd nginx-${{ matrix.version }} &&
           patch -p01 < ../nginx/nginx-1.16.patch &&
-          ./configure --with-http_ssl_module --with-http_v2_module --with-http_v3_module --with-openssl="${{ github.workspace }}/quiche/deps/boringssl" --with-quiche="${{ github.workspace }}" --with-debug &&
+          ./configure \
+              --with-http_ssl_module \
+              --with-http_v2_module \
+              --with-http_v3_module \
+              --with-openssl="${{ github.workspace }}/quiche/deps/boringssl" \
+              --with-quiche="${{ github.workspace }}" \
+              --with-debug &&
           make -j`nproc` &&
           objs/nginx -V
 
@@ -336,17 +305,13 @@ jobs:
           submodules: 'recursive'
 
       - name: Install stable toolchain for the target
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ env.TOOLCHAIN }}
-          target: ${{ matrix.target }}
-          override: true
+          toolchain: ${{ env.RUSTTOOLCHAIN }}
+          targets: ${{ matrix.target }}
 
       - name: Install cargo-ndk
-        uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-ndk
+        run: cargo install cargo-ndk
 
       - name: Download NDK
         run: curl --http1.1 -O https://dl.google.com/android/repository/android-ndk-r${{ env.NDK_LTS_VER }}-linux.zip
@@ -355,9 +320,6 @@ jobs:
         run: unzip -q android-ndk-r${{ env.NDK_LTS_VER }}-linux.zip
 
       - name: Run cargo ndk
-        uses: actions-rs/cargo@v1
-        with:
-          command: ndk
-          args: -t ${{ matrix.arch }} -p ${{ env.API_LEVEL }} -- build --verbose --features ffi
+        run: cargo ndk -t ${{ matrix.arch }} -p ${{ env.API_LEVEL }} -- build --verbose --features ffi
         env:
           ANDROID_NDK_HOME: ${{ github.workspace }}/android-ndk-r${{ env.NDK_LTS_VER  }}


### PR DESCRIPTION
- Deprecate use of action-rs (no longer maintained)
- Update macos runner type (x86_64 and M1)
- Upgrade checkout from v3 (Node.js version warning)
- Upgrade ghaction-chocolatey to v3 (Node.js version warning)