### PR TITLE
Fix clippy legacy_numeric_constants warning

### DIFF
--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -746,7 +746,7 @@ impl<'a> From<&RecvInfo<'a>> for crate::RecvInfo {
 pub extern fn quiche_conn_recv(
     conn: &mut Connection, buf: *mut u8, buf_len: size_t, info: &RecvInfo,
 ) -> ssize_t {
-    if buf_len > <ssize_t>::max_value() as usize {
+    if buf_len > <ssize_t>::MAX as usize {
         panic!("The provided buffer is too large");
     }
 
@@ -773,7 +773,7 @@ pub struct SendInfo {
 pub extern fn quiche_conn_send(
     conn: &mut Connection, out: *mut u8, out_len: size_t, out_info: &mut SendInfo,
 ) -> ssize_t {
-    if out_len > <ssize_t>::max_value() as usize {
+    if out_len > <ssize_t>::MAX as usize {
         panic!("The provided buffer is too large");
     }
 
@@ -799,7 +799,7 @@ pub extern fn quiche_conn_send_on_path(
     from_len: socklen_t, to: *const sockaddr, to_len: socklen_t,
     out_info: &mut SendInfo,
 ) -> ssize_t {
-    if out_len > <ssize_t>::max_value() as usize {
+    if out_len > <ssize_t>::MAX as usize {
         panic!("The provided buffer is too large");
     }
 
@@ -826,7 +826,7 @@ pub extern fn quiche_conn_stream_recv(
     conn: &mut Connection, stream_id: u64, out: *mut u8, out_len: size_t,
     fin: &mut bool, out_error_code: &mut u64,
 ) -> ssize_t {
-    if out_len > <ssize_t>::max_value() as usize {
+    if out_len > <ssize_t>::MAX as usize {
         panic!("The provided buffer is too large");
     }
 
@@ -855,7 +855,7 @@ pub extern fn quiche_conn_stream_send(
     conn: &mut Connection, stream_id: u64, buf: *const u8, buf_len: size_t,
     fin: bool, out_error_code: &mut u64,
 ) -> ssize_t {
-    if buf_len > <ssize_t>::max_value() as usize {
+    if buf_len > <ssize_t>::MAX as usize {
         panic!("The provided buffer is too large");
     }
 
@@ -1390,7 +1390,7 @@ pub extern fn quiche_conn_dgram_send_queue_byte_size(
 pub extern fn quiche_conn_dgram_send(
     conn: &mut Connection, buf: *const u8, buf_len: size_t,
 ) -> ssize_t {
-    if buf_len > <ssize_t>::max_value() as usize {
+    if buf_len > <ssize_t>::MAX as usize {
         panic!("The provided buffer is too large");
     }
 
@@ -1407,7 +1407,7 @@ pub extern fn quiche_conn_dgram_send(
 pub extern fn quiche_conn_dgram_recv(
     conn: &mut Connection, out: *mut u8, out_len: size_t,
 ) -> ssize_t {
-    if out_len > <ssize_t>::max_value() as usize {
+    if out_len > <ssize_t>::MAX as usize {
         panic!("The provided buffer is too large");
     }
 

--- a/quiche/src/h3/ffi.rs
+++ b/quiche/src/h3/ffi.rs
@@ -270,7 +270,7 @@ pub extern fn quiche_h3_send_body(
     conn: &mut h3::Connection, quic_conn: &mut Connection, stream_id: u64,
     body: *const u8, body_len: size_t, fin: bool,
 ) -> ssize_t {
-    if body_len > <ssize_t>::max_value() as usize {
+    if body_len > <ssize_t>::MAX as usize {
         panic!("The provided buffer is too large");
     }
 
@@ -288,7 +288,7 @@ pub extern fn quiche_h3_recv_body(
     conn: &mut h3::Connection, quic_conn: &mut Connection, stream_id: u64,
     out: *mut u8, out_len: size_t,
 ) -> ssize_t {
-    if out_len > <ssize_t>::max_value() as usize {
+    if out_len > <ssize_t>::MAX as usize {
         panic!("The provided buffer is too large");
     }
 

--- a/quiche/src/rand.rs
+++ b/quiche/src/rand.rs
@@ -47,7 +47,7 @@ pub fn rand_u64() -> u64 {
 }
 
 pub fn rand_u64_uniform(max: u64) -> u64 {
-    let chunk_size = u64::max_value() / max;
+    let chunk_size = u64::MAX / max;
     let end_of_last_chunk = chunk_size * max;
 
     let mut r = rand_u64();


### PR DESCRIPTION
Found by recent CI build.