### PR TITLE
tokio-quiche: add `license` field to metadata

### DIFF
--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tokio-quiche"
 version = "0.1.0"
 repository = { workspace = true }
+license = { workspace = true }
 description = "Asynchronous wrapper around quiche"
 keywords = ["quic", "http3", "tokio"]
 categories = { workspace = true }


### PR DESCRIPTION
This is required to publish to crates.io.