### PR TITLE
BbrParam to scale pacing rate when MSS changes

### DIFF
--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -219,6 +219,9 @@ pub struct BbrParams {
     /// the initial pacing rate, which is calculated by dividing the
     /// initial cwnd by the first RTT estimate.
     pub initial_pacing_rate_bytes_per_second: Option<u64>,
+
+    /// If true, scale the pacing rate when updating mss when doing pmtud.
+    pub scale_pacing_rate_by_mss: Option<bool>,
 }
 
 /// Controls BBR's bandwidth reduction strategy on congestion event.


### PR DESCRIPTION
Pacing rate limits BBR3's ability to measure bandwidth increases during startup.  If we do not scale pacing up, we can't take advantage of bandwidth gains from a higher MTU until the end of the startup phase.