### PR TITLE
introduce tx_cap factor

### DIFF
--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -695,6 +695,8 @@ pub struct ExData<'a> {
 
     pub recovery_config: crate::recovery::RecoveryConfig,
 
+    pub tx_cap_factor: f64,
+
     pub is_server: bool,
 }
 


### PR DESCRIPTION
Currently we buffer outgoing data up to `min(cwnd, flow_control)`, but this can be lead to starving a connection while waiting for additional data from the application.

This change adds a configuration option to change the send capacity "factor", that is multiplied to the existing send capacity calculation (so e.g. instead of `min(cwnd, flow_control)` once could change that to `2 * min(cwnd, flow_control)`).

Making this configurable rather than a fixed value lets application experiment with different values depending on their needs.