### PR TITLE
Parameterize recovery module tests so they run against all congestion control algorithms.

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3746,7 +3746,7 @@ impl<F: BufFactory> Connection<F> {
             from: send_path.local_addr(),
             to: send_path.peer_addr(),
 
-            at: send_path.recovery.get_packet_send_time(),
+            at: send_path.recovery.get_packet_send_time(now),
         };
 
         Ok((done, info))

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -587,7 +587,8 @@ impl RecoveryOps for LegacyRecovery {
         trace!("{} {:?}", trace_id, self);
     }
 
-    fn get_packet_send_time(&self) -> Instant {
+    fn get_packet_send_time(&self, _now: Instant) -> Instant {
+        // TODO .max(now)
         self.congestion.get_packet_send_time()
     }
 

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -636,8 +636,7 @@ impl RecoveryOps for GRecovery {
         trace!("{} {:?}", trace_id, self);
     }
 
-    fn get_packet_send_time(&self) -> Instant {
-        let now = Instant::now();
+    fn get_packet_send_time(&self, now: Instant) -> Instant {
         self.pacer.get_next_release_time().time(now).unwrap_or(now)
     }
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -556,6 +556,8 @@ impl ReleaseDecision {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
     use crate::packet;
     use crate::ranges;
@@ -610,10 +612,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn loss_on_pto() {
+    #[rstest]
+    fn loss_on_pto(
+        #[values("reno", "cubic", "bbr", "bbr2", "bbr2_gcongestion")]
+        cc_algorithm_name: &str,
+    ) {
         let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
-        cfg.set_cc_algorithm(CongestionControlAlgorithm::Reno);
+        assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
 
         let mut r = Recovery::new(&cfg);
 
@@ -866,10 +871,13 @@ mod tests {
         assert_eq!(r.sent_packets_len(packet::Epoch::Application), 0);
     }
 
-    #[test]
-    fn loss_on_timer() {
+    #[rstest]
+    fn loss_on_timer(
+        #[values("reno", "cubic", "bbr", "bbr2", "bbr2_gcongestion")]
+        cc_algorithm_name: &str,
+    ) {
         let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
-        cfg.set_cc_algorithm(CongestionControlAlgorithm::Reno);
+        assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
 
         let mut r = Recovery::new(&cfg);
 
@@ -1041,10 +1049,13 @@ mod tests {
         assert_eq!(r.sent_packets_len(packet::Epoch::Application), 0);
     }
 
-    #[test]
-    fn loss_on_reordering() {
+    #[rstest]
+    fn loss_on_reordering(
+        #[values("reno", "cubic", "bbr", "bbr2", "bbr2_gcongestion")]
+        cc_algorithm_name: &str,
+    ) {
         let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
-        cfg.set_cc_algorithm(CongestionControlAlgorithm::Reno);
+        assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
 
         let mut r = Recovery::new(&cfg);
 
@@ -1228,10 +1239,10 @@ mod tests {
         assert_eq!(r.sent_packets_len(packet::Epoch::Application), 0);
     }
 
-    #[test]
-    fn pacing() {
+    #[rstest]
+    fn pacing(#[values("reno", "cubic", "bbr", "bbr2")] cc_algorithm_name: &str) {
         let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
-        cfg.set_cc_algorithm(CongestionControlAlgorithm::CUBIC);
+        assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
 
         let mut r = Recovery::new(&cfg);
 
@@ -1296,8 +1307,12 @@ mod tests {
         assert_eq!(r.bytes_in_flight(), 0);
         assert_eq!(r.rtt(), Duration::from_millis(50));
 
-        // 1 MSS increased.
-        assert_eq!(r.cwnd(), 12000 + 1200);
+        assert_eq!(r.cwnd(), match cc_algorithm_name {
+            "bbr" => 24000,
+            "bbr2" => 24000,
+            // cubic and reno: 1 MSS increased.
+            _ => 12000 + 1200,
+        });
 
         // Send out second packet.
         let p = Sent {
@@ -1397,7 +1412,36 @@ mod tests {
 
         // We pace this outgoing packet. as all conditions for pacing
         // are passed.
-        let pacing_rate = (r.cwnd() as f64 * PACING_MULTIPLIER / 0.05) as u64;
+        let pacing_rate = match cc_algorithm_name {
+            "bbr" => {
+                // Constants from congestion/bbr/mod.rs
+                let cwnd_gain = 2.0;
+                let startup_pacing_gain = 2.89;
+                // Adjust for cwnd_gain.  BW estimate was made before the CWND
+                // increase.
+                let bw = r.cwnd() as f64 /
+                    cwnd_gain /
+                    Duration::from_millis(50).as_secs_f64();
+                (bw * startup_pacing_gain) as u64
+            },
+            "bbr2" => {
+                // Constants from congestion/bbr2/mod.rs
+                let cwnd_gain = 2.0;
+                let startup_pacing_gain = 2.77;
+                let pacing_margin_percent = 0.01;
+                // Adjust for cwnd_gain.  BW estimate was made before the CWND
+                // increase.
+                let bw = r.cwnd() as f64 /
+                    cwnd_gain /
+                    Duration::from_millis(50).as_secs_f64();
+                (bw * startup_pacing_gain * (1.0 - pacing_margin_percent)) as u64
+            },
+            _ => {
+                let bw =
+                    r.cwnd() as f64 / Duration::from_millis(50).as_secs_f64();
+                (bw * PACING_MULTIPLIER) as u64
+            },
+        };
         assert_eq!(r.pacing_rate(), pacing_rate);
 
         assert_eq!(
@@ -1406,12 +1450,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn pmtud_loss_on_timer() {
+    #[rstest]
+    fn pmtud_loss_on_timer(
+        #[values("reno", "cubic", "bbr", "bbr2", "bbr2_gcongestion")]
+        cc_algorithm_name: &str,
+    ) {
         let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
-        cfg.set_cc_algorithm(CongestionControlAlgorithm::Reno);
+        assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
 
         let mut r = Recovery::new(&cfg);
+        assert_eq!(r.cwnd(), 12000);
 
         let mut now = Instant::now();
 
@@ -1541,7 +1589,11 @@ mod tests {
         assert_eq!(r.sent_packets_len(packet::Epoch::Application), 2);
         assert_eq!(r.in_flight_count(packet::Epoch::Application), 0);
         assert_eq!(r.bytes_in_flight(), 0);
-        assert_eq!(r.cwnd(), 12000);
+        assert_eq!(r.cwnd(), match cc_algorithm_name {
+            "bbr" => 14000,
+            "bbr2" => 14000,
+            _ => 12000,
+        });
 
         assert_eq!(r.lost_count(), 0);
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -156,7 +156,7 @@ pub trait RecoveryOps {
         &mut self, pkt: Sent, epoch: packet::Epoch,
         handshake_status: HandshakeStatus, now: Instant, trace_id: &str,
     );
-    fn get_packet_send_time(&self) -> Instant;
+    fn get_packet_send_time(&self, now: Instant) -> Instant;
 
     fn on_ack_received(
         &mut self, ranges: &RangeSet, ack_delay: u64, epoch: packet::Epoch,
@@ -1272,7 +1272,7 @@ mod tests {
 
         // First packet will be sent out immediately.
         assert_eq!(r.pacing_rate(), 0);
-        assert_eq!(r.get_packet_send_time(), now);
+        assert_eq!(r.get_packet_send_time(now), now);
 
         // Wait 50ms for ACK.
         now += Duration::from_millis(50);
@@ -1331,7 +1331,7 @@ mod tests {
         assert_eq!(r.bytes_in_flight(), 6000);
 
         // Pacing is not done during initial phase of connection.
-        assert_eq!(r.get_packet_send_time(), now);
+        assert_eq!(r.get_packet_send_time(now), now);
 
         // Send the third packet out.
         let p = Sent {
@@ -1401,7 +1401,7 @@ mod tests {
         assert_eq!(r.pacing_rate(), pacing_rate);
 
         assert_eq!(
-            r.get_packet_send_time(),
+            r.get_packet_send_time(now),
             now + Duration::from_secs_f64(12000.0 / pacing_rate as f64)
         );
     }

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -1250,46 +1250,51 @@ mod tests {
 
         assert_eq!(r.sent_packets_len(packet::Epoch::Application), 0);
 
-        // send out first packet (a full initcwnd).
-        let p = Sent {
-            pkt_num: 0,
-            frames: smallvec![],
-            time_sent: now,
-            time_acked: None,
-            time_lost: None,
-            size: 12000,
-            ack_eliciting: true,
-            in_flight: true,
-            delivered: 0,
-            delivered_time: now,
-            first_sent_time: now,
-            is_app_limited: false,
-            tx_in_flight: 0,
-            lost: 0,
-            has_data: false,
-            pmtud: false,
-        };
+        // send out first packet burst (a full initcwnd).
+        for i in 0..10 {
+            let p = Sent {
+                pkt_num: i,
+                frames: smallvec![],
+                time_sent: now,
+                time_acked: None,
+                time_lost: None,
+                size: 1200,
+                ack_eliciting: true,
+                in_flight: true,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
+                has_data: true,
+                pmtud: false,
+            };
 
-        r.on_packet_sent(
-            p,
-            packet::Epoch::Application,
-            HandshakeStatus::default(),
-            now,
-            "",
-        );
+            r.on_packet_sent(
+                p,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+            );
+        }
 
-        assert_eq!(r.sent_packets_len(packet::Epoch::Application), 1);
+        assert_eq!(r.sent_packets_len(packet::Epoch::Application), 10);
         assert_eq!(r.bytes_in_flight(), 12000);
 
-        // First packet will be sent out immediately.
+        // Next packet will be sent out immediately.
         assert_eq!(r.pacing_rate(), 0);
         assert_eq!(r.get_packet_send_time(now), now);
+
+        assert_eq!(r.cwnd(), 12000);
+        assert_eq!(r.cwnd_available(), 0);
 
         // Wait 50ms for ACK.
         now += Duration::from_millis(50);
 
         let mut acked = ranges::RangeSet::default();
-        acked.insert(0..1);
+        acked.insert(0..10);
 
         assert_eq!(
             r.on_ack_received(
@@ -1307,16 +1312,12 @@ mod tests {
         assert_eq!(r.bytes_in_flight(), 0);
         assert_eq!(r.rtt(), Duration::from_millis(50));
 
-        assert_eq!(r.cwnd(), match cc_algorithm_name {
-            "bbr" => 24000,
-            "bbr2" => 24000,
-            // cubic and reno: 1 MSS increased.
-            _ => 12000 + 1200,
-        });
+        // 10 MSS increased due to acks.
+        assert_eq!(r.cwnd(), 12000 + 1200 * 10);
 
-        // Send out second packet.
+        // Send the second packet burst.
         let p = Sent {
-            pkt_num: 1,
+            pkt_num: 10,
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -1330,7 +1331,7 @@ mod tests {
             is_app_limited: false,
             tx_in_flight: 0,
             lost: 0,
-            has_data: false,
+            has_data: true,
             pmtud: false,
         };
 
@@ -1348,9 +1349,9 @@ mod tests {
         // Pacing is not done during initial phase of connection.
         assert_eq!(r.get_packet_send_time(now), now);
 
-        // Send the third packet out.
+        // Send the third packet burst.
         let p = Sent {
-            pkt_num: 2,
+            pkt_num: 11,
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -1364,7 +1365,7 @@ mod tests {
             is_app_limited: false,
             tx_in_flight: 0,
             lost: 0,
-            has_data: false,
+            has_data: true,
             pmtud: false,
         };
 
@@ -1379,9 +1380,9 @@ mod tests {
         assert_eq!(r.sent_packets_len(packet::Epoch::Application), 2);
         assert_eq!(r.bytes_in_flight(), 12000);
 
-        // Send the third packet out.
+        // Send the fourth packet burst.
         let p = Sent {
-            pkt_num: 3,
+            pkt_num: 12,
             frames: smallvec![],
             time_sent: now,
             time_acked: None,
@@ -1395,7 +1396,7 @@ mod tests {
             is_app_limited: false,
             tx_in_flight: 0,
             lost: 0,
-            has_data: false,
+            has_data: true,
             pmtud: false,
         };
 
@@ -1445,8 +1446,8 @@ mod tests {
         assert_eq!(r.pacing_rate(), pacing_rate);
 
         assert_eq!(
-            r.get_packet_send_time(now),
-            now + Duration::from_secs_f64(12000.0 / pacing_rate as f64)
+            r.get_packet_send_time(now) - now,
+            Duration::from_secs_f64(12000.0 / pacing_rate as f64)
         );
     }
 


### PR DESCRIPTION
As a pre-requisite, add Instant::now as an argument to get_packet_send_time so it can be driven by the test.