### PR TITLE
tls: don't log nullbytes from log_ssl_error

### DIFF
--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -1044,7 +1044,14 @@ fn log_ssl_error() {
         ERR_error_string_n(e, err.as_mut_ptr() as *mut c_char, err.len());
     }
 
-    trace!("{}", std::str::from_utf8(&err).unwrap());
+    let cstr = ffi::CStr::from_bytes_until_nul(&err)
+        .expect("ERR_error_string_n should write a null terminated string");
+
+    trace!(
+        "{}",
+        cstr.to_str()
+            .expect("ERR_error_string_n should create a valid UTF-8 message")
+    );
 }
 
 extern "C" {


### PR DESCRIPTION
The function was always logging a 1024 byte long buffer padded with nullbytes. This doesn't look intentional, and may cause trouble for some logger implementations that don't expect nulls in &str.

See also: rust-mobile/android_logger-rs#90