### PR TITLE
Move `extern "C"` below `#include`s in C API header.

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -27,10 +27,6 @@
 #ifndef QUICHE_H
 #define QUICHE_H
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -50,6 +46,10 @@ extern "C" {
 #ifdef _MSC_VER
 #include <BaseTsd.h>
 #define ssize_t SSIZE_T
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
 #endif
 
 // QUIC transport API.


### PR DESCRIPTION
This helps in using Quiche as a dependency in a Swift project.

Basically, the issue is that Swift does not support mixing C and C++ code when using interop, it has to use either C or C++, so if someone already has a C++ dependency in their project, Swift will try to import Quiche as Objective-C++, but this will cause issues due to #includes.

This technically is a shortcoming of Swift, not specifically an issue with Quiche, but the fix is very simple and shouldn't break anything for people using Quiche from C/C++/other languages with interop.