### PR TITLE
h3: set stream priority after headers buffered

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -1164,6 +1164,8 @@ impl Connection {
             return Err(Error::FrameUnexpected);
         }
 
+        self.send_headers(conn, stream_id, headers, fin)?;
+
         // Clamp and shift urgency into quiche-priority space
         let urgency = priority
             .urgency
@@ -1171,8 +1173,6 @@ impl Connection {
             PRIORITY_URGENCY_OFFSET;
 
         conn.stream_priority(stream_id, urgency, priority.incremental)?;
-
-        self.send_headers(conn, stream_id, headers, fin)?;
 
         Ok(())
     }


### PR DESCRIPTION
send_headers() can fail if there is not enough stream capacity to buffer
encoded headers. Applications are expected to try again later.
Previously, send_response_with_priority() would update
the stream priority prior to send_headers(), which might surprise
some types of applications relying on the writable() iterator.

This change swaps the ordering around so that priority is only changed
after headers have been successfully buffered.
