### PR TITLE
Fixes to BBR2 initial pacing rate for compliance with the BBR draft RFC, and introduce option to override initial pacing rate for new connections

### DIFF
--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -354,7 +354,7 @@ fn initial_pacing_rate(cwnd_in_bytes: usize, params: &Params) -> Bandwidth {
     }
 
     // sRTT is not known yet.  Compute the initial pacing rate by
-    // dividing cwnd by 1msec as recommented by draft-ietf-ccwg-bbr-03.
+    // dividing cwnd by 1msec as recommended by draft-ietf-ccwg-bbr-03.
     // https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-03.html#name-pacing-rate-cpacing_rate
     Bandwidth::from_bytes_and_time_delta(cwnd_in_bytes, Duration::from_millis(1)) *
         params.startup_pacing_gain

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -173,6 +173,12 @@ struct Params {
     /// Determines whether app limited rounds with no bandwidth growth count
     /// towards the rounds threshold to exit startup.
     ignore_app_limited_for_no_bandwidth_growth: bool,
+
+    /// Initial pacing rate for a new connection before an RTT
+    /// estimate is available.  This rate serves as an upper bound on
+    /// pacing rate calculated by dividing the initial cwnd by the
+    /// first RTT estimate.
+    initial_pacing_rate_bytes_per_second: Option<u64>,
 }
 
 impl Params {
@@ -181,6 +187,14 @@ impl Params {
             ($field:ident) => {
                 if let Some(custom_value) = custom_bbr_settings.$field {
                     self.$field = custom_value;
+                }
+            };
+        }
+
+        macro_rules! apply_optional_override {
+            ($field:ident) => {
+                if let Some(custom_value) = custom_bbr_settings.$field {
+                    self.$field = Some(custom_value);
                 }
             };
         }
@@ -202,6 +216,7 @@ impl Params {
         apply_override!(use_bytes_delivered_for_inflight_hi);
         apply_override!(decrease_startup_pacing_at_end_of_round);
         apply_override!(ignore_app_limited_for_no_bandwidth_growth);
+        apply_optional_override!(initial_pacing_rate_bytes_per_second);
 
         if let Some(custom_value) = custom_bbr_settings.bw_lo_reduction_strategy {
             self.bw_lo_mode = custom_value.into();
@@ -283,6 +298,8 @@ const DEFAULT_PARAMS: Params = Params {
     bw_lo_mode: BwLoMode::InflightReduction,
 
     ignore_app_limited_for_no_bandwidth_growth: false,
+
+    initial_pacing_rate_bytes_per_second: None,
 };
 
 #[derive(Debug, PartialEq)]
@@ -329,6 +346,18 @@ impl<T: Ord + Clone + Copy + From<u8>> Limits<T> {
             hi: val,
         }
     }
+}
+
+fn initial_pacing_rate(cwnd_in_bytes: usize, params: &Params) -> Bandwidth {
+    if let Some(pacing_rate) = params.initial_pacing_rate_bytes_per_second {
+        return Bandwidth::from_bytes_per_second(pacing_rate);
+    }
+
+    // sRTT is not known yet.  Compute the initial pacing rate by
+    // dividing cwnd by 1msec as recommented by draft-ietf-ccwg-bbr-03.
+    // https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-03.html#name-pacing-rate-cpacing_rate
+    Bandwidth::from_bytes_and_time_delta(cwnd_in_bytes, Duration::from_millis(1)) *
+        params.startup_pacing_gain
 }
 
 #[derive(Debug)]
@@ -421,13 +450,7 @@ impl BBRv2 {
         BBRv2 {
             mode: Mode::startup(BBRv2NetworkModel::new(&params, initial_rtt)),
             cwnd,
-            // sRTT is not known yet.  Compute the initial pacing rate by
-            // dividing cwnd by 1msec as recommented by draft-ietf-ccwg-bbr-03.
-            // https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-03.html#name-pacing-rate-cpacing_rate
-            pacing_rate: Bandwidth::from_bytes_and_time_delta(
-                cwnd,
-                Duration::from_millis(1),
-            ) * params.startup_pacing_gain,
+            pacing_rate: initial_pacing_rate(cwnd, &params),
             cwnd_limits: Limits {
                 lo: initial_congestion_window * max_segment_size,
                 hi: max_congestion_window * max_segment_size,
@@ -469,6 +492,15 @@ impl BBRv2 {
                 self.cwnd,
                 self.mode.min_rtt(),
             );
+
+            if let Some(pacing_rate) =
+                self.params.initial_pacing_rate_bytes_per_second
+            {
+                let initial_pacing_rate =
+                    Bandwidth::from_bytes_per_second(pacing_rate);
+                self.pacing_rate = self.pacing_rate.min(initial_pacing_rate);
+            }
+
             return;
         }
 

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -421,8 +421,13 @@ impl BBRv2 {
         BBRv2 {
             mode: Mode::startup(BBRv2NetworkModel::new(&params, initial_rtt)),
             cwnd,
-            pacing_rate: Bandwidth::from_bytes_and_time_delta(cwnd, initial_rtt) *
-                params.startup_pacing_gain,
+            // sRTT is not known yet.  Compute the initial pacing rate by
+            // dividing cwnd by 1msec as recommented by draft-ietf-ccwg-bbr-03.
+            // https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-03.html#name-pacing-rate-cpacing_rate
+            pacing_rate: Bandwidth::from_bytes_and_time_delta(
+                cwnd,
+                Duration::from_millis(1),
+            ) * params.startup_pacing_gain,
             cwnd_limits: Limits {
                 lo: initial_congestion_window * max_segment_size,
                 hi: max_congestion_window * max_segment_size,

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -408,7 +408,7 @@ impl BBRv2CongestionEvent {
 impl BBRv2 {
     pub fn new(
         initial_congestion_window: usize, max_congestion_window: usize,
-        max_segment_size: usize, smoothed_rtt: Duration,
+        max_segment_size: usize, initial_rtt: Duration,
         custom_bbr_params: Option<&BbrParams>,
     ) -> Self {
         let cwnd = initial_congestion_window * max_segment_size;
@@ -419,9 +419,9 @@ impl BBRv2 {
         };
 
         BBRv2 {
-            mode: Mode::startup(BBRv2NetworkModel::new(&params, smoothed_rtt)),
+            mode: Mode::startup(BBRv2NetworkModel::new(&params, initial_rtt)),
             cwnd,
-            pacing_rate: Bandwidth::from_bytes_and_time_delta(cwnd, smoothed_rtt) *
+            pacing_rate: Bandwidth::from_bytes_and_time_delta(cwnd, initial_rtt) *
                 params.startup_pacing_gain,
             cwnd_limits: Limits {
                 lo: initial_congestion_window * max_segment_size,

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -422,7 +422,7 @@ impl BBRv2 {
             mode: Mode::startup(BBRv2NetworkModel::new(&params, smoothed_rtt)),
             cwnd,
             pacing_rate: Bandwidth::from_bytes_and_time_delta(cwnd, smoothed_rtt) *
-                2.885,
+                params.startup_pacing_gain,
             cwnd_limits: Limits {
                 lo: initial_congestion_window * max_segment_size,
                 hi: max_congestion_window * max_segment_size,

--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -224,6 +224,12 @@ pub struct BbrParams {
     /// Determines whether app limited rounds with no bandwidth growth count
     /// towards the rounds threshold to exit startup.
     pub ignore_app_limited_for_no_bandwidth_growth: Option<bool>,
+
+    /// Initial pacing rate for a new connection before an RTT
+    /// estimate is available.  This rate serves as an upper bound on
+    /// pacing rate calculated by dividing the initial cwnd by the
+    /// first RTT estimate.
+    pub initial_pacing_rate_bytes_per_second: Option<u64>,
 }
 
 /// Controls BBR's bandwidth reduction strategy on congestion event.

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -1468,7 +1468,7 @@ mod tests {
         if cc_algorithm_name != "bbr2_gcongestion" {
             assert_eq!(r.pacing_rate(), 0);
         } else {
-            assert_eq!(r.pacing_rate(), 99927);
+            assert_eq!(r.pacing_rate(), 33276000);
         }
         assert_eq!(r.get_packet_send_time(now), now);
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -1468,7 +1468,7 @@ mod tests {
         if cc_algorithm_name != "bbr2_gcongestion" {
             assert_eq!(r.pacing_rate(), 0);
         } else {
-            assert_eq!(r.pacing_rate(), 103963);
+            assert_eq!(r.pacing_rate(), 99927);
         }
         assert_eq!(r.get_packet_send_time(now), now);
 


### PR DESCRIPTION
Changes:
* Use startup pacing gain when computing initial pacing rate.  2.885 is an old version of the startup pacing gain value.
* fix argument name to BBRv2::new to initial_rtt from smoothed_rtt.  sRTT is not known this early in the connection
* Fix BBR initial pacing rate calculation for consistency with draft-ietf-ccwg-bbr
* Add option to override initial pacing rate