### PR TITLE
qns: increase active CIDs limit for interop

### DIFF
--- a/apps/run_endpoint.sh
+++ b/apps/run_endpoint.sh
@@ -14,9 +14,9 @@ WWW_DIR=/www
 DOWNLOAD_DIR=/downloads
 QUICHE_CLIENT=quiche-client
 QUICHE_SERVER=quiche-server
-QUICHE_CLIENT_OPT="--no-verify --dump-responses ${DOWNLOAD_DIR} --wire-version 00000001"
+QUICHE_CLIENT_OPT="--no-verify --dump-responses ${DOWNLOAD_DIR} --wire-version 1 --max-active-cids 8"
 # interop container has tso off. need to disable gso as well.
-QUICHE_SERVER_OPT_COMMON="--listen [::]:443 --root $WWW_DIR --cert /certs/cert.pem --key /certs/priv.key --disable-gso --disable-pacing"
+QUICHE_SERVER_OPT_COMMON="--listen [::]:443 --root $WWW_DIR --cert /certs/cert.pem --key /certs/priv.key --max-active-cids 8 --disable-gso --disable-pacing"
 QUICHE_SERVER_OPT="$QUICHE_SERVER_OPT_COMMON --no-retry "
 LOG_DIR=/logs
 LOG=$LOG_DIR/log.txt


### PR DESCRIPTION
Currently the max active CIDs limit controls both the number of active CIDs as well as the number of active paths, so while during rebinding tests the CIDs don't change, we are still prevented from creating new paths because of the limit, causing the interop rebinding tests to fail.