### PR TITLE
add option to relax AEAD to not fips mode.  fixes #2108

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -39,6 +39,9 @@ boringssl-boring-crate = ["boring", "foreign-types-shared"]
 # Build quiche against OpenSSL instead of BoringSSL.
 openssl = ["pkg-config"]
 
+# Build quiche with relaxed boringssl aead, not FIPS compliant
+relax-aead = []
+
 # Generate pkg-config metadata file for libquiche.
 pkg-config-meta = []
 


### PR DESCRIPTION
This allows, for instance, a quiche client to communicate with a quic-go server.  Fixes #2108