### PR TITLE
support changing transport params from BoringSSL handshake callbacks

### DIFF
--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -493,6 +493,12 @@ impl<F: BufFactory> StreamMap<F> {
         self.local_max_streams_bidi = self.local_max_streams_bidi_next;
     }
 
+    /// Sets the max_streams_bidi limit to the given value.
+    pub fn set_max_streams_bidi(&mut self, max: u64) {
+        self.local_max_streams_bidi = max;
+        self.local_max_streams_bidi_next = max;
+    }
+
     /// Returns the current max_streams_bidi limit.
     pub fn max_streams_bidi(&self) -> u64 {
         self.local_max_streams_bidi


### PR DESCRIPTION
This adds support for changing some transport parameters during the QUIC hanshake from inside BoringSSL callbacks (e.g. `select_cert_cb`). Currently only `max_idle_timeout` and `initial_max_streams_bidi` are supported, but more can be added later if needed.

Each parameter is configured with its own method rather than having a single method taking a new `TransportParameters` value to allow applications to overwrite specific parameters rather than having to provide an entire new set of parameters.

In the future we might consider adding a new `TransportParameters`-like type with optional fields, but that didn't seem necessary here as we are only interested in a few TPs at this point.

Because the server's TPs are sent in the first flight inside TLS messages generated by BoringSSL itself, they need to be re-encoded during the early handshake callback before control is returned to quiche, so this is done directly inside each `*_in_handshake()` method rather than in a single place (e.g. `do_handshake()`).