### PR TITLE
Config protect fixes to a0 choice used in BW overestimation avoidance code

### DIFF
--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -163,6 +163,11 @@ struct Params {
     /// Avoid Overestimation in Bandwidth Sampler with ack aggregation
     enable_overestimate_avoidance: bool,
 
+    /// If true, apply the fix to A0 point selection logic so the
+    /// implementation is consistent with the behavior of the
+    /// google/quiche implementation.
+    choose_a0_point_fix: bool,
+
     bw_lo_mode: BwLoMode,
 
     /// Determines whether app limited rounds with no bandwidth growth count
@@ -188,6 +193,7 @@ impl Params {
         apply_override!(drain_pacing_gain);
         apply_override!(enable_reno_coexistence);
         apply_override!(enable_overestimate_avoidance);
+        apply_override!(choose_a0_point_fix);
         apply_override!(probe_bw_probe_up_pacing_gain);
         apply_override!(probe_bw_probe_down_pacing_gain);
         apply_override!(probe_bw_cwnd_gain);
@@ -271,6 +277,8 @@ const DEFAULT_PARAMS: Params = Params {
     decrease_startup_pacing_at_end_of_round: true,
 
     enable_overestimate_avoidance: true,
+
+    choose_a0_point_fix: false,
 
     bw_lo_mode: BwLoMode::InflightReduction,
 

--- a/quiche/src/recovery/gcongestion/bbr2/network_model.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/network_model.rs
@@ -198,6 +198,7 @@ impl BBRv2NetworkModel {
             bandwidth_sampler: BandwidthSampler::new(
                 params.initial_max_ack_height_filter_window,
                 params.enable_overestimate_avoidance,
+                params.choose_a0_point_fix,
             ),
             round_trip_counter: RoundTripCounter {
                 round_trip_count: 0,

--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -192,6 +192,10 @@ pub struct BbrParams {
     /// attempts to avoid overestimating bandwidth on ack compression.
     pub enable_overestimate_avoidance: Option<bool>,
 
+    /// Controls if BBR should enable a possible fix in Bandwidth
+    /// Sampler that attempts to bandwidth over estimation avoidance.
+    pub choose_a0_point_fix: Option<bool>,
+
     /// Controls the BBR bandwidth probe up pacing gain.
     pub probe_bw_probe_up_pacing_gain: Option<f32>,
 


### PR DESCRIPTION
This code doesn't seem to be working well, and we would like to compare results with and without the fix.  It seems that overestimation avoidance is a work in progress and we should recommend disabling the code for now.

Original change: https://github.com/cloudflare/quiche/pull/2073