### PR TITLE
[gcongestion] allow customizing BBR2 params

### DIFF
--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -266,7 +266,6 @@ const DEFAULT_PARAMS: Params = Params {
 };
 
 #[derive(Debug, PartialEq)]
-#[allow(dead_code)]
 enum BwLoMode {
     Default,
     MinRttReduction,

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -46,20 +46,13 @@ use self::mode::ModeImpl;
 use super::bandwidth::Bandwidth;
 use super::bbr::SendTimeState;
 use super::Acked;
+use super::BbrBwLoReductionStrategy;
+use super::BbrParams;
 use super::CongestionControl;
 use super::Lost;
 use super::RttStats;
 
 const MAX_MODE_CHANGES_PER_CONGESTION_EVENT: usize = 4;
-
-#[derive(Debug, PartialEq)]
-#[allow(dead_code)]
-enum BwLoMode {
-    Default,
-    MinRttReduction,
-    InflightReduction,
-    CwndReduction,
-}
 
 #[derive(Debug)]
 struct Params {
@@ -169,6 +162,39 @@ struct Params {
     bw_lo_mode: BwLoMode,
 }
 
+impl Params {
+    fn with_overrides(mut self, custom_bbr_settings: &BbrParams) -> Self {
+        macro_rules! apply_override {
+            ($field:ident) => {
+                if let Some(custom_value) = custom_bbr_settings.$field {
+                    self.$field = custom_value;
+                }
+            };
+        }
+
+        apply_override!(startup_cwnd_gain);
+        apply_override!(startup_pacing_gain);
+        apply_override!(full_bw_threshold);
+        apply_override!(startup_full_loss_count);
+        apply_override!(drain_cwnd_gain);
+        apply_override!(drain_pacing_gain);
+        apply_override!(enable_reno_coexistence);
+        apply_override!(probe_bw_probe_up_pacing_gain);
+        apply_override!(probe_bw_probe_down_pacing_gain);
+        apply_override!(probe_bw_cwnd_gain);
+        apply_override!(max_probe_up_queue_rounds);
+        apply_override!(loss_threshold);
+        apply_override!(use_bytes_delivered_for_inflight_hi);
+        apply_override!(decrease_startup_pacing_at_end_of_round);
+
+        if let Some(custom_value) = custom_bbr_settings.bw_lo_reduction_strategy {
+            self.bw_lo_mode = custom_value.into();
+        }
+
+        self
+    }
+}
+
 const DEFAULT_PARAMS: Params = Params {
     startup_cwnd_gain: 2.0,
 
@@ -238,6 +264,28 @@ const DEFAULT_PARAMS: Params = Params {
 
     bw_lo_mode: BwLoMode::InflightReduction,
 };
+
+#[derive(Debug, PartialEq)]
+#[allow(dead_code)]
+enum BwLoMode {
+    Default,
+    MinRttReduction,
+    InflightReduction,
+    CwndReduction,
+}
+
+impl From<BbrBwLoReductionStrategy> for BwLoMode {
+    fn from(value: BbrBwLoReductionStrategy) -> Self {
+        match value {
+            BbrBwLoReductionStrategy::Default => BwLoMode::Default,
+            BbrBwLoReductionStrategy::MinRttReduction =>
+                BwLoMode::MinRttReduction,
+            BbrBwLoReductionStrategy::InflightReduction =>
+                BwLoMode::InflightReduction,
+            BbrBwLoReductionStrategy::CwndReduction => BwLoMode::CwndReduction,
+        }
+    }
+}
 
 #[derive(Debug)]
 struct Limits<T: Ord> {
@@ -342,9 +390,14 @@ impl BBRv2 {
     pub fn new(
         initial_congestion_window: usize, max_congestion_window: usize,
         max_segment_size: usize, smoothed_rtt: Duration,
+        custom_bbr_params: Option<&BbrParams>,
     ) -> Self {
         let cwnd = initial_congestion_window * max_segment_size;
-        let params = DEFAULT_PARAMS;
+        let params = if let Some(custom_bbr_settings) = custom_bbr_params {
+            DEFAULT_PARAMS.with_overrides(custom_bbr_settings)
+        } else {
+            DEFAULT_PARAMS
+        };
 
         BBRv2 {
             mode: Mode::startup(BBRv2NetworkModel::new(&params)),

--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -31,6 +31,7 @@ pub mod pacer;
 mod recovery;
 
 use std::fmt::Debug;
+use std::str::FromStr;
 use std::time::Instant;
 
 use self::bandwidth::Bandwidth;
@@ -38,6 +39,7 @@ pub use self::recovery::GRecovery;
 
 use crate::recovery::rtt::RttStats;
 use crate::recovery::rtt::INITIAL_RTT;
+use crate::recovery::RecoveryConfig;
 
 #[derive(Debug)]
 pub struct Lost {
@@ -61,13 +63,14 @@ pub(crate) enum Congestion {
 impl Congestion {
     pub(super) fn bbrv2(
         initial_tcp_congestion_window: usize, max_congestion_window: usize,
-        max_segment_size: usize,
+        recovery_config: &RecoveryConfig,
     ) -> Self {
         Congestion::BBRv2(bbr2::BBRv2::new(
             initial_tcp_congestion_window,
             max_congestion_window,
-            max_segment_size,
+            recovery_config.max_send_udp_payload_size,
             INITIAL_RTT,
+            recovery_config.custom_bbr_params.as_ref(),
         ))
     }
 }
@@ -148,5 +151,104 @@ pub(super) trait CongestionControl: Debug {
     #[cfg(feature = "qlog")]
     fn ssthresh(&self) -> Option<u64> {
         None
+    }
+}
+
+/// BBR settings used to customize the algorithm's behavior.
+///
+/// This functionality is experimental and will be removed in the future.
+///
+/// A congestion control algorithm has dual-responsibility of effective network
+/// utilization and avoiding congestion. Custom values should be choosen
+/// carefully since incorrect values can lead to network degradation for all
+/// connections on the shared network.
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[repr(C)]
+#[doc(hidden)]
+pub struct BbrParams {
+    /// Control Bbr startup gain.
+    pub startup_cwnd_gain: Option<f32>,
+
+    /// Control Bbr startup pacing gain.
+    pub startup_pacing_gain: Option<f32>,
+
+    /// Control Bbr full bandwidth threshold.
+    pub full_bw_threshold: Option<f32>,
+
+    /// Control Bbr startup loss count necessary to exit startup.
+    pub startup_full_loss_count: Option<usize>,
+
+    /// Control Bbr drain cwnd gain.
+    pub drain_cwnd_gain: Option<f32>,
+
+    /// Control Bbr drain pacing gain.
+    pub drain_pacing_gain: Option<f32>,
+
+    /// Control if Bbr should respect reno coexistence.
+    pub enable_reno_coexistence: Option<bool>,
+
+    /// Control Bbr bandwidth probe up pacing gain.
+    pub probe_bw_probe_up_pacing_gain: Option<f32>,
+
+    /// Control Bbr bandwidth probe down pacing gain.
+    pub probe_bw_probe_down_pacing_gain: Option<f32>,
+
+    /// Control Bbr probe bandwidth cwnd gain.
+    pub probe_bw_cwnd_gain: Option<f32>,
+
+    /// Control number of rounds Bbr should stay in probe up if bytes_in_flight
+    /// doesn't drop below target.
+    pub max_probe_up_queue_rounds: Option<usize>,
+
+    /// Control Bbr loss threshold.
+    pub loss_threshold: Option<f32>,
+
+    /// Control if Bbr should use bytes delievered as an estimate for
+    /// inflight_hi.
+    pub use_bytes_delivered_for_inflight_hi: Option<bool>,
+
+    /// Control if Bbr should adjust startup pacing at round end.
+    pub decrease_startup_pacing_at_end_of_round: Option<bool>,
+
+    /// Control Bbr bandwidth lo reduction strategy.
+    pub bw_lo_reduction_strategy: Option<BbrBwLoReductionStrategy>,
+}
+
+/// Controls BBR's bandwidth reduction strategy on congestion event.
+///
+/// This functionality is experimental and will be removed in the future.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+#[doc(hidden)]
+pub enum BbrBwLoReductionStrategy {
+    /// Uses the default strategy based on `BBRBeta`.
+    Default           = 0,
+
+    /// Considers min-rtt to estimate bandwidth reduction.
+    MinRttReduction   = 1,
+
+    /// Considers inflight data to estimate bandwidth reduction.
+    InflightReduction = 2,
+
+    /// Considers cwnd to estimate bandwidth reduction.
+    CwndReduction     = 3,
+}
+
+#[doc(hidden)]
+impl FromStr for BbrBwLoReductionStrategy {
+    type Err = crate::Error;
+
+    /// Converts a string to `BbrBwLoReductionStrategy`.
+    ///
+    /// If `name` is not valid, `Error::CongestionControl` is returned.
+    fn from_str(name: &str) -> std::result::Result<Self, Self::Err> {
+        match name {
+            "default" => Ok(BbrBwLoReductionStrategy::Default),
+            "minrtt" => Ok(BbrBwLoReductionStrategy::MinRttReduction),
+            "inflight" => Ok(BbrBwLoReductionStrategy::InflightReduction),
+            "cwnd" => Ok(BbrBwLoReductionStrategy::CwndReduction),
+
+            _ => Err(crate::Error::CongestionControl),
+        }
     }
 }

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -380,7 +380,7 @@ impl GRecovery {
             CongestionControlAlgorithm::Bbr2Gcongestion => Congestion::bbrv2(
                 recovery_config.initial_congestion_window_packets,
                 MAX_WINDOW_PACKETS,
-                recovery_config.max_send_udp_payload_size,
+                recovery_config,
             ),
             _ => return None,
         };

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -40,6 +40,8 @@ use smallvec::SmallVec;
 
 use self::congestion::recovery::LegacyRecovery;
 use self::gcongestion::GRecovery;
+pub use gcongestion::BbrBwLoReductionStrategy;
+pub use gcongestion::BbrParams;
 
 // Loss Recovery
 const INITIAL_PACKET_THRESHOLD: u64 = 3;
@@ -92,11 +94,12 @@ impl std::fmt::Debug for LossDetectionTimer {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct RecoveryConfig {
     pub max_send_udp_payload_size: usize,
     pub max_ack_delay: Duration,
     pub cc_algorithm: CongestionControlAlgorithm,
+    pub custom_bbr_params: Option<BbrParams>,
     pub hystart: bool,
     pub pacing: bool,
     pub max_pacing_rate: Option<u64>,
@@ -109,6 +112,7 @@ impl RecoveryConfig {
             max_send_udp_payload_size: config.max_send_udp_payload_size,
             max_ack_delay: Duration::ZERO,
             cc_algorithm: config.cc_algorithm,
+            custom_bbr_params: config.custom_bbr_params,
             hystart: config.hystart,
             pacing: config.pacing,
             max_pacing_rate: config.max_pacing_rate,


### PR DESCRIPTION
## Desctiption
This PR expose methods for providing custom BBR2 params and changing algorithm behavior. I have marked these APIs as internal since they are for experimental purposes only.

## Callout
[refactor: pass bbr settings to components](https://github.com/cloudflare/quiche/pull/2023) is a refactor change. With this change we end up passing the Bbr Settings object rather than referencing the const value, which makes it easier to reasoning about overrides.