### PR TITLE
docker: update Rust version to 1.82

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81 AS build
+FROM rust:1.82 AS build
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ is disabled by default), by passing ``--features ffi`` to ``cargo``.
 Building
 --------
 
-quiche requires Rust 1.81 or later to build. The latest stable Rust release can
+quiche requires Rust 1.82 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched

--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
   "Evan Rittenhouse <evanrittenhouse@gmail.com>",
 ]
 description = "Low-level HTTP/3 debugging and testing"
-rust-version = "1.81"
+rust-version = "1.82"
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.24.2"
 authors = ["Alessandro Ghedini <alessandro@ghedini.me>"]
 description = "🥧 Savoury implementation of the QUIC transport protocol and HTTP/3"
 build = "src/build.rs"
-rust-version = "1.81"
+rust-version = "1.82"
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3101,7 +3101,7 @@ impl<F: BufFactory> Connection<F> {
             if !self.crypto_ctx[epoch]
                 .key_update
                 .as_ref()
-                .map_or(true, |prev| prev.update_acked)
+                .is_none_or(|prev| prev.update_acked)
             {
                 // Peer has updated keys twice without awaiting confirmation.
                 return Err(Error::KeyUpdate);


### PR DESCRIPTION
Fixes some CI failure where packages fail to build due to 1.81 being outdated

Successful build output:
```
❯ docker build --tag 'quiche' .
[+] Building 127.8s (24/24) FINISHED                                  docker:desktop-linux
 => [internal] load build definition from Dockerfile                                  0.0s
 => => transferring dockerfile: 1.43kB                                                0.0s
 => [internal] load metadata for docker.io/martenseemann/quic-network-simulator-endp  0.1s
 => [internal] load metadata for docker.io/library/rust:1.82                         55.1s
 => [internal] load .dockerignore                                                     0.0s
 => => transferring context: 2B                                                       0.0s
 => [build  1/14] FROM docker.io/library/rust:1.82@sha256:d9c3c6f1264a547d84560e06f  56.7s
 => => resolve docker.io/library/rust:1.82@sha256:d9c3c6f1264a547d84560e06ffd79ed7a7  0.0s
 => => sha256:8bc6ea9985d6735252067a2041e797c0dedef261a9695671fa4 64.35MB / 64.35MB  14.7s
 => => sha256:d9c3c6f1264a547d84560e06ffd79ed7a799ce0bff0980b26cf10d 7.75kB / 7.75kB  0.0s
 => => sha256:33580ebd9ce59225f0f73cd4f88d8ea2236bd9fe5d0867c913e16a 1.94kB / 1.94kB  0.0s
 => => sha256:26c3caeab5385e95f830d82c2c67f953a5f4838073395ecfd2ff6a 4.51kB / 4.51kB  0.0s
 => => sha256:1a3f1864ec54b1398987bbe673e93d8b09842ecd51e86ab87d6 49.59MB / 49.59MB  18.8s
 => => sha256:464f864cfaa846fbe1b8a889827404e18374f805d29d77c288a8 23.60MB / 23.60MB  5.3s
 => => sha256:9cbd322119a1fd6eb9df75f74273f9136ccdf6317336352e6 202.68MB / 202.68MB  42.1s
 => => sha256:11fb464f40e4004f5fff10a919bcd33153996e0ec882130f7 256.01MB / 256.01MB  53.8s
 => => extracting sha256:1a3f1864ec54b1398987bbe673e93d8b09842ecd51e86ab87d64857b70d  1.4s
 => => extracting sha256:464f864cfaa846fbe1b8a889827404e18374f805d29d77c288a813ae8c4  0.4s
 => => extracting sha256:8bc6ea9985d6735252067a2041e797c0dedef261a9695671fa4ef7891a9  1.6s
 => => extracting sha256:9cbd322119a1fd6eb9df75f74273f9136ccdf6317336352e605b41d5e5c  4.0s
 => => extracting sha256:11fb464f40e4004f5fff10a919bcd33153996e0ec882130f780f84b38a6  2.9s
 => [quiche-qns 1/4] FROM docker.io/martenseemann/quic-network-simulator-endpoint:la  0.0s
 => [internal] load build context                                                     0.3s
 => => transferring context: 929.32kB                                                 0.3s
 => CACHED [quiche-qns 2/4] WORKDIR /quiche                                           0.0s
 => CACHED [quiche-qns 3/4] RUN apt-get update && apt-get install -y wait-for-it &&   0.0s
 => [build  2/14] WORKDIR /build                                                      1.1s
 => [build  3/14] COPY Cargo.toml ./                                                  0.0s
 => [build  4/14] COPY apps/ ./apps/                                                  0.0s
 => [build  5/14] COPY buffer-pool ./buffer-pool/                                     0.0s
 => [build  6/14] COPY datagram-socket/ ./datagram-socket/                            0.0s
 => [build  7/14] COPY h3i/ ./h3i/                                                    0.0s
 => [build  8/14] COPY octets/ ./octets/                                              0.0s
 => [build  9/14] COPY qlog/ ./qlog/                                                  0.0s
 => [build 10/14] COPY quiche/ ./quiche/                                              0.3s
 => [build 11/14] COPY task-killswitch ./task-killswitch/                             0.0s
 => [build 12/14] COPY tokio-quiche ./tokio-quiche/                                   0.0s
 => [build 13/14] RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/  4.5s
 => [build 14/14] RUN cargo build --release --manifest-path apps/Cargo.toml          35.6s
 => [quiche-qns 4/4] COPY --from=build      /build/target/release/quiche-client       0.1s
 => exporting to image                                                                0.2s
 => => exporting layers                                                               0.2s
 => => writing image sha256:a7d3d2b51c5deece17541093a02fbb8171f9ca213f52ffca150c2efd  0.0s
 => => naming to docker.io/library/quiche                                             0.0s
```