### PR TITLE
tq: add monitoring of time taken to flush response headers

### DIFF
--- a/tokio-quiche/src/http3/driver/streams.rs
+++ b/tokio-quiche/src/http3/driver/streams.rs
@@ -29,6 +29,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
+use std::time::Instant;
 
 use tokio::sync::mpsc;
 use tokio_util::sync::PollSender;
@@ -52,6 +53,8 @@ pub(crate) struct StreamCtx {
     pub(crate) audit_stats: Arc<H3AuditStats>,
     /// Indicates the stream sent initial headers.
     pub(crate) initial_headers_sent: bool,
+    /// First time that a HEADERS frame was not fully flushed.
+    pub(crate) first_full_headers_flush_fail_time: Option<Instant>,
     /// Indicates the stream received fin. No more data will be received.
     pub(crate) fin_recv: bool,
     /// Indicates the stream sent fin. No more data will be sent.
@@ -77,6 +80,7 @@ impl StreamCtx {
             audit_stats: Arc::new(H3AuditStats::new(stream_id)),
 
             initial_headers_sent: false,
+            first_full_headers_flush_fail_time: None,
 
             fin_recv: false,
             fin_sent: false,


### PR DESCRIPTION
Sending headers in quiche means buffering from the application
layer into quiche. It is not always possible to do this due to
capacity at any moment in time.

Tokio-quiche currently sends response headers by processing the
writable frame queue (process_write_frame()) and acting on an
OutboundFrame::Headers. This supports informational headers,
final headers, and trailing headers. Each type might fail,
which results in leaving the OutboundFrame on the queue to be
retried later.

This change adds some time tracking to each stream. If the first
attempt to send headers fails, the time is marked. On completion,
a duration is calculated and the stream's aggregate flushing
time is incremented. This ensures retrying of any/all response
messages is accounted for.