### PR TITLE
Consider app_limited when generating new delivery_rate values

### DIFF
--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -900,6 +900,7 @@ impl RecoveryOps for LegacyRecovery {
         self.detect_lost_packets(epoch, now, "")
     }
 
+    // FIXME only used by gcongestion
     fn on_app_limited(&mut self) {
         // Not implemented for legacy recovery, update_app_limited and
         // delivery_rate_update_app_limited used instead.
@@ -911,13 +912,15 @@ impl RecoveryOps for LegacyRecovery {
     }
 
     fn update_app_limited(&mut self, v: bool) {
-        self.congestion.app_limited = v;
+        self.congestion.update_app_limited(v);
     }
 
+    // FIXME only used by congestion
     fn delivery_rate_update_app_limited(&mut self, v: bool) {
         self.congestion.delivery_rate.update_app_limited(v);
     }
 
+    // FIXME only used by congestion
     fn update_max_ack_delay(&mut self, max_ack_delay: Duration) {
         self.rtt_stats.max_ack_delay = max_ack_delay;
     }

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -886,6 +886,7 @@ impl RecoveryOps for GRecovery {
         )
     }
 
+    // FIXME only used by gcongestion
     fn on_app_limited(&mut self) {
         self.pacer.on_app_limited(self.bytes_in_flight)
     }
@@ -941,10 +942,12 @@ impl RecoveryOps for GRecovery {
         self.pacer.is_app_limited(self.bytes_in_flight)
     }
 
+    // FIXME only used by congestion
     fn update_app_limited(&mut self, _v: bool) {
         // TODO
     }
 
+    // FIXME only used by congestion
     fn delivery_rate_update_app_limited(&mut self, _v: bool) {
         // TODO
     }


### PR DESCRIPTION
With this PR, congestion delivery_rate matches the Linux implementation.

### Analysis
Q: How does TCP calculate delivery rate?

A: The TCP delivery rate consider if the connection is app limited.

- If NOT app_limited, record the latest value.
- If app_limited, record the max value `max(previous_rate, new_app_limited_rate)`.
 

This [blog](https://blog.mygraphql.com/en/notes/low-tec/network/tcp-inspect/) + this [linux commit](https://github.com/torvalds/linux/commit/eb8329e0a04db0061f714f033b4454326ba147f4) provides the answer:

> tcpi_delivery_rate: The most recent goodput, as measured by
tcp_rate_gen(). If the socket is limited by the sending
application (e.g., no data to send), it reports the highest
measurement instead of the most recent. The unit is bytes per
second (like other rate fields in tcp_info).


## Callout
I delete a the test `app_limited_check` which wasn't checking anything. It will be clearer if you look at the individual commits when reviewing this PR since the test removal are separate commits. 