### PR TITLE
[gcongestion] Use gcongestion BBRv2 when BBRv2 is requested if gcongestion feature is enabled

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -42,6 +42,10 @@ openssl = ["pkg-config"]
 # Generate pkg-config metadata file for libquiche.
 pkg-config-meta = []
 
+# Replaces quiche's original congestion control
+# implementation with one adapted from google/quiche.
+gcongestion = []
+
 # Equivalent to "--cfg fuzzing", but can also be checked in build.rs.
 fuzzing = []
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -286,9 +286,11 @@ impl FromStr for CongestionControlAlgorithm {
             "reno" => Ok(CongestionControlAlgorithm::Reno),
             "cubic" => Ok(CongestionControlAlgorithm::CUBIC),
             "bbr" => Ok(CongestionControlAlgorithm::BBR),
+            #[cfg(not(feature = "gcongestion"))]
             "bbr2" => Ok(CongestionControlAlgorithm::BBR2),
+            #[cfg(feature = "gcongestion")]
+            "bbr2" => Ok(CongestionControlAlgorithm::Bbr2Gcongestion),
             "bbr2_gcongestion" => Ok(CongestionControlAlgorithm::Bbr2Gcongestion),
-
             _ => Err(crate::Error::CongestionControl),
         }
     }
@@ -583,8 +585,16 @@ mod tests {
         assert!(!recovery_for_alg(algo).gcongestion_enabled());
 
         let algo = CongestionControlAlgorithm::from_str("bbr2").unwrap();
-        assert_eq!(algo, CongestionControlAlgorithm::BBR2);
-        assert!(!recovery_for_alg(algo).gcongestion_enabled());
+        #[cfg(not(feature = "gcongestion"))]
+        {
+            assert_eq!(algo, CongestionControlAlgorithm::BBR2);
+            assert!(!recovery_for_alg(algo).gcongestion_enabled());
+        }
+        #[cfg(feature = "gcongestion")]
+        {
+            assert_eq!(algo, CongestionControlAlgorithm::Bbr2Gcongestion);
+            assert!(recovery_for_alg(algo).gcongestion_enabled());
+        }
 
         let algo =
             CongestionControlAlgorithm::from_str("bbr2_gcongestion").unwrap();


### PR DESCRIPTION
This makes quiche a drop in replacement for quiche-mallard