### PR TITLE
ffi: make `quiche_conn_path_event_next` return `mut` pointer (fix #1905)

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -797,36 +797,36 @@ enum quiche_path_event_type {
 typedef struct quiche_path_event quiche_path_event;
 
 // Retrieves the next event. Returns NULL if there is no event to process.
-const quiche_path_event *quiche_conn_path_event_next(quiche_conn *conn);
+quiche_path_event *quiche_conn_path_event_next(quiche_conn *conn);
 
 // Returns the type of the event.
-enum quiche_path_event_type quiche_path_event_type(quiche_path_event *ev);
+enum quiche_path_event_type quiche_path_event_type(const quiche_path_event *ev);
 
 // Should be called if the quiche_path_event_type(...) returns QUICHE_PATH_EVENT_NEW.
-void quiche_path_event_new(quiche_path_event *ev,
+void quiche_path_event_new(const quiche_path_event *ev,
                            struct sockaddr_storage *local, socklen_t *local_len, struct sockaddr_storage *peer, socklen_t *peer_len);
 
 // Should be called if the quiche_path_event_type(...) returns QUICHE_PATH_EVENT_VALIDATED.
-void quiche_path_event_validated(quiche_path_event *ev,
+void quiche_path_event_validated(const quiche_path_event *ev,
                            struct sockaddr_storage *local, socklen_t *local_len, struct sockaddr_storage *peer, socklen_t *peer_len);
 
 // Should be called if the quiche_path_event_type(...) returns QUICHE_PATH_EVENT_FAILED_VALIDATION.
-void quiche_path_event_failed_validation(quiche_path_event *ev,
+void quiche_path_event_failed_validation(const quiche_path_event *ev,
                            struct sockaddr_storage *local, socklen_t *local_len, struct sockaddr_storage *peer, socklen_t *peer_len);
 
 // Should be called if the quiche_path_event_type(...) returns QUICHE_PATH_EVENT_CLOSED.
-void quiche_path_event_closed(quiche_path_event *ev,
+void quiche_path_event_closed(const quiche_path_event *ev,
                            struct sockaddr_storage *local, socklen_t *local_len, struct sockaddr_storage *peer, socklen_t *peer_len);
 
 // Should be called if the quiche_path_event_type(...) returns QUICHE_PATH_EVENT_REUSED_SOURCE_CONNECTION_ID.
-void quiche_path_event_reused_source_connection_id(quiche_path_event *ev, uint64_t *id,
+void quiche_path_event_reused_source_connection_id(const quiche_path_event *ev, uint64_t *id,
                            struct sockaddr_storage *old_local, socklen_t *old_local_len,
                            struct sockaddr_storage *old_peer, socklen_t *old_peer_len,
                            struct sockaddr_storage *local, socklen_t *local_len,
                            struct sockaddr_storage *peer, socklen_t *peer_len);
 
 // Should be called if the quiche_path_event_type(...) returns QUICHE_PATH_EVENT_PEER_MIGRATED.
-void quiche_path_event_peer_migrated(quiche_path_event *ev,
+void quiche_path_event_peer_migrated(const quiche_path_event *ev,
                            struct sockaddr_storage *local, socklen_t *local_len,
                            struct sockaddr_storage *peer, socklen_t *peer_len);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1670,10 +1670,10 @@ pub extern fn quiche_conn_migrate(
 #[no_mangle]
 pub extern fn quiche_conn_path_event_next(
     conn: &mut Connection,
-) -> *const PathEvent {
+) -> *mut PathEvent {
     match conn.path_event_next() {
         Some(v) => Box::into_raw(Box::new(v)),
-        None => ptr::null(),
+        None => ptr::null_mut(),
     }
 }
 


### PR DESCRIPTION
Changes `quiche_conn_path_event_next` so that it returns a mutable pointer on both the C and Rust side. This fixes issue #1905.
Also added `const` to the `quiche_path_event*` parameters in the following functions from  `quiche.h` in order to match their mutability in `ffi.rs`:
- `quiche_path_event_type`
- `quiche_path_event_new`
- `quiche_path_event_validated`
- `quiche_path_event_failed_validation`
- `quiche_path_event_closed`
- `quiche_path_event_reused_source_connection_id`
- `quiche_path_event_peer_migrated`