### PR TITLE
tokio-quiche: add support for sending additional headers

### DIFF
--- a/tokio-quiche/src/http3/driver/streams.rs
+++ b/tokio-quiche/src/http3/driver/streams.rs
@@ -50,6 +50,8 @@ pub(crate) struct StreamCtx {
     /// This is used as temporary storage when waiting for `recv`.
     pub(crate) queued_frame: Option<OutboundFrame>,
     pub(crate) audit_stats: Arc<H3AuditStats>,
+    /// Indicates the stream sent initial headers.
+    pub(crate) initial_headers_sent: bool,
     /// Indicates the stream received fin. No more data will be received.
     pub(crate) fin_recv: bool,
     /// Indicates the stream sent fin. No more data will be sent.
@@ -73,6 +75,8 @@ impl StreamCtx {
             recv: Some(backward_receiver),
             queued_frame: None,
             audit_stats: Arc::new(H3AuditStats::new(stream_id)),
+
+            initial_headers_sent: false,
 
             fin_recv: false,
             fin_sent: false,

--- a/tokio-quiche/tests/integration_tests/headers.rs
+++ b/tokio-quiche/tests/integration_tests/headers.rs
@@ -1,0 +1,98 @@
+// Copyright (C) 2025, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::fixtures::*;
+
+use futures::SinkExt;
+
+use tokio_quiche::http3::driver::H3Event;
+use tokio_quiche::http3::driver::IncomingH3Headers;
+use tokio_quiche::http3::driver::OutboundFrame;
+use tokio_quiche::http3::driver::ServerH3Event;
+use tokio_quiche::quiche::h3::Header;
+
+#[tokio::test]
+async fn test_additional_headers() {
+    let hook = TestConnectionHook::new();
+
+    let url = start_server_with_settings(
+        QuicSettings::default(),
+        Http3Settings::default(),
+        hook,
+        move |mut h3_conn| async move {
+            let event_rx = h3_conn.h3_controller.event_receiver_mut();
+
+            while let Some(frame) = event_rx.recv().await {
+                let ServerH3Event::Core(frame) = frame;
+
+                match frame {
+                    H3Event::IncomingHeaders(headers) => {
+                        let IncomingH3Headers { mut send, .. } = headers;
+
+                        // Send initial headers.
+                        send.send(OutboundFrame::Headers(vec![Header::new(
+                            b":status", b"103",
+                        )]))
+                        .await
+                        .unwrap();
+
+                        // Delay sending additional headers to the next cycle
+                        // just to make sure things work properly if the frames
+                        // aren't sent back to back.
+                        tokio::task::yield_now().await;
+
+                        // Send additional headers.
+                        send.send(OutboundFrame::Headers(vec![Header::new(
+                            b":status", b"200",
+                        )]))
+                        .await
+                        .unwrap();
+                    },
+
+                    H3Event::ConnectionShutdown(_) => break,
+
+                    _ => (),
+                }
+            }
+        },
+    );
+
+    let summary = h3i_fixtures::request(&url, 1)
+        .await
+        .expect("request failed");
+
+    let mut headers = summary.stream_map.headers_on_stream(0).into_iter();
+
+    assert_eq!(
+        headers.next().expect("initial headers").status_code(),
+        Some(&Vec::from("103".as_bytes()))
+    );
+    assert_eq!(
+        headers.next().expect("additional headers").status_code(),
+        Some(&Vec::from("200".as_bytes()))
+    );
+    assert!(headers.next().is_none());
+}

--- a/tokio-quiche/tests/integration_tests/mod.rs
+++ b/tokio-quiche/tests/integration_tests/mod.rs
@@ -43,6 +43,7 @@ use tokio_quiche::InitialQuicConnection;
 
 pub mod async_callbacks;
 pub mod connection_close;
+pub mod headers;
 pub mod timeouts;
 
 #[tokio::test]


### PR DESCRIPTION
Since quiche will reject multiple calls to `send_response*()` on the same stream, we need to call `send_additional_headers()` after the initial headers are sent.