### PR TITLE
quiche: release 0.24.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ octets = { version = "0.3.0", path = "./octets" }
 parking_lot = { version = "0.12.1", default-features = false }
 pin-project = { version = "1.0.12" }
 qlog = { version = "0.15.2", path = "./qlog" }
-quiche = { version = "0.24.1", path = "./quiche" }
+quiche = { version = "0.24.2", path = "./quiche" }
 rand = { version = "0.8" }
 regex = { version = "1.4.2" }
 ring = { version = "0.17.8" }

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quiche"
-version = "0.24.1"
+version = "0.24.2"
 authors = ["Alessandro Ghedini <alessandro@ghedini.me>"]
 description = "🥧 Savoury implementation of the QUIC transport protocol and HTTP/3"
 build = "src/build.rs"


### PR DESCRIPTION
Changes:
  a8d5999645787db722d903bbedbac4587fc74be1 Allow queueing at least 1 millisecond worth of packets in advance.
  49f2f5288778c5593eeb209d44310757537cebcd remove unnecessary &mut