### PR TITLE
fix: connection flow control updates with  STOP_SENDING and RESET_STREAM

### DIFF
--- a/quiche/src/flowcontrol.rs
+++ b/quiche/src/flowcontrol.rs
@@ -77,6 +77,12 @@ impl FlowControl {
         self.max_data
     }
 
+    /// Returns the consumed bytes by the receiver.
+    #[cfg(test)]
+    pub fn consumed(&self) -> u64 {
+        self.consumed
+    }
+
     /// Update consumed bytes.
     pub fn add_consumed(&mut self, consumed: u64) {
         self.consumed += consumed;


### PR DESCRIPTION
This fixes issues in quiche, where quiche does not properly update connection level flow control when sending STOP_SENDING or receiving RESET_STREAM frames.

On calling `shutdown_stream(id, Shutdown::Read)`, quiche drops the receive buffer (correct) but it should also mark these bytes as "consumed" to the connection-level flow-control. 

On receiving a `RESET_STREAM` frame, quiche drops the receive buffer but it should also mark these dropped bytes as "consumed" to the connection-level flow-control. 

When Quiche updates "consumed" in the two above cases, it should also check if needs to send a MAX_DATA frame after updating "consumed".

Note, the two added `quiche::h3` tests are not directly related but I started there because I first suspected streams not getting collected. I did add tests to quiche itself that test my changes though.