### PR TITLE
h3i: make Client a trait object

### DIFF
--- a/h3i/examples/content_length_mismatch.rs
+++ b/h3i/examples/content_length_mismatch.rs
@@ -18,7 +18,7 @@ const STREAM_ID: u64 = 0;
 /// blog.cloudflare.com.
 fn main() {
     let config = Config::new()
-        .with_host_port("blog.cloudflare.com".to_string())
+        .with_host_port("cloudflare-quic.com".to_string())
         .with_idle_timeout(2000)
         .build()
         .unwrap();
@@ -26,7 +26,7 @@ fn main() {
     let headers = vec![
         Header::new(b":method", b"POST"),
         Header::new(b":scheme", b"https"),
-        Header::new(b":authority", b"blog.cloudflare.com"),
+        Header::new(b":authority", b"cloudflare-quic.com"),
         Header::new(b":path", b"/"),
         // We say that we're going to send a body with 5 bytes...
         Header::new(b"content-length", b"5"),

--- a/h3i/src/client/connection_summary.rs
+++ b/h3i/src/client/connection_summary.rs
@@ -77,8 +77,8 @@ impl Serialize for ConnectionSummary {
     }
 }
 
-/// An aggregation of frames received over a connection, mapped to the stream ID
-/// over which they were received.
+/// A read-only aggregation of frames received over a connection, mapped to the
+/// stream ID over which they were received.
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct StreamMap(HashMap<u64, Vec<H3iFrame>>);
 

--- a/h3i/src/client/sync_client.rs
+++ b/h3i/src/client/sync_client.rs
@@ -53,7 +53,7 @@ use super::StreamParserMap;
 
 #[derive(Default)]
 struct SyncClient {
-    stream_map: StreamMap,
+    streams: StreamMap,
     stream_parsers: StreamParserMap,
 }
 
@@ -63,7 +63,7 @@ impl Client for SyncClient {
     }
 
     fn handle_response_frame(&mut self, stream_id: u64, frame: H3iFrame) {
-        self.stream_map.insert(stream_id, frame);
+        self.streams.insert(stream_id, frame);
     }
 }
 
@@ -371,7 +371,7 @@ pub fn connect(
     }
 
     Ok(ConnectionSummary {
-        stream_map: client.stream_map,
+        stream_map: client.streams,
         stats: Some(conn.stats()),
         path_stats: conn.path_stats().collect(),
         conn_close_details: ConnectionCloseDetails::new(&conn),


### PR DESCRIPTION
We originally had plans to completely deprecate the sync client once the async one was finished, but we've since found a use for the sync client.

This gets rid of the ugly hacks we originally implemented to speed up development by converting all sync/async conditional compilation into a trait object. This means that we can simply implement the Client trait for the async client

- [x] Test with internal services