### PR TITLE
crypto: replace ring constant-time comparison API

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2367,7 +2367,8 @@ impl Connection {
         match self.peer_transport_params.stateless_reset_token {
             Some(token) => {
                 let token_len = 16;
-                ring::constant_time::verify_slices_are_equal(
+
+                crypto::verify_slices_are_equal(
                     &token.to_be_bytes(),
                     &buf[buf_len - token_len..buf_len],
                 )

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -778,13 +778,10 @@ pub fn verify_retry_integrity(
 ) -> Result<()> {
     let tag = compute_retry_integrity_tag(b, odcid, version)?;
 
-    ring::constant_time::verify_slices_are_equal(
+    crypto::verify_slices_are_equal(
         &b.as_ref()[..aead::AES_128_GCM.tag_len()],
         tag.as_ref(),
     )
-    .map_err(|_| Error::CryptoFail)?;
-
-    Ok(())
 }
 
 fn compute_retry_integrity_tag(


### PR DESCRIPTION
Both BoringCrypto and OpenSSL provide `CRYPTO_memcmp()` for constant-time comparisons, so there's no point in pulling a whole dependency just for that.