### PR TITLE
tokio-quiche: add support for setting per-response h3 priorities

### DIFF
--- a/tokio-quiche/tests/fixtures/mod.rs
+++ b/tokio-quiche/tests/fixtures/mod.rs
@@ -168,9 +168,10 @@ pub async fn handle_forwarded_headers_frame(
     stream_id: u64, list: Vec<Header>, mut send: OutboundFrameSender,
     mut recv: InboundFrameStream,
 ) {
-    send.send(OutboundFrame::Headers(vec![h3::Header::new(
-        b":status", b"200",
-    )]))
+    send.send(OutboundFrame::Headers(
+        vec![h3::Header::new(b":status", b"200")],
+        None,
+    ))
     .await
     .unwrap();
 

--- a/tokio-quiche/tests/integration_tests/headers.rs
+++ b/tokio-quiche/tests/integration_tests/headers.rs
@@ -53,9 +53,10 @@ async fn test_additional_headers() {
                         let IncomingH3Headers { mut send, .. } = headers;
 
                         // Send initial headers.
-                        send.send(OutboundFrame::Headers(vec![Header::new(
-                            b":status", b"103",
-                        )]))
+                        send.send(OutboundFrame::Headers(
+                            vec![Header::new(b":status", b"103")],
+                            None,
+                        ))
                         .await
                         .unwrap();
 
@@ -65,9 +66,10 @@ async fn test_additional_headers() {
                         tokio::task::yield_now().await;
 
                         // Send additional headers.
-                        send.send(OutboundFrame::Headers(vec![Header::new(
-                            b":status", b"200",
-                        )]))
+                        send.send(OutboundFrame::Headers(
+                            vec![Header::new(b":status", b"200")],
+                            None,
+                        ))
                         .await
                         .unwrap();
                     },


### PR DESCRIPTION
Currently tokio-quiche always sets the same default ptiority for all h3 responses. This change adds support for applications to specify an optional priority on a response-by-response basis instead, while still keeping the current default priority for backwards compatibility.

This is done by adding a new `Option<Priority>` field to `OutboundFrame::Headers()`. Applications that don't want to provide any priority can simply set this to `None`, in which case the existing default priority logic applies.

In order to allow setting priorities for additional headers as well, a new method `send_additional_headers_with_priority()` is also added. This is required because the `Priority` fields are private, which means it would not be possible to call the lower level `stream_priority()` method with their values.

Finally, `Clone` and `Copy` traits are derived for `Priority` as well to simplify use in applications.

---

Testing the changes is a bit chllenging unfortunately, as there is no clearly visible signal for priorities, though in practice all this change amounts to calling `send_response_with_priority()` and `send_additional_headers_with_priority()` with a different value priority value, so in practice it shouldn't affect functionality much.