### PR TITLE
[gcongestion] Apply fixes to gcongestion implementation from the cloudflare/quiche-mallard repo.

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4799,7 +4799,7 @@ impl Connection {
             is_app_limited: false,
             tx_in_flight: 0,
             lost: 0,
-            has_data,
+            has_data: has_data | dgram_emitted,
             pmtud: pmtud_probe,
         };
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4784,6 +4784,12 @@ impl Connection {
             aead,
         )?;
 
+        let sent_pkt_has_data = if path.recovery.gcongestion_enabled() {
+            has_data || dgram_emitted
+        } else {
+            has_data
+        };
+
         let sent_pkt = recovery::Sent {
             pkt_num: pn,
             frames,
@@ -4799,7 +4805,7 @@ impl Connection {
             is_app_limited: false,
             tx_in_flight: 0,
             lost: 0,
-            has_data: has_data | dgram_emitted,
+            has_data: sent_pkt_has_data,
             pmtud: pmtud_probe,
         };
 

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -235,7 +235,7 @@ const PARAMS: Params = Params {
 
     overestimate_avoidance: true,
 
-    bw_lo_mode: BwLoMode::Default,
+    bw_lo_mode: BwLoMode::InflightReduction,
 };
 
 #[derive(Debug)]

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -784,7 +784,8 @@ impl RecoveryOps for GRecovery {
                 }
             })
             .take(epoch.loss_probes)
-            .flatten();
+            .flatten()
+            .filter(|f| !matches!(f, frame::Frame::DatagramHeader { .. }));
 
         // Retransmit the frames from the oldest sent packets on PTO. However
         // the packets are not actually declared lost (so there is no effect to

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -513,7 +513,7 @@ impl ReleaseTime {
 }
 
 impl ReleaseDecision {
-    pub(crate) const EQUAL_THRESHOLD: Duration = Duration::from_micros(35);
+    pub(crate) const EQUAL_THRESHOLD: Duration = Duration::from_micros(50);
 
     /// Get the [`Instant`] the next packet should be released. It will never be
     /// in the past.

--- a/quiche/src/recovery/rtt.rs
+++ b/quiche/src/recovery/rtt.rs
@@ -63,7 +63,7 @@ impl RttStats {
     pub(crate) fn new(max_ack_delay: Duration) -> Self {
         RttStats {
             latest_rtt: Duration::ZERO,
-            min_rtt: Minmax::new(Duration::ZERO),
+            min_rtt: Minmax::new(INITIAL_RTT),
             smoothed_rtt: INITIAL_RTT,
             rttvar: INITIAL_RTT / 2,
             first_rtt_sample: None,


### PR DESCRIPTION
After this change most of the functionality from quiche-mallard should be available from mainline quiche.  The exception being the "zero-copy" feature.