### PR TITLE
apps: use host header if authority unset during request handling

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -1054,6 +1054,9 @@ impl Http3Conn {
                     ":authority and host missing".to_string(),
                 )),
 
+            // Use Host if :authority is not set
+            (Some("") | None, Some(host)) => host,
+
             // Any other combo, prefer :authority
             (..) => authority.unwrap(),
         };


### PR DESCRIPTION
Host header can be used as an alternative to :authority in HTTP/3 request. However, such requests is not handled properly in Http3Conn::build_h3_response() as only authority is considered, which can cause a crash due to unwrapping.

Fix this by using host header value. Note that this is only the case if authority is null or unset. In other cases, authority is preferred, either if host is also set or not.