### PR TITLE
h3: Avoid unnecessary work on control streams

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -2130,6 +2130,10 @@ impl Connection {
             return Err(Error::ClosedCriticalStream);
         }
 
+        if !conn.stream_readable(stream_id) {
+            return Err(Error::Done);
+        }
+
         match self.process_readable_stream(conn, stream_id, true) {
             Ok(ev) => return Ok(ev),
 


### PR DESCRIPTION
Previously, quiche's poll() function would attempt to do work on control or
QPACK streams, whether they were readable or not. Since we encourage apps to
call poll() after each read loop, this could result in wasted work.

With this change, we'll return early if the stream is not actually readable.
