### PR TITLE
lib: add support for qlogging packet lost events

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1920,6 +1920,10 @@ const QLOG_METRICS: EventType =
     EventType::RecoveryEventType(RecoveryEventType::MetricsUpdated);
 
 #[cfg(feature = "qlog")]
+const QLOG_PACKET_LOST: EventType =
+    EventType::RecoveryEventType(RecoveryEventType::PacketLost);
+
+#[cfg(feature = "qlog")]
 const QLOG_CONNECTION_CLOSED: EventType =
     EventType::ConnectivityEventType(ConnectivityEventType::ConnectionClosed);
 
@@ -3364,6 +3368,20 @@ impl<F: BufFactory> Connection<F> {
         qlog_with_type!(QLOG_PACKET_RX, self.qlog, q, {
             let recv_path = self.paths.get_mut(recv_pid)?;
             recv_path.recovery.maybe_qlog(q, now);
+        });
+
+        qlog_with_type!(QLOG_PACKET_LOST, self.qlog, q, {
+            let recv_path = self.paths.get_mut(recv_pid)?;
+            for (header, time_lost) in recv_path.recovery.get_lost_pkts(epoch) {
+                let ev_data =
+                    EventData::PacketLost(qlog::events::quic::PacketLost {
+                        header: Some(header),
+                        frames: None,
+                        trigger: None,
+                    });
+
+                q.add_event_data_with_instant(ev_data, time_lost).ok();
+            }
         });
 
         if let Some(e) = frame_processing_err {
@@ -6474,6 +6492,29 @@ impl<F: BufFactory> Connection<F> {
 
                     qlog_with_type!(QLOG_METRICS, self.qlog, q, {
                         p.recovery.maybe_qlog(q, now);
+                    });
+
+                    qlog_with_type!(QLOG_PACKET_LOST, self.qlog, q, {
+                        for epoch in [
+                            packet::Epoch::Initial,
+                            packet::Epoch::Handshake,
+                            packet::Epoch::Application,
+                        ] {
+                            for (header, time_lost) in
+                                p.recovery.get_lost_pkts(epoch)
+                            {
+                                let ev_data = EventData::PacketLost(
+                                    qlog::events::quic::PacketLost {
+                                        header: Some(header),
+                                        frames: None,
+                                        trigger: None,
+                                    },
+                                );
+
+                                q.add_event_data_with_instant(ev_data, time_lost)
+                                    .ok();
+                            }
+                        }
                     });
                 }
             }

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -36,6 +36,8 @@ use crate::Config;
 use crate::Result;
 
 #[cfg(feature = "qlog")]
+use qlog::events;
+#[cfg(feature = "qlog")]
 use qlog::events::EventData;
 
 use smallvec::SmallVec;
@@ -159,6 +161,11 @@ pub trait RecoveryOps {
     fn get_acked_frames(&mut self, epoch: packet::Epoch) -> Vec<frame::Frame>;
 
     fn get_lost_frames(&mut self, epoch: packet::Epoch) -> Vec<frame::Frame>;
+
+    #[cfg(feature = "qlog")]
+    fn get_lost_pkts(
+        &mut self, epoch: packet::Epoch,
+    ) -> Vec<(events::quic::PacketHeader, Instant)>;
 
     fn get_largest_acked_on_epoch(&self, epoch: packet::Epoch) -> Option<u64>;
     fn has_lost_frames(&self, epoch: packet::Epoch) -> bool;
@@ -526,7 +533,7 @@ impl QlogMetrics {
         if emit_event {
             // QVis can't use all these fields and they can be large.
             return Some(EventData::MetricsUpdated(
-                qlog::events::quic::MetricsUpdated {
+                events::quic::MetricsUpdated {
                     min_rtt: new_min_rtt,
                     smoothed_rtt: new_smoothed_rtt,
                     latest_rtt: new_latest_rtt,


### PR DESCRIPTION
To date, we've focused on reporting packet loss counts as aggregate metrics.

This change adds support for the qlog packet_lost event. We already log packet_sent events and include the frames in that event, so we can reduce overheads by omitting them from the packet_lost events.

The tricky part of this change is wiring up logging so that it can access the data it needs. Rather than modify the recovery module to change it from passing a count to a list of packets, I opted instead to conditionally store lost packets based on the qlog feature, and then provide an accessor for reading them at key points in the connection lifecycle (in the receive loop, or after a timeout). By storing the loss Instant, we ensure the event is logged with a timestamp reflective of the actual time quiche determined the loss.