### PR TITLE
h3i: more workspace dependencies

### DIFF
--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -25,8 +25,7 @@ octets = { workspace = true }
 qlog = { workspace = true }
 quiche = { workspace = true, features = ["internal", "qlog"] }
 rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 smallvec = { workspace = true }
-serde_with = "1"
-serde_json = "1"
-serde = "1"
-url = "1"
+url = { workspace = true }

--- a/h3i/src/actions/h3.rs
+++ b/h3i/src/actions/h3.rs
@@ -39,7 +39,6 @@ use quiche::h3::Header;
 use quiche::ConnectionError;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_with::serde_as;
 
 use crate::encode_header_block;
 
@@ -108,10 +107,8 @@ pub enum Action {
 /// Configure the wait behavior for a connection.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
-#[serde_as]
 pub enum WaitType {
     /// Wait for a time before firing the next action
-    #[serde_as(as = "DurationMilliSeconds<f64>")]
     WaitDuration(Duration),
     /// Wait for some form of a response before firing the next action. This can
     /// be superseded in several cases:

--- a/h3i/src/client/sync_client.rs
+++ b/h3i/src/client/sync_client.rs
@@ -26,7 +26,6 @@
 
 //! Responsible for creating a [quiche::Connection] and managing I/O.
 
-use std::net::ToSocketAddrs;
 use std::slice::Iter;
 use std::time::Duration;
 use std::time::Instant;
@@ -103,11 +102,11 @@ pub fn connect(
         addr.parse().expect("--connect-to is expected to be a string containing an IPv4 or IPv6 address with a port. E.g. 192.0.2.0:443")
     } else {
         let x = format!("https://{}", args.host_port);
-        url::Url::parse(&x)
+        *url::Url::parse(&x)
             .unwrap()
-            .to_socket_addrs()
+            .socket_addrs(|| None)
             .unwrap()
-            .next()
+            .first()
             .unwrap()
     };
 


### PR DESCRIPTION
This bumps serde_with and url to match the versions specified in the workspace.

It also appears that the `serde_with` dependency was entirely unnecessary, as the `serde_as` use in the code never actually worked properly and it triggers a warning with newer versions (https://github.com/jonasbb/serde_with/pull/502) so I just removed it.

---

This depends on https://github.com/cloudflare/quiche/pull/1941.