### PR TITLE
tokio-quiche: Allow either foundations 4 or 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ buffer-pool = { version = "0.1.0", path = "./buffer-pool" }
 crossbeam = { version = "0.8.1", default-features = false }
 datagram-socket = { version = "0.4.0", path = "./datagram-socket" }
 env_logger = "0.10"
-foundations = { version = "5", default-features = false }
+foundations = { version = ">=4,<6", default-features = false }
 futures = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false }
 h3i = { version = "0.5", path = "./h3i" }


### PR DESCRIPTION
None of the breaking changes in foundations 5 affects tokio-quiche's usage of it, so we can allow either in our dependencies.