### PR TITLE
h3i: Improve ConnectionSummary stream_map serialization

### DIFF
--- a/h3i/src/client/connection_summary.rs
+++ b/h3i/src/client/connection_summary.rs
@@ -49,6 +49,12 @@ pub const MAX_SERIALIZED_BUFFER_LEN: usize = 16384;
 /// A summary of all frames received on a connection. There are some extra
 /// fields included to provide additional context into the connection's
 /// behavior.
+///
+/// ConnectionSummary implements [Serialize]. HTTP/3 frames that contain binary
+/// payload are serialized using the qlog
+/// [hexstring](https://www.ietf.org/archive/id/draft-ietf-quic-qlog-main-schema-10.html#section-1.2)
+/// format - "an even-length lowercase string of hexadecimally encoded bytes
+/// examples: 82dc, 027339, 4cdbfd9bf0"
 #[derive(Default, Debug)]
 pub struct ConnectionSummary {
     pub stream_map: StreamMap,

--- a/h3i/src/frame.rs
+++ b/h3i/src/frame.rs
@@ -304,8 +304,13 @@ impl Serialize for SerializableQFrame<'_> {
         let name = frame_name(self.0);
         match self.0 {
             QFrame::Data { payload } => {
-                let mut state = s.serialize_struct(name, 1)?;
+                let mut state = s.serialize_struct(name, 2)?;
+                let max = cmp::min(payload.len(), MAX_SERIALIZED_BUFFER_LEN);
                 state.serialize_field("payload_len", &payload.len())?;
+                state.serialize_field(
+                    "payload",
+                    &qlog::HexSlice::maybe_string(Some(&payload[..max])),
+                )?;
                 state.end()
             },
 
@@ -382,7 +387,7 @@ impl Serialize for SerializableQFrame<'_> {
                 prioritized_element_id,
                 priority_field_value,
             } => {
-                let mut state = s.serialize_struct(name, 2)?;
+                let mut state = s.serialize_struct(name, 3)?;
                 state.serialize_field(
                     "prioritized_element_id",
                     &prioritized_element_id,
@@ -392,6 +397,10 @@ impl Serialize for SerializableQFrame<'_> {
                     priority_field_value.len(),
                     MAX_SERIALIZED_BUFFER_LEN,
                 );
+                state.serialize_field(
+                    "priority_field_value_len",
+                    &priority_field_value.len(),
+                )?;
                 state.serialize_field(
                     "priority_field_value",
                     &String::from_utf8_lossy(&priority_field_value[..max]),
@@ -403,7 +412,7 @@ impl Serialize for SerializableQFrame<'_> {
                 prioritized_element_id,
                 priority_field_value,
             } => {
-                let mut state = s.serialize_struct(name, 1)?;
+                let mut state = s.serialize_struct(name, 3)?;
                 state.serialize_field(
                     "prioritized_element_id",
                     &prioritized_element_id,
@@ -413,6 +422,10 @@ impl Serialize for SerializableQFrame<'_> {
                     MAX_SERIALIZED_BUFFER_LEN,
                 );
                 state.serialize_field(
+                    "priority_field_value_len",
+                    &priority_field_value.len(),
+                )?;
+                state.serialize_field(
                     "priority_field_value",
                     &String::from_utf8_lossy(&priority_field_value[..max]),
                 )?;
@@ -420,10 +433,10 @@ impl Serialize for SerializableQFrame<'_> {
             },
 
             QFrame::Unknown { raw_type, payload } => {
-                let mut state = s.serialize_struct(name, 1)?;
+                let mut state = s.serialize_struct(name, 3)?;
                 state.serialize_field("raw_type", &raw_type)?;
                 let max = cmp::min(payload.len(), MAX_SERIALIZED_BUFFER_LEN);
-
+                state.serialize_field("payload_len", &payload.len())?;
                 state.serialize_field(
                     "payload",
                     &qlog::HexSlice::maybe_string(Some(&payload[..max])),


### PR DESCRIPTION
The ConnectionSummary can be serialized to help other tooling consume
the output of h3i. Previously we didn't support the seralization of
DATA frame payloads. Furthermore, we were a bit inconsistent with how
we serialize frames with binary payloads.

This change adds support for logging DATA frame payloads and ensures
that all frames consistently have a `_len` field to indicate the true
length of the frame. Documentation has been added with a pointer to
the hexstring qlog definition that we use here.

Closes #1917
