### PR TITLE
ffi: quiche_conn_close and quiche_conn_stream_send check for null pointers (fix #1914)

### DIFF
--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -880,7 +880,12 @@ pub extern "C" fn quiche_conn_stream_send(
         panic!("The provided buffer is too large");
     }
 
-    let buf = unsafe { slice::from_raw_parts(buf, buf_len) };
+    let buf = if buf.is_null() {
+        assert_eq!(buf_len, 0);
+        &[]
+    } else {
+        unsafe { slice::from_raw_parts(buf, buf_len) }
+    };
 
     match conn.stream_send(stream_id, buf, fin) {
         Ok(v) => v as ssize_t,
@@ -993,7 +998,12 @@ pub extern "C" fn quiche_conn_close(
     conn: &mut Connection, app: bool, err: u64, reason: *const u8,
     reason_len: size_t,
 ) -> c_int {
-    let reason = unsafe { slice::from_raw_parts(reason, reason_len) };
+    let reason = if reason.is_null() {
+        assert_eq!(reason_len, 0);
+        &[]
+    } else {
+        unsafe { slice::from_raw_parts(reason, reason_len) }
+    };
 
     match conn.close(app, err, reason) {
         Ok(_) => 0,


### PR DESCRIPTION
Functions `quiche_conn_close` and `quiche_conn_stream_send` now check to make sure the passed pointers are not null before creating a slice with them. If they are null, `&[]` is used instead. Length must be 0 when the buffer is null, of course.

- Fixes issue #1914.
- Allows passing null to `quiche_conn_stream_send` for convenience to trigger FIN STREAM.