### PR TITLE
tokio-quiche: expose max bandwidth and max loss percentage as stats

### DIFF
--- a/datagram-socket/src/socket_stats.rs
+++ b/datagram-socket/src/socket_stats.rs
@@ -26,6 +26,8 @@
 
 use std::ops::Deref;
 use std::sync::atomic::AtomicI64;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -65,21 +67,26 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 #[derive(Debug)]
 pub struct QuicAuditStats {
-    /// A transport-level connection error code received from the client
+    /// A transport-level connection error code received from the client.
     recvd_conn_close_transport_error_code: AtomicI64,
-    /// A transport-level connection error code sent to the client
+    /// A transport-level connection error code sent to the client.
     sent_conn_close_transport_error_code: AtomicI64,
-    /// An application-level connection error code received from the client
+    /// An application-level connection error code received from the client.
     recvd_conn_close_application_error_code: AtomicI64,
-    /// An application-level connection error code sent to the client
+    /// An application-level connection error code sent to the client.
     sent_conn_close_application_error_code: AtomicI64,
-    /// Time taken for the QUIC handshake in microseconds
+    /// Time taken for the QUIC handshake in microseconds.
     transport_handshake_duration_us: AtomicI64,
     /// The start time of the handshake.
     transport_handshake_start: Arc<RwLock<Option<SystemTime>>>,
     /// The reason the QUIC connection was closed
     connection_close_reason: RwLock<Option<BoxError>>,
-    /// The server's chosen QUIC connection ID
+    /// Max recorded bandwidth.
+    max_bandwidth: AtomicU64,
+    /// Loss at max recorded bandwidth.
+    max_loss_pct: AtomicU8,
+    /// The server's chosen QUIC connection ID.
+    ///
     /// The QUIC connection ID is presently an array of 20 bytes (160 bits)
     pub quic_connection_id: Vec<u8>,
 }
@@ -95,6 +102,8 @@ impl QuicAuditStats {
             transport_handshake_duration_us: AtomicI64::new(-1),
             transport_handshake_start: Arc::new(RwLock::new(None)),
             connection_close_reason: RwLock::new(None),
+            max_bandwidth: AtomicU64::new(0),
+            max_loss_pct: AtomicU8::new(0),
             quic_connection_id,
         }
     }
@@ -187,6 +196,26 @@ impl QuicAuditStats {
     #[inline]
     pub fn set_connection_close_reason(&self, error: BoxError) {
         *self.connection_close_reason.write().unwrap() = Some(error);
+    }
+
+    #[inline]
+    pub fn set_max_bandwidth(&self, max_bandwidth: u64) {
+        self.max_bandwidth.store(max_bandwidth, Ordering::Release)
+    }
+
+    #[inline]
+    pub fn max_bandwidth(&self) -> u64 {
+        self.max_bandwidth.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    pub fn set_max_loss_pct(&self, max_loss_pct: u8) {
+        self.max_loss_pct.store(max_loss_pct, Ordering::Release)
+    }
+
+    #[inline]
+    pub fn max_loss_pct(&self) -> u8 {
+        self.max_loss_pct.load(Ordering::Acquire)
     }
 }
 

--- a/tokio-quiche/src/quic/io/worker.rs
+++ b/tokio-quiche/src/quic/io/worker.rs
@@ -223,6 +223,12 @@ where
 
             self.bw_estimator.update(qconn, now);
 
+            self.audit_log_stats
+                .set_max_bandwidth(self.bw_estimator.max_bandwidth);
+            self.audit_log_stats.set_max_loss_pct(
+                (self.bw_estimator.max_loss_pct * 100_f32).round() as u8,
+            );
+
             let new_deadline = min_of_some(
                 qconn.timeout_instant(),
                 self.write_state.next_release_time,


### PR DESCRIPTION
Currently these values are only exposed as metrics, but it can be useful to collect them on a per-connection basis (rather than aggreagte metrics), so expose them via audit log stats.

Regarding max loss percentage, the underlying value is `f32` but it's converted to integer (`u8`) to allow using atomic operations like for the rest of the `QuicAuditStats` fields.