### PR TITLE
Drop dependency on quiche-mallard

### DIFF
--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 
 [features]
 # Forwarded quiche features for re-exports
-fuzzing = ["quiche/fuzzing", "quiche-mallard?/fuzzing"]
-quiche_internal = ["quiche/internal", "quiche-mallard?/internal"]
+fuzzing = ["quiche/fuzzing"]
+quiche_internal = ["quiche/internal"]
 
 # Enable extra timing instrumentation for QUIC handshakes, including protocol
 # overhead and network delays.
@@ -22,11 +22,10 @@ perf-quic-listener-metrics = []
 # Enable raw public key (RPK) support for QUIC handshakes.
 rpk = ["boring/rpk"]
 
-# Use the quiche-mallard fork in place of upstream quiche.
-# quiche-mallard replaces quiche's original congestion control
+# Replaces quiche's original congestion control
 # implementation with one adapted from google/quiche.
-gcongestion = ["dep:quiche-mallard"]
-# Use quiche-mallard with zero-copy send calls.
+gcongestion = ["quiche/gcongestion"]
+# Use quiche with zero-copy send calls.
 zero-copy = ["gcongestion"]
 
 # Deprecated: use `--cfg capture_keylogs` instead.
@@ -51,13 +50,9 @@ futures = { workspace = true }
 futures-util = { workspace = true }
 ipnetwork = { workspace = true }
 log = { workspace = true }
-octets = { version = "0.3.0" }
+octets = { workspace = true }
 pin-project = { workspace = true }
-quiche = { version = "0.24.0", features = ["boringssl-boring-crate", "qlog"] }
-quiche-mallard = { version = "0.21", features = [
-  "boringssl-boring-crate",
-  "qlog",
-], optional = true }
+quiche = { workspace = true, features = ["boringssl-boring-crate", "qlog"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_with = { workspace = true }
 slog-scope = { workspace = true }

--- a/tokio-quiche/README.md
+++ b/tokio-quiche/README.md
@@ -150,8 +150,8 @@ enabled.
 
 - `rpk`: Support for raw public keys (RPK) in QUIC handshakes (via [boring]).
 - `gcongestion`: Replace quiche's original congestion control implementation with one
-   adapted from google/quiche (via quiche-mallard).
-- `zero-copy`: Use zero-copy sends with quiche-mallard (implies `gcongestion`).
+   adapted from google/quiche.
+- `zero-copy`: Use zero-copy sends with quiche (implies `gcongestion`).
 - `perf-quic-listener-metrics`: Extra telemetry for QUIC handshake durations,
   including protocol overhead and network delays.
 - `tokio-task-metrics`: Scheduling & poll duration histograms for tokio tasks.

--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -554,20 +554,11 @@ impl<H: DriverHooks> H3Driver<H> {
 
         match event {
             // Requests/responses are exclusively handled by hooks.
-            #[cfg(not(feature = "gcongestion"))]
             h3::Event::Headers { list, more_frames } =>
                 H::headers_received(self, qconn, InboundHeaders {
                     stream_id,
                     headers: list,
                     has_body: more_frames,
-                }),
-
-            #[cfg(feature = "gcongestion")]
-            h3::Event::Headers { list, has_body } =>
-                H::headers_received(self, qconn, InboundHeaders {
-                    stream_id,
-                    headers: list,
-                    has_body,
                 }),
 
             h3::Event::Data => self.process_h3_data(qconn, stream_id),
@@ -633,7 +624,6 @@ impl<H: DriverHooks> H3Driver<H> {
 
         match frame {
             // Initial headers were already sent, send additional headers now.
-            #[cfg(not(feature = "gcongestion"))]
             OutboundFrame::Headers(headers) if ctx.initial_headers_sent => conn
                 .send_additional_headers(qconn, stream_id, headers, false, false),
 

--- a/tokio-quiche/src/lib.rs
+++ b/tokio-quiche/src/lib.rs
@@ -82,9 +82,8 @@
 //! - `rpk`: Support for raw public keys (RPK) in QUIC handshakes (via
 //!   [boring]).
 //! - `gcongestion`: Replace quiche's original congestion control implementation
-//!   with one adapted from google/quiche (via quiche-mallard).
-//! - `zero-copy`: Use zero-copy sends with quiche-mallard (implies
-//!   `gcongestion`).
+//!   with one adapted from google/quiche.
+//! - `zero-copy`: Use zero-copy sends with quiche (implies `gcongestion`).
 //! - `perf-quic-listener-metrics`: Extra telemetry for QUIC handshake
 //!   durations, including protocol overhead and network delays.
 //! - `tokio-task-metrics`: Scheduling & poll duration histograms for tokio
@@ -96,10 +95,7 @@
 //! - `--cfg capture_keylogs`: Optional `SSLKEYLOGFILE` capturing for QUIC
 //!   connections.
 
-#[cfg(not(feature = "gcongestion"))]
 pub extern crate quiche;
-#[cfg(feature = "gcongestion")]
-pub extern crate quiche_mallard as quiche;
 
 pub mod buf_factory;
 pub mod http3;


### PR DESCRIPTION
Quiche has all the required functionality, so mallard can switch over to mainline quiche.