### PR TITLE
Bump rust version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80 AS build
+FROM rust:1.81 AS build
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ is disabled by default), by passing ``--features ffi`` to ``cargo``.
 Building
 --------
 
-quiche requires Rust 1.80 or later to build. The latest stable Rust release can
+quiche requires Rust 1.81 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched

--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
   "Evan Rittenhouse <evanrittenhouse@gmail.com>",
 ]
 description = "Low-level HTTP/3 debugging and testing"
-rust-version = "1.67"
+rust-version = "1.81"
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.23.2"
 authors = ["Alessandro Ghedini <alessandro@ghedini.me>"]
 description = "🥧 Savoury implementation of the QUIC transport protocol and HTTP/3"
 build = "src/build.rs"
-rust-version = "1.80"
+rust-version = "1.81"
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION
The Docker builds are failing due to litemap and zerofrom crates
requiring rust 1.81.
