### PR TITLE
ci: add cargo-machete in the workflow

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -30,6 +30,10 @@ jobs:
           toolchain: ${{ env.RUSTTOOLCHAIN }}
           components: clippy
 
+      - name: Unused dependency check
+        if: ${{ matrix.tls-feature == '' }}
+        uses: bnjbvr/cargo-machete@main
+
       - name: Build OpenSSL
         if: ${{ matrix.tls-feature == 'openssl' }}
         run: |

--- a/qlog/Cargo.toml
+++ b/qlog/Cargo.toml
@@ -13,6 +13,5 @@ license = "BSD-2-Clause"
 [dependencies]
 serde = { version = "1.0.139", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-serde_derive = "1.0"
 serde_with = { version = "3.0.0", default-features = false, features = ["macros"] }
 smallvec = { version = "1.10", features = ["serde"] }

--- a/tools/http3_test/Cargo.toml
+++ b/tools/http3_test/Cargo.toml
@@ -9,13 +9,11 @@ publish = false
 test_resets = []
 
 [dependencies]
-docopt = "1"
 env_logger = "0.10"
 mio = { version = "0.8", features = ["net", "os-poll"] }
 url = "1"
 log = "0.4"
 ring = "0.17"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"
 quiche = { path = "../../quiche"}


### PR DESCRIPTION
Run cargo-machete for unused dependency check, only on
a default ssl target. Also removed unused dependencies 
recommended by an initial run of cargo-machete.