### PR TITLE
h3i: encode WaitType(Duration) as number

### DIFF
--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -27,5 +27,6 @@ quiche = { workspace = true, features = ["internal", "qlog"] }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_with = { workspace = true }
 smallvec = { workspace = true }
 url = { workspace = true }

--- a/h3i/src/actions/h3.rs
+++ b/h3i/src/actions/h3.rs
@@ -39,6 +39,7 @@ use quiche::h3::Header;
 use quiche::ConnectionError;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_with::serde_as;
 
 use crate::encode_header_block;
 
@@ -105,11 +106,15 @@ pub enum Action {
 }
 
 /// Configure the wait behavior for a connection.
+#[serde_as]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum WaitType {
     /// Wait for a time before firing the next action
-    WaitDuration(Duration),
+    #[serde(rename = "duration")]
+    WaitDuration(
+        #[serde_as(as = "serde_with::DurationMilliSecondsWithFrac<f64>")]
+        Duration,
+    ),
     /// Wait for some form of a response before firing the next action. This can
     /// be superseded in several cases:
     /// 1. The peer resets the specified stream.

--- a/h3i/src/recordreplay/qlog.rs
+++ b/h3i/src/recordreplay/qlog.rs
@@ -599,14 +599,14 @@ mod tests {
             importance: qlog::events::EventImportance::Core,
             name: H3I_WAIT.to_string(),
             data: serde_json::to_value(WaitType::WaitDuration(
-                Duration::from_millis(0),
+                Duration::from_millis(12345),
             ))
             .unwrap(),
         };
         let serialized = serde_json::to_string(&ev);
 
         let expected =
-            r#"{"time":123.0,"name":"h3i:wait","data":{"secs":0,"nanos":0}}"#;
+            r#"{"time":123.0,"name":"h3i:wait","data":{"duration":12345.0}}"#;
         assert_eq!(&serialized.unwrap(), expected);
     }
 
@@ -617,13 +617,13 @@ mod tests {
             importance: qlog::events::EventImportance::Core,
             name: H3I_WAIT.to_string(),
             data: serde_json::to_value(WaitType::WaitDuration(
-                Duration::from_millis(0),
+                Duration::from_millis(12345),
             ))
             .unwrap(),
         };
 
         let expected =
-            r#"{"time":123.0,"name":"h3i:wait","data":{"secs":0,"nanos":0}}"#;
+            r#"{"time":123.0,"name":"h3i:wait","data":{"duration":12345.0}}"#;
         let deser = serde_json::from_str::<JsonEvent>(expected).unwrap();
         assert_eq!(deser.data, ev.data);
     }


### PR DESCRIPTION
Currently the Duration type is serialized as a struct. This changes it to a simple number of milliseconds.