### PR TITLE
crypto/boringssl: perform dummy seal when client resets keys too

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2076,6 +2076,7 @@ impl Connection {
                 &dcid,
                 conn.version,
                 conn.is_server,
+                false,
             )?;
 
             let reset_token = conn.peer_transport_params.stateless_reset_token;
@@ -2531,6 +2532,7 @@ impl Connection {
                 &self.destination_id(),
                 self.version,
                 self.is_server,
+                true,
             )?;
 
             // Reset connection state to force sending another Initial packet.
@@ -2596,6 +2598,7 @@ impl Connection {
                 &hdr.scid,
                 self.version,
                 self.is_server,
+                true,
             )?;
 
             // Reset connection state to force sending another Initial packet.
@@ -2665,6 +2668,7 @@ impl Connection {
                 &hdr.dcid,
                 self.version,
                 self.is_server,
+                false,
             )?;
 
             self.pkt_num_spaces[packet::Epoch::Initial].crypto_open =
@@ -13056,22 +13060,92 @@ mod tests {
         // Client receives Retry and sends new Initial.
         assert_eq!(pipe.client_recv(&mut buf[..len]), Ok(len));
 
-        let (len, _) = pipe.client.send(&mut buf).unwrap();
+        let (len, send_info) = pipe.client.send(&mut buf).unwrap();
 
         let hdr = Header::from_slice(&mut buf[..len], MAX_CONN_ID_LEN).unwrap();
         assert_eq!(&hdr.token.unwrap(), token);
 
         // Server accepts connection.
-        let from = "127.0.0.1:1234".parse().unwrap();
         pipe.server = accept(
             &scid,
             Some(&odcid),
             testing::Pipe::server_addr(),
-            from,
+            send_info.from,
             &mut config,
         )
         .unwrap();
         assert_eq!(pipe.server_recv(&mut buf[..len]), Ok(len));
+
+        assert_eq!(pipe.advance(), Ok(()));
+
+        assert!(pipe.client.is_established());
+        assert!(pipe.server.is_established());
+    }
+
+    #[test]
+    fn retry_with_pto() {
+        let mut buf = [0; 65535];
+
+        let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config
+            .set_application_protos(&[b"proto1", b"proto2"])
+            .unwrap();
+
+        let mut pipe = testing::Pipe::with_server_config(&mut config).unwrap();
+
+        // Client sends initial flight.
+        let (mut len, _) = pipe.client.send(&mut buf).unwrap();
+
+        // Server sends Retry packet.
+        let hdr = Header::from_slice(&mut buf[..len], MAX_CONN_ID_LEN).unwrap();
+
+        let odcid = hdr.dcid.clone();
+
+        let mut scid = [0; MAX_CONN_ID_LEN];
+        rand::rand_bytes(&mut scid[..]);
+        let scid = ConnectionId::from_ref(&scid);
+
+        let token = b"quiche test retry token";
+
+        len = packet::retry(
+            &hdr.scid,
+            &hdr.dcid,
+            &scid,
+            token,
+            hdr.version,
+            &mut buf,
+        )
+        .unwrap();
+
+        // Client receives Retry and sends new Initial.
+        assert_eq!(pipe.client_recv(&mut buf[..len]), Ok(len));
+
+        let (len, send_info) = pipe.client.send(&mut buf).unwrap();
+
+        let hdr = Header::from_slice(&mut buf[..len], MAX_CONN_ID_LEN).unwrap();
+        assert_eq!(&hdr.token.unwrap(), token);
+
+        // Server accepts connection.
+        pipe.server = accept(
+            &scid,
+            Some(&odcid),
+            testing::Pipe::server_addr(),
+            send_info.from,
+            &mut config,
+        )
+        .unwrap();
+        assert_eq!(pipe.server_recv(&mut buf[..len]), Ok(len));
+
+        // Wait for the client's PTO so it will try to send an Initial again.
+        let timer = pipe.client.timeout().unwrap();
+        std::thread::sleep(timer + time::Duration::from_millis(1));
+        pipe.client.on_timeout();
 
         assert_eq!(pipe.advance(), Ok(()));
 

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -1312,9 +1312,13 @@ mod tests {
 
         let payload_len = b.get_varint().unwrap() as usize;
 
-        let (aead, _) =
-            crypto::derive_initial_key_material(dcid, hdr.version, is_server)
-                .unwrap();
+        let (aead, _) = crypto::derive_initial_key_material(
+            dcid,
+            hdr.version,
+            is_server,
+            false,
+        )
+        .unwrap();
 
         decrypt_hdr(&mut b, &mut hdr, &aead).unwrap();
         assert_eq!(hdr.pkt_num_len, expected_pn_len);
@@ -1561,9 +1565,13 @@ mod tests {
 
         b.put_bytes(header).unwrap();
 
-        let (_, aead) =
-            crypto::derive_initial_key_material(dcid, hdr.version, is_server)
-                .unwrap();
+        let (_, aead) = crypto::derive_initial_key_material(
+            dcid,
+            hdr.version,
+            is_server,
+            false,
+        )
+        .unwrap();
 
         let payload_len = frames.len();
 
@@ -1947,7 +1955,8 @@ mod tests {
         let payload_len = b.get_varint().unwrap() as usize;
 
         let (aead, _) =
-            crypto::derive_initial_key_material(b"", hdr.version, true).unwrap();
+            crypto::derive_initial_key_material(b"", hdr.version, true, false)
+                .unwrap();
 
         assert_eq!(
             decrypt_pkt(&mut b, 0, 1, payload_len, &aead),
@@ -1980,7 +1989,8 @@ mod tests {
         let payload_len = 1;
 
         let (aead, _) =
-            crypto::derive_initial_key_material(b"", hdr.version, true).unwrap();
+            crypto::derive_initial_key_material(b"", hdr.version, true, false)
+                .unwrap();
 
         assert_eq!(
             decrypt_pkt(&mut b, 0, 1, payload_len, &aead),


### PR DESCRIPTION
This is yet more fallout from b17904e5 (also see 7d686e1). This time the missing dummy seal is for clients, after the initial epoch is reset (e.g. due to retry or version negotiation), which also causes the initial key material to be dervied again.

When that happens, and if the client's PTO fires (e.g. because the server is slow to respond) that will trigger the client to create a new Initial packet that will fail to seal because the initial seal context expects a packet number of 0, while the actual packet number is greater than that as it's a retransmission.

This only happens when the client's initial PTO fires because otherwise it would just send a Handshake packet instead, without using the initial key material.