### PR TITLE
Separate crypto ctx from pkt number space

### DIFF
--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -884,11 +884,11 @@ impl PktNumSpace {
         }
     }
 
-    fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.ack_elicited = false;
     }
 
-    fn ready(&self) -> bool {
+    pub fn ready(&self) -> bool {
         self.ack_elicited
     }
 }
@@ -920,7 +920,9 @@ impl CryptoContext {
         }
     }
 
-    pub fn clear(&mut self, pkt_space: &mut PktNumSpace) {
+    pub fn clear(&mut self) {
+        self.crypto_open = None;
+        self.crypto_seal = None;
         self.crypto_stream = <stream::Stream>::new(
             0, // dummy
             u64::MAX,
@@ -929,12 +931,10 @@ impl CryptoContext {
             true,
             stream::MAX_STREAM_WINDOW,
         );
-
-        pkt_space.clear();
     }
 
-    pub fn ready(&self, pkt_space: &PktNumSpace) -> bool {
-        self.crypto_stream.is_flushable() || pkt_space.ready()
+    pub fn data_available(&self) -> bool {
+        self.crypto_stream.is_flushable()
     }
 
     pub fn crypto_overhead(&self) -> Option<usize> {

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -853,22 +853,22 @@ pub struct KeyUpdate {
 }
 
 pub struct PktNumSpace {
-    /// The largest packet number received
+    /// The largest packet number received.
     pub largest_rx_pkt_num: u64,
 
-    /// Time the largest packet number received
+    /// Time the largest packet number received.
     pub largest_rx_pkt_time: time::Instant,
 
-    /// The largest non-probing packet number
+    /// The largest non-probing packet number.
     pub largest_rx_non_probing_pkt_num: u64,
 
-    /// Range of pn that we need to send an ACK for
+    /// Range of packet numbers that we need to send an ACK for.
     pub recv_pkt_need_ack: ranges::RangeSet,
 
-    /// Tracks received packet numbers
+    /// Tracks received packet numbers.
     pub recv_pkt_num: PktNumWindow,
 
-    /// Track if a received packet is ack eliciting
+    /// Track if a received packet is ack eliciting.
     pub ack_elicited: bool,
 }
 

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -683,7 +683,7 @@ impl Drop for Handshake {
 pub struct ExData<'a> {
     pub application_protos: &'a Vec<Vec<u8>>,
 
-    pub pkt_num_spaces: &'a mut [packet::PktNumSpace; packet::Epoch::count()],
+    pub crypto_ctx: &'a mut [packet::CryptoContext; packet::Epoch::count()],
 
     pub session: &'a mut Option<Vec<u8>>,
 
@@ -749,14 +749,13 @@ extern "C" fn set_read_secret(
     trace!("{} set read secret lvl={:?}", ex_data.trace_id, level);
 
     let space = match level {
-        crypto::Level::Initial =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Initial],
+        crypto::Level::Initial => &mut ex_data.crypto_ctx[packet::Epoch::Initial],
         crypto::Level::ZeroRTT =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
+            &mut ex_data.crypto_ctx[packet::Epoch::Application],
         crypto::Level::Handshake =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Handshake],
+            &mut ex_data.crypto_ctx[packet::Epoch::Handshake],
         crypto::Level::OneRTT =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
+            &mut ex_data.crypto_ctx[packet::Epoch::Application],
     };
 
     let aead = match get_cipher_from_ptr(cipher) {
@@ -799,14 +798,13 @@ extern "C" fn set_write_secret(
     trace!("{} set write secret lvl={:?}", ex_data.trace_id, level);
 
     let space = match level {
-        crypto::Level::Initial =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Initial],
+        crypto::Level::Initial => &mut ex_data.crypto_ctx[packet::Epoch::Initial],
         crypto::Level::ZeroRTT =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
+            &mut ex_data.crypto_ctx[packet::Epoch::Application],
         crypto::Level::Handshake =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Handshake],
+            &mut ex_data.crypto_ctx[packet::Epoch::Handshake],
         crypto::Level::OneRTT =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
+            &mut ex_data.crypto_ctx[packet::Epoch::Application],
     };
 
     let aead = match get_cipher_from_ptr(cipher) {
@@ -850,13 +848,12 @@ extern "C" fn add_handshake_data(
     let buf = unsafe { slice::from_raw_parts(data, len) };
 
     let space = match level {
-        crypto::Level::Initial =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Initial],
+        crypto::Level::Initial => &mut ex_data.crypto_ctx[packet::Epoch::Initial],
         crypto::Level::ZeroRTT => unreachable!(),
         crypto::Level::Handshake =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Handshake],
+            &mut ex_data.crypto_ctx[packet::Epoch::Handshake],
         crypto::Level::OneRTT =>
-            &mut ex_data.pkt_num_spaces[packet::Epoch::Application],
+            &mut ex_data.crypto_ctx[packet::Epoch::Application],
     };
 
     if space.crypto_stream.send.write(buf, false).is_err() {


### PR DESCRIPTION
Currently we track sensitive crypto context along with general packet related context which makes it difficult to track its usage. This PR separates crypto context into its own structure, which should make it easier to reason about how the crypto context is initialized, accessed and freed.
