### PR TITLE
ci: limit CI jobs to read-only contents

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,10 @@ on: [push, pull_request]
 
 name: Nightly
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   RUSTFLAGS: "-D warnings"
   RUSTDOCFLAGS: "--cfg docsrs"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,6 +10,10 @@ on:
 
 name: Semgrep config
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.ref }}-semgrep
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -2,6 +2,10 @@ on: [push, pull_request]
 
 name: Stable
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   RUSTFLAGS: "-D warnings"
   RUSTTOOLCHAIN: "stable"


### PR DESCRIPTION
Mostly so security scanner stops complaining...