### PR TITLE
h3i: implement close trigger frames

### DIFF
--- a/h3i/examples/content_length_mismatch.rs
+++ b/h3i/examples/content_length_mismatch.rs
@@ -66,8 +66,12 @@ fn main() {
         },
     ];
 
-    let summary =
-        sync_client::connect(config, &actions).expect("connection failed");
+    // This example doesn't use close trigger frames, since we manually close the
+    // connection upon receiving a HEADERS frame on stream 0.
+    let close_trigger_frames = None;
+
+    let summary = sync_client::connect(config, &actions, close_trigger_frames)
+        .expect("connection failed");
 
     println!(
         "=== received connection summary! ===\n\n{}",

--- a/h3i/src/client/mod.rs
+++ b/h3i/src/client/mod.rs
@@ -56,6 +56,7 @@ use qlog::events::h3::H3FrameParsed;
 use qlog::events::h3::Http3Frame;
 use qlog::events::EventData;
 use qlog::streamer::QlogStreamer;
+use serde::Serialize;
 
 use quiche::h3::frame::Frame as QFrame;
 use quiche::h3::Error;
@@ -160,7 +161,7 @@ fn handle_qlog(
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 /// Represents different errors that can occur when [sync_client] runs.
 pub enum ClientError {
     /// An error during the QUIC handshake.

--- a/h3i/src/config.rs
+++ b/h3i/src/config.rs
@@ -28,6 +28,7 @@
 use std::io;
 
 /// Server details and QUIC connection properties.
+#[derive(Clone)]
 pub struct Config {
     /// A string representing the host and port to connect to using the format
     /// `<host>:<port>`.

--- a/h3i/src/lib.rs
+++ b/h3i/src/lib.rs
@@ -111,8 +111,10 @@
 //!        },
 //!    ];
 //!
-//!    let summary =
-//!        sync_client::connect(config, &actions).expect("connection failed");
+//!    // This example doesn't use close trigger frames, since we manually close the connection upon
+//!    // receiving a HEADERS frame on stream 0.
+//!    let close_trigger_frames = None;
+//!    let summary = sync_client::connect(config, &actions, close_trigger_frames);
 //!
 //!    println!(
 //!        "=== received connection summary! ===\n\n{}",

--- a/h3i/src/main.rs
+++ b/h3i/src/main.rs
@@ -298,7 +298,8 @@ fn config_from_clap() -> std::result::Result<Config, String> {
 fn sync_client(
     config: Config, actions: &[Action],
 ) -> Result<ConnectionSummary, ClientError> {
-    h3i::client::sync_client::connect(config.library_config, actions)
+    // TODO: CLI/qlog don't support passing close trigger frames at the moment
+    h3i::client::sync_client::connect(config.library_config, actions, None)
 }
 
 fn read_qlog(filename: &str, host_override: Option<&str>) -> Vec<Action> {


### PR DESCRIPTION
- [x] Squash commits

Close trigger frames allow the user to specify a list of frames that the h3i client expects to receive over a given connection.

If h3i sees all of the close trigger frames over the course of the connection, it will pre-emptively close the connection with a CONNECTION_CLOSE frame. If h3i does _not_ see all of the trigger frames, the resulting ConnectionSummary will contain a list of the missing target frames for future inspection.

This gives users a way to close tests out without waiting for the idle timeout, or adding Wait/ConnectionClose actions to the end of each test. This should vastly speed up test suites that have a large number of h3i tests.

In the absence of full-fledged integration tests, I modified the `content_length_mismatch` example to expect a `400`, and remove the existing `Wait/CC` actions:
```
-        Action::Wait {
-            wait_type: WaitType::StreamEvent(StreamEvent {
-                stream_id: STREAM_ID,
-                event_type: StreamEventType::Headers,
-            }),
-        },
-        Action::ConnectionClose {
-            error: quiche::ConnectionError {
-                is_app: true,
-                error_code: quiche::h3::WireErrorCode::NoError as u64,
-                reason: vec![],
-            },
-        },
     ];
 
-    let summary =
-        sync_client::connect(config, &actions, None).expect("connection failed");
+    let summary = sync_client::connect(
+        config,
+        &actions,
+        Some(vec![ExpectedFrame::new(
+            0,
+            vec![quiche::h3::Header::new(b":status", b"400")].into(),
+        )]),
+    )
+    .expect("connection failed");
```

Taking a PCAP:
<img width="1512" alt="Screenshot 2024-12-19 at 10 27 50 AM" src="https://github.com/user-attachments/assets/595f0a76-c743-4388-8278-534d140cbfeb" />


You can see that the client instantly sends the CC frame upon receiving the headers frame, without us needing to specify the action.
