### PR TITLE
add qlog event definitions for Careful Resume

### DIFF
--- a/qlog/README.md
+++ b/qlog/README.md
@@ -11,6 +11,8 @@ The crate uses Serde for conversion between Rust and JSON.
 https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-quic-events.html
 [HTTP/3 and QPACK event definitions]:
 https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-h3-events.html
+[Careful Resume]:
+https://datatracker.ietf.org/doc/html/draft-ietf-tsvwg-careful-resume-qlog
 
 Overview
 --------

--- a/qlog/src/events/mod.rs
+++ b/qlog/src/events/mod.rs
@@ -262,6 +262,10 @@ impl From<EventType> for EventImportance {
             EventType::QuicEventType(QuicEventType::EcnStateUpdated) =>
                 EventImportance::Extra,
 
+            EventType::QuicEventType(
+                QuicEventType::CarefulResumePhaseUpdated,
+            ) => EventImportance::Extra,
+
             EventType::Http3EventType(Http3EventType::ParametersSet) =>
                 EventImportance::Base,
             EventType::Http3EventType(Http3EventType::StreamTypeSet) =>
@@ -374,6 +378,9 @@ impl From<&EventData> for EventType {
                 EventType::QuicEventType(QuicEventType::MarkedForRetransmit),
             EventData::QuicEcnStateUpdated { .. } =>
                 EventType::QuicEventType(QuicEventType::EcnStateUpdated),
+
+            EventData::CarefulResumePhaseUpdated { .. } =>
+                EventType::QuicEventType(QuicEventType::CarefulResumePhaseUpdated),
 
             EventData::Http3ParametersSet { .. } =>
                 EventType::Http3EventType(Http3EventType::ParametersSet),
@@ -545,6 +552,9 @@ pub enum EventData {
     #[serde(rename = "quic:ecn_state_updated")]
     QuicEcnStateUpdated(quic::EcnStateUpdated),
 
+    #[serde(rename = "recovery:careful_resume_phase_updated")]
+    CarefulResumePhaseUpdated(resume::CarefulResumePhaseUpdated),
+
     // HTTP/3
     #[serde(rename = "http3:parameters_set")]
     Http3ParametersSet(http3::ParametersSet),
@@ -696,3 +706,4 @@ pub struct TupleEndpointInfo {
 
 pub mod http3;
 pub mod quic;
+pub mod resume;

--- a/qlog/src/events/mod.rs
+++ b/qlog/src/events/mod.rs
@@ -552,7 +552,7 @@ pub enum EventData {
     #[serde(rename = "quic:ecn_state_updated")]
     QuicEcnStateUpdated(quic::EcnStateUpdated),
 
-    #[serde(rename = "recovery:careful_resume_phase_updated")]
+    #[serde(rename = "quic:careful_resume_phase_updated")]
     CarefulResumePhaseUpdated(resume::CarefulResumePhaseUpdated),
 
     // HTTP/3

--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -267,6 +267,7 @@ pub enum QuicEventType {
     PacketLost,
     MarkedForRetransmit,
     EcnStateUpdated,
+    CarefulResumePhaseUpdated,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]

--- a/qlog/src/events/resume.rs
+++ b/qlog/src/events/resume.rs
@@ -20,7 +20,6 @@ pub enum CarefulResumeTrigger {
     /// When sender has confirmed the RTT, has received an ACK for the initial
     /// data without reported congestion and has more data to send than the CWND
     /// would allow.
-    #[serde(rename = "cwnd_limited")]
     CongestionWindowLimited,
 
     /// From [Reconnaissance][CarefulResumePhase::Reconnaissance]/

--- a/qlog/src/events/resume.rs
+++ b/qlog/src/events/resume.rs
@@ -1,0 +1,134 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct CarefulResumePhaseUpdated {
+    pub old: Option<CarefulResumePhase>,
+    pub new: CarefulResumePhase,
+    pub state_data: CarefulResumeStateParameters,
+    pub restored_data: Option<CarefulResumeRestoredParameters>,
+    pub trigger: Option<CarefulResumeTrigger>,
+}
+
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum CarefulResumeTrigger {
+    /// From [Reconnaissance][CarefulResumePhase::Reconnaissance] to
+    /// [Unvalidated][CarefulResumePhase::Unvalidated]
+    ///
+    /// When sender has confirmed the RTT, has received an ACK for the initial
+    /// data without reported congestion and has more data to send than the CWND
+    /// would allow.
+    #[serde(rename = "cwnd_limited")]
+    CongestionWindowLimited,
+
+    /// From [Reconnaissance][CarefulResumePhase::Reconnaissance]/
+    /// [Unvalidated][CarefulResumePhase::Unvalidated] to
+    /// [Normal][CarefulResumePhase::Normal]
+    ///
+    /// If the current_rtt is not confirmed the sender MUST enter the Normal
+    /// Phase.
+    RttNotValidated,
+
+    /// From [Unvalidated][CarefulResumePhase::Unvalidated] to
+    /// [Validating][CarefulResumePhase::Validating]
+    ///
+    /// Completed sending all packets, e.g., when flight_size is equal to the
+    /// CWND after the jump
+    LastUnvalidatedPacketSent,
+
+    /// From [Unvalidated][CarefulResumePhase::Unvalidated] to
+    /// [Validating][CarefulResumePhase::Validating]
+    ///
+    /// The sender enters the Validating Phase when an ACK is received for the
+    /// first packet number (or higher) sent in the Unvalidated Phase.
+    FirstUnvalidatedPacketAcknowledged,
+
+    /// From [Unvalidated][CarefulResumePhase::Unvalidated] to
+    /// [Validating][CarefulResumePhase::Validating]
+    ///
+    /// When greater than 1 RTT has passed in Unvalidated Phase.
+    RttExceeded,
+
+    /// From [Unvalidated][CarefulResumePhase::Unvalidated] to
+    /// [Normal][CarefulResumePhase::Normal]
+    ///
+    /// If the flight_size is less than or equal to the PipeSize sender enters
+    /// Normal Phase.
+    RateLimited,
+
+    /// From [Validating][CarefulResumePhase::Validating] to
+    /// [Normal][CarefulResumePhase::Normal]
+    ///
+    /// The sender enters the Normal Phase when an ACK is received for the last
+    /// packet number (or higher) that was sent in the Unvalidated Phase.
+    LastUnvalidatedPacketAcknowledged,
+
+    /// From [Unvalidated][CarefulResumePhase::Unvalidated] to
+    /// [SafeRetreat][CarefulResumePhase::SafeRetreat]
+    ///
+    /// If a sender determines that it is not valid to use the previous CC
+    /// parameters due to a deteced path change, e.g., a change in RTT or an
+    /// explicit signal indicating a path change.
+    PathChanged,
+
+    /// From [Reconnaissance][CarefulResumePhase::Reconnaissance] to
+    /// [Normal][CarefulResumePhase::Normal]
+    ///
+    /// and from [Unvalidated][CarefulResumePhase::Unvalidated]/
+    /// [Validating][CarefulResumePhase::Validating]
+    /// to [SafeRetreat][CarefulResumePhase::SafeRetreat]
+    ///
+    /// If a sender determines that congestion was experienced, e.g., packet
+    /// loss, the sender enters the Safe Retreat Phase.
+    PacketLoss,
+
+    /// From [Reconnaissance][CarefulResumePhase::Reconnaissance] to
+    /// [Normal][CarefulResumePhase::Normal]
+    ///
+    /// and from [Unvalidated][CarefulResumePhase::Unvalidated]/
+    /// [Validating][CarefulResumePhase::Validating]
+    /// to [SafeRetreat][CarefulResumePhase::SafeRetreat]
+    ///
+    /// If a sender determines that congestion was experienced, e.g., ECN-CE
+    /// marking, sender enters the Safe Retreat Phase.
+    #[serde(rename = "ECN_CE")]
+    EcnCe,
+
+    /// From [SafeRetreat][CarefulResumePhase::SafeRetreat] to
+    /// [Normal][CarefulResumePhase::Normal]
+    ///
+    /// The sender enters the Normal Phase when the last packet sent in the
+    /// Unvalidated Phase is ACKed.
+    ExitRecovery,
+}
+
+/// Careful Resume defines a series of phases that a congestion controller moves
+/// through as a connection uses the mechanism.
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum CarefulResumePhase {
+    Reconnaissance,
+    Unvalidated,
+    Validating,
+    Normal,
+    SafeRetreat,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Debug)]
+pub struct CarefulResumeStateParameters {
+    pub pipesize: u64,
+    pub first_unvalidated_packet: u64,
+    pub last_unvalidated_packet: u64,
+    pub congestion_window: Option<u64>,
+    pub ssthresh: Option<u64>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Debug)]
+pub struct CarefulResumeRestoredParameters {
+    pub saved_congestion_window: u64,
+    pub saved_rtt: f32,
+}

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -25,7 +25,8 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 //! The qlog crate is an implementation of the qlog [main logging schema],
-//! [QUIC event definitions], and [HTTP/3 and QPACK event definitions].
+//! [QUIC event definitions], [HTTP/3 and QPACK event definitions],
+//! and [Careful Resume event definitions].
 //! The crate provides a qlog data model that can be used for traces with
 //! events. It supports serialization and deserialization but defers logging IO
 //! choices to applications.
@@ -39,6 +40,8 @@
 //! https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-quic-events.html
 //! [HTTP/3 and QPACK event definitions]:
 //! https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-h3-events.html
+//! [Careful Resume event definitions]:
+//! https://datatracker.ietf.org/doc/html/draft-ietf-tsvwg-careful-resume-qlog
 //! [buffered mode]: #buffered-traces-with-standard-json
 //! [streaming mode]: #streaming-traces-with-json-seq
 //!


### PR DESCRIPTION
This adds the qlog event definitions for [Careful Resume](https://datatracker.ietf.org/doc/html/draft-ietf-tsvwg-careful-resume) according to the [draft](https://datatracker.ietf.org/doc/html/draft-ietf-tsvwg-careful-resume-qlog).