### PR TITLE
Revert "tokio-quiche: close connection when H3Event receiver closes"

### DIFF
--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -1102,11 +1102,6 @@ impl<H: DriverHooks> ApplicationOverQuic for H3Driver<H> {
             Some(dgram) = self.dgram_recv.recv() => self.dgram_ready(qconn, dgram),
             Some(cmd) = self.cmd_recv.recv() => H::conn_command(self, qconn, cmd),
             r = self.hooks.wait_for_action(qconn), if H::has_wait_action(self) => r,
-            _ = self.h3_event_sender.closed() => {
-                let _ = qconn.close(true, quiche::h3::WireErrorCode::NoError as u64, &[]);
-                // Allow the IOW to continue until quiche reports the connection closed.
-                Ok(())
-            }
         }?;
 
         // Make sure controller is not starved, but also not prioritized in the


### PR DESCRIPTION
This reverts commit bc31516462ec73035bab26641f3205dfad36ff1c.

It looks like this commit can cause issues with connections that use tunneling to communicate directly with the IOW, out-of-band with the Server. Since we need to unblock some feature work, let's just revert for now.