### PR TITLE
Make initial RTT configurable

### DIFF
--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -109,6 +109,7 @@ fn main() {
     config.set_application_protos(&conn_args.alpns).unwrap();
 
     config.discover_pmtu(args.enable_pmtud);
+    config.set_initial_rtt(conn_args.initial_rtt);
     config.set_max_idle_timeout(conn_args.idle_timeout);
     config.set_max_recv_udp_payload_size(max_datagram_size);
     config.set_max_send_udp_payload_size(max_datagram_size);

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -111,6 +111,7 @@ pub fn connect(
 
     config.set_application_protos(&conn_args.alpns).unwrap();
 
+    config.set_initial_rtt(conn_args.initial_rtt);
     config.set_max_idle_timeout(conn_args.idle_timeout);
     config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
     config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -438,6 +438,9 @@ pub const MAX_CONN_ID_LEN: usize = crate::packet::MAX_CID_LEN as usize;
 /// The minimum length of Initial packets sent by a client.
 pub const MIN_CLIENT_INITIAL_LEN: usize = 1200;
 
+/// The default initial RTT.
+const DEFAULT_INITIAL_RTT: Duration = Duration::from_millis(333);
+
 #[cfg(not(feature = "fuzzing"))]
 const PAYLOAD_MIN_LEN: usize = 4;
 
@@ -838,6 +841,8 @@ pub struct Config {
     disable_dcid_reuse: bool,
 
     track_unknown_transport_params: Option<usize>,
+
+    initial_rtt: Duration,
 }
 
 // See https://quicwg.org/base-drafts/rfc9000.html#section-15
@@ -911,6 +916,7 @@ impl Config {
             disable_dcid_reuse: false,
 
             track_unknown_transport_params: None,
+            initial_rtt: DEFAULT_INITIAL_RTT,
         })
     }
 
@@ -1111,6 +1117,13 @@ impl Config {
     /// The default value is `1`.
     pub fn set_send_capacity_factor(&mut self, v: f64) {
         self.tx_cap_factor = v;
+    }
+
+    /// Sets the connection's initial RTT.
+    ///
+    /// The default value is `333`.
+    pub fn set_initial_rtt(&mut self, v: Duration) {
+        self.initial_rtt = v;
     }
 
     /// Sets the `max_idle_timeout` transport parameter, in milliseconds.

--- a/quiche/src/recovery/congestion/bbr/init.rs
+++ b/quiche/src/recovery/congestion/bbr/init.rs
@@ -24,8 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use self::rtt::INITIAL_RTT;
-
 use super::*;
 
 use std::time::Instant;
@@ -37,7 +35,7 @@ use std::time::Instant;
 pub fn bbr_init(r: &mut Congestion) {
     let bbr = &mut r.bbr_state;
 
-    bbr.rtprop = INITIAL_RTT;
+    bbr.rtprop = r.initial_rtt;
     bbr.rtprop_stamp = Instant::now();
     bbr.next_round_delivered = r.delivery_rate.delivered();
 
@@ -62,7 +60,7 @@ fn bbr_init_round_counting(r: &mut Congestion) {
 fn bbr_init_pacing_rate(r: &mut Congestion) {
     let bbr = &mut r.bbr_state;
 
-    let srtt = INITIAL_RTT.as_secs_f64();
+    let srtt = r.initial_rtt.as_secs_f64();
 
     // At init, cwnd is initcwnd.
     let nominal_bandwidth = r.congestion_window as f64 / srtt;

--- a/quiche/src/recovery/congestion/bbr2/init.rs
+++ b/quiche/src/recovery/congestion/bbr2/init.rs
@@ -26,8 +26,6 @@
 
 use super::*;
 
-use rtt::INITIAL_RTT;
-
 use std::time::Instant;
 
 // BBR2 Functions at Initialization.
@@ -38,7 +36,7 @@ pub fn bbr2_init(r: &mut Congestion) {
     let now = Instant::now();
 
     let bbr = &mut r.bbr2_state;
-    bbr.min_rtt = INITIAL_RTT;
+    bbr.min_rtt = r.initial_rtt;
     bbr.min_rtt_stamp = now;
     bbr.probe_rtt_done_stamp = None;
     bbr.probe_rtt_round_done = false;

--- a/quiche/src/recovery/congestion/bbr2/pacing.rs
+++ b/quiche/src/recovery/congestion/bbr2/pacing.rs
@@ -24,8 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use self::rtt::INITIAL_RTT;
-
 use super::*;
 
 // BBR2 Transmit Packet Pacing Functions
@@ -35,7 +33,7 @@ use super::*;
 pub fn bbr2_init_pacing_rate(r: &mut Congestion) {
     let bbr = &mut r.bbr2_state;
 
-    let srtt = INITIAL_RTT.as_secs_f64();
+    let srtt = r.initial_rtt.as_secs_f64();
 
     // At init, cwnd is initcwnd.
     let nominal_bandwidth = r.congestion_window as f64 / srtt;

--- a/quiche/src/recovery/congestion/bbr2/per_ack.rs
+++ b/quiche/src/recovery/congestion/bbr2/per_ack.rs
@@ -461,7 +461,7 @@ fn bbr2_update_min_rtt(r: &mut Congestion, now: Instant) {
     // To do: Figure out Probe RTT logic
     // if bbr.probe_rtt_min_delay < bbr.min_rtt ||  bbr.min_rtt == INITIAL_RTT ||
     // min_rtt_expired {
-    if bbr.min_rtt == rtt::INITIAL_RTT || min_rtt_expired {
+    if bbr.min_rtt == r.initial_rtt || min_rtt_expired {
         // bbr.min_rtt = bbr.probe_rtt_min_delay;
         // bbr.min_rtt_stamp = bbr.probe_rtt_min_stamp;
         bbr.min_rtt = rs_rtt;

--- a/quiche/src/recovery/congestion/mod.rs
+++ b/quiche/src/recovery/congestion/mod.rs
@@ -25,6 +25,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use debug_panic::debug_panic;
+use std::time::Duration;
 use std::time::Instant;
 
 use self::recovery::Acked;
@@ -122,6 +123,8 @@ pub struct Congestion {
 
     pub(crate) delivery_rate: delivery_rate::Rate,
 
+    initial_rtt: Duration,
+
     /// Initial congestion window size in terms of packet count.
     pub(crate) initial_congestion_window_packets: usize,
 
@@ -153,6 +156,8 @@ impl Congestion {
             app_limited: false,
 
             lost_count: 0,
+
+            initial_rtt: recovery_config.initial_rtt,
 
             initial_congestion_window_packets: recovery_config
                 .initial_congestion_window_packets,

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -370,7 +370,10 @@ impl LegacyRecovery {
 
             pto_count: 0,
 
-            rtt_stats: RttStats::new(recovery_config.max_ack_delay),
+            rtt_stats: RttStats::new(
+                recovery_config.initial_rtt,
+                recovery_config.max_ack_delay,
+            ),
 
             lost_spurious_count: 0,
 

--- a/quiche/src/recovery/congestion/test_sender.rs
+++ b/quiche/src/recovery/congestion/test_sender.rs
@@ -36,6 +36,7 @@ use super::Congestion;
 use super::RecoveryConfig;
 use super::Sent;
 use crate::CongestionControlAlgorithm;
+use crate::DEFAULT_INITIAL_RTT;
 
 pub(crate) struct TestSender {
     cc: Congestion,
@@ -58,7 +59,10 @@ impl TestSender {
             next_ack: 0,
             bytes_in_flight: 0,
             time: Instant::now(),
-            rtt_stats: RttStats::new(Duration::from_micros(0)),
+            rtt_stats: RttStats::new(
+                DEFAULT_INITIAL_RTT,
+                Duration::from_micros(0),
+            ),
             cc: Congestion::from_config(&RecoveryConfig::from_config(&cfg)),
             sent_packets: VecDeque::new(),
         }

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -419,7 +419,7 @@ impl BBRv2 {
         };
 
         BBRv2 {
-            mode: Mode::startup(BBRv2NetworkModel::new(&params)),
+            mode: Mode::startup(BBRv2NetworkModel::new(&params, smoothed_rtt)),
             cwnd,
             pacing_rate: Bandwidth::from_bytes_and_time_delta(cwnd, smoothed_rtt) *
                 2.885,

--- a/quiche/src/recovery/gcongestion/bbr2/network_model.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/network_model.rs
@@ -37,7 +37,6 @@ use crate::recovery::gcongestion::bbr2::Params;
 use crate::recovery::gcongestion::Bandwidth;
 use crate::recovery::gcongestion::Lost;
 use crate::recovery::rtt::RttStats;
-use crate::recovery::rtt::INITIAL_RTT;
 
 use super::Acked;
 use super::BBRv2CongestionEvent;
@@ -191,7 +190,7 @@ pub(super) struct BBRv2NetworkModel {
 }
 
 impl BBRv2NetworkModel {
-    pub(super) fn new(params: &Params) -> Self {
+    pub(super) fn new(params: &Params, initial_rtt: Duration) -> Self {
         BBRv2NetworkModel {
             min_bytes_in_flight_in_round: usize::MAX,
             inflight_hi_limited_in_round: false,
@@ -206,7 +205,7 @@ impl BBRv2NetworkModel {
                 end_of_round_trip: None,
             },
             min_rtt_filter: MinRttFilter {
-                min_rtt: INITIAL_RTT,
+                min_rtt: initial_rtt,
                 min_rtt_timestamp: Instant::now(),
             },
             max_bandwidth_filter: MaxBandwidthFilter {

--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -37,7 +37,6 @@ pub use self::recovery::GRecovery;
 use crate::recovery::bandwidth::Bandwidth;
 
 use crate::recovery::rtt::RttStats;
-use crate::recovery::rtt::INITIAL_RTT;
 use crate::recovery::RecoveryConfig;
 use crate::recovery::RecoveryStats;
 
@@ -69,7 +68,7 @@ impl Congestion {
             initial_tcp_congestion_window,
             max_congestion_window,
             recovery_config.max_send_udp_payload_size,
-            INITIAL_RTT,
+            recovery_config.initial_rtt,
             recovery_config.custom_bbr_params.as_ref(),
         ))
     }

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -410,7 +410,10 @@ impl GRecovery {
 
         Some(Self {
             epochs: Default::default(),
-            rtt_stats: RttStats::new(recovery_config.max_ack_delay),
+            rtt_stats: RttStats::new(
+                recovery_config.initial_rtt,
+                recovery_config.max_ack_delay,
+            ),
             recovery_stats: RecoveryStats::default(),
             loss_timer: Default::default(),
             pto_count: 0,

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -98,6 +98,7 @@ impl std::fmt::Debug for LossDetectionTimer {
 
 #[derive(Clone, Copy, PartialEq)]
 pub struct RecoveryConfig {
+    pub initial_rtt: Duration,
     pub max_send_udp_payload_size: usize,
     pub max_ack_delay: Duration,
     pub cc_algorithm: CongestionControlAlgorithm,
@@ -111,6 +112,7 @@ pub struct RecoveryConfig {
 impl RecoveryConfig {
     pub fn from_config(config: &Config) -> Self {
         Self {
+            initial_rtt: config.initial_rtt,
             max_send_udp_payload_size: config.max_send_udp_payload_size,
             max_ack_delay: Duration::ZERO,
             cc_algorithm: config.cc_algorithm,

--- a/quiche/src/recovery/rtt.rs
+++ b/quiche/src/recovery/rtt.rs
@@ -30,8 +30,6 @@ use std::time::Instant;
 use crate::minmax::Minmax;
 use crate::recovery::GRANULARITY;
 
-pub(crate) const INITIAL_RTT: Duration = Duration::from_millis(333);
-
 pub(crate) const RTT_WINDOW: Duration = Duration::from_secs(300);
 
 pub struct RttStats {
@@ -62,13 +60,13 @@ impl std::fmt::Debug for RttStats {
 }
 
 impl RttStats {
-    pub(crate) fn new(max_ack_delay: Duration) -> Self {
+    pub(crate) fn new(initial_rtt: Duration, max_ack_delay: Duration) -> Self {
         RttStats {
             latest_rtt: Duration::ZERO,
-            min_rtt: Minmax::new(INITIAL_RTT),
-            smoothed_rtt: INITIAL_RTT,
-            max_rtt: INITIAL_RTT,
-            rttvar: INITIAL_RTT / 2,
+            min_rtt: Minmax::new(initial_rtt),
+            smoothed_rtt: initial_rtt,
+            max_rtt: initial_rtt,
+            rttvar: initial_rtt / 2,
             has_first_rtt_sample: false,
             max_ack_delay,
         }


### PR DESCRIPTION
Before this change, the initial RTT was hardcoded to `333`. With this change, it's now possible for the user to configure that value through `Config::set_initial_rtt`. This is important for high-latency networks.

Context: I'm collaborating with the [tiptop IETF working group](https://datatracker.ietf.org/doc/charter-ietf-tiptop/) to test QUIC in a deep-space setting.

cc @marcblanchet