### PR TITLE
Remove Examples Docker Image section from example README.

### DIFF
--- a/quiche/examples/README.md
+++ b/quiche/examples/README.md
@@ -18,23 +18,3 @@ Simply run `make` in this directory.
 % make clean
 % make
 ```
-
-Examples Docker image
----------------------
-You can experiment with [http3-client](http3-client.rs),
-[http3-server](http3-server.rs), [client](client.rs) and [server](server.rs)
-using Docker.
-
-The Examples [Dockerfile](Dockerfile) builds a Debian image.
-
-To build:
-
-```
-docker build -t cloudflare-quiche .
-```
-
-To make an HTTP/3 request:
-
-```
-docker run -it cloudflare-quiche http3-client https://cloudflare-quic.com
-```


### PR DESCRIPTION
Removed section containing the reference to the missing dockerfile. 
resolves cloudflare/quiche#2091 
