### PR TITLE
bbr: account for bytes buffered at lower layers

### DIFF
--- a/quiche/src/recovery/congestion/bbr/mod.rs
+++ b/quiche/src/recovery/congestion/bbr/mod.rs
@@ -537,8 +537,7 @@ mod tests {
             );
         }
 
-        // Stop at right before filled_pipe=true.
-        for _ in 0..5 {
+        for _ in 0..7 {
             let pkt = Sent {
                 pkt_num: pn,
                 frames: smallvec![],
@@ -574,9 +573,8 @@ mod tests {
 
         let mut acked = ranges::RangeSet::default();
 
-        // We sent 5 packets, but ack only one, to stay
-        // in Drain state.
-        acked.insert(0..pn - 4);
+        // We sent 7 packets, but ack only one, to stay in Drain state.
+        acked.insert(0..pn - 6);
 
         assert_eq!(
             r.on_ack_received(


### PR DESCRIPTION
For example, due to pacing offload some packets might be buffered in the fq qdisc queue and not yet sent on the network.

This is more or less meant to be equivalent to Linux' `bbr_packets_in_net_at_edt()` function.

---

This is an alternative to https://github.com/cloudflare/quiche/pull/1636 and instead of walking the list of sent packets which is quite expensive, we just sort of estimate the amount of bytes by looking at BW and pacing rate.