### PR TITLE
disable 'serde' feature for smallvec

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -75,7 +75,7 @@ foreign-types-shared = { version = "0.3.0", optional = true }
 intrusive-collections = "0.9.5"
 qlog = { version = "0.14", path = "../qlog", optional = true }
 sfv = { version = "0.9", optional = true }
-smallvec = { version = "1.10", features = ["serde", "union"] }
+smallvec = { version = "1.10", features = ["union"] }
 
 [target."cfg(windows)".dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Networking_WinSock", "Win32_Security_Cryptography"] }


### PR DESCRIPTION
This doesn't seem to be necessary, and was probably a copy-pasta from qlog since that one does require the feature to be enabled.