### PR TITLE
h3i: downgrade http crate to pre-1.0

### DIFF
--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.67"
 [dependencies]
 clap = "3"
 env_logger = "0.6"
-http = "1.1.0"
+http = "0.2"
 inquire = "0.6.2"
 log = { version = "0.4", features = ["std"] }
 mio = { version = "0.8", features = ["net", "os-poll"] }


### PR DESCRIPTION
Not everything has been ported to hyper/http 1.0 yet, so use the old version for now.