### PR TITLE
Add toolchain file for nightly formatting

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt"]


### PR DESCRIPTION
This will help instruct auto formatters like rust analyzer to use the
nightly toolchain.