### PR TITLE
Switch from feature to cfg flag for tokio-quiche's capture_keylogs

### DIFF
--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -29,11 +29,15 @@ gcongestion = ["dep:quiche-mallard"]
 # Use quiche-mallard with zero-copy send calls.
 zero-copy = ["gcongestion"]
 
-# Enable SSLKEYLOGFILE capturing for QUIC connections.
+# Deprecated: use `--cfg capture_keylogs` instead.
 capture_keylogs = []
 
 # Enable scheduling & poll duration histograms for tokio tasks.
 tokio-task-metrics = []
+
+[lints.rust]
+# capture_keylogs: enable SSLKEYLOGFILE capturing for QUIC connections.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(capture_keylogs)'] }
 
 [dependencies]
 boring = { workspace = true }

--- a/tokio-quiche/README.md
+++ b/tokio-quiche/README.md
@@ -149,13 +149,17 @@ performance enhancements, and additional telemetry. By default, no feature flags
 enabled.
 
 - `rpk`: Support for raw public keys (RPK) in QUIC handshakes (via [boring]).
-- `capture_keylogs`: Optional `SSLKEYLOGFILE` capturing for QUIC connections.
 - `gcongestion`: Replace quiche's original congestion control implementation with one
    adapted from google/quiche (via quiche-mallard).
 - `zero-copy`: Use zero-copy sends with quiche-mallard (implies `gcongestion`).
 - `perf-quic-listener-metrics`: Extra telemetry for QUIC handshake durations,
   including protocol overhead and network delays.
 - `tokio-task-metrics`: Scheduling & poll duration histograms for tokio tasks.
+
+Other parts of the crate are enabled by separate build flags instead, to be
+controlled by the final binary:
+
+- `--cfg capture_keylogs`: Optional `SSLKEYLOGFILE` capturing for QUIC connections.
 
 
 # Server usage architecture
@@ -173,3 +177,4 @@ enabled.
 [connect]: https://docs.rs/tokio-quiche/latest/tokio_quiche/quic/fn.connect.html
 [ApplicationOverQuic]: https://docs.rs/tokio-quiche/latest/tokio_quiche/trait.ApplicationOverQuic.html
 [H3Driver]: https://docs.rs/tokio-quiche/latest/tokio-quiche/http3/driver/struct.H3Driver.html
+[boring]: https://docs.rs/boring/latest/boring/

--- a/tokio-quiche/src/lib.rs
+++ b/tokio-quiche/src/lib.rs
@@ -81,8 +81,6 @@
 //!
 //! - `rpk`: Support for raw public keys (RPK) in QUIC handshakes (via
 //!   [boring]).
-//! - `capture_keylogs`: Optional `SSLKEYLOGFILE` capturing for QUIC
-//!   connections.
 //! - `gcongestion`: Replace quiche's original congestion control implementation
 //!   with one adapted from google/quiche (via quiche-mallard).
 //! - `zero-copy`: Use zero-copy sends with quiche-mallard (implies
@@ -91,6 +89,12 @@
 //!   durations, including protocol overhead and network delays.
 //! - `tokio-task-metrics`: Scheduling & poll duration histograms for tokio
 //!   tasks.
+//!
+//! Other parts of the crate are enabled by separate build flags instead, to be
+//! controlled by the final binary:
+//!
+//! - `--cfg capture_keylogs`: Optional `SSLKEYLOGFILE` capturing for QUIC
+//!   connections.
 
 #[cfg(not(feature = "gcongestion"))]
 pub extern crate quiche;


### PR DESCRIPTION
Whether to capture keylogs (i.e., secrets) should only be decided by the final binary that incorporates tokio-quiche somewhere in its dependency graph. Using a feature allows any dependency to enable keylog capturing, whereas a cfg flag must be explicitly set in RUSTFLAGS or similar.

I've opted to keep the feature flag around for now. We can remove it on the next major bump. This makes the migration a bit easier.