### PR TITLE
rtt: initialize min_rtt to zero

### DIFF
--- a/quiche/src/recovery/rtt.rs
+++ b/quiche/src/recovery/rtt.rs
@@ -62,7 +62,7 @@ impl RttStats {
     pub(crate) fn new(max_ack_delay: Duration) -> Self {
         RttStats {
             latest_rtt: Duration::ZERO,
-            min_rtt: Minmax::new(Duration::MAX),
+            min_rtt: Minmax::new(Duration::ZERO),
             smoothed_rtt: INITIAL_RTT,
             rttvar: INITIAL_RTT / 2,
             first_rtt_sample: None,
@@ -114,6 +114,6 @@ impl RttStats {
     }
 
     pub(crate) fn min_rtt(&self) -> Option<Duration> {
-        self.min_rtt.ne(&Duration::MAX).then_some(*self.min_rtt)
+        self.min_rtt.ne(&Duration::ZERO).then_some(*self.min_rtt)
     }
 }


### PR DESCRIPTION
Follow-up to 3b758cb122d2cde6c197947b027bab630f8c0f21 which changed the initial min_rtt value from Duration::ZERO to Duration::MAX.

This could potentially cause an overflow, for example if there is no previous RTT sample, and the CUBIC congestion avoidance logic is triggered.

Switch back the initial value to ZERO.