### PR TITLE
properly enable tokio unconstrained()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ slog-stdlog = { version = "4.1.1" }
 smallvec = { version = "1.10", default-features = false }
 task-killswitch = { version = "0.1.0", path = "./task-killswitch" }
 thiserror = { version = "1" }
-tokio = { version = "1.29", default-features = false }
+tokio = { version = "1.44", default-features = false }
 tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7.13" }
 triomphe = { version = "0.1" }

--- a/datagram-socket/Cargo.toml
+++ b/datagram-socket/Cargo.toml
@@ -13,7 +13,7 @@ buffer-pool = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
 smallvec = { workspace = true }
-tokio = { workspace = true, features = ["net"] }
+tokio = { workspace = true, features = ["net", "rt"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -65,7 +65,7 @@ slog-stdlog = { workspace = true }
 smallvec = { workspace = true }
 task-killswitch = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 tokio-stream = { workspace = true, features = ["net", "io-util"] }
 tokio-util = { workspace = true, features = [
   "compat",


### PR DESCRIPTION
This was added in tokio 1.44 so we need to bump the minimum tokio version required, and it's gated behing the "rt" feature as well.

Not entirely sure why this wasn't caught in CI before, but only by `cargo package`.