### PR TITLE
h3: add support for streaming HEADERS sends

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -334,6 +334,8 @@ pub trait HttpConn {
         &mut self, conn: &mut quiche::Connection, target_path: &Option<String>,
     );
 
+    fn retry_partial_headers(&mut self, conn: &mut quiche::Connection);
+
     fn handle_responses(
         &mut self, conn: &mut quiche::Connection, buf: &mut [u8],
         req_start: &std::time::Instant,
@@ -369,12 +371,19 @@ pub struct Http09Request {
     response_writer: Option<std::io::BufWriter<std::fs::File>>,
 }
 
+enum HeadersSendStatus {
+    NotStarted,
+    InProgess,
+    Completed,
+}
+
 /// Represents an HTTP/3 formatted request.
 struct Http3Request {
     url: url::Url,
     cardinal: u64,
     stream_id: Option<u64>,
     hdrs: Vec<quiche::h3::Header>,
+    hdrs_send_status: HeadersSendStatus,
     priority: Option<Priority>,
     response_hdrs: Vec<quiche::h3::Header>,
     response_body: Vec<u8>,
@@ -476,6 +485,8 @@ impl HttpConn for Http09Conn {
 
         self.reqs_sent += reqs_done;
     }
+
+    fn retry_partial_headers(&mut self, _conn: &mut quiche::Connection) {}
 
     fn handle_responses(
         &mut self, conn: &mut quiche::Connection, buf: &mut [u8],
@@ -829,6 +840,7 @@ impl Http3Conn {
                     url: url.clone(),
                     cardinal: i,
                     hdrs,
+                    hdrs_send_status: HeadersSendStatus::NotStarted,
                     priority,
                     response_hdrs: Vec::new(),
                     response_body: Vec::new(),
@@ -1120,19 +1132,56 @@ impl Http3Conn {
 }
 
 impl HttpConn for Http3Conn {
+    fn retry_partial_headers(&mut self, conn: &mut quiche::Connection) {
+        for req in self.reqs.iter_mut().filter(|r| {
+            matches!(r.hdrs_send_status, HeadersSendStatus::InProgess)
+        }) {
+            let stream_id = req
+                .stream_id
+                .expect("partial header resend but no stream ID");
+
+            debug!("retrying stream id={}", stream_id);
+            match self.h3_conn.continue_partial_headers(conn, stream_id) {
+                Ok(_) => {
+                    req.hdrs_send_status = HeadersSendStatus::Completed;
+                    debug!("Completed HTTP request {:?}", &req.hdrs);
+                    self.reqs_hdrs_sent += 1;
+                },
+
+                Err(e) => {
+                    error!("retry failed to send request {:?}", e);
+                    break;
+                },
+            }
+        }
+    }
+
     fn send_requests(
         &mut self, conn: &mut quiche::Connection, target_path: &Option<String>,
     ) {
-        let mut reqs_done = 0;
+        // First retry partial headers
+        self.retry_partial_headers(conn);
 
-        // First send headers.
-        for req in self.reqs.iter_mut().skip(self.reqs_hdrs_sent) {
-            let s = match self.h3_conn.send_request(
+        // Then send new headers.
+        for req in self.reqs.iter_mut().filter(|r| {
+            matches!(r.hdrs_send_status, HeadersSendStatus::NotStarted)
+        }) {
+            let stream_id = match self.h3_conn.send_request(
                 conn,
                 &req.hdrs,
                 self.body.is_none(),
             ) {
-                Ok(v) => v,
+                Ok((stream_id, is_complete)) => {
+                    if is_complete {
+                        req.hdrs_send_status = HeadersSendStatus::Completed;
+                        debug!("Completed HTTP request {:?}", &req.hdrs);
+                        self.reqs_hdrs_sent += 1;
+                    } else {
+                        req.hdrs_send_status = HeadersSendStatus::InProgess;
+                    }
+
+                    stream_id
+                },
 
                 Err(quiche::h3::Error::TransportError(
                     quiche::Error::StreamLimit,
@@ -1152,23 +1201,18 @@ impl HttpConn for Http3Conn {
                 },
             };
 
-            debug!("Sent HTTP request {:?}", &req.hdrs);
-
             if let Some(priority) = &req.priority {
                 // If sending the priority fails, don't try again.
                 self.h3_conn
-                    .send_priority_update_for_request(conn, s, priority)
+                    .send_priority_update_for_request(conn, stream_id, priority)
                     .ok();
             }
 
-            req.stream_id = Some(s);
+            req.stream_id = Some(stream_id);
             req.response_writer =
                 make_resource_writer(&req.url, target_path, req.cardinal);
-            self.sent_body_bytes.insert(s, 0);
-
-            reqs_done += 1;
+            self.sent_body_bytes.insert(stream_id, 0);
         }
-        self.reqs_hdrs_sent += reqs_done;
 
         // Then send any remaining body.
         if let Some(body) = &self.body {

--- a/quiche/src/h3/ffi.rs
+++ b/quiche/src/h3/ffi.rs
@@ -227,7 +227,7 @@ pub extern "C" fn quiche_h3_send_request(
     let req_headers = headers_from_ptr(headers, headers_len);
 
     match conn.send_request(quic_conn, &req_headers, fin) {
-        Ok(v) => v as i64,
+        Ok((stream_id, _hdrs_fully_sent)) => stream_id as i64,
 
         Err(e) => e.to_c() as i64,
     }

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -113,7 +113,7 @@
 //!     quiche::h3::Header::new(b"user-agent", b"quiche"),
 //! ];
 //!
-//! let stream_id = h3_conn.send_request(&mut conn, &req, false)?;
+//! let (stream_id, _hdrs_completely_sent) = h3_conn.send_request(&mut conn, &req, false)?;
 //! h3_conn.send_body(&mut conn, stream_id, b"Hello World!", true)?;
 //! # Ok::<(), quiche::h3::Error>(())
 //! ```
@@ -424,6 +424,9 @@ pub enum Error {
     /// The requested operation cannot be served over HTTP/3. Peer should retry
     /// over HTTP/1.1.
     VersionFallback,
+
+    /// TODO
+    PartialHeader,
 }
 
 /// HTTP/3 error codes sent on the wire.
@@ -503,6 +506,7 @@ impl Error {
             Error::MessageError => WireErrorCode::MessageError as u64,
             Error::ConnectError => WireErrorCode::ConnectError as u64,
             Error::VersionFallback => WireErrorCode::VersionFallback as u64,
+            Error::PartialHeader => 0x1000,
         }
     }
 
@@ -529,6 +533,7 @@ impl Error {
             Error::MessageError => -18,
             Error::ConnectError => -19,
             Error::VersionFallback => -20,
+            Error::PartialHeader => -21,
 
             Error::TransportError(quic_error) => quic_error.to_c() - 1000,
         }
@@ -1096,12 +1101,18 @@ impl Connection {
 
     /// Sends an HTTP/3 request.
     ///
-    /// The request is encoded from the provided list of headers without a
-    /// body, and sent on a newly allocated stream. To include a body,
-    /// set `fin` as `false` and subsequently call [`send_body()`] with the
-    /// same `conn` and the `stream_id` returned from this method.
+    /// The request is encoded from the provided list of headers without a body,
+    /// and sent on a newly allocated stream. To include a body, set `fin` as
+    /// `false` and subsequently call [`send_body()`] with the same `conn` and
+    /// the `stream_id` returned from this method.
     ///
-    /// On success the newly allocated stream ID is returned.
+    /// On success the newly allocated stream ID is returned, together with a
+    /// bool that indicates if the headers were fully sent or not. If this value
+    /// is false, it indicates the underlying stream or connection does not have
+    /// enough capacity to send the entire remaining header bytes.
+    ///
+    /// The application must call [`continue_partial_headers()`] once the stream
+    /// is reported as writable again.
     ///
     /// The [`StreamBlocked`] error is returned when the underlying QUIC stream
     /// doesn't have enough capacity for the operation to complete. When this
@@ -1109,10 +1120,12 @@ impl Connection {
     /// reported as writable again.
     ///
     /// [`send_body()`]: struct.Connection.html#method.send_body
+    /// [`continue_partial_headers()`]:
+    ///     struct.Connection.html#method.continue_partial_headers
     /// [`StreamBlocked`]: enum.Error.html#variant.StreamBlocked
     pub fn send_request<T: NameValue, F: BufFactory>(
         &mut self, conn: &mut super::Connection<F>, headers: &[T], fin: bool,
-    ) -> Result<u64> {
+    ) -> Result<(u64, bool)> {
         // If we received a GOAWAY from the peer, MUST NOT initiate new
         // requests.
         if self.peer_goaway_id.is_some() {
@@ -1120,34 +1133,33 @@ impl Connection {
         }
 
         let stream_id = self.next_request_stream_id;
-
-        self.streams
-            .insert(stream_id, <stream::Stream>::new(stream_id, true));
+        let stream = stream::Stream::new(stream_id, true);
 
         // The underlying QUIC stream does not exist yet, so calls to e.g.
         // stream_capacity() will fail. By writing a 0-length buffer, we force
         // the creation of the QUIC stream state, without actually writing
-        // anything.
-        if let Err(e) = conn.stream_send(stream_id, b"", false) {
-            self.streams.remove(&stream_id);
+        // anything. Errors on this call don't make sense to bubble up.
+        conn.stream_send(stream_id, b"", false).ok();
+        self.streams.insert(stream_id, stream);
 
-            if e == super::Error::Done {
-                return Err(Error::StreamBlocked);
-            }
-
-            return Err(e.into());
-        };
-
-        self.send_headers(conn, stream_id, headers, fin)?;
-
-        // To avoid skipping stream IDs, we only calculate the next available
-        // stream ID when a request has been successfully buffered.
         self.next_request_stream_id = self
             .next_request_stream_id
             .checked_add(4)
             .ok_or(Error::IdError)?;
 
-        Ok(stream_id)
+        if let Err(e) = self.send_headers(conn, stream_id, headers, false, fin) {
+            match e {
+                // At this stage, even Error::Done in the transport layer is a
+                // partial send because we committed the stream state changes to
+                // the connection.
+                Error::PartialHeader | Error::Done =>
+                    return Ok((stream_id, false)),
+
+                _ => return Err(e),
+            }
+        }
+
+        Ok((stream_id, true))
     }
 
     /// Sends an HTTP/3 response on the specified stream with default priority.
@@ -1175,18 +1187,20 @@ impl Connection {
     /// error is returned if this method, or [`send_response_with_priority()`],
     /// are called multiple times with the same `stream_id` value.
     ///
-    /// The [`StreamBlocked`] error is returned when the underlying QUIC stream
+    /// The [`PartialHeader`] error is returned when the underlying QUIC stream
     /// doesn't have enough capacity for the operation to complete. When this
-    /// happens the application should retry the operation once the stream is
-    /// reported as writable again.
+    /// happens the application must call [`continue_partial_headers()`] once
+    /// the stream is reported as writable again.
     ///
     /// [`send_body()`]: struct.Connection.html#method.send_body
     /// [`send_additional_headers()`]:
     ///     struct.Connection.html#method.send_additional_headers
     /// [`send_response_with_priority()`]:
     ///     struct.Connection.html#method.send_response_with_priority
+    /// [`continue_partial_headers()`]:
+    ///     struct.Connection.html#method.continue_partial_headers
     /// [`FrameUnexpected`]: enum.Error.html#variant.FrameUnexpected
-    /// [`StreamBlocked`]: enum.Error.html#variant.StreamBlocked
+    /// [`PartialHeader`]: enum.Error.html#variant.PartialHeader
     pub fn send_response<T: NameValue, F: BufFactory>(
         &mut self, conn: &mut super::Connection<F>, stream_id: u64,
         headers: &[T], fin: bool,
@@ -1247,20 +1261,15 @@ impl Connection {
         &mut self, conn: &mut super::Connection<F>, stream_id: u64,
         headers: &[T], priority: &Priority, fin: bool,
     ) -> Result<()> {
-        match self.streams.get(&stream_id) {
-            Some(s) => {
-                // Only one initial HEADERS allowed.
-                if s.local_initialized() {
-                    return Err(Error::FrameUnexpected);
-                }
+        let stream =
+            self.streams.get(&stream_id).ok_or(Error::FrameUnexpected)?;
 
-                s
-            },
+        // Only one initial HEADERS allowed.
+        if stream.local_initialized() {
+            return Err(Error::FrameUnexpected);
+        }
 
-            None => return Err(Error::FrameUnexpected),
-        };
-
-        self.send_headers(conn, stream_id, headers, fin)?;
+        self.send_headers(conn, stream_id, headers, false, fin)?;
 
         // Clamp and shift urgency into quiche-priority space
         let urgency = priority
@@ -1326,15 +1335,7 @@ impl Connection {
             None => return Err(Error::FrameUnexpected),
         };
 
-        self.send_headers(conn, stream_id, headers, fin)?;
-
-        if is_trailer_section {
-            // send_headers() might have tidied the stream away, so we need to
-            // check again.
-            if let Some(s) = self.streams.get_mut(&stream_id) {
-                s.mark_trailers_sent();
-            }
-        }
+        self.send_headers(conn, stream_id, headers, is_trailer_section, fin)?;
 
         Ok(())
     }
@@ -1393,70 +1394,54 @@ impl Connection {
         Ok(())
     }
 
-    fn encode_header_block<T: NameValue>(
-        &mut self, headers: &[T],
-    ) -> Result<Vec<u8>> {
+    fn send_headers<T: NameValue, F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>, stream_id: u64,
+        headers: &[T], is_trailer_section: bool, fin: bool,
+    ) -> Result<()> {
+        // Try to send grease once and don't error if it fails.
+        if !self.frames_greased && conn.grease {
+            self.send_grease_frames(conn, stream_id).ok();
+            self.frames_greased = true;
+        }
+
+        let stream = self
+            .streams
+            .get_mut(&stream_id)
+            .ok_or(Error::FrameUnexpected)?;
+
         let headers_len = headers
             .iter()
             .fold(0, |acc, h| acc + h.value().len() + h.name().len() + 32);
 
-        let mut header_block = vec![0; headers_len];
-        let len = self
+        let mut frame_payload = vec![0; headers_len];
+        let payload_len = self
             .qpack_encoder
-            .encode(headers, &mut header_block)
+            .encode(headers, &mut frame_payload)
             .map_err(|_| Error::InternalError)?;
 
-        header_block.truncate(len);
+        let frame_header_size = octets::varint_len(frame::HEADERS_FRAME_TYPE_ID) +
+            octets::varint_len(payload_len as u64);
 
-        Ok(header_block)
-    }
+        let mut frame_header = vec![0; frame_header_size];
 
-    fn send_headers<T: NameValue, F: BufFactory>(
-        &mut self, conn: &mut super::Connection<F>, stream_id: u64,
-        headers: &[T], fin: bool,
-    ) -> Result<()> {
-        let mut d = [42; 10];
-        let mut b = octets::OctetsMut::with_slice(&mut d);
-
-        if !self.frames_greased && conn.grease {
-            self.send_grease_frames(conn, stream_id)?;
-            self.frames_greased = true;
-        }
-
-        let header_block = self.encode_header_block(headers)?;
-
-        let overhead = octets::varint_len(frame::HEADERS_FRAME_TYPE_ID) +
-            octets::varint_len(header_block.len() as u64);
-
-        // Headers need to be sent atomically, so make sure the stream has
-        // enough capacity.
-        match conn.stream_writable(stream_id, overhead + header_block.len()) {
-            Ok(true) => (),
-
-            Ok(false) => return Err(Error::StreamBlocked),
-
-            Err(e) => {
-                if conn.stream_finished(stream_id) {
-                    self.streams.remove(&stream_id);
-                }
-
-                return Err(e.into());
-            },
-        };
-
+        let mut b = octets::OctetsMut::with_slice(&mut frame_header);
         b.put_varint(frame::HEADERS_FRAME_TYPE_ID)?;
-        b.put_varint(header_block.len() as u64)?;
-        let off = b.off();
-        conn.stream_send(stream_id, &d[..off], false)?;
+        b.put_varint(payload_len as u64)?;
 
-        // Sending header block separately avoids unnecessary copy.
-        conn.stream_send(stream_id, &header_block, fin)?;
+        stream.outgoing_frame_header = frame_header;
+        stream.outgoing_frame_header_off = 0;
+
+        frame_payload.truncate(payload_len);
+
+        stream.outgoing_frame_payload = frame_payload;
+        stream.outgoing_frame_payload_off = 0;
+        stream.fin_after_outgoing_frame = fin;
 
         trace!(
             "{} tx frm HEADERS stream={} len={} fin={}",
             conn.trace_id(),
             stream_id,
-            header_block.len(),
+            payload_len,
             fin
         );
 
@@ -1474,7 +1459,7 @@ impl Connection {
             };
             let ev_data = EventData::H3FrameCreated(H3FrameCreated {
                 stream_id,
-                length: Some(header_block.len() as u64),
+                length: Some(payload_len as u64),
                 frame,
                 ..Default::default()
             });
@@ -1482,11 +1467,160 @@ impl Connection {
             q.add_event_data_now(ev_data).ok();
         });
 
-        if let Some(s) = self.streams.get_mut(&stream_id) {
-            s.initialize_local();
+        match conn.stream_send(stream_id, &stream.outgoing_frame_header, false) {
+            Ok(v) =>
+                if v != stream.outgoing_frame_header.len() {
+                    stream.outgoing_frame_header_off += v;
+                    if is_trailer_section {
+                        stream.mark_trailers_in_flight();
+                    }
+                    trace!(
+                        "only sent {} of {} frame header bytes",
+                        v,
+                        stream.outgoing_frame_header.len()
+                    );
+                    return Err(Error::PartialHeader);
+                },
+
+            Err(e) => {
+                // TODO: check its actually sensible to return all errors
+                return Err(e.into());
+            },
         }
 
-        if fin && conn.stream_finished(stream_id) {
+        stream.outgoing_frame_header.clear();
+        stream.outgoing_frame_header_off = 0;
+
+        // Sending header block separately avoids unnecessary copy.
+        match conn.stream_send(
+            stream_id,
+            &stream.outgoing_frame_payload,
+            stream.fin_after_outgoing_frame,
+        ) {
+            Ok(v) =>
+                if v != stream.outgoing_frame_payload.len() {
+                    stream.outgoing_frame_payload_off += v;
+                    if is_trailer_section {
+                        stream.mark_trailers_in_flight();
+                    }
+                    trace!(
+                        "only sent {} of {} frame payload bytes",
+                        v,
+                        stream.outgoing_frame_payload.len()
+                    );
+                    return Err(Error::PartialHeader);
+                },
+
+            Err(..) => {
+                // TODO: check its actually sensible to capture all errors
+                // this case is slightly different because the frame's
+                // headers would have been sent at this point
+                return Err(Error::PartialHeader);
+            },
+        }
+
+        stream.outgoing_frame_payload.clear();
+        stream.outgoing_frame_payload_off = 0;
+
+        stream.initialize_local();
+
+        if is_trailer_section {
+            stream.mark_trailers_sent();
+        }
+
+        if stream.fin_after_outgoing_frame && conn.stream_finished(stream_id) {
+            self.streams.remove(&stream_id);
+        }
+
+        Ok(())
+    }
+
+    /// Continues sending headers on the given stream.
+    ///
+    /// The [`PartialHeader`] error is returned when the underlying QUIC stream
+    /// doesn't have enough capacity for the operation to complete. When this
+    /// happens the application should retry the operation once the stream is
+    /// reported as writable again.
+    ///
+    /// [`PartialHeader`]: enum.Error.html#variant.PartialHeaders
+    pub fn continue_partial_headers(
+        &mut self, conn: &mut super::Connection, stream_id: u64,
+    ) -> Result<()> {
+        let stream = self
+            .streams
+            .get_mut(&stream_id)
+            .ok_or(Error::FrameUnexpected)?;
+
+        if stream.outgoing_frame_header.is_empty() &&
+            stream.outgoing_frame_payload.is_empty()
+        {
+            // Can't continue when there is nothing to do.
+            return Err(Error::Done);
+        }
+
+        if !stream.outgoing_frame_header.is_empty() {
+            match conn.stream_send(
+                stream_id,
+                &stream.outgoing_frame_header[stream.outgoing_frame_header_off..],
+                false,
+            ) {
+                Ok(v) =>
+                    if v != stream.outgoing_frame_header.len() {
+                        stream.outgoing_frame_header_off += v;
+                        trace!(
+                            "only sent {} of {} frame header bytes",
+                            v,
+                            stream.outgoing_frame_header.len()
+                        );
+                        return Err(Error::PartialHeader);
+                    },
+
+                Err(e) => {
+                    error!("continue_partial_headers frame header fail {:?}", e);
+                    // TODO: check its actually sensible to capture all errors
+                    return Err(Error::PartialHeader);
+                },
+            }
+        }
+
+        stream.outgoing_frame_header.clear();
+        stream.outgoing_frame_header_off = 0;
+
+        match conn.stream_send(
+            stream_id,
+            &stream.outgoing_frame_payload[stream.outgoing_frame_payload_off..],
+            stream.fin_after_outgoing_frame,
+        ) {
+            Ok(sent) => {
+                stream.outgoing_frame_payload_off += sent;
+                if stream.outgoing_frame_payload_off !=
+                    stream.outgoing_frame_payload.len()
+                {
+                    trace!(
+                        "only sent {} of {} frame payload bytes",
+                        sent,
+                        stream.outgoing_frame_payload.len()
+                    );
+                    return Err(Error::PartialHeader);
+                }
+            },
+
+            Err(e) => {
+                // TODO: check its actually sensible to capture all errors
+                error!("continue_partial_headers frame payload fail {:?}", e);
+                return Err(Error::PartialHeader);
+            },
+        }
+
+        stream.outgoing_frame_payload.clear();
+        stream.outgoing_frame_payload_off = 0;
+
+        stream.initialize_local();
+        if stream.trailers_trailers_in_flight() {
+            stream.mark_trailers_sent();
+        }
+
+        if stream.fin_after_outgoing_frame && conn.stream_finished(stream_id) {
             self.streams.remove(&stream_id);
         }
 
@@ -3369,12 +3503,12 @@ pub mod testing {
                 Header::new(b"user-agent", b"quiche-test"),
             ];
 
-            let stream =
+            let (stream_id, _) =
                 self.client.send_request(&mut self.pipe.client, &req, fin)?;
 
             self.advance().ok();
 
-            Ok((stream, req))
+            Ok((stream_id, req))
         }
 
         /// Sends a response from server with default headers.
@@ -4541,7 +4675,7 @@ mod tests {
 
         let (stream, req) = s.send_request(false).unwrap();
 
-        let header_block = s.client.encode_header_block(&req).unwrap();
+        let header_block = vec![42; 10];
 
         s.send_frame_client(
             frame::Frame::PushPromise {
@@ -5443,7 +5577,7 @@ mod tests {
 
         assert_eq!(
             s.client.send_request(&mut s.pipe.client, &req, false),
-            Ok(0)
+            Ok((0, true))
         );
 
         s.advance().ok();
@@ -5583,14 +5717,14 @@ mod tests {
             Header::new(b"aaaaaaa", b"aaaaaaaa"),
         ];
 
-        let stream = s
+        let res = s
             .client
             .send_request(&mut s.pipe.client, &req, true)
             .unwrap();
 
         s.advance().ok();
 
-        assert_eq!(stream, 0);
+        assert_eq!(res, (0, true));
 
         assert_eq!(s.poll_server(), Err(Error::ExcessiveLoad));
 
@@ -5618,16 +5752,25 @@ mod tests {
         // Session::send_request() method because it also calls advance(),
         // otherwise the server would send a MAX_STREAMS frame and the client
         // wouldn't hit the streams limit.
-        assert_eq!(s.client.send_request(&mut s.pipe.client, &req, true), Ok(0));
-        assert_eq!(s.client.send_request(&mut s.pipe.client, &req, true), Ok(4));
-        assert_eq!(s.client.send_request(&mut s.pipe.client, &req, true), Ok(8));
         assert_eq!(
             s.client.send_request(&mut s.pipe.client, &req, true),
-            Ok(12)
+            Ok((0, true))
         );
         assert_eq!(
             s.client.send_request(&mut s.pipe.client, &req, true),
-            Ok(16)
+            Ok((4, true))
+        );
+        assert_eq!(
+            s.client.send_request(&mut s.pipe.client, &req, true),
+            Ok((8, true))
+        );
+        assert_eq!(
+            s.client.send_request(&mut s.pipe.client, &req, true),
+            Ok((12, true))
+        );
+        assert_eq!(
+            s.client.send_request(&mut s.pipe.client, &req, true),
+            Ok((16, true))
         );
 
         assert_eq!(
@@ -5718,29 +5861,45 @@ mod tests {
             Header::new(b":path", b"/test"),
         ];
 
-        assert_eq!(s.client.send_request(&mut s.pipe.client, &req, true), Ok(0));
+        let ev_headers = Event::Headers {
+            list: req.clone(),
+            more_frames: false,
+        };
 
         assert_eq!(
             s.client.send_request(&mut s.pipe.client, &req, true),
-            Err(Error::StreamBlocked)
+            Ok((0, true))
         );
 
-        // Clear the writable stream queue.
-        assert_eq!(s.pipe.client.stream_writable_next(), Some(2));
-        assert_eq!(s.pipe.client.stream_writable_next(), Some(6));
-        assert_eq!(s.pipe.client.stream_writable_next(), Some(10));
+        assert_eq!(
+            s.client.send_request(&mut s.pipe.client, &req, true),
+            Ok((4, false))
+        );
+
         assert_eq!(s.pipe.client.stream_writable_next(), None);
 
         s.advance().ok();
 
+        assert_eq!(s.poll_server(), Ok((0, ev_headers.clone())));
+        assert_eq!(s.poll_server(), Ok((0, Event::Finished)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
         // Once the server gives flow control credits back, we can send the
-        // request.
-        assert_eq!(s.pipe.client.stream_writable_next(), Some(4));
-        assert_eq!(s.client.send_request(&mut s.pipe.client, &req, true), Ok(4));
+        // remaining part of request.
+        s.client
+            .continue_partial_headers(&mut s.pipe.client, 4)
+            .unwrap();
+
+        s.advance().ok();
+
+        assert_eq!(s.poll_server(), Ok((4, ev_headers)));
+        assert_eq!(s.poll_server(), Ok((4, Event::Finished)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
     }
 
     #[test]
-    /// Ensure StreamBlocked when connection flow control prevents headers.
+    /// Ensure request headers recover when connection flow control prevents
+    /// them.
     fn headers_blocked_on_conn() {
         let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
         config
@@ -5779,10 +5938,12 @@ mod tests {
 
         // There is 0 connection-level flow control, so sending a request is
         // blocked.
-        assert_eq!(
-            s.client.send_request(&mut s.pipe.client, &req, true),
-            Err(Error::StreamBlocked)
-        );
+        let (stream_id, hdrs_completely_sent) = s
+            .client
+            .send_request(&mut s.pipe.client, &req, true)
+            .unwrap();
+        assert_eq!(stream_id, 0);
+        assert!(!hdrs_completely_sent);
         assert_eq!(s.pipe.client.stream_writable_next(), None);
 
         // Emit the control stream data and drain it at the server via poll() to
@@ -5792,9 +5953,380 @@ mod tests {
         s.advance().ok();
 
         // Now we can send the request.
+        // The writable iterator prefers higher-priority streams, so
+        // the request stream comes last
         assert_eq!(s.pipe.client.stream_writable_next(), Some(2));
         assert_eq!(s.pipe.client.stream_writable_next(), Some(6));
-        assert_eq!(s.client.send_request(&mut s.pipe.client, &req, true), Ok(0));
+        assert_eq!(s.pipe.client.stream_writable_next(), Some(10));
+        assert_eq!(s.pipe.client.stream_writable_next(), Some(0));
+        assert_eq!(s.pipe.client.stream_writable_next(), None);
+
+        assert_eq!(
+            s.client
+                .continue_partial_headers(&mut s.pipe.client, stream_id),
+            Ok(())
+        );
+    }
+
+    #[test]
+    /// Tests that we prevent other work while partial request HEADERS are in
+    /// progress.
+    fn headers_blocked_prevents_more_client_work() {
+        let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
+        config.set_initial_max_data(70);
+        config.set_initial_max_stream_data_bidi_local(150);
+        config.set_initial_max_stream_data_bidi_remote(150);
+        config.set_initial_max_stream_data_uni(150);
+        config.set_initial_max_streams_bidi(100);
+        config.set_initial_max_streams_uni(5);
+        config.verify_peer(false);
+
+        let h3_config = Config::new().unwrap();
+
+        let mut s = Session::with_configs(&mut config, &h3_config).unwrap();
+
+        s.handshake().unwrap();
+
+        let req = vec![
+            Header::new(b":method", b"GET"),
+            Header::new(b":scheme", b"https"),
+            Header::new(b":authority", b"quic.tech"),
+            Header::new(b":path", b"/test"),
+        ];
+
+        let ev_headers_1 = Event::Headers {
+            list: req.clone(),
+            more_frames: false,
+        };
+
+        let ev_headers_2 = Event::Headers {
+            list: req.clone(),
+            more_frames: true,
+        };
+
+        assert_eq!(
+            s.client.send_request(&mut s.pipe.client, &req, true),
+            Ok((0, true))
+        );
+
+        assert_eq!(
+            s.client.send_request(&mut s.pipe.client, &req, false),
+            Ok((4, false))
+        );
+
+        assert_eq!(s.pipe.client.stream_writable_next(), None);
+
+        s.advance().ok();
+
+        // Although partial HEADERS was sent on stream 4, server does not generate
+        // event until entire HEADERS are received.
+        assert_eq!(s.poll_server(), Ok((0, ev_headers_1.clone())));
+        assert_eq!(s.poll_server(), Ok((0, Event::Finished)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        s.advance().ok();
+
+        assert_eq!(s.pipe.server.stream_writable_next(), Some(3));
+        assert_eq!(s.pipe.server.stream_writable_next(), Some(7));
+        assert_eq!(s.pipe.server.stream_writable_next(), Some(11));
+        assert_eq!(s.pipe.server.stream_writable_next(), Some(0));
+        assert_eq!(s.pipe.server.stream_writable_next(), Some(4));
+        assert_eq!(s.pipe.server.stream_writable_next(), None);
+
+        // The server has given back flow control credits but sending other things
+        // should fail until we complete initial headers.
+        assert_eq!(
+            s.client.send_body(&mut s.pipe.client, 4, b"hello", false),
+            Err(Error::FrameUnexpected),
+        );
+
+        let trailers = vec![Header::new(b"trailer-foo", b"yes")];
+        let ev_trailers = Event::Headers {
+            list: trailers.clone(),
+            more_frames: false,
+        };
+
+        assert_eq!(
+            s.client.send_additional_headers(
+                &mut s.pipe.client,
+                4,
+                &trailers,
+                true,
+                true
+            ),
+            Err(Error::FrameUnexpected),
+        );
+
+        assert_eq!(
+            s.client.continue_partial_headers(&mut s.pipe.client, 4),
+            Ok(())
+        );
+
+        // Partial headers finished
+        assert_eq!(
+            s.client.continue_partial_headers(&mut s.pipe.client, 4),
+            Err(Error::Done)
+        );
+
+        // Now we can do remaining work
+        assert_eq!(
+            s.client.send_body(&mut s.pipe.client, 4, b"hello", false),
+            Ok(5),
+        );
+
+        assert_eq!(
+            s.client.send_additional_headers(
+                &mut s.pipe.client,
+                4,
+                &trailers,
+                true,
+                true
+            ),
+            Ok(()),
+        );
+
+        s.advance().ok();
+
+        assert_eq!(s.poll_server(), Ok((4, ev_headers_2)));
+        assert_eq!(s.poll_server(), Ok((4, Event::Data)));
+
+        let mut recv_buf = [0; 5];
+        assert_eq!(s.recv_body_server(4, &mut recv_buf), Ok(5));
+
+        assert_eq!(s.poll_server(), Ok((4, ev_trailers)));
+
+        assert_eq!(s.poll_server(), Ok((4, Event::Finished)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+    }
+
+    #[test]
+    /// Tests that we prevent other work while partial response HEADERS are in
+    /// progress.
+    fn headers_blocked_prevents_more_server_work() {
+        let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
+        config.set_initial_max_data(150);
+        config.set_initial_max_stream_data_bidi_local(200);
+        config.set_initial_max_stream_data_bidi_remote(200);
+        config.set_initial_max_stream_data_uni(200);
+        config.set_initial_max_streams_bidi(100);
+        config.set_initial_max_streams_uni(5);
+        config.verify_peer(false);
+
+        let h3_config = Config::new().unwrap();
+
+        let mut s = Session::with_configs(&mut config, &h3_config).unwrap();
+
+        s.handshake().unwrap();
+
+        let req = vec![
+            Header::new(b":method", b"GET"),
+            Header::new(b":scheme", b"https"),
+            Header::new(b":authority", b"quic.tech"),
+            Header::new(b":path", b"/test"),
+        ];
+
+        let ev_headers = Event::Headers {
+            list: req.clone(),
+            more_frames: false,
+        };
+
+        assert_eq!(
+            s.client.send_request(&mut s.pipe.client, &req, true),
+            Ok((0, true))
+        );
+        assert_eq!(
+            s.client.send_request(&mut s.pipe.client, &req, true),
+            Ok((4, true))
+        );
+        s.advance().ok();
+
+        assert_eq!(s.poll_server(), Ok((0, ev_headers.clone())));
+        assert_eq!(s.poll_server(), Ok((0, Event::Finished)));
+        assert_eq!(s.poll_server(), Ok((4, ev_headers)));
+        assert_eq!(s.poll_server(), Ok((4, Event::Finished)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        let info_resp = vec![
+            Header::new(b":status", b"103"),
+            Header::new(b"link", b"<https://example1.com>; rel=\"preconnect\""),
+        ];
+
+        let resp = vec![
+            Header::new(b":status", b"200"),
+            Header::new(b"server", b"quiche-test"),
+        ];
+
+        assert_eq!(
+            s.server.send_response(
+                &mut s.pipe.server,
+                0,
+                &info_resp.clone(),
+                false
+            ),
+            Ok(())
+        );
+
+        assert_eq!(
+            s.server.send_response(
+                &mut s.pipe.server,
+                4,
+                &info_resp.clone(),
+                false
+            ),
+            Err(Error::PartialHeader)
+        );
+
+        // Attempting to send another informational response fails
+        assert_eq!(
+            s.server.send_additional_headers(
+                &mut s.pipe.server,
+                4,
+                &info_resp.clone(),
+                false,
+                false,
+            ),
+            Err(Error::FrameUnexpected)
+        );
+
+        // Attempting to send final response headers fails
+        assert_eq!(
+            s.server.send_additional_headers(
+                &mut s.pipe.server,
+                4,
+                &resp.clone(),
+                false,
+                false,
+            ),
+            Err(Error::FrameUnexpected)
+        );
+
+        // Attempting to send response body fails
+        assert_eq!(
+            s.server.send_body(&mut s.pipe.server, 4, b"hello", true),
+            Err(Error::FrameUnexpected),
+        );
+
+        s.advance().ok();
+
+        let ev_info_headers = Event::Headers {
+            list: info_resp.clone(),
+            more_frames: true,
+        };
+
+        assert_eq!(s.poll_client(), Ok((0, ev_info_headers.clone())));
+        assert_eq!(s.poll_client(), Err(Error::Done));
+
+        s.advance().ok();
+
+        assert_eq!(s.pipe.server.stream_writable_next(), Some(3));
+        assert_eq!(s.pipe.server.stream_writable_next(), Some(7));
+        assert_eq!(s.pipe.server.stream_writable_next(), Some(11));
+        assert_eq!(s.pipe.server.stream_writable_next(), Some(0));
+        assert_eq!(s.pipe.server.stream_writable_next(), Some(4));
+        assert_eq!(s.pipe.server.stream_writable_next(), None);
+
+        // The client has given back flow control credits but other actions still
+        // fail until parital headers are completed.
+        assert_eq!(
+            s.server.send_additional_headers(
+                &mut s.pipe.server,
+                4,
+                &info_resp.clone(),
+                false,
+                false,
+            ),
+            Err(Error::FrameUnexpected)
+        );
+
+        assert_eq!(
+            s.server.send_additional_headers(
+                &mut s.pipe.server,
+                4,
+                &resp.clone(),
+                false,
+                false,
+            ),
+            Err(Error::FrameUnexpected)
+        );
+
+        assert_eq!(
+            s.server.send_body(&mut s.pipe.server, 4, b"hello", true),
+            Err(Error::FrameUnexpected),
+        );
+
+        assert_eq!(
+            s.server.continue_partial_headers(&mut s.pipe.server, 4),
+            Ok(())
+        );
+
+        s.advance().ok();
+
+        assert_eq!(s.pipe.server.stream_writable_next(), Some(4));
+        assert_eq!(s.pipe.server.stream_writable_next(), None);
+
+        assert_eq!(s.poll_client(), Ok((4, ev_info_headers.clone())));
+        assert_eq!(s.poll_client(), Err(Error::Done));
+
+        // Send second informational response103 now
+        assert_eq!(
+            s.server.send_additional_headers(
+                &mut s.pipe.server,
+                4,
+                &info_resp.clone(),
+                false,
+                false,
+            ),
+            Ok(())
+        );
+
+        s.advance().ok();
+
+        assert_eq!(s.poll_client(), Ok((4, ev_info_headers)));
+        assert_eq!(s.poll_client(), Err(Error::Done));
+
+        s.advance().ok();
+
+        // Now final headers and body
+        assert_eq!(
+            s.server.send_additional_headers(
+                &mut s.pipe.server,
+                4,
+                &resp.clone(),
+                false,
+                false,
+            ),
+            Ok(())
+        );
+
+        assert_eq!(
+            s.server.send_body(&mut s.pipe.server, 4, b"hello", true),
+            Ok(5),
+        );
+
+        s.advance().ok();
+
+        let ev_headers = Event::Headers {
+            list: resp,
+            more_frames: true,
+        };
+
+        assert_eq!(s.poll_client(), Ok((4, ev_headers)));
+        assert_eq!(s.poll_client(), Ok((4, Event::Data)));
+        assert_eq!(s.poll_client(), Err(Error::Done));
     }
 
     #[test]
@@ -6173,7 +6705,7 @@ mod tests {
 
         assert_eq!(
             s.client.send_request(&mut s.pipe.client, &req, false),
-            Ok(0)
+            Ok((0, true))
         );
 
         assert_eq!(
@@ -6953,7 +7485,7 @@ mod tests {
         let trailers = vec![Header::new(b"hello", b"world")];
 
         s.client
-            .send_headers(&mut s.pipe.client, r1_id, &trailers, true)
+            .send_headers(&mut s.pipe.client, r1_id, &trailers, true, true)
             .unwrap();
 
         let r1_ev_trailers = Event::Headers {
@@ -6974,7 +7506,7 @@ mod tests {
         let r2_body = s.send_body_client(r2_id, false).unwrap();
 
         s.client
-            .send_headers(&mut s.pipe.client, r2_id, &trailers, false)
+            .send_headers(&mut s.pipe.client, r2_id, &trailers, true, false)
             .unwrap();
 
         let r2_ev_trailers = Event::Headers {

--- a/quiche/src/h3/stream.rs
+++ b/quiche/src/h3/stream.rs
@@ -165,11 +165,25 @@ pub struct Stream {
     /// Whether a DATA frame has been received.
     data_received: bool,
 
+    /// Whether a trailing HEADER field is in flight.
+    trailers_in_flight: bool,
+
     /// Whether a trailing HEADER field has been sent.
     trailers_sent: bool,
 
     /// Whether a trailing HEADER field has been received.
     trailers_received: bool,
+
+    /// Tracking for outgoing frame header.
+    pub outgoing_frame_header: Vec<u8>,
+    pub outgoing_frame_header_off: usize,
+
+    /// Tracking for outgoing frame payload.
+    pub outgoing_frame_payload: Vec<u8>,
+    pub outgoing_frame_payload_off: usize,
+
+    /// Tracking for outgoing frame fin status.
+    pub fin_after_outgoing_frame: bool,
 }
 
 impl Stream {
@@ -215,10 +229,21 @@ impl Stream {
 
             data_received: false,
 
+            trailers_in_flight: false,
             trailers_sent: false,
             trailers_received: false,
+
+            outgoing_frame_header: vec![],
+            outgoing_frame_header_off: 0,
+
+            outgoing_frame_payload: vec![],
+            outgoing_frame_payload_off: 0,
+
+            fin_after_outgoing_frame: false,
         }
     }
+
+    // pub partial
 
     pub fn ty(&self) -> Option<Type> {
         self.ty
@@ -521,7 +546,16 @@ impl Stream {
         self.headers_received_count
     }
 
+    pub fn mark_trailers_in_flight(&mut self) {
+        self.trailers_in_flight = true;
+    }
+
+    pub fn trailers_trailers_in_flight(&self) -> bool {
+        self.trailers_in_flight
+    }
+
     pub fn mark_trailers_sent(&mut self) {
+        self.trailers_in_flight = true;
         self.trailers_sent = true;
     }
 

--- a/tokio-quiche/src/http3/driver/client.rs
+++ b/tokio-quiche/src/http3/driver/client.rs
@@ -152,7 +152,8 @@ impl ClientHooks {
         let body_finished = request.body_writer.is_none();
 
         // TODO: retry the request if the error is not fatal
-        let stream_id = driver.conn_mut()?.send_request(
+        // TODO: take note and use _hdrs_fully_sent for retries
+        let (stream_id, _hdrs_fully_sent) = driver.conn_mut()?.send_request(
             qconn,
             &request.headers,
             body_finished,

--- a/tools/http3_test/src/lib.rs
+++ b/tools/http3_test/src/lib.rs
@@ -467,7 +467,7 @@ impl Http3Test {
 
             info!("sending HTTP request {:?}", req.hdrs);
 
-            let s =
+            let (s, _hdrs_fully_sent) =
                 match h3_conn.send_request(conn, &req.hdrs, req.body.is_none()) {
                     Ok(stream_id) => stream_id,
 


### PR DESCRIPTION
Previously, calls to send_request(), send_response(), send_response_with_priority(),
and send_additional_headers() could fail with a StreamBlocked
error indicating lack of underlying transport capacity. When this
occurred, applications were expected to retry the operation when
the stream was later reported as writable. However, certain
conditions could mean that sufficient capacity was never made
available, effectively permenantly blocking header sends.

The root cause of this problem was the choice to enforce that
a HEADERS frame was always sent (buffered into a quiche stream)
in whole.

This change switches to a streaming send design. Methods that
send headers will produce a HEADERS frame that can be sent
in whole or in part, depending on available capacity. When
a frame is only partly sent, applications are notified and
can resume sending using the new continue_partial_headers()
method, once the stream is writable.

While headers are being streamed, other operations that
would cause an HTTP/3 frame to be sent on the stream are
prevented. HEADERS frames must be sent completly before
other operations are successful.

Applications do not need to manage the partial HEADERS
buffer, this is dealt with inside quiche.
