### PR TITLE
Emit RTO count statistics to estimate loss events

### DIFF
--- a/datagram-socket/src/socket_stats.rs
+++ b/datagram-socket/src/socket_stats.rs
@@ -50,6 +50,7 @@ pub struct SocketStats {
     pub max_rtt_us: i64,
     pub rtt_var_us: i64,
     pub cwnd: u64,
+    pub total_pto_count: u64,
     pub packets_sent: u64,
     pub packets_recvd: u64,
     pub packets_lost: u64,

--- a/octets/src/lib.rs
+++ b/octets/src/lib.rs
@@ -481,7 +481,7 @@ impl<'a> OctetsMut<'a> {
 
     /// Reads `len` bytes from the current offset without copying and advances
     /// the buffer.
-    pub fn get_bytes(&mut self, len: usize) -> Result<Octets> {
+    pub fn get_bytes(&mut self, len: usize) -> Result<Octets<'_>> {
         if self.cap() < len {
             return Err(BufferTooShortError);
         }
@@ -498,7 +498,7 @@ impl<'a> OctetsMut<'a> {
 
     /// Reads `len` bytes from the current offset without copying and advances
     /// the buffer.
-    pub fn get_bytes_mut(&mut self, len: usize) -> Result<OctetsMut> {
+    pub fn get_bytes_mut(&mut self, len: usize) -> Result<OctetsMut<'_>> {
         if self.cap() < len {
             return Err(BufferTooShortError);
         }
@@ -515,7 +515,7 @@ impl<'a> OctetsMut<'a> {
 
     /// Reads `len` bytes from the current offset without copying and advances
     /// the buffer, where `len` is an unsigned 8-bit integer prefix.
-    pub fn get_bytes_with_u8_length(&mut self) -> Result<Octets> {
+    pub fn get_bytes_with_u8_length(&mut self) -> Result<Octets<'_>> {
         let len = self.get_u8()?;
         self.get_bytes(len as usize)
     }
@@ -523,7 +523,7 @@ impl<'a> OctetsMut<'a> {
     /// Reads `len` bytes from the current offset without copying and advances
     /// the buffer, where `len` is an unsigned 16-bit integer prefix in network
     /// byte-order.
-    pub fn get_bytes_with_u16_length(&mut self) -> Result<Octets> {
+    pub fn get_bytes_with_u16_length(&mut self) -> Result<Octets<'_>> {
         let len = self.get_u16()?;
         self.get_bytes(len as usize)
     }
@@ -531,14 +531,14 @@ impl<'a> OctetsMut<'a> {
     /// Reads `len` bytes from the current offset without copying and advances
     /// the buffer, where `len` is an unsigned variable-length integer prefix
     /// in network byte-order.
-    pub fn get_bytes_with_varint_length(&mut self) -> Result<Octets> {
+    pub fn get_bytes_with_varint_length(&mut self) -> Result<Octets<'_>> {
         let len = self.get_varint()?;
         self.get_bytes(len as usize)
     }
 
     /// Reads `len` bytes from the current offset without copying and without
     /// advancing the buffer.
-    pub fn peek_bytes(&mut self, len: usize) -> Result<Octets> {
+    pub fn peek_bytes(&mut self, len: usize) -> Result<Octets<'_>> {
         if self.cap() < len {
             return Err(BufferTooShortError);
         }
@@ -553,7 +553,7 @@ impl<'a> OctetsMut<'a> {
 
     /// Reads `len` bytes from the current offset without copying and without
     /// advancing the buffer.
-    pub fn peek_bytes_mut(&mut self, len: usize) -> Result<OctetsMut> {
+    pub fn peek_bytes_mut(&mut self, len: usize) -> Result<OctetsMut<'_>> {
         if self.cap() < len {
             return Err(BufferTooShortError);
         }
@@ -587,7 +587,9 @@ impl<'a> OctetsMut<'a> {
     }
 
     /// Splits the buffer in two at the given absolute offset.
-    pub fn split_at(&mut self, off: usize) -> Result<(OctetsMut, OctetsMut)> {
+    pub fn split_at(
+        &mut self, off: usize,
+    ) -> Result<(OctetsMut<'_>, OctetsMut<'_>)> {
         if self.len() < off {
             return Err(BufferTooShortError);
         }

--- a/quiche/src/cid.rs
+++ b/quiche/src/cid.rs
@@ -601,7 +601,7 @@ impl ConnectionIdentifiers {
     }
 
     /// Returns an iterator over the source connection IDs.
-    pub fn scids_iter(&self) -> impl Iterator<Item = &ConnectionId> {
+    pub fn scids_iter(&self) -> impl Iterator<Item = &ConnectionId<'_>> {
         self.scids.iter().map(|e| &e.cid)
     }
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1066,7 +1066,7 @@ impl<'a> Iterator for ConnectionIdIter<'a> {
 #[no_mangle]
 pub extern "C" fn quiche_conn_source_ids(
     conn: &Connection,
-) -> *mut ConnectionIdIter {
+) -> *mut ConnectionIdIter<'_> {
     let vec = conn.source_ids().cloned().collect();
     Box::into_raw(Box::new(ConnectionIdIter {
         cids: vec,

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6948,7 +6948,7 @@ impl<F: BufFactory> Connection<F> {
     /// Note that the value returned can change throughout the connection's
     /// lifetime.
     #[inline]
-    pub fn source_id(&self) -> ConnectionId {
+    pub fn source_id(&self) -> ConnectionId<'_> {
         if let Ok(path) = self.paths.get_active() {
             if let Some(active_scid_seq) = path.active_scid_seq {
                 if let Ok(e) = self.ids.get_scid(active_scid_seq) {
@@ -6966,7 +6966,7 @@ impl<F: BufFactory> Connection<F> {
     /// An iterator is returned for all active IDs (i.e. ones that have not
     /// been explicitly retired yet).
     #[inline]
-    pub fn source_ids(&self) -> impl Iterator<Item = &ConnectionId> {
+    pub fn source_ids(&self) -> impl Iterator<Item = &ConnectionId<'_>> {
         self.ids.scids_iter()
     }
 
@@ -6975,7 +6975,7 @@ impl<F: BufFactory> Connection<F> {
     /// Note that the value returned can change throughout the connection's
     /// lifetime.
     #[inline]
-    pub fn destination_id(&self) -> ConnectionId {
+    pub fn destination_id(&self) -> ConnectionId<'_> {
         if let Ok(path) = self.paths.get_active() {
             if let Some(active_dcid_seq) = path.active_dcid_seq {
                 if let Ok(e) = self.ids.get_dcid(active_dcid_seq) {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -15389,12 +15389,14 @@ mod tests {
         // Client sends Initial packet.
         let (len, _) = pipe.client.send(&mut buf).unwrap();
         assert_eq!(len, 1200);
+        assert_eq!(pipe.client.path_stats().next().unwrap().total_pto_count, 0);
 
         // Wait for PTO to expire.
         let timer = pipe.client.timeout().unwrap();
         std::thread::sleep(timer + time::Duration::from_millis(1));
 
         pipe.client.on_timeout();
+        assert_eq!(pipe.client.path_stats().next().unwrap().total_pto_count, 1);
 
         let epoch = packet::Epoch::Initial;
         assert_eq!(
@@ -15425,6 +15427,7 @@ mod tests {
         std::thread::sleep(timer + time::Duration::from_millis(1));
 
         pipe.client.on_timeout();
+        assert_eq!(pipe.client.path_stats().next().unwrap().total_pto_count, 2);
 
         assert_eq!(
             pipe.client

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -680,13 +680,13 @@ impl PathMap {
 
     /// Returns an iterator over all existing paths.
     #[inline]
-    pub fn iter(&self) -> slab::Iter<Path> {
+    pub fn iter(&self) -> slab::Iter<'_, Path> {
         self.paths.iter()
     }
 
     /// Returns a mutable iterator over all existing paths.
     #[inline]
-    pub fn iter_mut(&mut self) -> slab::IterMut<Path> {
+    pub fn iter_mut(&mut self) -> slab::IterMut<'_, Path> {
         self.paths.iter_mut()
     }
 

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -170,6 +170,14 @@ pub struct Path {
     /// Total number of packets sent with data retransmitted from this path.
     pub retrans_count: usize,
 
+    /// Total number of times PTO (probe timeout) fired.
+    ///
+    /// Loss usually happens in a burst so the number of packets lost will
+    /// depend on the volume of inflight packets at the time of loss (which
+    /// can be arbitrary). PTO count measures the number of loss events and
+    /// provides a normalized loss metric.
+    pub total_pto_count: usize,
+
     /// Number of DATAGRAM frames sent on this path.
     pub dgram_sent_count: usize,
 
@@ -245,6 +253,7 @@ impl Path {
             sent_count: 0,
             recv_count: 0,
             retrans_count: 0,
+            total_pto_count: 0,
             dgram_sent_count: 0,
             dgram_recv_count: 0,
             sent_bytes: 0,
@@ -481,6 +490,9 @@ impl Path {
             }
         }
 
+        // Track PTO timeout event
+        self.total_pto_count += 1;
+
         outcome
     }
 
@@ -500,6 +512,7 @@ impl Path {
             sent: self.sent_count,
             lost: self.recovery.lost_count(),
             retrans: self.retrans_count,
+            total_pto_count: self.total_pto_count,
             dgram_recv: self.dgram_recv_count,
             dgram_sent: self.dgram_sent_count,
             rtt: self.recovery.rtt(),
@@ -893,6 +906,14 @@ pub struct PathStats {
 
     /// The number of sent QUIC packets with retransmitted data.
     pub retrans: usize,
+
+    /// The number of times PTO (probe timeout) fired.
+    ///
+    /// Loss usually happens in a burst so the number of packets lost will
+    /// depend on the volume of inflight packets at the time of loss (which
+    /// can be arbitrary). PTO count measures the number of loss events and
+    /// provides a normalized loss metric.
+    pub total_pto_count: usize,
 
     /// The number of DATAGRAM frames received.
     pub dgram_recv: usize,

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -581,17 +581,17 @@ impl<F: BufFactory> StreamMap<F> {
     }
 
     /// Creates an iterator over streams that need to send STREAM_DATA_BLOCKED.
-    pub fn blocked(&self) -> hash_map::Iter<u64, u64> {
+    pub fn blocked(&self) -> hash_map::Iter<'_, u64, u64> {
         self.blocked.iter()
     }
 
     /// Creates an iterator over streams that need to send RESET_STREAM.
-    pub fn reset(&self) -> hash_map::Iter<u64, (u64, u64)> {
+    pub fn reset(&self) -> hash_map::Iter<'_, u64, (u64, u64)> {
         self.reset.iter()
     }
 
     /// Creates an iterator over streams that need to send STOP_SENDING.
-    pub fn stopped(&self) -> hash_map::Iter<u64, u64> {
+    pub fn stopped(&self) -> hash_map::Iter<'_, u64, u64> {
         self.stopped.iter()
     }
 

--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -145,6 +145,11 @@ impl AsSocketStats for QuicConnectionStats {
                 .as_ref()
                 .map(|p| p.cwnd as u64)
                 .unwrap_or_default(),
+            total_pto_count: self
+                .path_stats
+                .as_ref()
+                .map(|p| p.total_pto_count as u64)
+                .unwrap_or_default(),
             packets_sent: self.stats.sent as u64,
             packets_recvd: self.stats.recv as u64,
             packets_lost: self.stats.lost as u64,

--- a/tokio-quiche/src/quic/io/gso.rs
+++ b/tokio-quiche/src/quic/io/gso.rs
@@ -82,7 +82,7 @@ pub(crate) enum PktInfo {
 
 #[cfg(target_os = "linux")]
 impl PktInfo {
-    fn make_cmsg(&'_ self) -> ControlMessage {
+    fn make_cmsg(&'_ self) -> ControlMessage<'_> {
         match self {
             Self::V4(pkt) => ControlMessage::Ipv4PacketInfo(pkt),
             Self::V6(pkt) => ControlMessage::Ipv6PacketInfo(pkt),

--- a/tokio-quiche/src/socket/listener.rs
+++ b/tokio-quiche/src/socket/listener.rs
@@ -95,7 +95,7 @@ impl TryFrom<std::net::UdpSocket> for QuicListener {
 
 #[cfg(unix)]
 impl AsFd for QuicListener {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.socket.as_fd()
     }
 }


### PR DESCRIPTION
Loss usually happens in burst so the number of packets lost will depend on the volume of inflight packets at the time of loss (which can be arbitrary). RTO count measures the number of loss events and provide a normalized loss metric.