### PR TITLE
lib, qlog: Track and Log Unknown Transport Parameters

### DIFF
--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -571,6 +571,14 @@ pub struct TransportParametersSet {
     pub initial_max_streams_uni: Option<u64>,
 
     pub preferred_address: Option<PreferredAddress>,
+
+    pub unknown_parameters: Vec<UnknownTransportParameter>,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct UnknownTransportParameter {
+    pub id: u64,
+    pub value: Bytes,
 }
 
 #[serde_with::skip_serializing_none]


### PR DESCRIPTION
Track (and make available to qlog for logging) transport parameters and their values that this implementation does not specifically recognize.
