### PR TITLE
crypto: replace ring AEAD API for header protection

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -66,7 +66,6 @@ either = { version = "1.8", default-features = false }
 log = { version = "0.4", features = ["std"] }
 libc = "0.2"
 libm = "0.2"
-ring = "0.17"
 slab = "0.4"
 once_cell = "1"
 octets = { version = "0.3", path = "../octets" }
@@ -82,6 +81,7 @@ windows-sys = { version = "0.59", features = ["Win32_Networking_WinSock", "Win32
 
 [dev-dependencies]
 mio = { version = "0.8", features = ["net", "os-poll"] }
+ring = "0.17"
 url = "2.5"
 
 [lib]


### PR DESCRIPTION
This is currently only used for generating header protection masks, which, again, doesn't seem like something worth pulling a whole dependency for. This may or may not fall under FIPS scope.

Note that the ring dependency itself is still needed to build examples, but it can be downgraded to `dev-dependencies`.