### PR TITLE
tokio-quiche: always set UDP_SEGMENT cmsg when calling sendmsg()

### DIFF
--- a/tokio-quiche/src/lib.rs
+++ b/tokio-quiche/src/lib.rs
@@ -194,9 +194,7 @@ where
             #[cfg_attr(not(target_os = "linux"), expect(unused_mut))]
             let mut socket = s.try_into()?;
             #[cfg(target_os = "linux")]
-            socket.apply_max_capabilities(
-                params.settings.max_send_udp_payload_size,
-            );
+            socket.apply_max_capabilities();
             Ok(socket)
         })
         .collect::<io::Result<_>>()?;

--- a/tokio-quiche/src/quic/io/gso.rs
+++ b/tokio-quiche/src/quic/io/gso.rs
@@ -114,8 +114,7 @@ impl PktInfo {
 #[cfg(all(target_os = "linux", not(feature = "fuzzing")))]
 pub async fn send_to(
     socket: &tokio::net::UdpSocket, to: SocketAddr, from: Option<SocketAddr>,
-    send_buf: &[u8], segment_size: usize, num_pkts: usize,
-    tx_time: Option<Instant>,
+    send_buf: &[u8], segment_size: usize, tx_time: Option<Instant>,
 ) -> io::Result<usize> {
     // An instant with the value of zero, since [`Instant`] is backed by a version
     // of timespec this allows to extract raw values from an [`Instant`]
@@ -133,10 +132,8 @@ pub async fn send_to(
 
         let mut cmsgs: SmallVec<[ControlMessage; 3]> = SmallVec::new();
 
-        if num_pkts > 1 {
-            // Create cmsg for UDP_SEGMENT.
-            cmsgs.push(ControlMessage::UdpGsoSegments(&segment_size_u16));
-        }
+        // Create cmsg for UDP_SEGMENT.
+        cmsgs.push(ControlMessage::UdpGsoSegments(&segment_size_u16));
 
         if tx_time.is_some() {
             // Create cmsg for TXTIME.
@@ -169,8 +166,7 @@ pub async fn send_to(
 #[cfg(any(not(target_os = "linux"), feature = "fuzzing"))]
 pub(crate) async fn send_to(
     socket: &tokio::net::UdpSocket, to: SocketAddr, _from: Option<SocketAddr>,
-    send_buf: &[u8], _segment_size: usize, _num_pkts: usize,
-    _tx_time: Option<Instant>,
+    send_buf: &[u8], _segment_size: usize, _tx_time: Option<Instant>,
 ) -> io::Result<usize> {
     socket.send_to(send_buf, to).await
 }

--- a/tokio-quiche/src/quic/io/worker.rs
+++ b/tokio-quiche/src/quic/io/worker.rs
@@ -521,7 +521,6 @@ where
                     self.write_state.send_from.filter(|_| self.cfg.with_pktinfo),
                     current_send_buf,
                     self.write_state.segment_size,
-                    self.write_state.num_pkts,
                     self.write_state.tx_time,
                 )
                 .await

--- a/tokio-quiche/src/quic/router/acceptor.rs
+++ b/tokio-quiche/src/quic/router/acceptor.rs
@@ -164,7 +164,12 @@ where
             {
                 let from = Some(incoming.local_addr).filter(|_| with_pktinfo);
                 let _ = crate::quic::io::gso::send_to(
-                    udp, to, from, send_buf, 1, 1, None,
+                    udp,
+                    to,
+                    from,
+                    send_buf,
+                    send_buf.len(),
+                    None,
                 )
                 .await;
             }

--- a/tokio-quiche/src/socket/connected.rs
+++ b/tokio-quiche/src/socket/connected.rs
@@ -113,15 +113,13 @@ where
     /// FD. See `SocketCapabilities::apply_all_and_get_compatibility` for
     /// details.
     #[cfg(target_os = "linux")]
-    pub fn apply_max_capabilities(&mut self, max_send_udp_payload_size: usize) {
+    pub fn apply_max_capabilities(&mut self) {
         let Some(socket) = self.as_udp_socket() else {
             return;
         };
 
-        let capabilities = SocketCapabilities::apply_all_and_get_compatibility(
-            socket,
-            max_send_udp_payload_size,
-        );
+        let capabilities =
+            SocketCapabilities::apply_all_and_get_compatibility(socket);
         self.capabilities = capabilities;
     }
 }

--- a/tokio-quiche/src/socket/listener.rs
+++ b/tokio-quiche/src/socket/listener.rs
@@ -64,11 +64,9 @@ impl QuicListener {
     /// Tries to enable all sockopts supported by the crate for this socket.
     /// See `SocketCapabilities::apply_all_and_get_compatibility` for details.
     #[cfg(target_os = "linux")]
-    pub fn apply_max_capabilities(&mut self, max_send_udp_payload_size: usize) {
-        let capabilities = SocketCapabilities::apply_all_and_get_compatibility(
-            &self.socket,
-            max_send_udp_payload_size,
-        );
+    pub fn apply_max_capabilities(&mut self) {
+        let capabilities =
+            SocketCapabilities::apply_all_and_get_compatibility(&self.socket);
         self.capabilities = capabilities;
     }
 }


### PR DESCRIPTION
Current logic avoids setting the UDP_SEGMENT cmsg on sendmsg() calls when sending a single packet over the wire. However, there are niche cases where it's desirable to update the segment size after a socket has been created. If the updated segment size is greater than what the socket was initialized with, and we omit the UDP_SEGMENT cmsg, then the kernel will fall back to the segment size that is configured on the socket and erroneously truncate the packet on the way out.

We now set the UDP_SEGMENT cmsg on each packet no matter what.

To help avoid this footgun, we now initialize GSO on the socket with the maximum possible segment size.