### PR TITLE
Revert "tokio-quiche: expose verify_peer, max_(connection/stream)_win…

### DIFF
--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -163,10 +163,6 @@ fn make_quiche_config(
     config.set_cc_algorithm_name(quic_settings.cc_algorithm.as_str())?;
     config.enable_hystart(quic_settings.enable_hystart);
     config.enable_pacing(quic_settings.enable_pacing);
-    config.verify_peer(quic_settings.verify_peer);
-    config.set_max_connection_window(quic_settings.max_connection_window);
-    config.set_max_stream_window(quic_settings.max_stream_window);
-    config.grease(quic_settings.grease);
 
     if should_log_keys {
         config.log_keys();

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -170,33 +170,6 @@ pub struct QuicSettings {
     /// Defaults to 1024 connections.
     #[serde(default = "QuicSettings::default_listen_backlog")]
     pub listen_backlog: usize,
-
-    /// Whether or not to verify the peer's certificate.
-    ///
-    /// Defaults to `false`, meaning no peer verification is performed. Note
-    /// that clients should usually set this value to `true` - see
-    /// [`verify_peer()`] for more.
-    ///
-    /// [`verify_peer()`]: https://docs.rs/quiche/latest/quiche/struct.Config.html#method.verify_peer
-    pub verify_peer: bool,
-
-    /// The maximum size of the receiver connection flow control window.
-    ///
-    /// Defaults to 24MB.
-    #[serde(default = "QuicSettings::default_max_connection_window")]
-    pub max_connection_window: u64,
-
-    /// The maximum size of the receiveer stream flow control window.
-    ///
-    /// Defaults to 16MB.
-    #[serde(default = "QuicSettings::default_max_stream_window")]
-    pub max_stream_window: u64,
-
-    /// Configures whether to send GREASE values.
-    ///
-    /// Defaults to true.
-    #[serde(default = "QuicSettings::default_grease")]
-    pub grease: bool,
 }
 
 impl QuicSettings {
@@ -270,21 +243,6 @@ impl QuicSettings {
         // This means this backlog size limits the queueing latency to
         // ~15s.
         1024
-    }
-
-    #[inline]
-    fn default_max_connection_window() -> u64 {
-        24 * 1024 * 1024
-    }
-
-    #[inline]
-    fn default_max_stream_window() -> u64 {
-        16 * 1024 * 1024
-    }
-
-    #[inline]
-    fn default_grease() -> bool {
-        true
     }
 }
 


### PR DESCRIPTION
…dow, grease in QuicSettings"

This reverts commit 50fb8dd97d2dc3ed4ee13be3326886a28c5b4dbe.

---

Reverting for now to avoid having to do a major release, will land again after next release.