### PR TITLE
tokio-quiche: Handle zero-length HTTP bodies without FIN

### DIFF
--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -650,6 +650,11 @@ impl<H: DriverHooks> H3Driver<H> {
 
             OutboundFrame::Body(body, fin) => {
                 let len = body.as_ref().len();
+                if len == 0 && !*fin {
+                    // quiche doesn't allow sending an empty body when the fin
+                    // flag is not set
+                    return Ok(());
+                }
                 if *fin {
                     // If this is the last body frame, close the receiver in the
                     // stream map to signal that we shouldn't


### PR DESCRIPTION
Change the return value of h3::Connection::send_body() to return Ok(0) if a zero-length body *without* FIN is sent (from Err(Done)).

Two reasons why:
* It eliminiates a possible infinte loop in tokio-quiche. If TQ gets a Err(Done) it will retry the send, which will never succeed. But if it gets an Ok(n) TQ will move on if `n == body.len()`.
* It brings the behavior in line with what send_stream() does, which also returns Ok(0) if a zero-length write w/o fin is attempted.