### PR TITLE
[gcongestion] Add bbr2_congestion algorithm which uses the gcongestion BBRv2 implementation.

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -66,6 +66,7 @@ cdylib-link-lines = { version = "0.1", optional = true }
 
 [dependencies]
 boring = { workspace = true, optional = true }
+debug_panic = { version = "0.2.1" }
 either = { version = "1.8", default-features = false }
 foreign-types-shared = { version = "0.3.0", optional = true }
 intrusive-collections = "0.9.5"

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4887,14 +4887,8 @@ impl Connection {
 
     /// Get the desired send time for the next packet
     #[inline]
-    pub fn use_get_next_release_time(&self) -> Option<bool> {
-        Some(
-            self.paths
-                .get_active()
-                .ok()?
-                .recovery
-                .use_get_next_release_time(),
-        )
+    pub fn gcongestion_enabled(&self) -> Option<bool> {
+        Some(self.paths.get_active().ok()?.recovery.gcongestion_enabled())
     }
 
     /// The maximum pacing into the future, equals 1/8 of the smoothed rtt, but

--- a/quiche/src/recovery/congestion/mod.rs
+++ b/quiche/src/recovery/congestion/mod.rs
@@ -24,6 +24,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use debug_panic::debug_panic;
 use std::time::Instant;
 
 use self::recovery::Acked;
@@ -292,6 +293,10 @@ impl From<CongestionControlAlgorithm> for &'static CongestionControlOps {
             CongestionControlAlgorithm::CUBIC => &cubic::CUBIC,
             CongestionControlAlgorithm::BBR => &bbr::BBR,
             CongestionControlAlgorithm::BBR2 => &bbr2::BBR2,
+            CongestionControlAlgorithm::Bbr2Gcongestion => {
+                debug_panic!("legacy implementation, not gcongestion");
+                &bbr2::BBR2
+            },
         }
     }
 }

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -946,7 +946,7 @@ impl RecoveryOps for LegacyRecovery {
         }
     }
 
-    fn use_get_next_release_time(&self) -> bool {
+    fn gcongestion_enabled(&self) -> bool {
         false
     }
 

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -946,6 +946,10 @@ impl RecoveryOps for LegacyRecovery {
         }
     }
 
+    fn use_get_next_release_time(&self) -> bool {
+        false
+    }
+
     fn lost_count(&self) -> usize {
         self.congestion.lost_count
     }

--- a/quiche/src/recovery/gcongestion/bbr/bandwidth_sampler.rs
+++ b/quiche/src/recovery/gcongestion/bbr/bandwidth_sampler.rs
@@ -279,6 +279,7 @@ impl MaxAckHeightTracker {
         }
     }
 
+    #[allow(dead_code)]
     fn reset(&mut self, new_height: usize, new_time: usize) {
         self.max_ack_height_filter.reset(
             ExtraAckedEvent {
@@ -488,6 +489,7 @@ impl BandwidthSampler {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_app_limited(&self) -> bool {
         self.is_app_limited
     }
@@ -803,6 +805,7 @@ impl BandwidthSampler {
         self.total_bytes_lost
     }
 
+    #[allow(dead_code)]
     pub(crate) fn reset_max_ack_height_tracker(
         &mut self, new_height: usize, new_time: usize,
     ) {

--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -34,6 +34,7 @@ use std::fmt::Debug;
 use std::time::Instant;
 
 use self::bandwidth::Bandwidth;
+pub use self::recovery::GRecovery;
 
 use crate::recovery::rtt::RttStats;
 use crate::recovery::rtt::INITIAL_RTT;

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -950,7 +950,7 @@ impl RecoveryOps for GRecovery {
         self.pacer.get_next_release_time()
     }
 
-    fn use_get_next_release_time(&self) -> bool {
+    fn gcongestion_enabled(&self) -> bool {
         true
     }
 

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -950,6 +950,10 @@ impl RecoveryOps for GRecovery {
         self.pacer.get_next_release_time()
     }
 
+    fn use_get_next_release_time(&self) -> bool {
+        true
+    }
+
     #[cfg(feature = "qlog")]
     fn maybe_qlog(&mut self) -> Option<EventData> {
         let qlog_metrics = QlogMetrics {

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -379,7 +379,7 @@ pub struct GRecovery {
 impl GRecovery {
     pub fn new(recovery_config: &RecoveryConfig) -> Option<Self> {
         let cc = match recovery_config.cc_algorithm {
-            CongestionControlAlgorithm::BBR2 => Congestion::bbrv2(
+            CongestionControlAlgorithm::Bbr2Gcongestion => Congestion::bbrv2(
                 INITIAL_WINDOW_PACKETS,
                 MAX_WINDOW_PACKETS,
                 recovery_config.max_send_udp_payload_size,

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -231,6 +231,8 @@ pub trait RecoveryOps {
     fn send_quantum(&self) -> usize;
 
     fn get_next_release_time(&self) -> ReleaseDecision;
+
+    fn use_get_next_release_time(&self) -> bool;
 }
 
 impl Recovery {
@@ -556,23 +558,34 @@ mod tests {
     use smallvec::smallvec;
     use std::str::FromStr;
 
+    fn recovery_for_alg(algo: CongestionControlAlgorithm) -> Recovery {
+        let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        cfg.set_cc_algorithm(algo);
+        Recovery::new(&cfg)
+    }
+
     #[test]
     fn lookup_cc_algo_ok() {
         let algo = CongestionControlAlgorithm::from_str("reno").unwrap();
         assert_eq!(algo, CongestionControlAlgorithm::Reno);
+        assert!(!recovery_for_alg(algo).use_get_next_release_time());
 
         let algo = CongestionControlAlgorithm::from_str("cubic").unwrap();
         assert_eq!(algo, CongestionControlAlgorithm::CUBIC);
+        assert!(!recovery_for_alg(algo).use_get_next_release_time());
 
         let algo = CongestionControlAlgorithm::from_str("bbr").unwrap();
         assert_eq!(algo, CongestionControlAlgorithm::BBR);
+        assert!(!recovery_for_alg(algo).use_get_next_release_time());
 
         let algo = CongestionControlAlgorithm::from_str("bbr2").unwrap();
         assert_eq!(algo, CongestionControlAlgorithm::BBR2);
+        assert!(!recovery_for_alg(algo).use_get_next_release_time());
 
         let algo =
             CongestionControlAlgorithm::from_str("bbr2_gcongestion").unwrap();
         assert_eq!(algo, CongestionControlAlgorithm::Bbr2Gcongestion);
+        assert!(recovery_for_alg(algo).use_get_next_release_time());
     }
 
     #[test]

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -232,7 +232,7 @@ pub trait RecoveryOps {
 
     fn get_next_release_time(&self) -> ReleaseDecision;
 
-    fn use_get_next_release_time(&self) -> bool;
+    fn gcongestion_enabled(&self) -> bool;
 }
 
 impl Recovery {
@@ -568,24 +568,24 @@ mod tests {
     fn lookup_cc_algo_ok() {
         let algo = CongestionControlAlgorithm::from_str("reno").unwrap();
         assert_eq!(algo, CongestionControlAlgorithm::Reno);
-        assert!(!recovery_for_alg(algo).use_get_next_release_time());
+        assert!(!recovery_for_alg(algo).gcongestion_enabled());
 
         let algo = CongestionControlAlgorithm::from_str("cubic").unwrap();
         assert_eq!(algo, CongestionControlAlgorithm::CUBIC);
-        assert!(!recovery_for_alg(algo).use_get_next_release_time());
+        assert!(!recovery_for_alg(algo).gcongestion_enabled());
 
         let algo = CongestionControlAlgorithm::from_str("bbr").unwrap();
         assert_eq!(algo, CongestionControlAlgorithm::BBR);
-        assert!(!recovery_for_alg(algo).use_get_next_release_time());
+        assert!(!recovery_for_alg(algo).gcongestion_enabled());
 
         let algo = CongestionControlAlgorithm::from_str("bbr2").unwrap();
         assert_eq!(algo, CongestionControlAlgorithm::BBR2);
-        assert!(!recovery_for_alg(algo).use_get_next_release_time());
+        assert!(!recovery_for_alg(algo).gcongestion_enabled());
 
         let algo =
             CongestionControlAlgorithm::from_str("bbr2_gcongestion").unwrap();
         assert_eq!(algo, CongestionControlAlgorithm::Bbr2Gcongestion);
-        assert!(recovery_for_alg(algo).use_get_next_release_time());
+        assert!(recovery_for_alg(algo).gcongestion_enabled());
     }
 
     #[test]

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -51,9 +51,9 @@ futures = { workspace = true }
 futures-util = { workspace = true }
 ipnetwork = { workspace = true }
 log = { workspace = true }
-octets = { version = "0.3.0" }
+octets = { workspace = true }
 pin-project = { workspace = true }
-quiche = { version = "0.23", features = ["boringssl-boring-crate", "qlog"] }
+quiche = { workspace = true, features = ["boringssl-boring-crate", "qlog"] }
 quiche-mallard = { version = "0.21", features = [
   "boringssl-boring-crate",
   "qlog",


### PR DESCRIPTION
This PR hooks the implementation in the gcongestion subdirectory into the Recovery object defined in the `quiche/src/recovery/mod.rs`

Also, update `tokio-quiche/src/quic/io/worker.rs` to use get_next_release_time when using the gcongestion BBRv2 implementation even in cases where the "gcongestion" feature is disabled.