### PR TITLE
refactor: remove enum_dispatch indirection from CongestionControl trait now that it is not needed

### DIFF
--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -37,7 +37,6 @@ pub use self::recovery::GRecovery;
 use crate::recovery::bandwidth::Bandwidth;
 
 use crate::recovery::rtt::RttStats;
-use crate::recovery::RecoveryConfig;
 use crate::recovery::RecoveryStats;
 
 #[derive(Debug)]
@@ -52,29 +51,6 @@ pub struct Acked {
     pub(super) time_sent: Instant,
 }
 
-#[enum_dispatch::enum_dispatch(CongestionControl)]
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
-pub(crate) enum Congestion {
-    BBRv2(bbr2::BBRv2),
-}
-
-impl Congestion {
-    pub(super) fn bbrv2(
-        initial_tcp_congestion_window: usize, max_congestion_window: usize,
-        recovery_config: &RecoveryConfig,
-    ) -> Self {
-        Congestion::BBRv2(bbr2::BBRv2::new(
-            initial_tcp_congestion_window,
-            max_congestion_window,
-            recovery_config.max_send_udp_payload_size,
-            recovery_config.initial_rtt,
-            recovery_config.custom_bbr_params.as_ref(),
-        ))
-    }
-}
-
-#[enum_dispatch::enum_dispatch]
 pub(super) trait CongestionControl: Debug {
     /// Returns the name of the current state of the congestion control state
     /// machine. Used to annotate qlogs after state transitions.

--- a/quiche/src/recovery/gcongestion/pacer.rs
+++ b/quiche/src/recovery/gcongestion/pacer.rs
@@ -30,15 +30,15 @@
 
 use std::time::Instant;
 
+use crate::recovery::gcongestion::bbr2::BBRv2;
 use crate::recovery::gcongestion::Bandwidth;
+use crate::recovery::gcongestion::CongestionControl;
 use crate::recovery::rtt::RttStats;
 use crate::recovery::RecoveryStats;
 use crate::recovery::ReleaseDecision;
 use crate::recovery::ReleaseTime;
 
 use super::Acked;
-use super::Congestion;
-use super::CongestionControl;
 use super::Lost;
 
 /// Congestion window fraction that the pacing sender allows in bursts during
@@ -63,7 +63,7 @@ pub struct Pacer {
     /// Should this [`Pacer`] be making any release decisions?
     enabled: bool,
     /// Underlying sender
-    sender: Congestion,
+    sender: BBRv2,
     /// The maximum rate the [`Pacer`] will use.
     max_pacing_rate: Option<Bandwidth>,
     /// Number of unpaced packets to be sent before packets are delayed.
@@ -84,7 +84,7 @@ impl Pacer {
     /// implementation, and an optional throttling as specified by
     /// `max_pacing_rate`.
     pub(crate) fn new(
-        enabled: bool, congestion: Congestion, max_pacing_rate: Option<Bandwidth>,
+        enabled: bool, congestion: BBRv2, max_pacing_rate: Option<Bandwidth>,
     ) -> Self {
         Pacer {
             enabled,

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -38,9 +38,9 @@ use crate::recovery::MAX_PTO_PROBES_COUNT;
 use crate::Error;
 use crate::Result;
 
+use super::bbr2::BBRv2;
 use super::pacer::Pacer;
 use super::Acked;
-use super::Congestion;
 use super::Lost;
 
 // Congestion Control
@@ -399,10 +399,12 @@ pub struct GRecovery {
 impl GRecovery {
     pub fn new(recovery_config: &RecoveryConfig) -> Option<Self> {
         let cc = match recovery_config.cc_algorithm {
-            CongestionControlAlgorithm::Bbr2Gcongestion => Congestion::bbrv2(
+            CongestionControlAlgorithm::Bbr2Gcongestion => BBRv2::new(
                 recovery_config.initial_congestion_window_packets,
                 MAX_WINDOW_PACKETS,
-                recovery_config,
+                recovery_config.max_send_udp_payload_size,
+                recovery_config.initial_rtt,
+                recovery_config.custom_bbr_params.as_ref(),
             ),
             _ => return None,
         };


### PR DESCRIPTION
Now that pacer no longer implements the CongestionControl trait, the enum_dispatch abstraction serves no purpose.