### PR TITLE
tokio-quiche: close connection when H3Event receiver closes

### DIFF
--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -1102,6 +1102,11 @@ impl<H: DriverHooks> ApplicationOverQuic for H3Driver<H> {
             Some(dgram) = self.dgram_recv.recv() => self.dgram_ready(qconn, dgram),
             Some(cmd) = self.cmd_recv.recv() => H::conn_command(self, qconn, cmd),
             r = self.hooks.wait_for_action(qconn), if H::has_wait_action(self) => r,
+            _ = self.h3_event_sender.closed() => {
+                let _ = qconn.close(true, quiche::h3::WireErrorCode::NoError as u64, &[]);
+                // Allow the IOW to continue until quiche reports the connection closed.
+                Ok(())
+            }
         }?;
 
         // Make sure controller is not starved, but also not prioritized in the


### PR DESCRIPTION
Applications built on top of H3Driver process events by spinning on the `UnboundedReceiver` corresponding to H3Driver's `h3_event_sender`. When they no longer need to listen for these events, they typically terminate their event loop and clean up their state.

The problem is that tokio-quiche doesn't always know about that. We currently kill the connection in a few places by propagating `H3ConnectionError::ControllerWentAway` up to the event loop. This doesn't happen deterministically at the moment. Specifically, if the client doesn't send any data, the RunningApplication IOW can spin until idle timeout in certain cases.

Instead, tokio-quiche should know when the application can no longer process `H3Event`s and immediately tear down its own state when the `H3Event` receiver closes.