### PR TITLE
Reduce amount of SHA-256 operations when deriving keys

### DIFF
--- a/quiche/src/crypto/boringssl.rs
+++ b/quiche/src/crypto/boringssl.rs
@@ -164,15 +164,17 @@ impl PacketKey {
         })
     }
 
-    pub fn from_secret(aead: Algorithm, secret: &[u8], enc: u32) -> Result<Self> {
+    pub fn from_secret_prk(
+        aead: Algorithm, secret_prk: &hkdf::Prk, enc: u32,
+    ) -> Result<Self> {
         let key_len = aead.key_len();
         let nonce_len = aead.nonce_len();
 
         let mut key = vec![0; key_len];
         let mut iv = vec![0; nonce_len];
 
-        derive_pkt_key(aead, secret, &mut key)?;
-        derive_pkt_iv(aead, secret, &mut iv)?;
+        derive_pkt_key(aead, secret_prk, &mut key)?;
+        derive_pkt_iv(aead, secret_prk, &mut iv)?;
 
         Self::new(aead, key, iv, enc)
     }

--- a/quiche/src/crypto/openssl_quictls.rs
+++ b/quiche/src/crypto/openssl_quictls.rs
@@ -312,15 +312,17 @@ impl PacketKey {
         })
     }
 
-    pub fn from_secret(aead: Algorithm, secret: &[u8], enc: u32) -> Result<Self> {
+    pub fn from_secret_prk(
+        aead: Algorithm, secret_prk: &hkdf::Prk, enc: u32,
+    ) -> Result<Self> {
         let key_len = aead.key_len();
         let nonce_len = aead.nonce_len();
 
         let mut key = vec![0; key_len];
         let mut iv = vec![0; nonce_len];
 
-        derive_pkt_key(aead, secret, &mut key)?;
-        derive_pkt_iv(aead, secret, &mut iv)?;
+        derive_pkt_key(aead, secret_prk, &mut key)?;
+        derive_pkt_iv(aead, secret_prk, &mut iv)?;
 
         Self::new(aead, key, iv, enc)
     }

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -1524,7 +1524,7 @@ mod tests {
 
         let alg = crypto::Algorithm::ChaCha20_Poly1305;
 
-        let aead = crypto::Open::from_secret(alg, secret.into()).unwrap();
+        let aead = crypto::Open::from_secret(alg, &secret).unwrap();
 
         let mut hdr = Header::from_bytes(&mut b, 0).unwrap();
         assert_eq!(hdr.ty, Type::Short);
@@ -1892,7 +1892,7 @@ mod tests {
 
         let alg = crypto::Algorithm::ChaCha20_Poly1305;
 
-        let aead = crypto::Seal::from_secret(alg, secret.into()).unwrap();
+        let aead = crypto::Seal::from_secret(alg, &secret).unwrap();
 
         let pn = 654_360_564;
         let pn_len = 3;

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -749,7 +749,7 @@ extern fn set_read_secret(
     if level != crypto::Level::ZeroRTT || ex_data.is_server {
         let secret = unsafe { slice::from_raw_parts(secret, secret_len) };
 
-        let open = match crypto::Open::from_secret(aead, secret.to_vec()) {
+        let open = match crypto::Open::from_secret(aead, secret) {
             Ok(v) => v,
 
             Err(_) => return 0,
@@ -800,7 +800,7 @@ extern fn set_write_secret(
     if level != crypto::Level::ZeroRTT || !ex_data.is_server {
         let secret = unsafe { slice::from_raw_parts(secret, secret_len) };
 
-        let seal = match crypto::Seal::from_secret(aead, secret.to_vec()) {
+        let seal = match crypto::Seal::from_secret(aead, secret) {
             Ok(v) => v,
 
             Err(_) => return 0,


### PR DESCRIPTION
Calling Prk::new_less_safe results in at least 4 rounds of SHA-256.

This change reuses previosly created instances of Prk to reduce cost of key derivation.