### PR TITLE
Allow queueing at least 1 millisecond worth of packets in advance.

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4983,12 +4983,14 @@ impl<F: BufFactory> Connection<F> {
 
     /// Returns the maximum pacing into the future.
     ///
-    /// Equals 1/8 of the smoothed RTT, but not greater than 5ms.
+    /// Equals 1/8 of the smoothed RTT, but at least 1ms and not greater than
+    /// 5ms.
     pub fn max_release_into_future(&self) -> time::Duration {
         self.paths
             .get_active()
             .map(|p| p.recovery.rtt().mul_f64(0.125))
             .unwrap_or(time::Duration::from_millis(1))
+            .max(Duration::from_millis(1))
             .min(Duration::from_millis(5))
     }
 


### PR DESCRIPTION
In cases the RTT is very low, the old logic prevents use of TxTime to schedule send for packets on low RTT connections, which results in instability due to wakeup timing granularity.  epoll_wait accepts a timeout in milliseconds.