### PR TITLE
Ensure peer verification when using apps/client

### DIFF
--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -110,6 +110,7 @@ pub fn connect(
                     e
                 ))
             })?;
+        config.verify_peer(true);
     } else {
         config.verify_peer(!args.no_verify);
     }


### PR DESCRIPTION
The apps/client example doesn't verify peer when the `--trust-origin-ca-pem` is specified.

Before:

```
$ target/debug/quiche-server --name localhost --listen [::1]:4443 --cert certificate.crt --key private.key --index index.html --root $PWD

[...]

$ target/debug/quiche-client https://localhost:4443/ --trust-origin-ca-pem t/certificate.crt # t/certificate.crt is wrong cert
foobar
```

After:

```
$ target/debug/quiche-client https://localhost:4443/ --trust-origin-ca-pem t/certificate.crt
[2024-09-27T22:09:17.019056000Z ERROR quiche_apps::client] [::]:62349: recv failed: TlsFail
[2024-09-27T22:09:17.038019000Z ERROR quiche_apps::client] connection timed out after 22.2585ms

$ target/debug/quiche-client https://localhost:4443/ --trust-origin-ca-pem certificate.crt # correct cert
foobar
```