### PR TITLE
fix: dynamically adjust time threshold on packet reordering

### DIFF
--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -66,6 +66,7 @@ use crate::recovery::INITIAL_TIME_THRESHOLD;
 use crate::recovery::MAX_OUTSTANDING_NON_ACK_ELICITING;
 use crate::recovery::MAX_PACKET_THRESHOLD;
 use crate::recovery::MAX_PTO_PROBES_COUNT;
+use crate::recovery::PACKET_REORDER_TIME_THRESHOLD;
 
 #[derive(Default)]
 struct RecoveryEpoch {
@@ -658,6 +659,7 @@ impl RecoveryOps for LegacyRecovery {
         if let Some(thresh) = spurious_pkt_thresh {
             self.pkt_thresh =
                 self.pkt_thresh.max(thresh.min(MAX_PACKET_THRESHOLD));
+            self.time_thresh = PACKET_REORDER_TIME_THRESHOLD;
         }
 
         // Undo congestion window update.
@@ -947,6 +949,11 @@ impl RecoveryOps for LegacyRecovery {
     #[cfg(test)]
     fn pkt_thresh(&self) -> u64 {
         self.pkt_thresh
+    }
+
+    #[cfg(test)]
+    fn time_thresh(&self) -> f64 {
+        self.time_thresh
     }
 
     #[cfg(test)]

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -711,7 +711,11 @@ impl RecoveryOps for GRecovery {
         }
 
         if self.newly_acked.is_empty() {
-            return Ok(OnAckReceivedOutcome::default());
+            return Ok(OnAckReceivedOutcome {
+                acked_bytes,
+                spurious_losses,
+                ..Default::default()
+            });
         }
 
         self.bytes_in_flight.saturating_subtract(acked_bytes, now);

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -1,5 +1,7 @@
 use crate::packet;
 use crate::recovery::OnLossDetectionTimeoutOutcome;
+use crate::Error;
+use crate::Result;
 
 use std::collections::VecDeque;
 use std::time::Duration;
@@ -35,8 +37,7 @@ use crate::recovery::INITIAL_TIME_THRESHOLD;
 use crate::recovery::MAX_OUTSTANDING_NON_ACK_ELICITING;
 use crate::recovery::MAX_PACKET_THRESHOLD;
 use crate::recovery::MAX_PTO_PROBES_COUNT;
-use crate::Error;
-use crate::Result;
+use crate::recovery::PACKET_REORDER_TIME_THRESHOLD;
 
 use super::bbr2::BBRv2;
 use super::pacer::Pacer;
@@ -706,6 +707,7 @@ impl RecoveryOps for GRecovery {
         if let Some(thresh) = spurious_pkt_thresh {
             self.pkt_thresh =
                 self.pkt_thresh.max(thresh.min(MAX_PACKET_THRESHOLD));
+            self.time_thresh = PACKET_REORDER_TIME_THRESHOLD;
         }
 
         if self.newly_acked.is_empty() {
@@ -993,6 +995,11 @@ impl RecoveryOps for GRecovery {
     #[cfg(test)]
     fn pkt_thresh(&self) -> u64 {
         self.pkt_thresh
+    }
+
+    #[cfg(test)]
+    fn time_thresh(&self) -> f64 {
+        self.time_thresh
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Dynamic time threshold logic from
https://github.com/cloudflare/quiche/pull/470 was accidentally removed.

The goal is to make time-based detection less sensitive when a spurious loss is detected.

## Reviewing
It would be best to review this change as separate commits:
- 1st commit adds the time_thresh change
- 2nd commit refactors an existing reordering tests to make it easier to read
- 3rd commit adds the new test to test the time_thresh change

## Testing
I also added the same test to the [previous version (0.21.0)](https://github.com/cloudflare/quiche/compare/akothari/test_time_thresh_0.21.0?expand=1) of code to confirm the behavior.

### network simulator testing
I did some simulation testing to measure the effectiveness of this fix for BBRv3 in the gconsgestion branch. Because reordering is hard to control for there is a lot of variability between runs. However, across ~5 runs each the branch with the fix seems more resilient to packet reordering.

**Setup**
[tc](https://man7.org/linux/man-pages/man8/tc.8.html) based simulator with
- fq used to enable packet pacing
- htb used for rate limiting (`htb quantum 1514 rate 20mbit` + queue `pfifo limit 10800`)
- netem used for delay + packet reordering (`netem limit 2000000 delay 52ms 2ms distribution pareto`). (To eliminate reordering also apply `rate 100gbit`)

**Before fix**
<img width="1202" height="743" alt="before_time_thresh_fix" src="https://github.com/user-attachments/assets/6a1dd67d-68fa-4e90-ab07-be099773d89c" />

**After fix**
<img width="1202" height="743" alt="after_time_thresh_fix" src="https://github.com/user-attachments/assets/cb7c53b4-bd77-411d-8350-75c9f954a8ff" />

