### PR TITLE
h3i: extract connection creation to its own function

### DIFF
--- a/h3i/src/main.rs
+++ b/h3i/src/main.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), ClientError> {
         None => prompt_frames(&config),
     };
 
-    match sync_client(&config, &actions) {
+    match sync_client(config, &actions) {
         Ok(summary) => {
             log::debug!(
                 "received connection_summary: {}",
@@ -296,9 +296,9 @@ fn config_from_clap() -> std::result::Result<Config, String> {
 }
 
 fn sync_client(
-    config: &Config, actions: &[Action],
+    config: Config, actions: &[Action],
 ) -> Result<ConnectionSummary, ClientError> {
-    h3i::client::sync_client::connect(&config.library_config, actions)
+    h3i::client::sync_client::connect(config.library_config, actions)
 }
 
 fn read_qlog(filename: &str, host_override: Option<&str>) -> Vec<Action> {


### PR DESCRIPTION
Most of the diff is just copy-pasting the function from one place to another. This will deduplicate a bunch of code between the sync and async versions