### PR TITLE
crypto/boringssl: do dummy seal on key update too

### DIFF
--- a/quiche/src/crypto/mod.rs
+++ b/quiche/src/crypto/mod.rs
@@ -235,7 +235,7 @@ impl Seal {
     }
 
     pub fn from_secret(aead: Algorithm, secret: &[u8]) -> Result<Seal> {
-        let seal = Seal {
+        Ok(Seal {
             alg: aead,
 
             secret: secret.to_vec(),
@@ -243,17 +243,7 @@ impl Seal {
             header: HeaderProtectionKey::from_secret(aead, secret)?,
 
             packet: PacketKey::from_secret(aead, secret, Self::ENCRYPT)?,
-        };
-
-        // Dummy seal operation to prime the AEAD context with the nonce mask.
-        //
-        // This is needed because BoringCrypto requires the first counter (i.e.
-        // packet number) to be zero, which would not be the case for packet
-        // number spaces after Initial as the same packet number sequence is
-        // shared.
-        let _ = seal.seal_with_u64_counter(0, b"", &mut [0_u8; 16], 0, None);
-
-        Ok(seal)
+        })
     }
 
     pub fn new_mask(&self, sample: &[u8]) -> Result<[u8; 5]> {


### PR DESCRIPTION
Follow-up to b17904e522777746b2a6b12667d85283e1df368c.

Currently the dummy seal operation done to prime the AEAD context is done in `Seal::from_secret()`, but really it needs to be done as part of `PacketKey::from_secret()` to make sure every code path is covered, including the key update one which doesn't call `Seal::from_secret()`.

It's not entirely clear why, but the problem (i.e. seal operation fail when trying to encrypt a packet) seems to only appear after several packets have already been encrypted with the new key, which is why this wasn't caught by the existing key update test.

To cover that, the test is expanded by making the server send additional packets which from local testing seems to trigger the issue.