### PR TITLE
[gcongestion] Add get_next_release_time and on_app_limited methods to RecoveryOps

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4656,6 +4656,13 @@ impl Connection {
             path.recovery.ping_sent(epoch);
         }
 
+        if !has_data &&
+            !dgram_emitted &&
+            cwnd_available > frame::MAX_STREAM_OVERHEAD
+        {
+            path.recovery.on_app_limited();
+        }
+
         if frames.is_empty() {
             // When we reach this point we are not able to write more, so set
             // app_limited to false.

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -885,6 +885,11 @@ impl RecoveryOps for LegacyRecovery {
         self.detect_lost_packets(epoch, now, "")
     }
 
+    fn on_app_limited(&mut self) {
+        // Not implemented for legacy recovery, update_app_limited and
+        // delivery_rate_update_app_limited used instead.
+    }
+
     #[cfg(test)]
     fn app_limited(&self) -> bool {
         self.congestion.app_limited

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -54,6 +54,8 @@ use super::pacer;
 use super::Congestion;
 use crate::recovery::rtt::RttStats;
 use crate::recovery::LossDetectionTimer;
+use crate::recovery::ReleaseDecision;
+use crate::recovery::ReleaseTime;
 use crate::recovery::GRANULARITY;
 use crate::recovery::INITIAL_PACKET_THRESHOLD;
 use crate::recovery::INITIAL_TIME_THRESHOLD;
@@ -925,6 +927,23 @@ impl RecoveryOps for LegacyRecovery {
 
     fn send_quantum(&self) -> usize {
         self.congestion.send_quantum()
+    }
+
+    // TODO tests
+    fn get_next_release_time(&self) -> ReleaseDecision {
+        let now = Instant::now();
+        let next_send_time = self.congestion.get_packet_send_time();
+        if next_send_time > now {
+            ReleaseDecision {
+                time: ReleaseTime::At(next_send_time),
+                allow_burst: false,
+            }
+        } else {
+            ReleaseDecision {
+                time: ReleaseTime::Immediate,
+                allow_burst: false,
+            }
+        }
     }
 
     fn lost_count(&self) -> usize {

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -227,6 +227,8 @@ pub trait RecoveryOps {
     #[cfg(feature = "qlog")]
     fn maybe_qlog(&mut self) -> Option<EventData>;
     fn send_quantum(&self) -> usize;
+
+    fn get_next_release_time(&self) -> ReleaseDecision;
 }
 
 impl Recovery {
@@ -460,6 +462,76 @@ impl QlogMetrics {
         }
 
         None
+    }
+}
+
+/// When the pacer thinks is a good time to release the next packet
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReleaseTime {
+    Immediate,
+    At(Instant),
+}
+
+/// When the next packet should be release and if it can be part of a burst
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReleaseDecision {
+    time: ReleaseTime,
+    allow_burst: bool,
+}
+
+impl ReleaseTime {
+    /// Add the specific delay to the current time
+    #[allow(dead_code)]
+    fn inc(&mut self, delay: Duration) {
+        match self {
+            ReleaseTime::Immediate => {},
+            ReleaseTime::At(time) => *time += delay,
+        }
+    }
+
+    /// Set the time to the later of two times
+    #[allow(dead_code)]
+    fn set_max(&mut self, other: Instant) {
+        match self {
+            ReleaseTime::Immediate => *self = ReleaseTime::At(other),
+            ReleaseTime::At(time) => *self = ReleaseTime::At(other.max(*time)),
+        }
+    }
+}
+
+impl ReleaseDecision {
+    pub(crate) const EQUAL_THRESHOLD: Duration = Duration::from_micros(35);
+
+    /// Get the [`Instant`] the next packet should be released. It will never be
+    /// in the past.
+    #[allow(dead_code)]
+    #[inline]
+    pub fn time(&self, now: Instant) -> Option<Instant> {
+        match self.time {
+            ReleaseTime::Immediate => None,
+            ReleaseTime::At(other) => other.gt(&now).then_some(other),
+        }
+    }
+
+    /// Can this packet be appended to a previous burst
+    #[allow(dead_code)]
+    #[inline]
+    pub fn can_burst(&self) -> bool {
+        self.allow_burst
+    }
+
+    /// Check if the two packets can be released at the same time
+    #[allow(dead_code)]
+    #[inline]
+    pub fn time_eq(&self, other: &Self, now: Instant) -> bool {
+        let delta = match (self.time(now), other.time(now)) {
+            (None, None) => Duration::ZERO,
+            (Some(t), None) | (None, Some(t)) => t.duration_since(now),
+            (Some(t1), Some(t2)) if t1 < t2 => t2.duration_since(t1),
+            (Some(t1), Some(t2)) => t1.duration_since(t2),
+        };
+
+        delta <= Self::EQUAL_THRESHOLD
     }
 }
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -187,6 +187,8 @@ pub trait RecoveryOps {
 
     fn update_max_datagram_size(&mut self, new_max_datagram_size: usize);
 
+    fn on_app_limited(&mut self);
+
     #[cfg(test)]
     fn app_limited(&self) -> bool;
 


### PR DESCRIPTION
Changes in preparation for gcongestion integration.  Functional no-op since new methods are not used yet.