### PR TITLE
tokio-quiche: Clean up packet router logging TODO

### DIFF
--- a/tokio-quiche/src/metrics/labels.rs
+++ b/tokio-quiche/src/metrics/labels.rs
@@ -104,7 +104,7 @@ impl From<&BoxError> for HandshakeError {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum QuicInvalidInitialPacketError {
     TokenValidationFail,
-    SmallPacket,
+    FailedToParse,
     WrongType(quiche::Type),
     AcceptQueueOverflow,
     Unexpected,
@@ -113,7 +113,7 @@ pub enum QuicInvalidInitialPacketError {
 impl std::fmt::Display for QuicInvalidInitialPacketError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::SmallPacket => f.write_str("small packet"),
+            Self::FailedToParse => f.write_str("failed to parse packet"),
             Self::TokenValidationFail => f.write_str("token validation fail"),
             Self::WrongType(ty) => write!(f, "wrong type: {ty:?}"),
             Self::AcceptQueueOverflow => f.write_str("accept queue overflow"),


### PR DESCRIPTION
I checked the last 7 days of these logs. While there are a few ten thousand of them, they were all instances of
`quiche::Error::InvalidPacket`. Those are not unexpected errors, so I added an entry for them to QuicInvalidInitialPacketError.

No other unexpected errors were observed at all in the last 7 days. I feel confident to remove the trial logging and pass those errors up to users of tokio-quiche now.