### PR TITLE
chore(Cargo.toml): disable serde_with default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ regex = { version = "1.4.2" }
 ring = { version = "0.17.8" }
 serde = { version = "1" }
 serde_json = { version = "1" }
-serde_with = { version = "3.3" }
+serde_with = { version = "3.3", default-features = false }
 slog-scope = { version = "4.0" }
 slog-stdlog = { version = "4.1.1" }
 smallvec = { version = "1.10", default-features = false }

--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -27,6 +27,6 @@ quiche = { workspace = true, features = ["internal", "qlog"] }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_with = { workspace = true }
+serde_with = { workspace = true, features = ["macros", "std"] }
 smallvec = { workspace = true }
 url = { workspace = true }

--- a/qlog/Cargo.toml
+++ b/qlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qlog"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Lucas Pardue <lucaspardue.24.7@gmail.com>"]
 description = "qlog data model for QUIC and HTTP/3"
 edition = { workspace = true }

--- a/qlog/Cargo.toml
+++ b/qlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qlog"
-version = "0.15.2"
+version = "0.15.1"
 authors = ["Lucas Pardue <lucaspardue.24.7@gmail.com>"]
 description = "qlog data model for QUIC and HTTP/3"
 edition = { workspace = true }


### PR DESCRIPTION
Previously `qlog` `<= v0.15.0` dependet on `serde_with` without `default-features`. It would only enable `serde_with`'s `macro` feature. See `crates.io` link below, hovering over the `serde_with` `1 EXTRA FEATURE` field.

https://crates.io/crates/qlog/0.15.0/dependencies

https://github.com/cloudflare/quiche/pull/1938 introduced the `serde_with` workspace dependency. Note that this workspace dependency does not disable `serde_with` `default-features`.

https://github.com/cloudflare/quiche/pull/1953 updated `qlog` to use the `serde_with` workspace import, instead of the previous crate specific import in `qlog/Cargo.toml`. Effectively, this enabled `serde_with` `default-features` for `qlog`. See `crates.io` link below, this time for `qlog` `v0.15.1`:

https://crates.io/crates/qlog/0.15.1/dependencies

`serde_with` default features introduce a lot of additional dependencies. See:

https://github.com/jonasbb/serde_with/blob/master/serde_with/Cargo.toml

Mozilla (very happily) consumes `qlog` through https://github.com/mozilla/neqo. Mozilla requires dependency vetting via https://github.com/mozilla/cargo-vet of every dependency. Instead of vetting each of the (I assume) accidentally introduced new dependencies through `serde_with` `default-features`, this commit instead sets `default-features = false` on `serde_with`.

Effectively, this removes the following crates from `qlog`'s dependency tree:

- android-tzdata
- android_system_properties
- base64
- bumpalo
- chrono
- core-foundation-sys
- deranged
- hashbrown
- iana-time-zone
- iana-time-zone-haiku
- indexmap
- js-sys
- num-conv
- powerfmt
- time
- time-core
- time-macros
- wasm-bindgen
- wasm-bindgen-backend
- wasm-bindgen-macro
- wasm-bindgen-macro-support
- wasm-bindgen-shared
- windows-core
- windows-link