### PR TITLE
chore: use qlog PacketSent default inside quiche

### DIFF
--- a/h3i/src/client/mod.rs
+++ b/h3i/src/client/mod.rs
@@ -152,9 +152,8 @@ fn handle_qlog(
     if let Some(s) = qlog_streamer {
         let ev_data = EventData::H3FrameParsed(H3FrameParsed {
             stream_id,
-            length: None,
             frame: qlog_frame,
-            raw: None,
+            ..Default::default()
         });
 
         s.add_event_data_now(ev_data).ok();

--- a/h3i/src/lib.rs
+++ b/h3i/src/lib.rs
@@ -236,15 +236,8 @@ fn fake_packet_header() -> PacketHeader {
 fn fake_packet_sent(frames: Option<SmallVec<[QuicFrame; 1]>>) -> EventData {
     EventData::PacketSent(PacketSent {
         header: fake_packet_header(),
-        is_coalesced: None,
-        retry_token: None,
-        stateless_reset_token: None,
-        supported_versions: None,
-        raw: None,
-        datagram_id: None,
-        trigger: None,
-        send_at_time: None,
         frames,
+        ..Default::default()
     })
 }
 

--- a/h3i/src/recordreplay/qlog.rs
+++ b/h3i/src/recordreplay/qlog.rs
@@ -88,9 +88,8 @@ impl From<&Action> for QlogEvents {
             } => {
                 let frame_ev = EventData::H3FrameCreated(H3FrameCreated {
                     stream_id: *stream_id,
-                    length: None,
                     frame: frame.to_qlog(),
-                    raw: None,
+                    ..Default::default()
                 });
 
                 let mut ex = BTreeMap::new();
@@ -125,9 +124,8 @@ impl From<&Action> for QlogEvents {
 
                 let frame_ev = EventData::H3FrameCreated(H3FrameCreated {
                     stream_id: *stream_id,
-                    length: None,
                     frame,
-                    raw: None,
+                    ..Default::default()
                 });
 
                 let mut ex = BTreeMap::new();
@@ -171,7 +169,7 @@ impl From<&Action> for QlogEvents {
                     stream_id: *stream_id,
                     stream_type: ty,
                     stream_type_value: ty_val,
-                    associated_push_id: None,
+                    ..Default::default()
                 });
                 let mut ex = BTreeMap::new();
 

--- a/qlog/src/events/h3.rs
+++ b/qlog/src/events/h3.rs
@@ -36,13 +36,14 @@ pub enum H3Owner {
     Remote,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum H3StreamType {
     Request,
     Control,
     Push,
     Reserved,
+    #[default]
     Unknown,
     QpackEncode,
     QpackDecode,
@@ -205,7 +206,7 @@ pub struct H3ParametersRestored {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Default)]
 pub struct H3StreamTypeSet {
     pub owner: Option<H3Owner>,
     pub stream_id: u64,

--- a/qlog/src/events/h3.rs
+++ b/qlog/src/events/h3.rs
@@ -232,7 +232,7 @@ pub struct H3FrameCreated {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Default)]
 pub struct H3FrameParsed {
     pub stream_id: u64,
     pub length: Option<u64>,

--- a/qlog/src/events/h3.rs
+++ b/qlog/src/events/h3.rs
@@ -178,6 +178,12 @@ pub enum Http3Frame {
     },
 }
 
+impl Default for Http3Frame {
+    fn default() -> Self {
+        Self::Unknown { frame_type_value: 0, raw: None }
+    }
+}
+
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct H3ParametersSet {
@@ -216,7 +222,7 @@ pub struct H3StreamTypeSet {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Default)]
 pub struct H3FrameCreated {
     pub stream_id: u64,
     pub length: Option<u64>,

--- a/qlog/src/events/h3.rs
+++ b/qlog/src/events/h3.rs
@@ -180,7 +180,10 @@ pub enum Http3Frame {
 
 impl Default for Http3Frame {
     fn default() -> Self {
-        Self::Unknown { frame_type_value: 0, raw: None }
+        Self::Unknown {
+            frame_type_value: 0,
+            raw: None,
+        }
     }
 }
 

--- a/qlog/src/events/security.rs
+++ b/qlog/src/events/security.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use super::Bytes;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum KeyType {
     ServerInitialSecret,
@@ -46,6 +46,9 @@ pub enum KeyType {
     Server1RttSecret,
     #[serde(rename = "client_1rtt_secret")]
     Client1RttSecret,
+
+    #[default]
+    Unknown,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
@@ -57,7 +60,7 @@ pub enum KeyUpdateOrRetiredTrigger {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Default)]
 pub struct KeyUpdated {
     pub key_type: KeyType,
 

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -755,19 +755,12 @@ mod tests {
         let pkt_hdr = make_pkt_hdr(PacketType::Initial);
         let ev_data = EventData::PacketSent(PacketSent {
             header: pkt_hdr,
-            frames: None,
-            is_coalesced: None,
-            retry_token: None,
-            stateless_reset_token: None,
-            supported_versions: None,
             raw: Some(RawInfo {
                 length: Some(1251),
                 payload_length: Some(1224),
                 data: None,
             }),
-            datagram_id: None,
-            send_at_time: None,
-            trigger: None,
+            ..Default::default()
         });
 
         let ev = Event::with_time(0.0, ev_data);
@@ -836,18 +829,12 @@ mod tests {
         let ev_data = EventData::PacketSent(PacketSent {
             header: pkt_hdr,
             frames: Some(frames.into()),
-            is_coalesced: None,
-            retry_token: None,
-            stateless_reset_token: None,
-            supported_versions: None,
             raw: Some(RawInfo {
                 length: Some(1251),
                 payload_length: Some(1224),
                 data: None,
             }),
-            datagram_id: None,
-            send_at_time: None,
-            trigger: None,
+            ..Default::default()
         });
 
         let ev = Event::with_time(0.0, ev_data);
@@ -956,18 +943,12 @@ mod tests {
         let event_data = EventData::PacketSent(PacketSent {
             header: pkt_hdr,
             frames: Some(frames.into()),
-            is_coalesced: None,
-            retry_token: None,
-            stateless_reset_token: None,
-            supported_versions: None,
             raw: Some(RawInfo {
                 length: Some(1251),
                 payload_length: Some(1224),
                 data: None,
             }),
-            datagram_id: None,
-            send_at_time: None,
-            trigger: None,
+            ..Default::default()
         });
 
         let ev = Event::with_time(0.0, event_data);

--- a/qlog/src/streamer.rs
+++ b/qlog/src/streamer.rs
@@ -395,14 +395,8 @@ mod tests {
         let event_data1 = EventData::PacketSent(quic::PacketSent {
             header: pkt_hdr.clone(),
             frames: Some(smallvec![frame1]),
-            is_coalesced: None,
-            retry_token: None,
-            stateless_reset_token: None,
-            supported_versions: None,
             raw: raw.clone(),
-            datagram_id: None,
-            send_at_time: None,
-            trigger: None,
+            ..Default::default()
         });
 
         let ev1 = Event::with_time(0.0, event_data1);
@@ -426,14 +420,8 @@ mod tests {
         let event_data2 = EventData::PacketSent(quic::PacketSent {
             header: pkt_hdr.clone(),
             frames: Some(smallvec![frame2]),
-            is_coalesced: None,
-            retry_token: None,
-            stateless_reset_token: None,
-            supported_versions: None,
             raw: raw.clone(),
-            datagram_id: None,
-            send_at_time: None,
-            trigger: None,
+            ..Default::default()
         });
 
         let ev2 = Event::with_time(0.0, event_data2);
@@ -441,14 +429,9 @@ mod tests {
         let event_data3 = EventData::PacketSent(quic::PacketSent {
             header: pkt_hdr,
             frames: Some(smallvec![frame3]),
-            is_coalesced: None,
-            retry_token: None,
             stateless_reset_token: Some("reset_token".to_string()),
-            supported_versions: None,
             raw,
-            datagram_id: None,
-            send_at_time: None,
-            trigger: None,
+            ..Default::default()
         });
 
         let ev3 = Event::with_time(0.0, event_data3);
@@ -570,14 +553,8 @@ mod tests {
         let event_data1 = EventData::PacketSent(quic::PacketSent {
             header: pkt_hdr.clone(),
             frames: Some(smallvec![frame1]),
-            is_coalesced: None,
-            retry_token: None,
-            stateless_reset_token: None,
-            supported_versions: None,
             raw: raw.clone(),
-            datagram_id: None,
-            send_at_time: None,
-            trigger: None,
+            ..Default::default()
         });
         let j1 = json!({"foo": "Bar", "hello": 123});
         let j2 = json!({"baz": [1,2,3,4]});
@@ -598,14 +575,8 @@ mod tests {
         let event_data2 = EventData::PacketSent(quic::PacketSent {
             header: pkt_hdr.clone(),
             frames: Some(smallvec![frame2]),
-            is_coalesced: None,
-            retry_token: None,
-            stateless_reset_token: None,
-            supported_versions: None,
             raw: raw.clone(),
-            datagram_id: None,
-            send_at_time: None,
-            trigger: None,
+            ..Default::default()
         });
 
         let ev2 = Event::with_time(0.0, event_data2);

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -1417,7 +1417,7 @@ impl Connection {
                 stream_id,
                 length: Some(header_block.len() as u64),
                 frame,
-                raw: None,
+                ..Default::default()
             });
 
             q.add_event_data_now(ev_data).ok();
@@ -1538,7 +1538,7 @@ impl Connection {
                 stream_id,
                 length: Some(written as u64),
                 frame,
-                raw: None,
+                ..Default::default()
             });
 
             q.add_event_data_now(ev_data).ok();
@@ -1748,7 +1748,7 @@ impl Connection {
                 stream_id,
                 length: Some(priority_field_value.len() as u64),
                 frame,
-                raw: None,
+                ..Default::default()
             });
 
             q.add_event_data_now(ev_data).ok();
@@ -1961,7 +1961,7 @@ impl Connection {
                     stream_id,
                     length: Some(octets::varint_len(id) as u64),
                     frame: frame.to_qlog(),
-                    raw: None,
+                    ..Default::default()
                 });
 
                 q.add_event_data_now(ev_data).ok();
@@ -2117,7 +2117,7 @@ impl Connection {
                 stream_id,
                 length: Some(0),
                 frame,
-                raw: None,
+                ..Default::default()
             });
 
             q.add_event_data_now(ev_data).ok();
@@ -2147,7 +2147,7 @@ impl Connection {
                 stream_id,
                 length: Some(grease_payload.len() as u64),
                 frame,
-                raw: None,
+                ..Default::default()
             });
 
             q.add_event_data_now(ev_data).ok();
@@ -2266,7 +2266,7 @@ impl Connection {
                     stream_id: id,
                     length: Some(off as u64),
                     frame,
-                    raw: None,
+                    ..Default::default()
                 });
 
                 q.add_event_data_now(ev_data).ok();

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -2033,8 +2033,7 @@ impl Connection {
                 stream_id,
                 owner: Some(H3Owner::Local),
                 stream_type: H3StreamType::QpackEncode,
-                stream_type_value: None,
-                associated_push_id: None,
+                ..Default::default()
             });
 
             q.add_event_data_now(ev_data).ok();
@@ -2056,8 +2055,7 @@ impl Connection {
                 stream_id,
                 owner: Some(H3Owner::Local),
                 stream_type: H3StreamType::QpackDecode,
-                stream_type_value: None,
-                associated_push_id: None,
+                ..Default::default()
             });
 
             q.add_event_data_now(ev_data).ok();
@@ -2174,7 +2172,7 @@ impl Connection {
                         owner: Some(H3Owner::Local),
                         stream_type: H3StreamType::Unknown,
                         stream_type_value: Some(ty),
-                        associated_push_id: None,
+                        ..Default::default()
                     });
 
                     q.add_event_data_now(ev_data).ok();
@@ -2218,8 +2216,7 @@ impl Connection {
                 stream_id,
                 owner: Some(H3Owner::Local),
                 stream_type: H3StreamType::Control,
-                stream_type_value: None,
-                associated_push_id: None,
+                ..Default::default()
             });
 
             q.add_event_data_now(ev_data).ok();
@@ -2343,7 +2340,7 @@ impl Connection {
                                 owner: Some(H3Owner::Remote),
                                 stream_type: ty.to_qlog(),
                                 stream_type_value: ty_val,
-                                associated_push_id: None,
+                                ..Default::default()
                             });
 
                         q.add_event_data_now(ev_data).ok();

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -2514,7 +2514,7 @@ impl Connection {
                                     stream_id,
                                     length: Some(payload_len),
                                     frame,
-                                    raw: None,
+                                    ..Default::default()
                                 });
 
                             q.add_event_data_now(ev_data).ok();
@@ -2665,7 +2665,7 @@ impl Connection {
                     stream_id,
                     length: Some(payload_len),
                     frame,
-                    raw: None,
+                    ..Default::default()
                 });
 
                 q.add_event_data_now(ev_data).ok();
@@ -2777,7 +2777,7 @@ impl Connection {
                         stream_id,
                         length: Some(payload_len),
                         frame,
-                        raw: None,
+                        ..Default::default()
                     });
 
                     q.add_event_data_now(ev_data).ok();

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4610,14 +4610,9 @@ impl Connection {
                     EventData::PacketSent(qlog::events::quic::PacketSent {
                         header,
                         frames: Some(qlog_frames),
-                        is_coalesced: None,
-                        retry_token: None,
-                        stateless_reset_token: None,
-                        supported_versions: None,
                         raw: Some(qlog_raw_info),
-                        datagram_id: None,
                         send_at_time: Some(send_at_time),
-                        trigger: None,
+                        ..Default::default()
                     });
 
                 q.add_event_data_with_instant(ev_data, now).ok();

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -8569,13 +8569,8 @@ impl TransportParams {
         EventData::TransportParametersSet(
             qlog::events::quic::TransportParametersSet {
                 owner: Some(owner),
-                resumption_allowed: None,
-                early_data_enabled: None,
                 tls_cipher: Some(format!("{cipher:?}")),
-                aead_tag_length: None,
                 original_destination_connection_id,
-                initial_source_connection_id: None,
-                retry_source_connection_id: None,
                 stateless_reset_token,
                 disable_active_migration: Some(self.disable_active_migration),
                 max_idle_timeout: Some(self.max_idle_timeout),
@@ -8598,9 +8593,7 @@ impl TransportParams {
                 ),
                 initial_max_streams_bidi: Some(self.initial_max_streams_bidi),
                 initial_max_streams_uni: Some(self.initial_max_streams_uni),
-
-                preferred_address: None,
-
+                
                 unknown_parameters: self
                     .unknown_params
                     .as_ref()
@@ -8616,6 +8609,8 @@ impl TransportParams {
                             .collect()
                     })
                     .unwrap_or_default(),
+
+                ..Default::default()
             },
         )
     }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -8593,7 +8593,7 @@ impl TransportParams {
                 ),
                 initial_max_streams_bidi: Some(self.initial_max_streams_bidi),
                 initial_max_streams_uni: Some(self.initial_max_streams_uni),
-                
+
                 unknown_parameters: self
                     .unknown_params
                     .as_ref()

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2960,13 +2960,8 @@ impl Connection {
                 EventData::PacketReceived(qlog::events::quic::PacketReceived {
                     header: qlog_pkt_hdr,
                     frames: Some(qlog_frames),
-                    is_coalesced: None,
-                    retry_token: None,
-                    stateless_reset_token: None,
-                    supported_versions: None,
                     raw: Some(qlog_raw_info),
-                    datagram_id: None,
-                    trigger: None,
+                    ..Default::default()
                 });
 
             q.add_event_data_with_instant(ev_data, now).ok();

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3064,7 +3064,7 @@ impl Connection {
                                     length: Some(length as u64),
                                     from: Some(DataRecipient::Transport),
                                     to: Some(DataRecipient::Dropped),
-                                    raw: None,
+                                    ..Default::default()
                                 },
                             );
 
@@ -4848,7 +4848,7 @@ impl Connection {
                 length: Some(read as u64),
                 from: Some(DataRecipient::Transport),
                 to: Some(DataRecipient::Application),
-                raw: None,
+                ..Default::default()
             });
 
             let now = time::Instant::now();
@@ -5037,7 +5037,7 @@ impl Connection {
                 length: Some(sent as u64),
                 from: Some(DataRecipient::Application),
                 to: Some(DataRecipient::Transport),
-                raw: None,
+                ..Default::default()
             });
 
             let now = time::Instant::now();

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2855,10 +2855,8 @@ impl Connection {
                     EventData::KeyUpdated(qlog::events::security::KeyUpdated {
                         key_type:
                             qlog::events::security::KeyType::Client1RttSecret,
-                        old: None,
-                        new: String::new(),
-                        generation: None,
                         trigger: trigger.clone(),
+                        ..Default::default()
                     });
 
                 q.add_event_data_with_instant(ev_data_client, now).ok();
@@ -2867,10 +2865,8 @@ impl Connection {
                     EventData::KeyUpdated(qlog::events::security::KeyUpdated {
                         key_type:
                             qlog::events::security::KeyType::Server1RttSecret,
-                        old: None,
-                        new: String::new(),
-                        generation: None,
                         trigger,
+                        ..Default::default()
                     });
 
                 q.add_event_data_with_instant(ev_data_server, now).ok();

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -1178,12 +1178,11 @@ impl QlogMetrics {
                     smoothed_rtt: new_smoothed_rtt,
                     latest_rtt: new_latest_rtt,
                     rtt_variance: new_rttvar,
-                    pto_count: None,
                     congestion_window: new_cwnd,
                     bytes_in_flight: new_bytes_in_flight,
                     ssthresh: new_ssthresh,
-                    packets_in_flight: None,
                     pacing_rate: new_pacing_rate,
+                    ..Default::default()
                 },
             ));
         }


### PR DESCRIPTION
In followup to https://github.com/cloudflare/quiche/pull/1931, we can cut down on boilerplate internally