### PR TITLE
WIP: gracefully handle Initial+Handshake packets after dropping Initial epoch

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2708,6 +2708,17 @@ impl Connection {
                     return Ok(pkt_len);
                 }
 
+                // A datagram with Initial+Handshake coalesced packets might be
+                // received after the Initial epoch has already been dropped.
+                //
+                // To avoid rejecting the Handshake packet (due to the Initial
+                // being undecryptable), simply skip over the Initial packet and
+                // continue processing the rest of the datagram.
+                if hdr.ty == packet::Type::Initial {
+                    let pkt_len = b.off() + payload_len;
+                    return Ok(pkt_len);
+                }
+
                 let e = drop_pkt_on_err(
                     Error::CryptoFail,
                     self.recv_count,


### PR DESCRIPTION
When datagram with Initial+Handshake coalesced packets is received after the Initial epoch has already been dropped, we would drop the entire datagram, causing the peer to resend the Handshake packet.

Instead we should just skip over the Initial packet and continue processing the datagram.

Closes #1834.

---

TODO:
* [ ] Make test?