### PR TITLE
Emit statistics from when a CCA exits Startup

### DIFF
--- a/datagram-socket/src/socket_stats.rs
+++ b/datagram-socket/src/socket_stats.rs
@@ -59,6 +59,27 @@ pub struct SocketStats {
     pub bytes_retrans: u64,
     pub bytes_unsent: u64,
     pub delivery_rate: u64,
+    pub startup_exit: Option<StartupExit>,
+}
+
+/// Statistics from when a CCA first exited the startup phase.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StartupExit {
+    pub cwnd: usize,
+    pub reason: StartupExitReason,
+}
+
+/// The reason a CCA exited the startup phase.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum StartupExitReason {
+    /// Exit startup due to excessive loss
+    Loss,
+
+    /// Exit startup due to bandwidth plateau.
+    BandwidthPlateau,
+
+    /// Exit startup due to persistent queue.
+    PersistentQueue,
 }
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -18883,6 +18883,8 @@ pub use crate::recovery::BbrBwLoReductionStrategy;
 pub use crate::recovery::BbrParams;
 pub use crate::recovery::CongestionControlAlgorithm;
 use crate::recovery::RecoveryOps;
+pub use crate::recovery::StartupExit;
+pub use crate::recovery::StartupExitReason;
 
 pub use crate::stream::StreamIter;
 

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -36,6 +36,7 @@ use slab::Slab;
 
 use crate::Error;
 use crate::Result;
+use crate::StartupExit;
 
 use crate::pmtud;
 use crate::recovery;
@@ -511,6 +512,7 @@ impl Path {
             stream_retrans_bytes: self.stream_retrans_bytes,
             pmtu: self.recovery.max_datagram_size(),
             delivery_rate: self.recovery.delivery_rate().to_bytes_per_second(),
+            startup_exit: self.recovery.startup_exit(),
         }
     }
 }
@@ -920,6 +922,9 @@ pub struct PathStats {
     /// [`SendInfo.at`]: struct.SendInfo.html#structfield.at
     /// [Pacing]: index.html#pacing
     pub delivery_rate: u64,
+
+    /// Statistics from when a CCA first exited the startup phase.
+    pub startup_exit: Option<StartupExit>,
 }
 
 impl std::fmt::Debug for PathStats {

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -39,6 +39,7 @@ use crate::ranges::RangeSet;
 use crate::recovery::Bandwidth;
 use crate::recovery::HandshakeStatus;
 use crate::recovery::RecoveryOps;
+use crate::recovery::StartupExit;
 
 #[cfg(feature = "qlog")]
 use crate::recovery::QlogMetrics;
@@ -824,6 +825,12 @@ impl RecoveryOps for LegacyRecovery {
     /// The most recent data delivery rate estimate.
     fn delivery_rate(&self) -> Bandwidth {
         self.congestion.delivery_rate()
+    }
+
+    /// Statistics from when a CCA first exited the startup phase.
+    fn startup_exit(&self) -> Option<StartupExit> {
+        // TODO implement
+        None
     }
 
     fn max_datagram_size(&self) -> usize {

--- a/quiche/src/recovery/gcongestion/bbr2/drain.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/drain.rs
@@ -33,6 +33,7 @@ use std::time::Instant;
 use crate::recovery::gcongestion::bbr2::Params;
 use crate::recovery::gcongestion::Acked;
 use crate::recovery::gcongestion::Lost;
+use crate::recovery::RecoveryStats;
 
 use super::mode::Cycle;
 use super::mode::Mode;
@@ -57,6 +58,7 @@ impl ModeImpl for Drain {
         _acked_packets: &[Acked], _lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         _target_bytes_inflight: usize, params: &Params,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
     ) -> Mode {
         self.model.set_pacing_gain(params.drain_pacing_gain);
         // Only STARTUP can transition to DRAIN, both of them use the same cwnd

--- a/quiche/src/recovery/gcongestion/bbr2/mode.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/mode.rs
@@ -36,6 +36,7 @@ use std::time::Instant;
 
 use crate::recovery::gcongestion::bbr2::Params;
 use crate::recovery::gcongestion::Lost;
+use crate::recovery::RecoveryStats;
 
 use super::drain::Drain;
 use super::network_model::BBRv2NetworkModel;
@@ -130,6 +131,7 @@ pub(super) trait ModeImpl: Debug {
         acked_packets: &[Acked], lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
+        recovery_stats: &mut RecoveryStats, cwnd: usize,
     ) -> Mode;
 
     fn get_cwnd_limits(&self, params: &Params) -> Limits<usize>;
@@ -181,6 +183,7 @@ impl Mode {
         acked_packets: &[Acked], lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
+        recovery_stats: &mut RecoveryStats, cwnd: usize,
     ) -> bool {
         let mode_before = std::mem::discriminant(self);
 
@@ -192,6 +195,8 @@ impl Mode {
             congestion_event,
             target_bytes_inflight,
             params,
+            recovery_stats,
+            cwnd,
         );
 
         let mode_after = std::mem::discriminant(self);
@@ -257,6 +262,7 @@ impl ModeImpl for Placeholder {
     fn on_congestion_event(
         self, _: usize, _: Instant, _: &[Acked], _: &[Lost],
         _: &mut BBRv2CongestionEvent, _: usize, _params: &Params,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
     ) -> Mode {
         unreachable!()
     }

--- a/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
@@ -35,6 +35,7 @@ use std::time::Instant;
 use crate::recovery::gcongestion::bbr2::Params;
 use crate::recovery::gcongestion::Acked;
 use crate::recovery::gcongestion::Lost;
+use crate::recovery::RecoveryStats;
 
 use super::mode::Cycle;
 use super::mode::CyclePhase;
@@ -83,6 +84,7 @@ impl ModeImpl for ProbeBW {
         mut self, prior_in_flight: usize, event_time: Instant, _: &[Acked],
         _: &[Lost], congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
     ) -> Mode {
         if congestion_event.end_of_round_trip {
             if self.cycle.start_time != event_time {

--- a/quiche/src/recovery/gcongestion/bbr2/probe_rtt.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_rtt.rs
@@ -33,6 +33,7 @@ use std::time::Instant;
 use crate::recovery::gcongestion::bbr2::Params;
 use crate::recovery::gcongestion::Acked;
 use crate::recovery::gcongestion::Lost;
+use crate::recovery::RecoveryStats;
 
 use super::mode::Cycle;
 use super::mode::Mode;
@@ -85,6 +86,7 @@ impl ModeImpl for ProbeRTT {
         _acked_packets: &[Acked], _lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         _target_bytes_inflight: usize, params: &Params,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
     ) -> Mode {
         match self.exit_time {
             None => {

--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -39,6 +39,7 @@ use crate::recovery::bandwidth::Bandwidth;
 use crate::recovery::rtt::RttStats;
 use crate::recovery::rtt::INITIAL_RTT;
 use crate::recovery::RecoveryConfig;
+use crate::recovery::RecoveryStats;
 
 #[derive(Debug)]
 pub struct Lost {
@@ -114,6 +115,7 @@ pub(super) trait CongestionControl: Debug {
         &mut self, rtt_updated: bool, prior_in_flight: usize,
         bytes_in_flight: usize, event_time: Instant, acked_packets: &[Acked],
         lost_packets: &[Lost], least_unacked: u64, rtt_stats: &RttStats,
+        recovery_stats: &mut RecoveryStats,
     );
 
     /// Called when an RTO fires.  Resets the retransmission alarm if there are

--- a/quiche/src/recovery/gcongestion/pacer.rs
+++ b/quiche/src/recovery/gcongestion/pacer.rs
@@ -32,6 +32,7 @@ use std::time::Instant;
 
 use crate::recovery::gcongestion::Bandwidth;
 use crate::recovery::rtt::RttStats;
+use crate::recovery::RecoveryStats;
 use crate::recovery::ReleaseDecision;
 use crate::recovery::ReleaseTime;
 
@@ -203,6 +204,7 @@ impl CongestionControl for Pacer {
         &mut self, rtt_updated: bool, prior_in_flight: usize,
         bytes_in_flight: usize, event_time: Instant, acked_packets: &[Acked],
         lost_packets: &[Lost], least_unacked: u64, rtt_stats: &RttStats,
+        recovery_stats: &mut RecoveryStats,
     ) {
         self.sender.on_congestion_event(
             rtt_updated,
@@ -213,6 +215,7 @@ impl CongestionControl for Pacer {
             lost_packets,
             least_unacked,
             rtt_stats,
+            recovery_stats,
         );
 
         if !self.enabled {


### PR DESCRIPTION
This PR emits stats from when a CCA exits the startup phase. Its currently only implemented for gcongestion (BBR).

**How to review**
Its probably best to review this code one commit at a time. The second commit modified the `startup.rs` and the most important piece. The other two commits are essentially the glue.

**Callouts**
This replaces https://github.com/cloudflare/quiche/pull/2057 and https://github.com/cloudflare/quiche/pull/2061. Those were trying to refactor the code, which has a lot of side effects and were introducing bugs in the process. This PR avoids refactoring the code to avoid that pitfall.