### PR TITLE
tokio-quiche: replace ring/rand with boring

### DIFF
--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -55,7 +55,6 @@ quiche-mallard = { version = "0.21", features = [
   "boringssl-boring-crate",
   "qlog",
 ], optional = true }
-ring = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_with = { workspace = true }
 slog-scope = { workspace = true }
@@ -77,7 +76,6 @@ url = { workspace = true }
 
 [dev-dependencies]
 h3i = { workspace = true }
-rand = { workspace = true, features = ["small_rng"] }
 regex = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time", "test-util"] }

--- a/tokio-quiche/src/quic/connection/id.rs
+++ b/tokio-quiche/src/quic/connection/id.rs
@@ -64,12 +64,8 @@ pub struct SimpleConnectionIdGenerator;
 
 impl ConnectionIdGenerator<'static> for SimpleConnectionIdGenerator {
     fn new_connection_id(&self, _socket_cookie: u64) -> ConnectionId<'static> {
-        use ring::rand::SecureRandom;
-
         let mut buf = vec![0; 20];
-        let rng = ring::rand::SystemRandom::new();
-
-        rng.fill(&mut buf).unwrap();
+        boring::rand::rand_bytes(&mut buf).unwrap();
 
         ConnectionId::from_vec(buf)
     }

--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -44,10 +44,6 @@ use foundations::telemetry::log;
 use futures::future::BoxFuture;
 use futures::Future;
 use quiche::ConnectionId;
-use ring::rand::SecureRandom;
-use ring::rand::{
-    self,
-};
 use std::fmt;
 use std::io;
 use std::net::SocketAddr;
@@ -398,9 +394,8 @@ where
 
     fn generate_id() -> u64 {
         let mut buf = [0; 8];
-        let rng = rand::SystemRandom::new();
 
-        rng.fill(&mut buf).unwrap();
+        boring::rand::rand_bytes(&mut buf).unwrap();
 
         u64::from_ne_bytes(buf)
     }

--- a/tokio-quiche/tests/integration_tests/timeouts.rs
+++ b/tokio-quiche/tests/integration_tests/timeouts.rs
@@ -162,7 +162,7 @@ async fn test_handshake_timeout_with_one_client_flight() {
     socket.connect(peer_addr).await.unwrap();
 
     let mut scid = [0; quiche::MAX_CONN_ID_LEN];
-    rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut scid);
+    boring::rand::rand_bytes(&mut scid).unwrap();
     let scid = quiche::ConnectionId::from_ref(&scid);
 
     let local_addr = socket.local_addr().unwrap();


### PR DESCRIPTION
The same functionality is already provided by the `boring` crate anyway, which also happens to be FIPS validated (if built appropriately), so not much point in having additional dependencies.