### PR TITLE
ci: disable cargo package builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Run cargo doc test
         run: cargo test --verbose --doc --features=ffi,qlog
 
-      - name: Run cargo package
-        run: cargo package --verbose --workspace --exclude=quiche_apps --allow-dirty
+      # NOTE: this is disabled as it fails when building changes that bump
+      # version of local crates (e.g. when doing a `qlog` release) that have not
+      # been published yet, and we couldn't find a workaround.
+      #
+      # - name: Run cargo package
+      #   run: cargo package --verbose --workspace --exclude=quiche_apps --allow-dirty
 
       - name: Run cargo doc
         run: cargo doc --no-deps --all-features --document-private-items

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -49,8 +49,12 @@ jobs:
       - name: Run cargo doc test
         run: cargo test --verbose --doc --features=ffi,qlog,${{ matrix.tls-feature }}
 
-      - name: Run cargo package
-        run: cargo package --verbose --workspace --exclude=quiche_apps --allow-dirty
+      # NOTE: this is disabled as it fails when building changes that bump
+      # version of local crates (e.g. when doing a `qlog` release) that have not
+      # been published yet, and we couldn't find a workaround.
+      #
+      # - name: Run cargo package
+      #   run: cargo package --verbose --workspace --exclude=quiche_apps --allow-dirty
 
       - name: Run cargo clippy
         run: cargo clippy --features=ffi,qlog,${{ matrix.tls-feature }} -- -D warnings

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.67 as build
+FROM rust:1.70 as build
 
 WORKDIR /build
 

--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -19,7 +19,7 @@ log = { version = "0.4", features = ["std"] }
 mio = { version = "0.8", features = ["net", "os-poll"] }
 multimap = "0.10"
 octets = { version = "0.3", path = "../octets"}
-qlog = { version = "0.13.0", path = "../qlog" }
+qlog = { version = "0.14", path = "../qlog" }
 quiche = { version = "0.22", path = "../quiche", features = ["internal", "qlog"] }
 rand = "0.8.5"
 smallvec = "1.11.2"

--- a/qlog/Cargo.toml
+++ b/qlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qlog"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Lucas Pardue <lucaspardue.24.7@gmail.com>"]
 edition = "2018"
 description = "qlog data model for QUIC and HTTP/3"

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -73,7 +73,7 @@ octets = { version = "0.3", path = "../octets" }
 boring = { version = "4", optional = true }
 foreign-types-shared = { version = "0.3.0", optional = true }
 intrusive-collections = "0.9.5"
-qlog = { version = "0.13", path = "../qlog", optional = true }
+qlog = { version = "0.14", path = "../qlog", optional = true }
 sfv = { version = "0.9", optional = true }
 smallvec = { version = "1.10", features = ["serde", "union"] }
 

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["quic", "http3"]
 categories = ["network-programming"]
 license = "BSD-2-Clause"
-rust-version = "1.67"
+rust-version = "1.70"
 include = [
     "/*.md",
     "/*.toml",


### PR DESCRIPTION
Per the comments, when doing a qlog release we end up in a situation where quiche or h3i might be updated to a new qlog version in the same PR as the qlog version bump itself, which requires the qlog release to be published before the PR is merged (and _not_ bumping the version would break other builds that use the `path = ../qlog` as dependency).

Also includes https://github.com/cloudflare/quiche/pull/1885 to test, and bumps MSRV to 1.70 to fix builds.