### PR TITLE
apps: log both source and destination addresses

### DIFF
--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -226,7 +226,7 @@ fn main() {
                 },
             };
 
-            trace!("got {} bytes", len);
+            trace!("got {len} bytes from {from} to {local_addr}");
 
             let pkt_buf = &mut buf[..len];
 
@@ -609,7 +609,10 @@ fn main() {
                 panic!("send_to() failed: {:?}", e);
             }
 
-            trace!("{} written {} bytes", client.conn.trace_id(), total_write);
+            trace!(
+                "{} written {total_write} bytes with {dst_info:?}",
+                client.conn.trace_id()
+            );
 
             if total_write >= max_send_burst {
                 trace!("{} pause writing", client.conn.trace_id(),);

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -299,7 +299,7 @@ pub fn connect(
                     },
                 };
 
-                trace!("{}: got {} bytes", local_addr, len);
+                trace!("got {len} bytes from {from} to {local_addr}");
 
                 if let Some(target_path) = conn_args.dump_packet_path.as_ref() {
                     let path = format!("{target_path}/{pkt_count}.pkt");
@@ -553,10 +553,8 @@ pub fn connect(
                     }
 
                     trace!(
-                        "{} -> {}: written {}",
-                        local_addr,
-                        send_info.to,
-                        write
+                        "written {write} bytes from {local_addr} to {}",
+                        send_info.to
                     );
                 }
             }


### PR DESCRIPTION
This can be useful to debug address rebinding problems.