### PR TITLE
tokio-quiche: use workspace quiche, octets and h3i dependencies

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -50,12 +50,29 @@ jobs:
           echo "LD_LIBRARY_PATH=$PWD" >> "$GITHUB_ENV"
 
       - name: Run cargo test
+        if: ${{ matrix.tls-feature != 'openssl' }}
         run: cargo test --verbose --all-targets --features=ffi,qlog,${{ matrix.tls-feature }}
+
+      # Don't run tokio-quiche tests when building with OpenSSL as they require
+      # BoringSSL.
+      - name: Run cargo test
+        if: ${{ matrix.tls-feature == 'openssl' }}
+        run: cargo test --verbose --all-targets --features=ffi,qlog,${{ matrix.tls-feature }} --workspace --exclude tokio-quiche
 
       # Need to run doc tests separately.
       # (https://github.com/rust-lang/cargo/issues/6669)
       - name: Run cargo doc test
+        if: ${{ matrix.tls-feature != 'openssl' }}
         run: cargo test --verbose --doc --features=ffi,qlog,${{ matrix.tls-feature }}
+
+      # Need to run doc tests separately.
+      # (https://github.com/rust-lang/cargo/issues/6669)
+      #
+      # Don't run tokio-quiche tests when building with OpenSSL as they require
+      # BoringSSL.
+      - name: Run cargo doc test
+        if: ${{ matrix.tls-feature == 'openssl' }}
+        run: cargo test --verbose --doc --features=ffi,qlog,${{ matrix.tls-feature }} --workspace --exclude tokio-quiche
 
       # NOTE: this is disabled as it fails when building changes that bump
       # version of local crates (e.g. when doing a `qlog` release) that have not

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,23 +32,21 @@ publish = false
 boring = { version = "4.3" }
 buffer-pool = { version = "0.1.0", path = "./buffer-pool" }
 crossbeam = { version = "0.8.1", default-features = false }
-datagram-socket = { version = "0.1.0", path = "datagram-socket" }
+datagram-socket = { version = "0.1.0", path = "./datagram-socket" }
 env_logger = "0.10"
 foundations = { version = "4", default-features = false }
 futures = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false }
-h3i = { version = "0.2" }
+h3i = { version = "0.3", path = "./h3i" }
 ipnetwork = { version = "0.20" }
 libc = { version = "0.2.76", default-features = false }
 log = { version = "0.4.20" }
 nix = { version = "0.26.2" }
-octets = { version = "0.3.0", path = "octets" }
+octets = { version = "0.3.0", path = "./octets" }
 parking_lot = { version = "0.12.1", default-features = false }
 pin-project = { version = "1.0.12" }
 qlog = { version = "0.15", path = "./qlog" }
-quiche = { version = "0.23.2", path = "quiche" }
-quiche-cf = { version = "0.22", package = "quiche" }
-quiche-mallard = { version = "0.21.0" }
+quiche = { version = "0.23", path = "./quiche" }
 rand = { version = "0.8" }
 regex = { version = "1.4.2" }
 ring = { version = "0.17.8" }
@@ -58,7 +56,7 @@ serde_with = { version = "3.3" }
 slog-scope = { version = "4.0" }
 slog-stdlog = { version = "4.1.1" }
 smallvec = { version = "1.10", default-features = false }
-task-killswitch = { version = "0.1.0", path = "task-killswitch" }
+task-killswitch = { version = "0.1.0", path = "./task-killswitch" }
 thiserror = { version = "1" }
 tokio = { version = "1.29", default-features = false }
 tokio-stream = { version = "0.1" }

--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -23,11 +23,8 @@ mio = { version = "0.8", features = ["net", "os-poll"] }
 multimap = "0.10"
 octets = { workspace = true }
 qlog = { workspace = true }
-quiche = { version = "0.23", path = "../quiche", features = [
-  "internal",
-  "qlog",
-] }
-rand = "0.8.5"
+quiche = { workspace = true, features = ["internal", "qlog"] }
+rand = { workspace = true }
 smallvec = { workspace = true }
 serde_with = "1"
 serde_json = "1"

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 
 [features]
 # Forwarded quiche features for re-exports
-fuzzing = ["quiche-cf/fuzzing", "quiche-mallard?/fuzzing"]
-quiche_internal = ["quiche-cf/internal", "quiche-mallard?/internal"]
+fuzzing = ["quiche/fuzzing", "quiche-mallard?/fuzzing"]
+quiche_internal = ["quiche/internal", "quiche-mallard?/internal"]
 
 # Enable extra timing instrumentation for QUIC handshakes, including protocol
 # overhead and network delays.
@@ -24,7 +24,7 @@ rpk = ["boring/rpk"]
 # Use the quiche-mallard fork in place of upstream quiche.
 # quiche-mallard replaces quiche's original congestion control
 # implementation with one adapted from google/quiche.
-gcongestion = ["dep:quiche-mallard"]
+gcongestion = ["dep:quiche-mallard", "dep:octets-mallard"]
 # Use quiche-mallard with zero-copy send calls.
 zero-copy = ["gcongestion"]
 
@@ -39,15 +39,21 @@ boring = { workspace = true }
 buffer-pool = { workspace = true }
 crossbeam = { workspace = true, default-features = false }
 datagram-socket = { workspace = true }
-foundations = { workspace = true, default-features = false, features = ["server-client-common-default"] }
+foundations = { workspace = true, default-features = false, features = [
+  "server-client-common-default",
+] }
 futures = { workspace = true }
 futures-util = { workspace = true }
 ipnetwork = { workspace = true }
 log = { workspace = true }
-octets = { version = "0.3.0" }
+octets = { workspace = true }
+octets-mallard = { package = "octets", version = "0.3.0", optional = true }
 pin-project = { workspace = true }
-quiche-cf = { workspace = true, features = ["boringssl-boring-crate", "qlog"] }
-quiche-mallard = { workspace = true, features = ["boringssl-boring-crate", "qlog"], optional = true }
+quiche = { workspace = true, features = ["boringssl-boring-crate", "qlog"] }
+quiche-mallard = { version = "0.21", features = [
+  "boringssl-boring-crate",
+  "qlog",
+], optional = true }
 ring = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_with = { workspace = true }
@@ -58,7 +64,13 @@ task-killswitch = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tokio-stream = { workspace = true, features = ["net", "io-util"] }
-tokio-util = { workspace = true, features = ["compat", "time", "codec", "io", "rt"] }
+tokio-util = { workspace = true, features = [
+  "compat",
+  "time",
+  "codec",
+  "io",
+  "rt",
+] }
 triomphe = { workspace = true }
 url = { workspace = true }
 

--- a/tokio-quiche/src/http3/driver/datagram.rs
+++ b/tokio-quiche/src/http3/driver/datagram.rs
@@ -24,6 +24,9 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[cfg(feature = "gcongestion")]
+extern crate octets_mallard as octets;
+
 use super::InboundFrame;
 use crate::buf_factory::BufFactory;
 use crate::buf_factory::PooledDgram;

--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -555,7 +555,16 @@ impl<H: DriverHooks> H3Driver<H> {
         self.forward_settings()?;
 
         match event {
-            // Requests/responses are exclusively handled by hooks
+            // Requests/responses are exclusively handled by hooks.
+            #[cfg(not(feature = "gcongestion"))]
+            h3::Event::Headers { list, more_frames } =>
+                H::headers_received(self, qconn, InboundHeaders {
+                    stream_id,
+                    headers: list,
+                    has_body: more_frames,
+                }),
+
+            #[cfg(feature = "gcongestion")]
             h3::Event::Headers { list, has_body } =>
                 H::headers_received(self, qconn, InboundHeaders {
                     stream_id,

--- a/tokio-quiche/src/lib.rs
+++ b/tokio-quiche/src/lib.rs
@@ -93,7 +93,7 @@
 //!   tasks.
 
 #[cfg(not(feature = "gcongestion"))]
-pub extern crate quiche_cf as quiche;
+pub extern crate quiche;
 #[cfg(feature = "gcongestion")]
 pub extern crate quiche_mallard as quiche;
 

--- a/tokio-quiche/src/quic/router/mod.rs
+++ b/tokio-quiche/src/quic/router/mod.rs
@@ -874,7 +874,7 @@ mod tests {
         };
         let actions = [Action::ConnectionClose { error: conn_close }];
 
-        let _ = h3i::client::sync_client::connect(&h3i_config, &actions);
+        let _ = h3i::client::sync_client::connect(h3i_config, &actions, None);
     }
 
     #[tokio::test]

--- a/tokio-quiche/tests/fixtures/h3i_fixtures.rs
+++ b/tokio-quiche/tests/fixtures/h3i_fixtures.rs
@@ -88,7 +88,7 @@ pub async fn summarize_connection(
     h3i: h3i::config::Config, actions: Vec<Action>,
 ) -> ConnectionSummary {
     tokio::task::spawn_blocking(move || {
-        h3i::client::sync_client::connect(&h3i, &actions).unwrap()
+        h3i::client::sync_client::connect(h3i, &actions, None).unwrap()
     })
     .await
     .unwrap()
@@ -123,7 +123,7 @@ pub async fn request(
     });
 
     tokio::task::spawn_blocking(move || {
-        h3i::client::sync_client::connect(&h3i, &actions)
+        h3i::client::sync_client::connect(h3i, &actions, None)
     })
     .await
     .unwrap()
@@ -137,10 +137,13 @@ pub fn received_status_code_on_stream(
         .headers_on_stream(stream)
         .iter()
         .any(|e| {
-            e.status_code()
-                .expect("no status code")
-                .expect("unparsable status code") ==
-                code
+            let u16 =
+                std::str::from_utf8(e.status_code().expect("no status code"))
+                    .expect("invalid utf8 in status code")
+                    .parse::<u16>()
+                    .expect("unparseable status code");
+
+            u16 == code
         })
 }
 


### PR DESCRIPTION
Newer quiche had a breaking API change compared to the gcongestion branch that needs to be handled explicitly. gcongestion also can't use the workspace octets dependency.

h3i is updated to use the workspace quiche dependency as well.