### PR TITLE
tokio-quiche: dynamically check for pacing enablement

### DIFF
--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -53,7 +53,7 @@ ipnetwork = { workspace = true }
 log = { workspace = true }
 octets = { version = "0.3.0" }
 pin-project = { workspace = true }
-quiche = { version = "0.23.6", features = ["boringssl-boring-crate", "qlog"] }
+quiche = { version = "0.23.7", features = ["boringssl-boring-crate", "qlog"] }
 quiche-mallard = { version = "0.21", features = [
   "boringssl-boring-crate",
   "qlog",

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -87,15 +87,16 @@ impl Config {
             ..
         } = socket_capabilities;
 
+        #[cfg(feature = "gcongestion")]
+        let pacing_offload = quic_settings.enable_pacing && pacing_offload;
+
         Ok(Config {
             quiche_config: make_quiche_config(params, keylog_file.is_some())?,
             disable_client_ip_validation: quic_settings
                 .disable_client_ip_validation,
             qlog_dir: quic_settings.qlog_dir.clone(),
             has_gso,
-            // Only enable pacing if it is explicitly enabled in the configuration
-            // and offload is supported.
-            pacing_offload: quic_settings.enable_pacing && pacing_offload,
+            pacing_offload,
             enable_expensive_packet_count_metrics: quic_settings
                 .enable_expensive_packet_count_metrics,
             keylog_file,


### PR DESCRIPTION
Rather than gating whether pacing is enabled or not on a configuration parameter, query the underlying quiche connection directly.

This allows enabling pacing when a connection has already be created (e.g. using the mechanism added in fd5c01ad).