### PR TITLE
crypto/boringssl: don't overwrite mask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY quiche/ ./quiche/
 
 RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 
-RUN cargo build --manifest-path apps/Cargo.toml
+RUN cargo build --release --manifest-path apps/Cargo.toml
 
 ##
 ## quiche-base: quiche image for apps
@@ -20,8 +20,8 @@ RUN apt-get update && apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=build \
-     /build/apps/target/debug/quiche-client \
-     /build/apps/target/debug/quiche-server \
+     /build/apps/target/release/quiche-client \
+     /build/apps/target/release/quiche-server \
      /usr/local/bin/
 
 ENV PATH="/usr/local/bin/:${PATH}"
@@ -39,8 +39,8 @@ WORKDIR /quiche
 RUN apt-get update && apt-get install -y wait-for-it && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build \
-     /build/apps/target/debug/quiche-client \
-     /build/apps/target/debug/quiche-server \
+     /build/apps/target/release/quiche-client \
+     /build/apps/target/release/quiche-server \
      /build/apps/run_endpoint.sh \
      ./
 

--- a/quiche/src/crypto/mod.rs
+++ b/quiche/src/crypto/mod.rs
@@ -35,6 +35,9 @@ use crate::packet;
 // All the AEAD algorithms we support use 96-bit nonces.
 pub const MAX_NONCE_LEN: usize = 12;
 
+// Length of header protection mask.
+pub const HP_MASK_LEN: usize = 5;
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Level {
@@ -119,6 +122,8 @@ pub struct EVP_AEAD {
 struct EVP_MD {
     _unused: c_void,
 }
+
+type HeaderProtectionMask = [u8; HP_MASK_LEN];
 
 pub struct Open {
     alg: Algorithm,

--- a/quiche/src/crypto/openssl_quictls.rs
+++ b/quiche/src/crypto/openssl_quictls.rs
@@ -316,10 +316,10 @@ impl HeaderProtectionKey {
         })
     }
 
-    pub fn new_mask(&self, sample: &[u8]) -> Result<[u8; 5]> {
+    pub fn new_mask(&self, sample: &[u8]) -> Result<HeaderProtectionMask> {
         const PLAINTEXT: &[u8; 5] = &[0_u8; 5];
 
-        let mut new_mask = [0_u8; 5];
+        let mut new_mask = HeaderProtectionMask::default();
 
         // Set IV (i.e. the sample).
         let rc = unsafe {


### PR DESCRIPTION
`AES_ecb_encrypt()` will always write 16 bytes (an AES block length), but the new header protection code was passing in only 5 bytes... fun ensued.

This also refactors the header protection methods somewhat to not hard-code the mask length all over the place.

Closes #1924.