### PR TITLE
fix: Derive an additional `default`

### DIFF
--- a/qlog/src/events/mod.rs
+++ b/qlog/src/events/mod.rs
@@ -512,7 +512,7 @@ pub enum DataRecipient {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Default)]
 pub struct RawInfo {
     pub length: Option<u64>,
     pub payload_length: Option<u64>,


### PR DESCRIPTION
Missed this in #1931.