### PR TITLE
refactor: remove impl CongestionControl for Pacer

### DIFF
--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -138,11 +138,6 @@ pub(super) trait CongestionControl: Debug {
     #[allow(dead_code)]
     fn is_cwnd_limited(&self, bytes_in_flight: usize) -> bool;
 
-    #[cfg(test)]
-    fn is_app_limited(&self, bytes_in_flight: usize) -> bool {
-        !self.is_cwnd_limited(bytes_in_flight)
-    }
-
     fn pacing_rate(
         &self, bytes_in_flight: usize, rtt_stats: &RttStats,
     ) -> Bandwidth;

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -41,7 +41,6 @@ use crate::Result;
 use super::pacer::Pacer;
 use super::Acked;
 use super::Congestion;
-use super::CongestionControl;
 use super::Lost;
 
 // Congestion Control
@@ -128,7 +127,7 @@ struct LossDetectionResult {
 impl RecoveryEpoch {
     /// Discard the Epoch state and return the total size of unacked packets
     /// that were discarded
-    fn discard(&mut self, cc: &mut impl CongestionControl) -> usize {
+    fn discard(&mut self, cc: &mut Pacer) -> usize {
         let unacked_bytes = self
             .sent_packets
             .drain(..)


### PR DESCRIPTION
The original impl had a bunch of abstraction to support bbr1/bbr2/bbr3. Making pacer implement CongestionControl, using enum_dispatch, etc were some of the abstractions. We are only using bbr3 so we need to get rid of the weird stuff like pacer implementing CongestionControl trait (which makes no sense).
