### PR TITLE
ci: add ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -12,13 +12,14 @@ concurrency:
 
 jobs:
   quiche:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         tls-feature:
           - "" # default, boringssl-vendored
           - "boringssl-boring-crate"
           - "openssl"
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
     # Only run on "pull_request" event for external PRs. This is to avoid
     # duplicate builds for PRs created from internal branches.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
Ubuntu ARM runner is available now: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/