### PR TITLE
apps: more eagerly attempt to write HTTP response stream data in quiche-server

### DIFF
--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -495,8 +495,9 @@ fn main() {
                 let http_conn = client.http_conn.as_mut().unwrap();
                 let partial_responses = &mut client.partial_responses;
 
-                // Handle writable streams.
-                for stream_id in conn.writable() {
+                // Visit all writable response streams to send any remaining HTTP
+                // content.
+                for stream_id in writable_response_streams(conn) {
                     http_conn.handle_writable(conn, partial_responses, stream_id);
                 }
 


### PR DESCRIPTION
Previously, the quiche-server HTTP/3 poll() loop would preference writing HTTP
response headers for all received requests ahead of any other data. Once
completed, no attempt to use remaining stream capacity was made. This had the
effect of deferring writing HTTP response content until the next time the read
loop was triggered. Especially noticeable when the path had a high RTT.

This change forces an attempt to write on any writable response streams
immediately after all response headers have been flushed.
