### PR TITLE
replace once_cell with LazyLock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70 as build
+FROM rust:1.80 as build
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ is disabled by default), by passing ``--features ffi`` to ``cargo``.
 Building
 --------
 
-quiche requires Rust 1.70 or later to build. The latest stable Rust release can
+quiche requires Rust 1.80 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["quic", "http3"]
 categories = ["network-programming"]
 license = "BSD-2-Clause"
-rust-version = "1.70"
+rust-version = "1.80"
 include = [
     "/*.md",
     "/*.toml",
@@ -67,7 +67,6 @@ log = { version = "0.4", features = ["std"] }
 libc = "0.2"
 libm = "0.2"
 slab = "0.4"
-once_cell = "1"
 octets = { version = "0.3", path = "../octets" }
 boring = { version = "4", optional = true }
 foreign-types-shared = { version = "0.3.0", optional = true }

--- a/quiche/src/recovery/congestion/prr.rs
+++ b/quiche/src/recovery/congestion/prr.rs
@@ -73,8 +73,8 @@ impl PRR {
         self.snd_cnt = if pipe > ssthresh {
             // Proportional Rate Reduction.
             if self.recoverfs > 0 {
-                ((self.prr_delivered * ssthresh + self.recoverfs - 1) /
-                    self.recoverfs)
+                (self.prr_delivered * ssthresh)
+                    .div_ceil(self.recoverfs)
                     .saturating_sub(self.prr_out)
             } else {
                 0

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -30,7 +30,7 @@ use std::slice;
 
 use std::io::Write;
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 use libc::c_char;
 use libc::c_int;
@@ -123,9 +123,7 @@ enum ssl_private_key_result_t {
 }
 
 /// BoringSSL ex_data index for quiche connections.
-///
-/// TODO: replace with `std::sync::LazyLock` when stable.
-pub static QUICHE_EX_DATA_INDEX: Lazy<c_int> = Lazy::new(|| unsafe {
+pub static QUICHE_EX_DATA_INDEX: LazyLock<c_int> = LazyLock::new(|| unsafe {
     SSL_get_ex_new_index(0, ptr::null(), ptr::null(), ptr::null(), ptr::null())
 });
 


### PR DESCRIPTION
We can drop the once_cell dependency since the same functionality is implemented in std now.

Requires bumping MSRV to 1.80.