### PR TITLE
Add support for literal headers for h3i

### DIFF
--- a/h3i/examples/content_length_mismatch.rs
+++ b/h3i/examples/content_length_mismatch.rs
@@ -39,6 +39,7 @@ fn main() {
             stream_id: STREAM_ID,
             fin_stream: false,
             headers,
+            literal_headers: false,
             frame: Frame::Headers { header_block },
         },
         Action::SendFrame {

--- a/h3i/src/actions/h3.rs
+++ b/h3i/src/actions/h3.rs
@@ -42,6 +42,7 @@ use serde::Serialize;
 use serde_with::serde_as;
 
 use crate::encode_header_block;
+use crate::encode_header_block_literal;
 
 /// An action which the HTTP/3 client should take.
 ///
@@ -62,6 +63,7 @@ pub enum Action {
     SendHeadersFrame {
         stream_id: u64,
         fin_stream: bool,
+        literal_headers: bool,
         headers: Vec<Header>,
         frame: Frame,
     },
@@ -201,6 +203,25 @@ pub fn send_headers_frame(
         stream_id,
         fin_stream,
         headers,
+        literal_headers: false,
+        frame: Frame::Headers { header_block },
+    }
+}
+
+/// Convenience to convert between header-related data and a
+/// [Action::SendHeadersFrame]. Unlike [`send_headers_frame`],
+/// this version encodes the headers literally as they are provided,
+/// not converting the header names to lower-case.
+pub fn send_headers_frame_literal(
+    stream_id: u64, fin_stream: bool, headers: Vec<Header>,
+) -> Action {
+    let header_block = encode_header_block_literal(&headers).unwrap();
+
+    Action::SendHeadersFrame {
+        stream_id,
+        fin_stream,
+        headers,
+        literal_headers: true,
         frame: Frame::Headers { header_block },
     }
 }

--- a/h3i/src/prompts/h3/headers.rs
+++ b/h3i/src/prompts/h3/headers.rs
@@ -33,6 +33,7 @@ use quiche;
 use quiche::h3::frame::Frame;
 
 use crate::encode_header_block;
+use crate::encode_header_block_literal;
 use crate::prompts::h3;
 use crate::StreamIdAllocator;
 
@@ -47,7 +48,7 @@ use super::STREAM_ID_PROMPT;
 use crate::actions::h3::Action;
 
 pub fn prompt_headers(
-    sid_alloc: &mut StreamIdAllocator, host_port: &str, raw: bool,
+    sid_alloc: &mut StreamIdAllocator, host_port: &str, raw: bool, literal: bool,
 ) -> InquireResult<Action> {
     let stream_id = Text::new(STREAM_ID_PROMPT)
         .with_placeholder(EMPTY_PICKS)
@@ -75,7 +76,11 @@ pub fn prompt_headers(
 
     sid_alloc.take_next_id();
 
-    let header_block = encode_header_block(&headers).unwrap_or_default();
+    let header_block = if literal {
+        encode_header_block_literal(&headers).unwrap_or_default()
+    } else {
+        encode_header_block(&headers).unwrap_or_default()
+    };
 
     let fin_stream = prompt_fin_stream()?;
 
@@ -83,6 +88,7 @@ pub fn prompt_headers(
         stream_id,
         fin_stream,
         headers,
+        literal_headers: literal,
         frame: Frame::Headers { header_block },
     };
 

--- a/h3i/src/prompts/h3/mod.rs
+++ b/h3i/src/prompts/h3/mod.rs
@@ -80,6 +80,8 @@ thread_local! {static CONNECTION_IDLE_TIMEOUT: RefCell<u64> = const { RefCell::n
 // TODO(erittenhouse): exploring generating prompts at compile-time
 const HEADERS: &str = "headers";
 const HEADERS_NO_PSEUDO: &str = "headers_no_pseudo";
+const HEADERS_LITERAL: &str = "headers_literal";
+const HEADERS_NO_PSEUDO_LITERAL: &str = "headers_no_pseudo_literal";
 const DATA: &str = "data";
 const SETTINGS: &str = "settings";
 const PUSH_PROMISE: &str = "push_promise";
@@ -137,12 +139,19 @@ impl Prompter {
 
     fn handle_action(&mut self, action: &str) -> PromptOutcome {
         let res = match action {
-            HEADERS | HEADERS_NO_PSEUDO => {
-                let raw = action == HEADERS_NO_PSEUDO;
+            HEADERS |
+            HEADERS_NO_PSEUDO |
+            HEADERS_LITERAL |
+            HEADERS_NO_PSEUDO_LITERAL => {
+                let literal = action == HEADERS_LITERAL ||
+                    action == HEADERS_NO_PSEUDO_LITERAL;
+                let raw = action == HEADERS_NO_PSEUDO ||
+                    action == HEADERS_NO_PSEUDO_LITERAL;
                 headers::prompt_headers(
                     &mut self.bidi_sid_alloc,
                     &self.host_port,
                     raw,
+                    literal,
                 )
             },
 
@@ -244,6 +253,8 @@ fn action_suggester(val: &str) -> SuggestionResult<Vec<String>> {
     let suggestions = [
         HEADERS,
         HEADERS_NO_PSEUDO,
+        HEADERS_LITERAL,
+        HEADERS_NO_PSEUDO_LITERAL,
         DATA,
         SETTINGS,
         GOAWAY,

--- a/quiche/src/h3/qpack/encoder.rs
+++ b/quiche/src/h3/qpack/encoder.rs
@@ -117,7 +117,7 @@ fn lookup_static<T: NameValue>(h: &T) -> Option<(u64, bool)> {
     None
 }
 
-fn encode_int(
+pub fn encode_int(
     mut v: u64, first: u8, prefix: usize, b: &mut octets::OctetsMut,
 ) -> Result<()> {
     let mask = 2u64.pow(prefix as u32) - 1;
@@ -147,7 +147,7 @@ fn encode_int(
 }
 
 #[inline]
-fn encode_str<const LOWER_CASE: bool>(
+pub fn encode_str<const LOWER_CASE: bool>(
     v: &[u8], first: u8, prefix: usize, b: &mut octets::OctetsMut,
 ) -> Result<()> {
     // Huffman-encoding generally saves space but in some cases it doesn't, for

--- a/quiche/src/h3/qpack/mod.rs
+++ b/quiche/src/h3/qpack/mod.rs
@@ -26,10 +26,13 @@
 
 //! HTTP/3 header compression (QPACK).
 
-const INDEXED: u8 = 0b1000_0000;
-const INDEXED_WITH_POST_BASE: u8 = 0b0001_0000;
-const LITERAL: u8 = 0b0010_0000;
-const LITERAL_WITH_NAME_REF: u8 = 0b0100_0000;
+pub use encoder::encode_int;
+pub use encoder::encode_str;
+
+pub const INDEXED: u8 = 0b1000_0000;
+pub const INDEXED_WITH_POST_BASE: u8 = 0b0001_0000;
+pub const LITERAL: u8 = 0b0010_0000;
+pub const LITERAL_WITH_NAME_REF: u8 = 0b0100_0000;
 
 /// A specialized [`Result`] type for quiche QPACK operations.
 ///


### PR DESCRIPTION
This PR adds support for literal headers, such as header names with upper-case letters, to h3i.
It does not affect the existing functions, instead introducing a new one (`send_headers_frame_literal`) that can be used when testing specifically for these invalid headers.

I made sure that the internal quiche functions and constants that needed to be exposed to h3i are hidden behind the `internal` feature.