### PR TITLE
BbrParams for BBR ProbeBw and ProbeRtt stages

### DIFF
--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -107,7 +107,11 @@ struct Params {
     probe_bw_probe_down_pacing_gain: f32,
     probe_bw_default_pacing_gain: f32,
 
+    /// cwnd_gain for probe bw phases other than ProbeBW_UP
     probe_bw_cwnd_gain: f32,
+
+    /// cwnd_gain for ProbeBW_UP
+    probe_bw_up_cwnd_gain: f32,
 
     // PROBE_UP parameters.
     probe_up_ignore_inflight_hi: bool,
@@ -125,6 +129,9 @@ struct Params {
     probe_rtt_period: Duration,
 
     probe_rtt_duration: Duration,
+
+    probe_rtt_pacing_gain: f32,
+    probe_rtt_cwnd_gain: f32,
 
     // Parameters used by multiple modes.
     /// The initial value of the max ack height filter's window length.
@@ -212,6 +219,9 @@ impl Params {
         apply_override!(probe_bw_probe_up_pacing_gain);
         apply_override!(probe_bw_probe_down_pacing_gain);
         apply_override!(probe_bw_cwnd_gain);
+        apply_override!(probe_bw_up_cwnd_gain);
+        apply_override!(probe_rtt_pacing_gain);
+        apply_override!(probe_rtt_cwnd_gain);
         apply_override!(max_probe_up_queue_rounds);
         apply_override!(loss_threshold);
         apply_override!(use_bytes_delivered_for_inflight_hi);
@@ -262,6 +272,8 @@ const DEFAULT_PARAMS: Params = Params {
 
     probe_bw_cwnd_gain: 2.25, // BBRv3
 
+    probe_bw_up_cwnd_gain: 2.25, // BBRv3
+
     probe_up_ignore_inflight_hi: false,
 
     max_probe_up_queue_rounds: 2,
@@ -271,6 +283,10 @@ const DEFAULT_PARAMS: Params = Params {
     probe_rtt_period: Duration::from_millis(10000),
 
     probe_rtt_duration: Duration::from_millis(200),
+
+    probe_rtt_pacing_gain: 1.0,
+
+    probe_rtt_cwnd_gain: 1.0,
 
     initial_max_ack_height_filter_window: 10,
 

--- a/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
@@ -144,8 +144,9 @@ impl ModeImpl for ProbeBW {
         // Do not need to set the gains if switching to PROBE_RTT, they will be
         // set when `ProbeRTT::enter` is called.
         if !switch_to_probe_rtt {
-            self.model.set_pacing_gain(self.cycle.phase.gain(params));
-            self.model.set_cwnd_gain(params.probe_bw_cwnd_gain);
+            self.model
+                .set_pacing_gain(self.cycle.phase.pacing_gain(params));
+            self.model.set_cwnd_gain(self.cycle.phase.cwnd_gain(params));
         }
 
         if switch_to_probe_rtt {

--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -181,8 +181,17 @@ pub struct BbrParams {
     /// Controls the BBR bandwidth probe down pacing gain.
     pub probe_bw_probe_down_pacing_gain: Option<f32>,
 
-    /// Controls the BBR probe bandwidth cwnd gain.
+    /// Controls the BBR probe bandwidth DOWN/CRUISE/REFILL cwnd gain.
     pub probe_bw_cwnd_gain: Option<f32>,
+
+    /// Controls the BBR probe bandwidth UP cwnd gain.
+    pub probe_bw_up_cwnd_gain: Option<f32>,
+
+    /// Controls the BBR probe RTT pacing gain.
+    pub probe_rtt_pacing_gain: Option<f32>,
+
+    /// Controls the BBR probe RTT cwnd gain.
+    pub probe_rtt_cwnd_gain: Option<f32>,
 
     /// Controls the number of rounds BBR should stay in probe up if
     /// bytes_in_flight doesn't drop below target.


### PR DESCRIPTION
* Split ProbeBW cwnd_gain parameter for ProbeBW_UP phase from param used for other ProbeBW phases.
* Add parameters for ProbeRTT pacing gain and cwnd gain.

Some of these params are inconsistent with the BBR RFC draft.  Having them as config is the first step towards getting the inconsistency fixed.