### PR TITLE
Bump rust version to 1.67

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.66 as build
+FROM rust:1.67 as build
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ is disabled by default), by passing ``--features ffi`` to ``cargo``.
 Building
 --------
 
-quiche requires Rust 1.66 or later to build. The latest stable Rust release can
+quiche requires Rust 1.67 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["quic", "http3"]
 categories = ["network-programming"]
 license = "BSD-2-Clause"
-rust-version = "1.66"
+rust-version = "1.67"
 include = [
     "/*.md",
     "/*.toml",


### PR DESCRIPTION
Handling the following error:
```
error: package `serde_with v3.8.2` cannot be built because it requires
rustc 1.67 or newer
```