### PR TITLE
Add bounds check in un-safe code in octets macros

### DIFF
--- a/octets/Cargo.toml
+++ b/octets/Cargo.toml
@@ -8,3 +8,8 @@ repository = { workspace = true }
 license = { workspace = true }
 keywords = { workspace = true }
 categories = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(test_invalid_len_compilation_fail)',
+] }


### PR DESCRIPTION
The `put_u` and `peek_u` macros in `octets` contains unsafe blocks. This commit adds a safety check to make sure the length we are being passed is within the proper bounds. Without this check it's possible to access invalid memory.

Note that the macro is not exported and all current uses of it are safe. So this commits just prevents future issues.