### PR TITLE
Specify nightly for cargo fmt

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt"]


### PR DESCRIPTION
quiche uses the nightly cargo fmt. Specify this in code so those that switch between nightly and stable use the correct formatter