### PR TITLE
refactor: Remove deref to network_model for mode.

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -300,7 +300,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk
+        run: cargo install cargo-ndk --version ^3.0.0
 
       - name: Run cargo ndk
-        run: cargo ndk --manifest-path quiche/Cargo.toml -t ${{ matrix.arch }} -p ${{ env.API_LEVEL }} -- build --verbose --features ffi
+        run: cargo ndk --manifest-path quiche/Cargo.toml --target ${{ matrix.arch }} --platform ${{ env.API_LEVEL }} -- build --verbose --features ffi

--- a/quiche/src/recovery/gcongestion/bbr2/mode.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/mode.rs
@@ -29,8 +29,6 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::fmt::Debug;
-use std::ops::Deref;
-use std::ops::DerefMut;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -216,12 +214,8 @@ impl Mode {
             params,
         )
     }
-}
 
-impl Deref for Mode {
-    type Target = BBRv2NetworkModel;
-
-    fn deref(&self) -> &Self::Target {
+    pub fn network_model(&self) -> &BBRv2NetworkModel {
         match self {
             Mode::Startup(Startup { model }) => model,
             Mode::Drain(Drain { model, .. }) => model,
@@ -230,10 +224,8 @@ impl Deref for Mode {
             Mode::Placheolder(_) => unreachable!(),
         }
     }
-}
 
-impl DerefMut for Mode {
-    fn deref_mut(&mut self) -> &mut Self::Target {
+    pub fn network_model_mut(&mut self) -> &mut BBRv2NetworkModel {
         match self {
             Mode::Startup(Startup { model }) => model,
             Mode::Drain(Drain { model, .. }) => model,

--- a/quiche/src/recovery/gcongestion/bbr2/startup.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/startup.rs
@@ -85,6 +85,7 @@ impl ModeImpl for Startup {
         let check_persisten_queue =
             params.max_startup_queue_rounds > 0 && !has_bandwidth_growth;
         if check_persisten_queue {
+            // https://github.com/google/quiche/blob/27eca0257490df89d2bd2c2a8bcea15565e7831c/quiche/quic/core/congestion_control/bbr2_startup.cc#L60-L62
             // 1.75 is less than the 2x CWND gain, but substantially more than
             // 1.25x, the minimum bandwidth increase expected during
             // STARTUP.


### PR DESCRIPTION
Deref makes it difficult to tell what component is being modified/accessed. Deref-ing to network is also surprising, makes the code harder to read and could potentially introduce mistakes.