### PR TITLE
tokio-quiche: Add input path to file errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tag-message = "{{crate_name}} {{version}}"
 publish = false
 
 [workspace.dependencies]
+anyhow = { version = "1" }
 boring = { version = "4.3" }
 buffer-pool = { version = "0.1.0", path = "./buffer-pool" }
 crossbeam = { version = "0.8.1", default-features = false }

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -39,6 +39,7 @@ tokio-task-metrics = []
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(capture_keylogs)'] }
 
 [dependencies]
+anyhow = { workspace = true }
 boring = { workspace = true }
 buffer-pool = { workspace = true }
 crossbeam = { workspace = true, default-features = false }

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -223,10 +223,10 @@ fn quiche_config_with_tls(
         #[cfg(feature = "rpk")]
         CertificateKind::RawPublicKey => {
             let mut ssl_ctx_builder = boring::ssl::SslContextBuilder::new_rpk()?;
-            let raw_public_key = std::fs::read(tls.cert)?;
+            let raw_public_key = read_file(tls.cert)?;
             ssl_ctx_builder.set_rpk_certificate(&raw_public_key)?;
 
-            let raw_private_key = std::fs::read(tls.private_key)?;
+            let raw_private_key = read_file(tls.private_key)?;
             let pkey =
                 boring::pkey::PKey::private_key_from_pem(&raw_private_key)?;
             ssl_ctx_builder.set_null_chain_private_key(&pkey)?;
@@ -244,4 +244,12 @@ fn quiche_config_with_tls(
             Ok(config)
         },
     }
+}
+
+#[cfg(feature = "rpk")]
+fn read_file(path: &str) -> QuicResult<Vec<u8>> {
+    use anyhow::Context as _;
+    std::fs::read(path)
+        .with_context(|| format!("read {path}"))
+        .map_err(Into::into)
 }


### PR DESCRIPTION
BoringSSL does this internally when we ask it to load a PEM file, but for RPK we call `fs::read` ourselves. The error message is not very helpful in those cases, as we simply bubble up an io::Error without any context.

`anyhow` is already an implicit dependency via foundations, so I figured using it was fine.