### PR TITLE
h3i: add --replay-host-override option

### DIFF
--- a/h3i/src/actions/h3.rs
+++ b/h3i/src/actions/h3.rs
@@ -49,7 +49,7 @@ use crate::encode_header_block;
 /// sequentially. Note that packets will be flushed when said iteration has
 /// completed, regardless of if an [`Action::FlushPackets`] was the terminal
 /// action.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Action {
     /// Send a [quiche::h3::frame::Frame] over a stream.
     SendFrame {


### PR DESCRIPTION
One use case for replaying a recorded session with the h3i CLI is to execture
the same sequence of actions to different target servers. Many servers will
validate that there is a provided "host" or ":authority" header field, and that
it matches the certificate SAN.

This change adds the "--replay-host-override" option that can be used in
combination with the --qlog-input option. It replaces any "host" or ":authority"
header in a HEADERS frame, with the provided value.

note: the diff looks huge but most of what its doing is swapping a From impl to a function so the host_override value can be passed to the correct place