### PR TITLE
lib: fix qlog parameters_set tls_cipher field

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -8566,10 +8566,12 @@ impl TransportParams {
             self.stateless_reset_token.map(|s| s.to_be_bytes()).as_ref(),
         );
 
+        let tls_cipher: Option<String> = cipher.map(|f| format!("{f:?}"));
+
         EventData::TransportParametersSet(
             qlog::events::quic::TransportParametersSet {
                 owner: Some(owner),
-                tls_cipher: Some(format!("{cipher:?}")),
+                tls_cipher,
                 original_destination_connection_id,
                 stateless_reset_token,
                 disable_active_migration: Some(self.disable_active_migration),


### PR DESCRIPTION
 We've been always producing a value of either `None` or
 `Some(_algo name_)`, which is unexpected. This commit
 ensures the field is only generated if the input Option
 is some.