### PR TITLE
Handle low PMTU on macOS

### DIFF
--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -50,7 +50,6 @@ foundations = { workspace = true, default-features = false, features = [
 futures = { workspace = true }
 futures-util = { workspace = true }
 ipnetwork = { workspace = true }
-libc = { workspace = true }
 log = { workspace = true }
 octets = { workspace = true }
 pin-project = { workspace = true }
@@ -81,4 +80,5 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time", "test-util"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
 nix = { workspace = true, features = ["signal"] }

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -50,6 +50,7 @@ foundations = { workspace = true, default-features = false, features = [
 futures = { workspace = true }
 futures-util = { workspace = true }
 ipnetwork = { workspace = true }
+libc = { workspace = true }
 log = { workspace = true }
 octets = { workspace = true }
 pin-project = { workspace = true }
@@ -80,5 +81,4 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time", "test-util"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = { workspace = true }
 nix = { workspace = true, features = ["signal"] }

--- a/tokio-quiche/src/quic/router/mod.rs
+++ b/tokio-quiche/src/quic/router/mod.rs
@@ -694,7 +694,7 @@ where
 
                 Poll::Ready(Err(e)) => {
                     log::error!("Incoming packet router encountered recvmsg error"; "error" => e);
-                        continue;
+                    continue;
                 },
 
                 Poll::Pending => {

--- a/tokio-quiche/src/quic/router/mod.rs
+++ b/tokio-quiche/src/quic/router/mod.rs
@@ -693,15 +693,8 @@ where
                 },
 
                 Poll::Ready(Err(e)) => {
-                    // On macOS the incoming packet router should not stop on an incoming
-                    // packet marked with "fragmentation needed"
-                    if cfg!(target_os = "macos")
-                        && e.raw_os_error().is_some_and(|e| e == libc::EMSGSIZE)
-                    {
+                    log::error!("Incoming packet router encountered recvmsg error"; "error" => e);
                         continue;
-                    }
-
-                    return Poll::Ready(Err(e));
                 },
 
                 Poll::Pending => {


### PR DESCRIPTION
On macOS with a quiche client in low MTU situations the incoming packet router should be able to gracefully handle packets marked with fragmentation needed