### PR TITLE
PMTUD Fixes

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -5162,13 +5162,6 @@ impl<F: BufFactory> Connection<F> {
             self.ack_eliciting_sent = true;
         }
 
-        let active_path = self.paths.get_active_mut()?;
-        if let Some(pmtud) = active_path.pmtud.as_mut() {
-            active_path
-                .recovery
-                .pmtud_update_max_datagram_size(pmtud.get_current_mtu());
-        }
-
         Ok((pkt_type, written))
     }
 

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -382,7 +382,6 @@ impl Path {
         };
 
         (hs_confirmed && hs_done) &&
-            pmtud.get_probe_size() > pmtud.get_current_mtu() &&
             self.recovery.cwnd_available() > pmtud.get_probe_size() &&
             out_len >= pmtud.get_probe_size() &&
             pmtud.should_probe() &&


### PR DESCRIPTION
Two small fixes

1. No longer update max datagram size from PMTUD on every sent packet. This was unnecessary to begin with but not harmful in most cases, however, in some cases this sets the max datagram size to 1200 if there wasn't a successful probe which can interfere with the PMTUD process.

2. Remove a condition on when PMTUD probing should happen as pmtud.should_probe() handles this and the current condition blocks revalidation of PMTUD from occurring.