### PR TITLE
h3i: Add else branch to wait_for_data in async client

### DIFF
--- a/h3i/src/client/async_client.rs
+++ b/h3i/src/client/async_client.rs
@@ -401,6 +401,7 @@ impl ApplicationOverQuic for H3iDriver {
             _ = sleep_until(self.next_fire_time), if waiting => {
                 log::debug!("h3i: releasing wait timer");
             }
+            else => {}
         }
 
         Ok(())


### PR DESCRIPTION
This prevents panics in cases where work_loop has to continue to iterate even after seeing all CloseTriggerFrames.