### PR TITLE
tokio-quiche: remove unconstrained() call

### DIFF
--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -51,7 +51,6 @@ use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::task::coop::unconstrained;
 use tokio_stream::StreamExt;
 use tokio_util::sync::PollSender;
 
@@ -1039,9 +1038,7 @@ impl<H: DriverHooks> ApplicationOverQuic for H3Driver<H> {
         }
 
         // Also optimistically check for any ready streams
-        while let Some(Some(ready)) =
-            unconstrained(self.waiting_streams.next()).now_or_never()
-        {
+        while let Some(Some(ready)) = self.waiting_streams.next().now_or_never() {
             self.upstream_ready(qconn, ready)?;
         }
 


### PR DESCRIPTION
This partially reverts 35130251 as the change was found to cause regressions on some internal deployments.