### PR TITLE
PMTUD Tests and Updates

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3283,17 +3283,14 @@ impl<F: BufFactory> Connection<F> {
                     frame::Frame::Ping {
                         mtu_probe: Some(mtu_probe),
                     } => {
-                        let pmtud_next = p.pmtud.get_current();
-                        p.pmtud.set_current(cmp::max(pmtud_next, mtu_probe));
-
-                        // Stop sending path MTU probes after successful probe.
-                        p.pmtud.should_probe(false);
+                        p.pmtud.set_estimated_pmtu(mtu_probe);
+                        p.pmtud.successful_probe(mtu_probe);
                         pmtud_probe = true;
 
                         trace!(
                             "{} pmtud acked; pmtu size {:?}",
                             self.trace_id,
-                            p.pmtud.get_current()
+                            p.pmtud.get_estimated_pmtu()
                         );
                     },
 
@@ -3388,8 +3385,8 @@ impl<F: BufFactory> Connection<F> {
             if pmtud_probe {
                 trace!(
                     "{} updating pmtu {:?}",
-                    p.pmtud.get_current(),
-                    self.trace_id
+                    self.trace_id,
+                    p.pmtud.get_estimated_pmtu()
                 );
 
                 qlog_with_type!(
@@ -3402,7 +3399,7 @@ impl<F: BufFactory> Connection<F> {
                         let pmtu_data = EventData::MtuUpdated(
                             qlog::events::connectivity::MtuUpdated {
                                 old: Some(p.recovery.max_datagram_size() as u16),
-                                new: p.pmtud.get_current() as u16,
+                                new: p.pmtud.get_estimated_pmtu() as u16,
                                 done: Some(pmtud_probe),
                             },
                         );
@@ -3412,7 +3409,7 @@ impl<F: BufFactory> Connection<F> {
                 );
 
                 p.recovery
-                    .pmtud_update_max_datagram_size(p.pmtud.get_current());
+                    .pmtud_update_max_datagram_size(p.pmtud.get_estimated_pmtu());
             }
         }
 
@@ -3701,11 +3698,11 @@ impl<F: BufFactory> Connection<F> {
         let send_path = self.paths.get_mut(send_pid)?;
 
         // Update max datagram size to allow path MTU discovery probe to be sent.
-        if send_path.pmtud.get_probe_status() {
+        if send_path.pmtud.should_probe() {
             let size = if self.handshake_confirmed || self.handshake_done_sent {
                 send_path.pmtud.get_probe_size()
             } else {
-                send_path.pmtud.get_current()
+                send_path.pmtud.get_estimated_pmtu()
             };
 
             send_path.recovery.pmtud_update_max_datagram_size(size);
@@ -3912,8 +3909,11 @@ impl<F: BufFactory> Connection<F> {
                         self.ids.mark_retire_dcid_seq(seq_num, true)?;
                     },
 
-                    frame::Frame::Ping { mtu_probe } if mtu_probe.is_some() => {
-                        p.pmtud.pmtu_probe_lost();
+                    frame::Frame::Ping {
+                        mtu_probe: Some(failed_probe),
+                    } => {
+                        trace!("pmtud probe dropped: {}", failed_probe);
+                        p.pmtud.failed_probe(failed_probe);
                     },
 
                     _ => (),
@@ -3930,7 +3930,7 @@ impl<F: BufFactory> Connection<F> {
 
         let mut left = if path.pmtud.is_enabled() {
             // Limit output buffer size by estimated path MTU.
-            cmp::min(path.pmtud.get_current(), b.cap())
+            cmp::min(path.pmtud.get_estimated_pmtu(), b.cap())
         } else {
             b.cap()
         };
@@ -4131,25 +4131,22 @@ impl<F: BufFactory> Connection<F> {
 
             let pmtu_probe = active_path.should_send_pmtu_probe(
                 self.handshake_confirmed,
-                self.handshake_done_sent,
+                self.handshake_completed,
                 out_len,
                 is_closing,
                 frames.is_empty(),
             );
 
-            trace!("{} pmtud probe status {} hs_con={} hs_sent={} cwnd_avail={} out_len={} left={}", self.trace_id, pmtu_probe, self.handshake_confirmed, self.handshake_done_sent,
-                    active_path.recovery.cwnd_available(), out_len, left);
-
             if pmtu_probe {
+                let probe_size = active_path.pmtud.get_probe_size();
                 trace!(
-                    "{} sending pmtud probe pmtu_probe={} next_size={} pmtu={}",
+                    "{} sending pmtud probe pmtu_probe={} estimated_pmtu={}",
                     self.trace_id,
-                    active_path.pmtud.get_probe_size(),
-                    active_path.pmtud.get_probe_status(),
-                    active_path.pmtud.get_current(),
+                    probe_size,
+                    active_path.pmtud.get_estimated_pmtu(),
                 );
 
-                left = active_path.pmtud.get_probe_size();
+                left = probe_size;
 
                 match left.checked_sub(overhead) {
                     Some(v) => left = v,
@@ -4169,12 +4166,12 @@ impl<F: BufFactory> Connection<F> {
                 }
 
                 let frame = frame::Frame::Padding {
-                    len: active_path.pmtud.get_probe_size() - overhead - 1,
+                    len: probe_size - overhead - 1,
                 };
 
                 if push_frame_to_pkt!(b, frames, frame, left) {
                     let frame = frame::Frame::Ping {
-                        mtu_probe: Some(active_path.pmtud.get_probe_size()),
+                        mtu_probe: Some(probe_size),
                     };
 
                     if push_frame_to_pkt!(b, frames, frame, left) {
@@ -4183,6 +4180,7 @@ impl<F: BufFactory> Connection<F> {
                     }
                 }
 
+                active_path.pmtud.set_inflight(true);
                 pmtud_probe = true;
             }
 
@@ -4999,7 +4997,7 @@ impl<F: BufFactory> Connection<F> {
         if active_path.pmtud.is_enabled() {
             active_path
                 .recovery
-                .pmtud_update_max_datagram_size(active_path.pmtud.get_current());
+                .pmtud_update_max_datagram_size(active_path.pmtud.get_estimated_pmtu());
         }
 
         Ok((pkt_type, written))
@@ -6883,6 +6881,16 @@ impl<F: BufFactory> Connection<F> {
         ConnectionId::from_ref(e.cid.as_ref())
     }
 
+    /// Returns the PMTU for the active path if it exists
+    #[inline]
+    pub fn pmtu(&self) -> Option<usize> {
+        if let Ok(path) = self.paths.get_active() {
+            path.pmtud.get_pmtu()
+        } else {
+            None
+        }
+    }
+
     /// Returns true if the connection handshake is complete.
     #[inline]
     pub fn is_established(&self) -> bool {
@@ -7120,7 +7128,7 @@ impl<F: BufFactory> Connection<F> {
 
         active_path.recovery.update_max_ack_delay(max_ack_delay);
 
-        if active_path.pmtud.get_probe_status() {
+        if active_path.pmtud.should_probe() {
             active_path.recovery.pmtud_update_max_datagram_size(
                 active_path
                     .pmtud
@@ -7341,7 +7349,7 @@ impl<F: BufFactory> Connection<F> {
                 self.streams.has_stopped() ||
                 self.ids.has_new_scids() ||
                 self.ids.has_retire_dcids() ||
-                send_path.pmtud.get_probe_status() ||
+                send_path.pmtud.should_probe() ||
                 send_path.needs_ack_eliciting ||
                 send_path.probing_required())
         {
@@ -18766,13 +18774,13 @@ mod tests {
 
         // Check that PMTU params are configured correctly
         let pmtu_param = &mut pipe.server.paths.get_mut(pid_1).unwrap().pmtud;
-        assert!(pmtu_param.get_probe_status());
+        assert!(pmtu_param.should_probe());
         assert_eq!(pmtu_param.get_probe_size(), 1350);
         assert_eq!(pipe.advance(), Ok(()));
 
         for (_, p) in pipe.server.paths.iter_mut() {
-            assert_eq!(p.pmtud.get_current(), 1350);
-            assert!(!p.pmtud.get_probe_status());
+            assert_eq!(p.pmtud.get_estimated_pmtu(), 1350);
+            assert!(!p.pmtud.should_probe());
         }
     }
 
@@ -18815,7 +18823,7 @@ mod tests {
 
         // Check that PMTU params are configured correctly
         let pmtu_param = &mut pipe.server.paths.get_mut(pid_1).unwrap().pmtud;
-        assert!(pmtu_param.get_probe_status());
+        assert!(pmtu_param.should_probe());
         assert_eq!(pmtu_param.get_probe_size(), 1350);
         std::thread::sleep(
             pipe.server.paths.get_mut(pid_1).unwrap().recovery.rtt() +
@@ -18826,10 +18834,10 @@ mod tests {
         let pmtu_param = &mut active_server_path.pmtud;
 
         // PMTU not updated since probe is not ACKed
-        assert_eq!(pmtu_param.get_current(), 1200);
+        assert_eq!(pmtu_param.get_estimated_pmtu(), 1200);
 
         // Continue searching for PMTU
-        assert!(pmtu_param.get_probe_status());
+        assert!(pmtu_param.should_probe());
     }
 }
 

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -346,10 +346,11 @@ impl Path {
         is_closing: bool, frames_empty: bool,
     ) -> bool {
         (hs_confirmed && hs_done) &&
-            self.pmtud.get_probe_size() > self.pmtud.get_current() &&
+            self.pmtud.get_probe_size() > self.pmtud.get_estimated_pmtu() &&
             self.recovery.cwnd_available() > self.pmtud.get_probe_size() &&
             out_len >= self.pmtud.get_probe_size() &&
-            self.pmtud.get_probe_status() &&
+            self.pmtud.should_probe() &&
+            !self.pmtud.get_inflight() &&
             !is_closing &&
             frames_empty
     }
@@ -578,7 +579,6 @@ impl PathMap {
         // Enable path MTU Discovery and start probing with the largest datagram
         // size.
         if enable_pmtud {
-            initial_path.pmtud.should_probe(enable_pmtud);
             initial_path.pmtud.set_probe_size(max_send_udp_payload_size);
             initial_path.pmtud.enable(enable_pmtud);
         }

--- a/quiche/src/pmtud.rs
+++ b/quiche/src/pmtud.rs
@@ -1,92 +1,289 @@
+/// This file contains the logic to implement PMTUD. Given a minimum supported MTU and an initial
+/// probe size that marks the maximum supported MTU, finds the PMTU between the two.
+
 #[derive(Default)]
 pub struct Pmtud {
-    /// The current path MTU estimate.
-    cur_size: usize,
+    /// The current PMTU estimate.
+    estimated_pmtu: usize,
 
-    /// The last MTU probe size that was attempted.
-    probe: usize,
+    /// The PMTU after the completion of PMTUD.
+    /// Will be [`None`] if the PMTU is less than the minimum supported MTU.
+    pmtu: Option<usize>,
 
-    /// Indicated if Path MTU probe needs to be generated.
-    next_size: bool,
+    /// The current PMTUD probe size. The initial value is the largest supported MTU.
+    probe_size: usize,
 
-    /// Check config for PMTU variable.
-    enable: bool,
+    /// The minimum supported MTU.
+    minimum_supported_mtu: usize,
+
+    /// The size of the smallest failed probe.
+    last_failed_probe_size: Option<usize>,
+
+    /// The size of the largest successful probe.
+    last_successful_probe_size: Option<usize>,
+
+    /// Indicates if PMTUD requires continued probing.
+    should_probe: bool,
+
+    /// Is PMTUD enabled.
+    enabled: bool,
+
+    /// Indicates if a PMTUD probe is inflight.
+    inflight: bool,
 }
 
 impl Pmtud {
     /// Creates new PMTUD instance.
-    pub fn new(cur_size: usize) -> Self {
+    pub fn new(minimum_supported_mtu: usize) -> Self {
         Self {
-            cur_size,
+            estimated_pmtu: minimum_supported_mtu,
+            minimum_supported_mtu,
             ..Default::default()
         }
     }
 
-    /// Enables Path MTU Discovery for the connection.
+    /// Enables PMTUD for the connection.
     pub fn enable(&mut self, enable: bool) {
-        self.enable = enable;
+        self.enabled = enable;
     }
 
-    /// Returns enable status for Path MTU Discovery for the connection.
+    /// Returns enabled status for PMTUD for the connection.
     pub fn is_enabled(&mut self) -> bool {
-        self.enable
+        self.enabled
     }
 
-    /// Specifies whether Path MTU Discovery should be performed at the next
-    /// opportunity, i.e., when the next packet is sent out if possible.
-    ///
-    /// Once Path MTU has been discovered, this maybe set to false.
-    pub fn should_probe(&mut self, pmtu_next: bool) {
-        self.next_size = pmtu_next;
+    /// Indicates whether probing should continue on the connection.
+    pub fn should_probe(&self) -> bool {
+        self.enabled
+            && self.pmtu.is_none()
+            && !(self
+                .last_failed_probe_size
+                .is_some_and(|failed_probe| failed_probe == self.estimated_pmtu))
     }
 
-    /// Returns the value of the Path MTU Discovery flag.
-    pub fn get_probe_status(&self) -> bool {
-        self.next_size
+    /// Sets the PMTUD probe size.
+    pub fn set_probe_size(&mut self, probe_size: usize) {
+        self.probe_size = probe_size;
     }
 
-    /// Sets the next Path MTU Discovery probe size.
-    pub fn set_probe_size(&mut self, pmtu_probe: usize) {
-        self.probe = pmtu_probe;
-    }
-
-    /// Returns the next Path MTU Discovery probe size.
+    /// Returns the PMTUD probe size.
     pub fn get_probe_size(&mut self) -> usize {
-        self.probe
+        self.probe_size
     }
 
-    /// Sets the current Path MTU Discovery size after a successful probe has
-    /// been performed.
-    pub fn set_current(&mut self, pmtu: usize) {
-        self.cur_size = pmtu;
+    /// Sets the estimated PMTU.
+    pub fn set_estimated_pmtu(&mut self, pmtu: usize) {
+        self.estimated_pmtu = std::cmp::max(self.estimated_pmtu, pmtu);
     }
 
-    /// Returns the discovered PATH MTU size.
-    pub fn get_current(&mut self) -> usize {
-        self.cur_size
+    /// Returns the estimated PMTU.
+    pub fn get_estimated_pmtu(&mut self) -> usize {
+        self.estimated_pmtu
     }
 
-    /// Selects path MTU probe based on the binary search algorithm.
+    /// Returns the PMTU.
+    pub fn get_pmtu(&self) -> Option<usize> {
+        self.pmtu
+    }
+
+    /// Selects PMTU probe size based on the binary search algorithm.
     ///
     /// Based on the Optimistic Binary algorithm defined in:
     /// Ref: <https://www.hb.fh-muenster.de/opus4/frontdoor/deliver/index/docId/14965/file/dplpmtudQuicPaper.pdf>
-    pub fn update_probe_size(&mut self) {
-        self.probe = self.cur_size + ((self.probe - self.cur_size) / 2);
+    fn update_probe_size(&mut self) {
+        match (self.last_failed_probe_size, self.last_successful_probe_size) {
+            // Binary search between successful and failed probes
+            (Some(failed_probe_size), Some(successful_probe_size)) => {
+                // Found the PMTU
+                if failed_probe_size - successful_probe_size <= 1 {
+                    self.pmtu = Some(successful_probe_size);
+                    self.probe_size = successful_probe_size
+                } else {
+                    self.probe_size =
+                        (successful_probe_size + failed_probe_size) / 2
+                }
+            },
+
+            // With only failed probes, binary search between the smallest failed
+            // probe and the minimum supported MTU
+            (Some(failed_probe_size), None) => {
+                self.probe_size =
+                    (self.minimum_supported_mtu + failed_probe_size) / 2
+            },
+
+            // As the algorithm is optimistic in that the initial probe size
+            // is the maximum supported MTU, then having only a successful probe
+            // means the maximum supported MTU is <= PMTU
+            (None, Some(successful_probe_size)) => {
+                self.pmtu = Some(successful_probe_size);
+                self.probe_size = successful_probe_size
+            },
+
+            // Use the initial probe size if no record of success/failures
+            (None, None) => {},
+        }
     }
 
-    /// Updates probe value when the Path MTU Discovery probe is lost.
-    pub fn pmtu_probe_lost(&mut self) {
+    /// Returns whether a probe is currently inflight for this connection.
+    pub fn get_inflight(&mut self) -> bool {
+        self.inflight
+    }
+
+    /// Sets whether a probe is currently inflight for this connection.
+    pub fn set_inflight(&mut self, inflight: bool) {
+        self.inflight = inflight;
+    }
+
+    /// Records a successful probe
+    pub fn successful_probe(&mut self, probe_size: usize) {
+        self.last_successful_probe_size =
+            std::cmp::max(Some(probe_size), self.last_successful_probe_size);
+
         self.update_probe_size();
-        self.should_probe(true);
+        self.inflight = false;
+    }
+
+    /// Records a failed probe
+    pub fn failed_probe(&mut self, probe_size: usize) {
+        // Check if we have one instance of a failed probe so that a min comparison
+        // can be made otherwise if this is the first failed probe just record it
+        if self.last_failed_probe_size.is_some() {
+            self.last_failed_probe_size =
+                std::cmp::min(Some(probe_size), self.last_failed_probe_size);
+        } else {
+            self.last_failed_probe_size = Some(probe_size);
+        }
+
+        self.update_probe_size();
+        self.inflight = false;
     }
 }
 
 impl std::fmt::Debug for Pmtud {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "current={:?} ", self.cur_size)?;
-        write!(f, "probe_size={:?} ", self.probe)?;
-        write!(f, "continue_probing={:?} ", self.next_size)?;
-        write!(f, "enable={:?} ", self.enable)?;
+        write!(f, "estimated_pmtu={:?} ", self.estimated_pmtu)?;
+        write!(f, "pmtu={:?} ", self.pmtu)?;
+        write!(f, "probe_size={:?} ", self.probe_size)?;
+        write!(f, "should_probe={:?} ", self.should_probe)?;
+        write!(f, "enable={:?} ", self.enabled)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Simulate an environment where the PMTU is 1272 and ensure the
+    // algorithm finds this
+    #[test]
+    fn test_example_pmtud() {
+        let mut search = Pmtud::new(1200);
+
+        search.failed_probe(1350);
+        assert_eq!(search.get_probe_size(), 1275);
+
+        search.failed_probe(1275);
+        assert_eq!(search.get_probe_size(), 1237);
+
+        search.successful_probe(1237);
+        assert_eq!(search.get_probe_size(), 1256);
+
+        search.successful_probe(1256);
+        assert_eq!(search.get_probe_size(), 1265);
+
+        search.successful_probe(1265);
+        assert_eq!(search.get_probe_size(), 1270);
+
+        search.successful_probe(1270);
+        assert_eq!(search.get_probe_size(), 1272);
+
+        search.successful_probe(1272);
+        assert_eq!(search.get_probe_size(), 1273);
+
+        search.failed_probe(1273);
+
+        assert_eq!(search.pmtu, Some(1272));
+        assert!(!search.should_probe());
+    }
+
+    #[test]
+    fn test_pmtu_more_than_max_supported_mtu() {
+        let mut search = Pmtud::new(1200);
+        search.set_probe_size(1350);
+        search.successful_probe(1350);
+        assert_eq!(search.pmtu, Some(1350));
+        assert!(!search.should_probe());
+    }
+
+    #[test]
+    fn test_pmtu_less_than_min_supported_mtu() {
+        let mut search = Pmtud::new(1200);
+        search.set_probe_size(1350);
+
+        search.failed_probe(1350);
+        assert_eq!(search.get_probe_size(), 1275);
+
+        search.failed_probe(1275);
+        assert_eq!(search.get_probe_size(), 1237);
+
+        search.failed_probe(1237);
+        assert_eq!(search.get_probe_size(), 1218);
+
+        search.failed_probe(1218);
+        assert_eq!(search.get_probe_size(), 1209);
+
+        search.failed_probe(1209);
+        assert_eq!(search.get_probe_size(), 1204);
+
+        search.failed_probe(1204);
+        assert_eq!(search.get_probe_size(), 1202);
+
+        search.failed_probe(1202);
+        assert_eq!(search.get_probe_size(), 1201);
+
+        search.failed_probe(1201);
+        assert_eq!(search.get_probe_size(), 1200);
+
+        search.failed_probe(1200);
+        assert_eq!(search.get_probe_size(), 1200);
+
+        // Make sure we do not continue to probe when the algorithm
+        // hits the minimum supported MTU
+        assert!(!search.should_probe());
+    }
+
+    #[test]
+    fn test_pmtu_equal_to_min_supported_mtu() {
+        let mut search = Pmtud::new(1200);
+        search.set_probe_size(1350);
+
+        search.failed_probe(1350);
+        assert_eq!(search.get_probe_size(), 1275);
+
+        search.failed_probe(1275);
+        assert_eq!(search.get_probe_size(), 1237);
+
+        search.failed_probe(1237);
+        assert_eq!(search.get_probe_size(), 1218);
+
+        search.failed_probe(1218);
+        assert_eq!(search.get_probe_size(), 1209);
+
+        search.failed_probe(1209);
+        assert_eq!(search.get_probe_size(), 1204);
+
+        search.failed_probe(1204);
+        assert_eq!(search.get_probe_size(), 1202);
+
+        search.failed_probe(1202);
+        assert_eq!(search.get_probe_size(), 1201);
+
+        search.failed_probe(1201);
+        assert_eq!(search.get_probe_size(), 1200);
+
+        search.successful_probe(1200);
+        assert_eq!(search.pmtu, Some(1200));
+        assert!(!search.should_probe());
     }
 }


### PR DESCRIPTION
In attempts to use PMTUD I found a number of issues with the existing implementation. This PR attempts to address the following

1. PMTUD probes were only sent when handshake_done_sent was true. As this will only be true for the server implementation, I've changed this to handshake_completed which I believe conforms to original intent
2. If I do not limit the number of probes being sent at once, then they are not consistently acked/dropped so PMTUD cannot function. Additionally, the algorithm did not take into account the sized of the failed probes so many 100s/1000s of probes would be sent at the initial probe size and if the PMTU was less than the probe size this would cause the PMTU to be calculated to always be 1200 (minimum supported MTU)
3. PMTUD was stopped at the first acked probe. e.g if the the PMTU was 1349 the prior implementation would calculate the PMTU to be 1275 with minimum MTU of 1200 and maximum of 1350. 


I've additionally modified some of the function names to be more readable 