### PR TITLE
Make host:port argument optional

### DIFF
--- a/h3i/src/config.rs
+++ b/h3i/src/config.rs
@@ -32,7 +32,9 @@ use std::io;
 pub struct Config {
     /// A string representing the host and port to connect to using the format
     /// `<host>:<port>`.
-    pub host_port: String,
+    ///
+    /// If value of `host_port` is `None`, the `connect_to` option must be used.
+    pub host_port: Option<String>,
     /// Set a specific IP address to connect to, rather than use DNS resolution.
     pub connect_to: Option<String>,
     /// The source port to use when connecting to a server.
@@ -67,7 +69,7 @@ impl Config {
         Self::default()
     }
 
-    pub fn with_host_port(mut self, host_port: String) -> Self {
+    pub fn with_host_port(mut self, host_port: Option<String>) -> Self {
         self.host_port = host_port;
         self
     }
@@ -137,7 +139,9 @@ impl Config {
     }
 
     pub fn build(self) -> Result<Self, io::Error> {
-        if self.host_port.is_empty() {
+        let no_host_port = self.host_port.is_none() ||
+            self.host_port.as_ref().filter(|s| *s == "").is_some();
+        if no_host_port && self.connect_to.is_none() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Must provide a <host:port> to connect".to_string(),

--- a/h3i/src/main.rs
+++ b/h3i/src/main.rs
@@ -93,14 +93,15 @@ fn config_from_clap() -> std::result::Result<Config, String> {
         .arg(
             Arg::with_name("host:port")
                 .help("Hostname and port of the HTTP/3 server")
-                .required(true)
+                .required(false)
                 .index(1),
         )
         .arg(
             Arg::with_name("connect-to")
                 .long("connect-to")
                 .help("Set a specific IP address to connect to, rather than use DNS resolution")
-                .takes_value(true),
+                .takes_value(true)
+                .required_unless_present("host:port"),
         )
         .arg(
             Arg::with_name("no-verify")
@@ -183,7 +184,7 @@ fn config_from_clap() -> std::result::Result<Config, String> {
         )
         .get_matches();
 
-    let host_port = matches.value_of("host:port").unwrap().to_string();
+    let host_port = matches.value_of("host:port").map(str::to_string);
     let connect_to: Option<String> =
         matches.value_of("connect-to").map(|s| s.to_string());
     let verify_peer = !matches.is_present("no-verify");

--- a/h3i/src/prompts/h3/headers.rs
+++ b/h3i/src/prompts/h3/headers.rs
@@ -47,7 +47,7 @@ use super::STREAM_ID_PROMPT;
 use crate::actions::h3::Action;
 
 pub fn prompt_headers(
-    sid_alloc: &mut StreamIdAllocator, host_port: &str, raw: bool,
+    sid_alloc: &mut StreamIdAllocator, host_port: Option<&String>, raw: bool,
 ) -> InquireResult<Action> {
     let stream_id = Text::new(STREAM_ID_PROMPT)
         .with_placeholder(EMPTY_PICKS)
@@ -114,15 +114,18 @@ pub fn prompt_push_promise() -> InquireResult<Action> {
     Ok(action)
 }
 
-fn pseudo_headers(host_port: &str) -> InquireResult<Vec<quiche::h3::Header>> {
+fn pseudo_headers(
+    host_port: Option<&String>,
+) -> InquireResult<Vec<quiche::h3::Header>> {
     let method = Text::new("method:")
         .with_autocomplete(&method_suggester)
         .with_help_message(ESC_TO_RET)
         .prompt()?;
 
-    let help = format!("Press enter/return for default ({host_port}");
+    let help = format!("Press enter/return for default ({host_port:?}");
     let authority = Text::new("authority:")
-        .with_default(host_port)
+        // unwrap_or prevents `Some()` from showing up when we have a host_port passed
+        .with_default(host_port.unwrap_or(&"N/A".to_string()))
         .with_help_message(&help)
         .prompt()?;
 

--- a/h3i/src/prompts/h3/mod.rs
+++ b/h3i/src/prompts/h3/mod.rs
@@ -112,7 +112,7 @@ enum PromptOutcome {
 
 /// The main prompter interface and state management.
 pub struct Prompter {
-    host_port: String,
+    host_port: Option<String>,
     bidi_sid_alloc: StreamIdAllocator,
     uni_sid_alloc: StreamIdAllocator,
 }
@@ -135,7 +135,7 @@ impl Prompter {
                 let raw = action == HEADERS_NO_PSEUDO;
                 headers::prompt_headers(
                     &mut self.bidi_sid_alloc,
-                    &self.host_port,
+                    self.host_port.as_ref(),
                     raw,
                 )
             },


### PR DESCRIPTION
`host:port` is now optional, though `--connect-to` is required if it's missing to prevent useless no-ops. Tested with:
```shell
cargo run --bin h3i -- --connect-to 127.0.0.1:8081
```

And observing a handshake failure as expected.