### PR TITLE
refactor: make it easier to reason about startup exit

### DIFF
--- a/quiche/src/recovery/gcongestion/bbr2/network_model.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/network_model.rs
@@ -631,11 +631,6 @@ impl BBRv2NetworkModel {
     pub(super) fn check_persistent_queue(
         &mut self, target_gain: f32, params: &Params,
     ) -> PersistentQueueOutcome {
-        let mut outcome = PersistentQueueOutcome {
-            full_bandwidth_reached: false,
-            rounds_with_queueing: 0,
-        };
-
         let target = self
             .bdp(self.max_bandwidth(), target_gain)
             .max(self.bdp0() + self.queueing_threshold_extra_bytes());
@@ -650,10 +645,10 @@ impl BBRv2NetworkModel {
             }
         }
 
-        outcome.full_bandwidth_reached = self.full_bandwidth_reached;
-        outcome.rounds_with_queueing = self.rounds_with_queueing;
-
-        outcome
+        PersistentQueueOutcome {
+            full_bandwidth_reached: self.full_bandwidth_reached,
+            rounds_with_queueing: self.rounds_with_queueing,
+        }
     }
 
     pub(super) fn max_bytes_delivered_in_round(&self) -> usize {

--- a/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
@@ -41,6 +41,7 @@ use super::mode::CyclePhase;
 use super::mode::Mode;
 use super::mode::ModeImpl;
 use super::network_model::BBRv2NetworkModel;
+use super::network_model::PersistentQueueOutcome;
 use super::network_model::DEFAULT_MSS;
 use super::BBRv2CongestionEvent;
 use super::BwLoMode;
@@ -394,11 +395,14 @@ impl ProbeBW {
         } else if self.cycle.rounds_in_phase > 0 {
             if params.max_probe_up_queue_rounds > 0 {
                 if congestion_event.end_of_round_trip {
-                    self.model
+                    let PersistentQueueOutcome {
+                        full_bandwidth_reached: _,
+                        rounds_with_queueing,
+                    } = self
+                        .model
                         .check_persistent_queue(params.full_bw_threshold, params);
-                    if self.model.rounds_with_queueing() >=
-                        params.max_probe_up_queue_rounds
-                    {
+
+                    if rounds_with_queueing >= params.max_probe_up_queue_rounds {
                         is_queuing = true;
                     }
                 }


### PR DESCRIPTION
This PR refactors the startup on_congestion code to more clearly identify why we exit the startup phase. We will use this in a follow up PR to emit metrics about exit reason.