### PR TITLE
tokio-quiche: expose quiche settings

### DIFF
--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -162,9 +162,40 @@ fn make_quiche_config(
     config.set_initial_max_streams_bidi(quic_settings.initial_max_streams_bidi);
     config.set_initial_max_streams_uni(quic_settings.initial_max_streams_uni);
     config.set_disable_active_migration(quic_settings.disable_active_migration);
+    config
+        .set_active_connection_id_limit(quic_settings.active_connection_id_limit);
     config.set_cc_algorithm_name(quic_settings.cc_algorithm.as_str())?;
+    config.set_initial_congestion_window_packets(
+        quic_settings.initial_congestion_window_packets,
+    );
+    config.discover_pmtu(quic_settings.discover_path_mtu);
     config.enable_hystart(quic_settings.enable_hystart);
+
     config.enable_pacing(quic_settings.enable_pacing);
+    if let Some(max_pacing_rate) = quic_settings.max_pacing_rate {
+        config.set_max_pacing_rate(max_pacing_rate);
+    }
+
+    config.verify_peer(quic_settings.verify_peer);
+    config.set_max_connection_window(quic_settings.max_connection_window);
+    config.set_max_stream_window(quic_settings.max_stream_window);
+    config.grease(quic_settings.grease);
+    config.set_max_amplification_factor(quic_settings.max_amplification_factor);
+    config.set_ack_delay_exponent(quic_settings.ack_delay_exponent);
+    config.set_max_ack_delay(quic_settings.max_ack_delay);
+    config.set_path_challenge_recv_max_queue_len(
+        quic_settings.max_path_challenge_recv_queue_len,
+    );
+    config.set_stateless_reset_token(quic_settings.stateless_reset_token);
+    config.set_disable_dcid_reuse(quic_settings.disable_dcid_reuse);
+
+    if let Some(track_unknown_transport_params) =
+        quic_settings.track_unknown_transport_parameters
+    {
+        config.enable_track_unknown_transport_parameters(
+            track_unknown_transport_params,
+        );
+    }
 
     if should_log_keys {
         config.log_keys();

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -128,6 +128,7 @@ fn make_quiche_config(
     };
 
     let quic_settings = &params.settings;
+
     let alpns: Vec<&[u8]> =
         quic_settings.alpn.iter().map(Vec::as_slice).collect();
     config.set_application_protos(&alpns).unwrap();

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -33,8 +33,9 @@ use std::time::Duration;
 #[serde_as]
 #[settings]
 pub struct QuicSettings {
-    /// Configures the list of supported application protocols. Defaults to
-    /// `[b"h3"]`.
+    /// Configures the list of supported application protocols.
+    ///
+    /// Defaults to `[b"h3"]`.
     #[serde(skip, default = "QuicSettings::default_alpn")]
     pub alpn: Vec<Vec<u8>>,
 
@@ -45,39 +46,50 @@ pub struct QuicSettings {
     #[serde(default = "QuicSettings::default_enable_dgram")]
     pub enable_dgram: bool,
 
-    /// Max queue length for received DATAGRAM frames. Defaults to `2^16`.
+    /// Max queue length for received DATAGRAM frames.
+    ///
+    /// Defaults to `2^16`.
     #[serde(default = "QuicSettings::default_dgram_max_queue_len")]
     pub dgram_recv_max_queue_len: usize,
 
-    /// Max queue length for sending DATAGRAM frames. Defaults to `2^16`.
+    /// Max queue length for sending DATAGRAM frames.
+    ///
+    /// Defaults to `2^16`.
     #[serde(default = "QuicSettings::default_dgram_max_queue_len")]
     pub dgram_send_max_queue_len: usize,
 
-    /// Sets the `initial_max_data` transport parameter. Defaults to 10 MB.
+    /// Sets the `initial_max_data` transport parameter.
+    ///
+    /// Defaults to 10 MB.
     #[serde(default = "QuicSettings::default_initial_max_data")]
     pub initial_max_data: u64,
 
     /// Sets the `initial_max_stream_data_bidi_local` transport parameter.
+    ///
     /// Defaults to 1 MB.
     #[serde(default = "QuicSettings::default_initial_max_stream_data")]
     pub initial_max_stream_data_bidi_local: u64,
 
     /// Sets the `initial_max_stream_data_bidi_remote` transport parameter.
+    ///
     /// Defaults to 1 MB.
     #[serde(default = "QuicSettings::default_initial_max_stream_data")]
     pub initial_max_stream_data_bidi_remote: u64,
 
     /// Sets the `initial_max_stream_data_uni` transport parameter.
+    ///
     /// Defaults to 1 MB.
     #[serde(default = "QuicSettings::default_initial_max_stream_data")]
     pub initial_max_stream_data_uni: u64,
 
     /// Sets the `initial_max_streams_bidi` transport parameter.
+    ///
     /// Defaults to `100`.
     #[serde(default = "QuicSettings::default_initial_max_streams")]
     pub initial_max_streams_bidi: u64,
 
     /// Sets the `initial_max_streams_uni` transport parameter.
+    ///
     /// Defaults to `100`.
     #[serde(default = "QuicSettings::default_initial_max_streams")]
     pub initial_max_streams_uni: u64,
@@ -95,15 +107,21 @@ pub struct QuicSettings {
     pub max_idle_timeout: Option<Duration>,
 
     /// Configures whether the local endpoint supports active connection
-    /// migration. Defaults to `true` (meaning disabled).
+    /// migration.
+    ///
+    /// Defaults to `true` (meaning disabled).
     #[serde(default = "QuicSettings::default_disable_active_migration")]
     pub disable_active_migration: bool,
 
-    /// Sets the maximum incoming UDP payload size. Defaults to 1350 bytes.
+    /// Sets the maximum incoming UDP payload size.
+    ///
+    /// Defaults to 1350 bytes.
     #[serde(default = "QuicSettings::default_max_recv_udp_payload_size")]
     pub max_recv_udp_payload_size: usize,
 
-    /// Sets the maximum outgoing UDP payload size. Defaults to 1350 bytes.
+    /// Sets the maximum outgoing UDP payload size.
+    ///
+    /// Defaults to 1350 bytes.
     #[serde(default = "QuicSettings::default_max_send_udp_payload_size")]
     pub max_send_udp_payload_size: usize,
 
@@ -125,12 +143,14 @@ pub struct QuicSettings {
     ///
     /// For available values, see
     /// [`CongestionControlAlgorithm`](quiche::CongestionControlAlgorithm).
+    ///
     /// Defaults to `cubic`.
     #[serde(default = "QuicSettings::default_cc_algorithm")]
     pub cc_algorithm: String,
 
-    /// Whether to use HyStart++ (only with `cubic` and `reno` CC). Defaults to
-    /// `true`.
+    /// Whether to use HyStart++ (only with `cubic` and `reno` CC).
+    ///
+    /// Defaults to `true`.
     #[serde(default = "QuicSettings::default_enable_hystart")]
     pub enable_hystart: bool,
 
@@ -150,7 +170,9 @@ pub struct QuicSettings {
     pub enable_expensive_packet_count_metrics: bool,
 
     /// Forwards [`quiche`] logs into the logging system currently used by
-    /// [`foundations`]. Defaults to `false`.
+    /// [`foundations`].
+    ///
+    /// Defaults to `false`.
     ///
     /// # Warning
     /// This should **only be used for local debugging**. `quiche` can emit lots
@@ -159,7 +181,9 @@ pub struct QuicSettings {
     /// logging pipeline.
     pub capture_quiche_logs: bool,
 
-    /// A timeout for the QUIC handshake, in milliseconds. Disabled by default.
+    /// A timeout for the QUIC handshake, in milliseconds.
+    ///
+    /// Disabled by default.
     #[serde(rename = "handshake_timeout_ms")]
     #[serde_as(as = "Option<DurationMilliSeconds>")]
     pub handshake_timeout: Option<Duration>,

--- a/tokio-quiche/tests/fixtures/mod.rs
+++ b/tokio-quiche/tests/fixtures/mod.rs
@@ -201,17 +201,15 @@ pub async fn handle_forwarded_headers_frame(
 }
 
 pub fn start_server() -> (String, Arc<TestConnectionHook>) {
-    let quic = QuicSettings {
-        max_recv_udp_payload_size: 1400,
-        max_send_udp_payload_size: 1400,
-        ..Default::default()
-    };
+    let mut quic_settings = QuicSettings::default();
+    quic_settings.max_send_udp_payload_size = 1400;
+    quic_settings.max_recv_udp_payload_size = 1400;
 
     let hook = TestConnectionHook::new();
 
     (
         start_server_with_settings(
-            quic,
+            quic_settings,
             Http3Settings::default(),
             hook.clone(),
             handle_connection,

--- a/tokio-quiche/tests/integration_tests/connection_close.rs
+++ b/tokio-quiche/tests/integration_tests/connection_close.rs
@@ -147,11 +147,12 @@ async fn test_no_connection_close_frame_on_idle_timeout() -> QuicResult<()> {
     const IDLE_TIMEOUT: Duration = Duration::from_secs(1);
 
     let hook = TestConnectionHook::new();
+
+    let mut quic_settings = QuicSettings::default();
+    quic_settings.max_idle_timeout = Some(IDLE_TIMEOUT);
+
     let url = start_server_with_settings(
-        QuicSettings {
-            max_idle_timeout: Some(IDLE_TIMEOUT),
-            ..Default::default()
-        },
+        quic_settings,
         Http3Settings::default(),
         hook,
         handle_connection,

--- a/tokio-quiche/tests/integration_tests/mod.rs
+++ b/tokio-quiche/tests/integration_tests/mod.rs
@@ -91,13 +91,12 @@ async fn e2e() {
 
 #[tokio::test]
 async fn e2e_client_ip_validation_disabled() {
-    let quic_settings = QuicSettings {
-        max_recv_udp_payload_size: 1400,
-        max_send_udp_payload_size: 1400,
-        max_idle_timeout: Some(Duration::from_secs(5)),
-        disable_client_ip_validation: true,
-        ..Default::default()
-    };
+    let mut quic_settings = QuicSettings::default();
+    quic_settings.max_recv_udp_payload_size = 1400;
+    quic_settings.max_send_udp_payload_size = 1400;
+    quic_settings.max_idle_timeout = Some(Duration::from_secs(5));
+    quic_settings.disable_client_ip_validation = true;
+
     let hook = TestConnectionHook::new();
 
     let url = start_server_with_settings(
@@ -121,10 +120,9 @@ async fn e2e_client_ip_validation_disabled() {
 
 #[with_test_telemetry(tokio::test)]
 async fn quiche_logs_forwarded_server_side(cx: TestTelemetryContext) {
-    let quic_settings = QuicSettings {
-        capture_quiche_logs: true,
-        ..QuicSettings::default()
-    };
+    let mut quic_settings = QuicSettings::default();
+    quic_settings.capture_quiche_logs = true;
+
     let hook = TestConnectionHook::new();
 
     let url = start_server_with_settings(

--- a/tokio-quiche/tests/integration_tests/timeouts.rs
+++ b/tokio-quiche/tests/integration_tests/timeouts.rs
@@ -98,15 +98,12 @@ async fn test_handshake_duration_ioworker() {
         was_called: Arc::new(AtomicBool::new(false)),
     });
 
+    let mut quic_settings = QuicSettings::default();
+    quic_settings.max_idle_timeout = Some(Duration::from_secs(5));
+    quic_settings.handshake_timeout = Some(HANDSHAKE_TIMEOUT);
+
     let url = start_server_with_settings(
-        QuicSettings {
-            // Since this is longer than the handshake timeout, if the connection
-            // fails we know that it's from the handshake timing out
-            // rather than Quiche's idle timeout.
-            max_idle_timeout: Some(Duration::from_secs(5)),
-            handshake_timeout: Some(HANDSHAKE_TIMEOUT),
-            ..Default::default()
-        },
+        quic_settings,
         Http3Settings {
             post_accept_timeout: Some(HANDSHAKE_TIMEOUT),
             ..Default::default()
@@ -137,11 +134,11 @@ async fn test_handshake_timeout_with_one_client_flight() {
     let hook = TestConnectionHook::new();
 
     const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(1);
+    let mut quic_settings = QuicSettings::default();
+    quic_settings.handshake_timeout = Some(HANDSHAKE_TIMEOUT);
+
     let url = start_server_with_settings(
-        QuicSettings {
-            handshake_timeout: Some(HANDSHAKE_TIMEOUT),
-            ..Default::default()
-        },
+        quic_settings,
         Http3Settings::default(),
         hook.clone(),
         handle_connection,
@@ -232,14 +229,14 @@ async fn test_post_accept_timeout() {
     let request_counter = Arc::new(AtomicUsize::new(0));
     let clone = Arc::clone(&request_counter);
 
+    let mut quic_settings = QuicSettings::default();
+    // Since this is longer than the H3Driver's post-accept timeout, if
+    // the connection fails we know that it's from the
+    // post-accept timeout rather than Quiche's idle timeout.
+    quic_settings.max_idle_timeout = Some(Duration::from_secs(5));
+
     let url = start_server_with_settings(
-        QuicSettings {
-            // Since this is longer than the H3Driver's post-accept timeout, if
-            // the connection fails we know that it's from the
-            // post-accept timeout rather than Quiche's idle timeout.
-            max_idle_timeout: Some(Duration::from_secs(5)),
-            ..Default::default()
-        },
+        quic_settings,
         Http3Settings {
             post_accept_timeout: Some(POST_ACCEPT_TIMEOUT),
             ..Default::default()
@@ -292,14 +289,14 @@ async fn test_post_accept_timeout_is_reset() {
     let request_counter = Arc::new(AtomicUsize::new(0));
     let clone = Arc::clone(&request_counter);
 
+    let mut quic_settings = QuicSettings::default();
+    // Since this is longer than the H3Driver's post-accept timeout, if
+    // the connection fails we know that it's from the
+    // post-accept timeout rather than Quiche's idle timeout.
+    quic_settings.max_idle_timeout = Some(Duration::from_secs(5));
+
     let url = start_server_with_settings(
-        QuicSettings {
-            // Since this is longer than the H3Driver's post-accept timeout, if
-            // the connection fails we know that it's from the
-            // post-accept timeout rather than Quiche's idle timeout.
-            max_idle_timeout: Some(Duration::from_secs(5)),
-            ..Default::default()
-        },
+        quic_settings,
         Http3Settings {
             post_accept_timeout: Some(POST_ACCEPT_TIMEOUT),
             ..Default::default()


### PR DESCRIPTION
I opted to not change to a builder pattern for API consistency's sake. If we include one on `QuicSettings`, we should also include one on `Http3Settings`, which would significantly increase the scope of this PR.

If we really want to do that, I'm fine doing it as a separate commit/follow-up