### PR TITLE
Cargo: specify release tag prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ categories = ["network-programming"]
 [workspace.metadata.release]
 pre-release-commit-message = "{{crate_name}}: release {{version}}"
 consolidate-commits = false
-tag-name = "{{version}}"
+tag-prefix = "{{crate_name}}-"
+tag-name = "{{prefix}}{{version}}"
 tag-message = "{{crate_name}} {{version}}"
 publish = false
 

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -51,6 +51,9 @@ ffi = ["dep:cdylib-link-lines"]
 # Exposes internal APIs that have no stability guarantees across versions.
 internal = []
 
+[package.metadata.release]
+tag-prefix = ""
+
 [package.metadata.docs.rs]
 no-default-features = true
 features = ["boringssl-boring-crate", "qlog"]


### PR DESCRIPTION
This allows tagging releases of every crate rather than just quiche.

For backwards consistency, quiche's tags will keep the same format (without crate name) for the time being.