### PR TITLE
tokio-quiche: expose additional Quiche settings in QuicSettings

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -960,14 +960,17 @@ impl Config {
 
     /// Configures whether to verify the peer's certificate.
     ///
-    /// The default value is `true` for client connections, and `false` for
-    /// server ones.
+    /// This should usually be `true` for client-side connections and `false`
+    /// for server-side ones.
     ///
-    /// Note that on the server-side, enabling verification of the peer will
-    /// trigger a certificate request and make authentication errors fatal, but
-    /// will still allow anonymous clients (i.e. clients that don't present a
-    /// certificate at all). Servers can check whether a client presented a
-    /// certificate by calling [`peer_cert()`] if they need to.
+    /// Note that by default, no verification is performed.
+    ///
+    /// Also note that on the server-side, enabling verification of the peer
+    /// will trigger a certificate request and make authentication errors
+    /// fatal, but will still allow anonymous clients (i.e. clients that
+    /// don't present a certificate at all). Servers can check whether a
+    /// client presented a certificate by calling [`peer_cert()`] if they
+    /// need to.
     ///
     /// [`peer_cert()`]: struct.Connection.html#method.peer_cert
     pub fn verify_peer(&mut self, verify: bool) {

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -163,6 +163,10 @@ fn make_quiche_config(
     config.set_cc_algorithm_name(quic_settings.cc_algorithm.as_str())?;
     config.enable_hystart(quic_settings.enable_hystart);
     config.enable_pacing(quic_settings.enable_pacing);
+    config.verify_peer(quic_settings.verify_peer);
+    config.set_max_connection_window(quic_settings.max_connection_window);
+    config.set_max_stream_window(quic_settings.max_stream_window);
+    config.grease(quic_settings.grease);
 
     if should_log_keys {
         config.log_keys();

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -170,6 +170,33 @@ pub struct QuicSettings {
     /// Defaults to 1024 connections.
     #[serde(default = "QuicSettings::default_listen_backlog")]
     pub listen_backlog: usize,
+
+    /// Whether or not to verify the peer's certificate.
+    ///
+    /// Defaults to `false`, meaning no peer verification is performed. Note
+    /// that clients should usually set this value to `true` - see
+    /// [`verify_peer()`] for more.
+    ///
+    /// [`verify_peer()`]: https://docs.rs/quiche/latest/quiche/struct.Config.html#method.verify_peer
+    pub verify_peer: bool,
+
+    /// The maximum size of the receiver connection flow control window.
+    ///
+    /// Defaults to 24MB.
+    #[serde(default = "QuicSettings::default_max_connection_window")]
+    pub max_connection_window: u64,
+
+    /// The maximum size of the receiveer stream flow control window.
+    ///
+    /// Defaults to 16MB.
+    #[serde(default = "QuicSettings::default_max_stream_window")]
+    pub max_stream_window: u64,
+
+    /// Configures whether to send GREASE values.
+    ///
+    /// Defaults to true.
+    #[serde(default = "QuicSettings::default_grease")]
+    pub grease: bool,
 }
 
 impl QuicSettings {
@@ -243,6 +270,21 @@ impl QuicSettings {
         // This means this backlog size limits the queueing latency to
         // ~15s.
         1024
+    }
+
+    #[inline]
+    fn default_max_connection_window() -> u64 {
+        24 * 1024 * 1024
+    }
+
+    #[inline]
+    fn default_max_stream_window() -> u64 {
+        16 * 1024 * 1024
+    }
+
+    #[inline]
+    fn default_grease() -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
Needed for async h3i to use the same arguments as sync h3i. 

The docs change is something I noticed while investigating `verify_peer`.