### PR TITLE
stats: expose the startup stats for connection

### DIFF
--- a/datagram-socket/src/socket_stats.rs
+++ b/datagram-socket/src/socket_stats.rs
@@ -59,6 +59,26 @@ pub struct SocketStats {
     pub bytes_retrans: u64,
     pub bytes_unsent: u64,
     pub delivery_rate: u64,
+    pub startup_exit_reason: Option<StartupExit>,
+}
+
+/// The reason a CCA exited the startup phase.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StartupExit {
+    pub cwnd: usize,
+    pub reason: StartupExitReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum StartupExitReason {
+    /// Exit startup due to excessive loss
+    Loss,
+
+    /// Exit startup due to bandwidth plateau.
+    BandwidthPlateau,
+
+    /// Exit startup due to persistent queue.
+    PersistentQueue,
 }
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -34,6 +34,7 @@ use smallvec::SmallVec;
 
 use slab::Slab;
 
+use crate::recovery::OnLossDetectionTimeoutOutcome;
 use crate::Error;
 use crate::Result;
 
@@ -430,12 +431,10 @@ impl Path {
     pub fn on_loss_detection_timeout(
         &mut self, handshake_status: HandshakeStatus, now: time::Instant,
         is_server: bool, trace_id: &str,
-    ) -> (usize, usize) {
-        let (lost_packets, lost_bytes) = self.recovery.on_loss_detection_timeout(
-            handshake_status,
-            now,
-            trace_id,
-        );
+    ) -> OnLossDetectionTimeoutOutcome {
+        let on_loss_detection_timeout_outcome = self
+            .recovery
+            .on_loss_detection_timeout(handshake_status, now, trace_id);
 
         let mut lost_probe_time = None;
         self.in_flight_challenges.retain(|(_, _, sent_time)| {
@@ -479,7 +478,7 @@ impl Path {
             }
         }
 
-        (lost_packets, lost_bytes)
+        on_loss_detection_timeout_outcome
     }
 
     pub fn reinit_recovery(

--- a/quiche/src/recovery/congestion/bbr/mod.rs
+++ b/quiche/src/recovery/congestion/bbr/mod.rs
@@ -475,6 +475,7 @@ mod tests {
                 lost_bytes: 2 * mss,
                 acked_bytes: mss,
                 spurious_losses: 0,
+                ..Default::default()
             },
         );
 
@@ -547,6 +548,7 @@ mod tests {
                     lost_bytes: 0,
                     acked_bytes: mss,
                     spurious_losses: 0,
+                    ..Default::default()
                 },
             );
         }
@@ -604,6 +606,7 @@ mod tests {
                 lost_bytes: 0,
                 acked_bytes: mss,
                 spurious_losses: 0,
+                ..Default::default()
             },
         );
 
@@ -673,6 +676,7 @@ mod tests {
                     lost_bytes: 0,
                     acked_bytes: mss,
                     spurious_losses: 0,
+                    ..Default::default()
                 },
             );
         }
@@ -749,6 +753,7 @@ mod tests {
                     lost_bytes: 0,
                     acked_bytes: mss,
                     spurious_losses: 0,
+                    ..Default::default()
                 },
             );
         }
@@ -810,6 +815,7 @@ mod tests {
                 lost_bytes: 0,
                 acked_bytes: mss,
                 spurious_losses: 0,
+                ..Default::default()
             },
         );
 

--- a/quiche/src/recovery/congestion/bbr2/mod.rs
+++ b/quiche/src/recovery/congestion/bbr2/mod.rs
@@ -750,6 +750,7 @@ mod tests {
                 lost_bytes: 0,
                 acked_bytes: mss * 5,
                 spurious_losses: 0,
+                ..Default::default()
             }
         );
 
@@ -827,6 +828,7 @@ mod tests {
                 lost_bytes: 2 * mss,
                 acked_bytes: mss,
                 spurious_losses: 0,
+                ..Default::default()
             }
         );
 
@@ -903,6 +905,7 @@ mod tests {
                     lost_bytes: 0,
                     acked_bytes: mss,
                     spurious_losses: 0,
+                    ..Default::default()
                 }
             );
         }
@@ -962,6 +965,7 @@ mod tests {
                 lost_bytes: 0,
                 acked_bytes: mss,
                 spurious_losses: 0,
+                ..Default::default()
             }
         );
 
@@ -1034,6 +1038,7 @@ mod tests {
                     lost_bytes: 0,
                     acked_bytes: mss,
                     spurious_losses: 0,
+                    ..Default::default()
                 }
             );
         }
@@ -1098,6 +1103,7 @@ mod tests {
                 lost_bytes: 0,
                 acked_bytes: mss,
                 spurious_losses: 0,
+                ..Default::default()
             }
         );
 

--- a/quiche/src/recovery/congestion/delivery_rate.rs
+++ b/quiche/src/recovery/congestion/delivery_rate.rs
@@ -514,6 +514,7 @@ mod tests {
             lost_bytes: 0,
             acked_bytes: mss * packet_count,
             spurious_losses: 0,
+            ..Default::default()
         });
     }
 }

--- a/quiche/src/recovery/gcongestion/bbr2/drain.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/drain.rs
@@ -33,6 +33,7 @@ use std::time::Instant;
 use crate::recovery::gcongestion::bbr2::Params;
 use crate::recovery::gcongestion::Acked;
 use crate::recovery::gcongestion::Lost;
+use crate::recovery::RecoveryStats;
 
 use super::mode::Cycle;
 use super::mode::Mode;
@@ -57,6 +58,7 @@ impl ModeImpl for Drain {
         _acked_packets: &[Acked], _lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         _target_bytes_inflight: usize, params: &Params,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
     ) -> Mode {
         self.model.set_pacing_gain(params.drain_pacing_gain);
         // Only STARTUP can transition to DRAIN, both of them use the same cwnd

--- a/quiche/src/recovery/gcongestion/bbr2/mode.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/mode.rs
@@ -36,6 +36,7 @@ use std::time::Instant;
 
 use crate::recovery::gcongestion::bbr2::Params;
 use crate::recovery::gcongestion::Lost;
+use crate::recovery::RecoveryStats;
 
 use super::drain::Drain;
 use super::network_model::BBRv2NetworkModel;
@@ -130,6 +131,7 @@ pub(super) trait ModeImpl: Debug {
         acked_packets: &[Acked], lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
+        recovery_stats: &mut RecoveryStats, cwnd: usize,
     ) -> Mode;
 
     fn get_cwnd_limits(&self, params: &Params) -> Limits<usize>;
@@ -181,6 +183,7 @@ impl Mode {
         acked_packets: &[Acked], lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
+        recovery_stats: &mut RecoveryStats, cwnd: usize,
     ) -> bool {
         let mode_before = std::mem::discriminant(self);
 
@@ -192,6 +195,8 @@ impl Mode {
             congestion_event,
             target_bytes_inflight,
             params,
+            recovery_stats,
+            cwnd,
         );
 
         let mode_after = std::mem::discriminant(self);
@@ -257,6 +262,7 @@ impl ModeImpl for Placeholder {
     fn on_congestion_event(
         self, _: usize, _: Instant, _: &[Acked], _: &[Lost],
         _: &mut BBRv2CongestionEvent, _: usize, _params: &Params,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
     ) -> Mode {
         unreachable!()
     }

--- a/quiche/src/recovery/gcongestion/bbr2/network_model.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/network_model.rs
@@ -631,11 +631,6 @@ impl BBRv2NetworkModel {
     pub(super) fn check_persistent_queue(
         &mut self, target_gain: f32, params: &Params,
     ) -> PersistentQueueOutcome {
-        let mut outcome = PersistentQueueOutcome {
-            full_bandwidth_reached: false,
-            rounds_with_queueing: 0,
-        };
-
         let target = self
             .bdp(self.max_bandwidth(), target_gain)
             .max(self.bdp0() + self.queueing_threshold_extra_bytes());
@@ -650,10 +645,10 @@ impl BBRv2NetworkModel {
             }
         }
 
-        outcome.full_bandwidth_reached = self.full_bandwidth_reached;
-        outcome.rounds_with_queueing = self.rounds_with_queueing;
-
-        outcome
+        PersistentQueueOutcome {
+            full_bandwidth_reached: self.full_bandwidth_reached,
+            rounds_with_queueing: self.rounds_with_queueing,
+        }
     }
 
     pub(super) fn max_bytes_delivered_in_round(&self) -> usize {

--- a/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
@@ -35,6 +35,7 @@ use std::time::Instant;
 use crate::recovery::gcongestion::bbr2::Params;
 use crate::recovery::gcongestion::Acked;
 use crate::recovery::gcongestion::Lost;
+use crate::recovery::RecoveryStats;
 
 use super::mode::Cycle;
 use super::mode::CyclePhase;
@@ -84,6 +85,7 @@ impl ModeImpl for ProbeBW {
         mut self, prior_in_flight: usize, event_time: Instant, _: &[Acked],
         _: &[Lost], congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
     ) -> Mode {
         if congestion_event.end_of_round_trip {
             if self.cycle.start_time != event_time {

--- a/quiche/src/recovery/gcongestion/bbr2/probe_rtt.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_rtt.rs
@@ -33,6 +33,7 @@ use std::time::Instant;
 use crate::recovery::gcongestion::bbr2::Params;
 use crate::recovery::gcongestion::Acked;
 use crate::recovery::gcongestion::Lost;
+use crate::recovery::RecoveryStats;
 
 use super::mode::Cycle;
 use super::mode::Mode;
@@ -85,6 +86,7 @@ impl ModeImpl for ProbeRTT {
         _acked_packets: &[Acked], _lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         _target_bytes_inflight: usize, params: &Params,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
     ) -> Mode {
         match self.exit_time {
             None => {

--- a/quiche/src/recovery/gcongestion/bbr2/startup.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/startup.rs
@@ -65,17 +65,12 @@ impl ModeImpl for Startup {
             return Mode::Startup(self);
         }
 
-        // Exit startup due to bw plateau
-        let mut exit_due_to_bw_plateau = false;
-        // Exit startup due to excessive loss
-        let mut exit_due_to_excessive_loss = false;
-
         let has_bandwidth_growth =
             self.model.has_bandwidth_growth(congestion_event, params);
+        // TODO: Check full_bandwidth_reached to determine if exit due to
+        // bandwidth plateau
 
-        let check_bw_plateau =
-            params.max_startup_queue_rounds > 0 && !has_bandwidth_growth;
-        if check_bw_plateau {
+        if params.max_startup_queue_rounds > 0 && !has_bandwidth_growth {
             // 1.75 is less than the 2x CWND gain, but substantially more than
             // 1.25x, the minimum bandwidth increase expected during
             // STARTUP.
@@ -84,23 +79,25 @@ impl ModeImpl for Startup {
                 rounds_with_queueing: _,
             } = self.model.check_persistent_queue(1.75, params);
 
-            exit_due_to_bw_plateau = full_bandwidth_reached;
+            // TODO: Exit due to persistent queue
+            let _exit_due_to_persistent_queue = full_bandwidth_reached;
         };
 
+        // TCP BBR always exits upon excessive losses. QUIC BBRv1 does not exit
+        // upon excessive losses, if enough bandwidth growth is observed
+        // or if the sample was app limited.
         let check_for_excessive_loss = !congestion_event.last_packet_send_state.is_app_limited &&
                 !has_bandwidth_growth &&
-                // check for loss only if not already Bandwidth plateaued
-                !exit_due_to_bw_plateau;
+                // check for excessive loss only if not exiting for other reasons
+                !self.model.full_bandwidth_reached();
 
         if check_for_excessive_loss {
-            // TCP BBR always exits upon excessive losses. QUIC BBRv1 does not
-            // exit upon excessive losses, if enough bandwidth growth
-            // is observed or if the sample was app limited.
-            exit_due_to_excessive_loss =
+            // TODO: Exit due to excessive loss
+            let _exit_due_to_excessive_loss =
                 self.check_excessive_losses(congestion_event, params);
         }
 
-        if exit_due_to_bw_plateau || exit_due_to_excessive_loss {
+        if self.model.full_bandwidth_reached() {
             self.into_drain(event_time, Some(congestion_event), params)
         } else {
             Mode::Startup(self)

--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -40,6 +40,8 @@ use crate::recovery::rtt::RttStats;
 use crate::recovery::rtt::INITIAL_RTT;
 use crate::recovery::RecoveryConfig;
 
+use super::RecoveryStats;
+
 #[derive(Debug)]
 pub struct Lost {
     pub(super) packet_number: u64,
@@ -114,6 +116,7 @@ pub(super) trait CongestionControl: Debug {
         &mut self, rtt_updated: bool, prior_in_flight: usize,
         bytes_in_flight: usize, event_time: Instant, acked_packets: &[Acked],
         lost_packets: &[Lost], least_unacked: u64, rtt_stats: &RttStats,
+        recovery_stats: &mut RecoveryStats,
     );
 
     /// Called when an RTO fires.  Resets the retransmission alarm if there are

--- a/quiche/src/recovery/gcongestion/pacer.rs
+++ b/quiche/src/recovery/gcongestion/pacer.rs
@@ -32,6 +32,7 @@ use std::time::Instant;
 
 use crate::recovery::gcongestion::Bandwidth;
 use crate::recovery::rtt::RttStats;
+use crate::recovery::RecoveryStats;
 use crate::recovery::ReleaseDecision;
 use crate::recovery::ReleaseTime;
 
@@ -203,6 +204,7 @@ impl CongestionControl for Pacer {
         &mut self, rtt_updated: bool, prior_in_flight: usize,
         bytes_in_flight: usize, event_time: Instant, acked_packets: &[Acked],
         lost_packets: &[Lost], least_unacked: u64, rtt_stats: &RttStats,
+        recovery_stats: &mut RecoveryStats,
     ) {
         self.sender.on_congestion_event(
             rtt_updated,
@@ -213,6 +215,7 @@ impl CongestionControl for Pacer {
             lost_packets,
             least_unacked,
             rtt_stats,
+            recovery_stats,
         );
 
         if !self.enabled {

--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -92,6 +92,24 @@ impl QuicConnectionStats {
             path_stats: qconn.path_stats().next(),
         }
     }
+
+    fn startup_exit_to_socket_stats(
+        value: quiche::StartupExit,
+    ) -> datagram_socket::StartupExit {
+        let reason = match value.reason {
+            quiche::StartupExitReason::Loss =>
+                datagram_socket::StartupExitReason::Loss,
+            quiche::StartupExitReason::BandwidthPlateau =>
+                datagram_socket::StartupExitReason::BandwidthPlateau,
+            quiche::StartupExitReason::PersistentQueue =>
+                datagram_socket::StartupExitReason::PersistentQueue,
+        };
+
+        datagram_socket::StartupExit {
+            cwnd: value.cwnd,
+            reason,
+        }
+    }
 }
 
 impl AsSocketStats for QuicConnectionStats {
@@ -143,6 +161,10 @@ impl AsSocketStats for QuicConnectionStats {
                 .as_ref()
                 .map(|p| p.delivery_rate)
                 .unwrap_or_default(),
+            startup_exit_reason: self
+                .stats
+                .startup_exit_reason
+                .map(QuicConnectionStats::startup_exit_to_socket_stats),
         }
     }
 }


### PR DESCRIPTION
Based on https://github.com/cloudflare/quiche/pull/2061

BBR can exit the statup mode either due to excessive loss or bandwidth plateau. Exposing this reason can help in understanding CCA behavior and network characteristics.