### PR TITLE
chore(ci): update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,55 +1,34 @@
 version: 2
 updates:
 - package-ecosystem: cargo
+  directories:
+    - "/"
+    - "/tools/apps"
+  schedule:
+    interval: daily
+    time: "13:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: url
+    versions:
+    - ">= 2.a, < 3"
+- package-ecosystem: cargo
+  directories:
+    - "/tools/qlog"
+    - "/fuzz"
+  schedule:
+    interval: daily
+    time: "13:00"
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "13:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: env_logger
-    versions:
-    - ">= 0.7.a, < 0.8"
-  - dependency-name: mio
-    versions:
-    - ">= 0.7.a, < 0.8"
-  - dependency-name: ring
-    versions:
-    - ">= 0.15.a, < 0.16"
-  - dependency-name: ring
-    versions:
-    - ">= 0.16.a, < 0.17"
-  - dependency-name: url
-    versions:
-    - ">= 2.a, < 3"
-- package-ecosystem: cargo
-  directory: "/tools/apps"
+- package-ecosystem: gitsubmodule
+  directory: "/"
   schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: env_logger
-    versions:
-    - ">= 0.7.a, < 0.8"
-  - dependency-name: env_logger
-    versions:
-    - ">= 0.8.a, < 0.9"
-  - dependency-name: mio
-    versions:
-    - ">= 0.7.a, < 0.8"
-  - dependency-name: url
-    versions:
-    - ">= 2.a, < 3"
-- package-ecosystem: cargo
-  directory: "/tools/qlog"
-  schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 10
-- package-ecosystem: cargo
-  directory: "/fuzz"
-  schedule:
-    interval: daily
+    interval: weekly
     time: "13:00"
   open-pull-requests-limit: 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -24,7 +24,7 @@ jobs:
         run: cargo doc --no-deps --all-features
 
       - name: Deploy to GitHub Pages
-        uses: crazy-max/ghaction-github-pages@v3
+        uses: crazy-max/ghaction-github-pages@v4
         with:
           target_branch: gh-pages
           build_dir: target/doc
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -44,7 +44,7 @@ jobs:
         run: make docker-build
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -63,7 +63,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -91,7 +91,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -110,7 +110,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -30,5 +30,5 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: semgrep ci

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -47,7 +47,9 @@ jobs:
       - name: Build OpenSSL
         if: ${{ matrix.tls-feature == 'openssl' }}
         run: |
-          git clone https://github.com/quictls/openssl
+          # TODO openssl has been archived, move to new project: https://github.com/quictls/quictls
+          # Attention: Default branch is 3.1.7, not 3.3.0. Latest tag was openssl-3.3.0-quic1
+          git clone --depth 1 https://github.com/quictls/openssl
           cd openssl
           ./Configure --prefix="$PWD/install"
           make -j"$(nproc)"
@@ -113,7 +115,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -142,7 +144,7 @@ jobs:
       IPHONEOS_DEPLOYMENT_TARGET: "10.0"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -169,7 +171,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -181,16 +183,16 @@ jobs:
 
       - name: Set up MinGW for 64 bit
         if: matrix.target == 'x86_64-pc-windows-gnu'
-        uses: bwoodsend/setup-winlibs-action@v1.10
+        uses: bwoodsend/setup-winlibs-action@v1.16
         with:
-          tag: 12.2.0-16.0.0-10.0.0-msvcrt-r5
+          tag: 15.1.0posix-13.0.0-msvcrt-r2
 
       - name: Set up MinGW for 32 bit
         if: matrix.target == 'i686-pc-windows-gnu'
-        uses: bwoodsend/setup-winlibs-action@v1.10
+        uses: bwoodsend/setup-winlibs-action@v1.16
         with:
           architecture: i686
-          tag: 12.2.0-16.0.0-10.0.0-msvcrt-r5
+          tag: 15.1.0posix-13.0.0-msvcrt-r2
 
       - name: Install dependencies
         uses: crazy-max/ghaction-chocolatey@v3
@@ -215,7 +217,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -240,7 +242,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -263,7 +265,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -291,7 +293,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 


### PR DESCRIPTION
### Updated
- Updated GitHub Actions
- Updated MinGW to `15.1.0posix-13.0.0-msvcrt-r2`
- Let Dependabot update GitHub Actions and .gitmodules
- Removed outdated Dependabot ignore rules and grouped directories

### TODO
- https://github.com/quictls/openssl defaults to 3.1.7, but `openssl-3.3.0-quic1` could be used
- https://github.com/quictls/openssl has been archived, project moved to https://github.com/quictls/quictls