### PR TITLE
apps: keep processing connections after draining one

### DIFF
--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -589,7 +589,7 @@ fn main() {
             }
 
             if total_write == 0 || dst_info.is_none() {
-                break;
+                continue;
             }
 
             if let Err(e) = send_to(


### PR DESCRIPTION
If a connection doesn't have any more packets to send, we should keep processing other connections, rather than going back to polling.