### PR TITLE
add mechanism to change connection settings from BoringSSL handshake callbacks

### DIFF
--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -481,6 +481,12 @@ impl Path {
         (lost_packets, lost_bytes)
     }
 
+    pub fn reinit_recovery(
+        &mut self, recovery_config: &recovery::RecoveryConfig,
+    ) {
+        self.recovery = recovery::Recovery::new_with_config(recovery_config)
+    }
+
     pub fn stats(&self) -> PathStats {
         PathStats {
             local_addr: self.local_addr,

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -353,14 +353,15 @@ pub struct Recovery {
     newly_acked: Vec<Acked>,
 }
 
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub struct RecoveryConfig {
-    max_send_udp_payload_size: usize,
+    pub max_send_udp_payload_size: usize,
     pub max_ack_delay: Duration,
-    cc_algorithm: CongestionControlAlgorithm,
-    hystart: bool,
-    pacing: bool,
-    max_pacing_rate: Option<u64>,
-    initial_congestion_window_packets: usize,
+    pub cc_algorithm: CongestionControlAlgorithm,
+    pub hystart: bool,
+    pub pacing: bool,
+    pub max_pacing_rate: Option<u64>,
+    pub initial_congestion_window_packets: usize,
 }
 
 impl RecoveryConfig {


### PR DESCRIPTION
It can be useful to tweak a specific connection's configuration based on information like SNI. However this is only available after the client's ClientHello is fully processed, which is not entirely apparent from an application PoV (e.g. ClientHello can be split across multiple Initial packets).

BoringSSL provides a number of callbacks called during the TLS handshake and sometimes even before any packet has been sent (e.g. `select_cert_cb`) which is useful to tweak congestion control settings or transport parameters,  that provide the required information, but the underlying quiche connection is not exposed to application code from inside these callbacks currently.

This change adds a mechanism to allow applications to change specific connection settings from inside these BoringSSL callbacks.