### PR TITLE
tokio-quiche: better RESET_STREAM and STOP_SENDING handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ publish = false
 
 [workspace.dependencies]
 anyhow = { version = "1" }
+assert_matches = { version = "1" }
 boring = { version = "4.3" }
 buffer-pool = { version = "0.1.0", path = "./buffer-pool" }
 crossbeam = { version = "0.8.1", default-features = false }

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -7193,8 +7193,53 @@ mod tests {
 
         assert_eq!(s.pipe.advance(), Ok(()));
 
-        // Server receives the reset and there are no more readable streams.
+        // The server does *not* attempt to read from the stream,
+        // but polls and receives the reset and there are no more
+        // readable streams.
         assert_eq!(s.poll_server(), Ok((stream, Event::Reset(0))));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+        assert_eq!(s.pipe.server.readable().len(), 0);
+    }
+
+    #[test]
+    fn reset_finished_at_server_with_data_pending_2() {
+        let mut s = Session::new().unwrap();
+        s.handshake().unwrap();
+
+        // Client sends HEADERS and doesn't fin.
+        let (stream, req) = s.send_request(false).unwrap();
+
+        assert!(s.send_body_client(stream, false).is_ok());
+
+        assert_eq!(s.pipe.advance(), Ok(()));
+
+        let ev_headers = Event::Headers {
+            list: req,
+            more_frames: true,
+        };
+
+        // Server receives headers and data...
+        assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_server(), Ok((stream, Event::Data)));
+
+        // ..then Client sends RESET_STREAM.
+        assert_eq!(
+            s.pipe
+                .client
+                .stream_shutdown(stream, crate::Shutdown::Write, 0),
+            Ok(())
+        );
+
+        assert_eq!(s.pipe.advance(), Ok(()));
+
+        // Server reads from the stream and receives the reset while
+        // attempting to read.
+        assert_eq!(
+            s.recv_body_server(stream, &mut [0; 100]),
+            Err(Error::TransportError(crate::Error::StreamReset(0)))
+        );
+
+        // No more events and there are no more readable streams.
         assert_eq!(s.poll_server(), Err(Error::Done));
         assert_eq!(s.pipe.server.readable().len(), 0);
     }

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -74,6 +74,7 @@ triomphe = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 clap = { version = "4.5.40", features = ["derive"] }
 env_logger = { workspace = true }
 h3i = { workspace = true }

--- a/tokio-quiche/src/http3/driver/streams.rs
+++ b/tokio-quiche/src/http3/driver/streams.rs
@@ -55,10 +55,11 @@ pub(crate) struct StreamCtx {
     pub(crate) initial_headers_sent: bool,
     /// First time that a HEADERS frame was not fully flushed.
     pub(crate) first_full_headers_flush_fail_time: Option<Instant>,
-    /// Indicates the stream received fin. No more data will be received.
-    pub(crate) fin_recv: bool,
-    /// Indicates the stream sent fin. No more data will be sent.
-    pub(crate) fin_sent: bool,
+    /// Indicates the stream received fin or reset. No more data will be
+    /// received.
+    pub(crate) fin_or_reset_recv: bool,
+    /// Indicates the stream sent fin or reset. No more data will be sent.
+    pub(crate) fin_or_reset_sent: bool,
     /// The flow ID for proxying datagrams over this stream. If `None`,
     /// the stream has no associated DATAGRAM flow.
     pub(crate) associated_dgram_flow_id: Option<u64>,
@@ -82,8 +83,8 @@ impl StreamCtx {
             initial_headers_sent: false,
             first_full_headers_flush_fail_time: None,
 
-            fin_recv: false,
-            fin_sent: false,
+            fin_or_reset_recv: false,
+            fin_or_reset_sent: false,
 
             associated_dgram_flow_id: None,
         };
@@ -105,6 +106,60 @@ impl StreamCtx {
             stream_id,
             chan: self.recv.take(),
         })
+    }
+
+    /// Handle the case when we received a STOP_SENDING frame. Note, that
+    /// we'll only learn about a STOP_SENDING frame from the write path.
+    /// Also note, that quiche will automatically send a RESET_STREAM frame
+    /// in response when it receives a STOP_SENDING (as recommended by the
+    /// RFC)
+    pub(crate) fn handle_recvd_stop_sending(&mut self, wire_err_code: u64) {
+        debug_assert!(!self.fin_or_reset_sent);
+        // We received a STOP_SENDING frame. This indicates that the
+        // write direction has closed. We still need to continue
+        // reading from the stream until we receive a RESET_FRAME or
+        // `fin`.
+        self.audit_stats
+            .set_recvd_stop_sending_error_code(wire_err_code as i64);
+        self.fin_or_reset_sent = true;
+        // Drop any pending data and close the write side.
+        // We can't accept additional frames
+        self.queued_frame = None;
+        debug_assert!(self.recv.is_some());
+        self.recv = None;
+    }
+
+    pub(crate) fn handle_recvd_reset(&mut self, wire_err_code: u64) {
+        debug_assert!(!self.fin_or_reset_recv);
+        // We received a RESET_STREAM frame, which closes the read direction
+        // but not the write direction. If the peer wants to shut down write,
+        // it must also send STOP_SENDING
+        self.audit_stats
+            .set_recvd_reset_stream_error_code(wire_err_code as i64);
+        self.fin_or_reset_recv = true;
+        self.send = None;
+    }
+
+    pub(crate) fn handle_sent_reset(&mut self, wire_err_code: u64) {
+        debug_assert!(!self.fin_or_reset_sent);
+        self.audit_stats
+            .set_sent_reset_stream_error_code(wire_err_code as i64);
+        self.fin_or_reset_sent = true;
+    }
+
+    pub(crate) fn handle_sent_stop_sending(&mut self, wire_err_code: u64) {
+        debug_assert!(!self.fin_or_reset_recv);
+        self.audit_stats
+            .set_sent_stop_sending_error_code(wire_err_code as i64);
+        // It is ok for us to set the `fin_reset_recv` flag here.  While the peer
+        // must still send a fin or reset_stream with its final size, we don't
+        // need to read it from the stream. Quiche will take care of that.
+        self.fin_or_reset_recv = true;
+        self.send = None;
+    }
+
+    pub(crate) fn both_directions_done(&self) -> bool {
+        self.fin_or_reset_recv && self.fin_or_reset_sent
     }
 }
 

--- a/tokio-quiche/src/http3/driver/test_utils.rs
+++ b/tokio-quiche/src/http3/driver/test_utils.rs
@@ -1,0 +1,401 @@
+use std::time::Instant;
+
+use anyhow::Context;
+use futures::FutureExt as _;
+use quiche::h3;
+use quiche::h3::Header;
+use tokio::sync::mpsc::error::TryRecvError;
+use tokio::sync::oneshot;
+
+use crate::http3::driver::client::ClientHooks;
+use crate::http3::driver::hooks::DriverHooks;
+use crate::http3::driver::server::ServerHooks;
+use crate::http3::driver::ClientH3Event;
+use crate::http3::driver::H3Controller;
+use crate::http3::driver::H3Driver;
+use crate::http3::driver::H3Event;
+use crate::http3::driver::InboundFrame;
+use crate::http3::driver::InboundFrameStream;
+use crate::http3::driver::NewClientRequest;
+use crate::http3::driver::OutboundFrameSender;
+use crate::http3::driver::ServerH3Event;
+use crate::http3::settings::Http3Settings;
+use crate::quic::HandshakeInfo;
+use crate::ApplicationOverQuic as _;
+use quiche::test_utils::Pipe;
+
+pub fn default_quiche_config() -> quiche::Config {
+    let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config.set_application_protos(&[b"h3"]).unwrap();
+    config.set_initial_max_data(1500);
+    config.set_initial_max_stream_data_bidi_local(150);
+    config.set_initial_max_stream_data_bidi_remote(150);
+    config.set_initial_max_stream_data_uni(150);
+    config.set_initial_max_streams_bidi(100);
+    config.set_initial_max_streams_uni(5);
+    config.verify_peer(false);
+    config
+}
+
+pub fn make_request_headers(method: &str) -> Vec<Header> {
+    vec![
+        Header::new(b":method", method.as_bytes()),
+        Header::new(b":scheme", b"https"),
+        Header::new(b":authority", b"quic.tech"),
+        Header::new(b":path", b"/test"),
+    ]
+}
+
+pub fn make_response_headers() -> Vec<Header> {
+    vec![
+        Header::new(b":status", b"200"),
+        Header::new(b"server", b"quiche-test"),
+    ]
+}
+
+/// Helper trait to get the either right `quiche::Connection` for
+/// ourselvers (to use with the `H3Driver`) or our peer (to use
+/// with `quiche::H3::Connection`
+pub trait GetConnectionForHook {
+    fn qconn(pipe: &mut Pipe) -> &mut quiche::Connection;
+    fn peer_qconn(pipe: &mut Pipe) -> &mut quiche::Connection;
+}
+
+impl GetConnectionForHook for ClientHooks {
+    fn qconn(pipe: &mut Pipe) -> &mut quiche::Connection {
+        &mut pipe.client
+    }
+
+    fn peer_qconn(pipe: &mut Pipe) -> &mut quiche::Connection {
+        &mut pipe.server
+    }
+}
+
+impl GetConnectionForHook for ServerHooks {
+    fn qconn(pipe: &mut Pipe) -> &mut quiche::Connection {
+        &mut pipe.server
+    }
+
+    fn peer_qconn(pipe: &mut Pipe) -> &mut quiche::Connection {
+        &mut pipe.client
+    }
+}
+
+/// Similar to `quiche::test_utils::Pipe`, a wrapper with helper functions
+/// for a client and server endpoint. One endpoint is driven by an H3Driver
+/// to allow testing the H3Driver logic. The other endpoint (the peer) is
+/// driven directly by an `quiche::h3::Connection`.
+pub struct DriverTestHelper<H: DriverHooks + GetConnectionForHook> {
+    pub pipe: quiche::test_utils::Pipe,
+    pub driver: H3Driver<H>,
+    pub controller: H3Controller<H>,
+    /// Our peer, not using a driver, just the h3::Connection directly
+    pub peer: h3::Connection,
+}
+
+impl<H: DriverHooks + GetConnectionForHook> DriverTestHelper<H> {
+    pub fn new() -> anyhow::Result<Self> {
+        Self::with_pipe_and_http3_settings(
+            Pipe::with_config(&mut default_quiche_config())?,
+            Http3Settings::default(),
+        )
+    }
+
+    pub fn with_pipe(pipe: Pipe) -> anyhow::Result<Self> {
+        Self::with_pipe_and_http3_settings(pipe, Http3Settings::default())
+    }
+
+    pub fn with_pipe_and_http3_settings(
+        mut pipe: Pipe, h3_settings: Http3Settings,
+    ) -> anyhow::Result<Self> {
+        pipe.handshake().context("Failed to handshake pipe")?;
+        let (driver, controller) = H3Driver::<H>::new(h3_settings);
+        let peer = h3::Connection::with_transport(
+            H::peer_qconn(&mut pipe),
+            &h3::Config::new().unwrap(),
+        )
+        .context("create H3 peer connection")?;
+        Ok(Self {
+            pipe,
+            driver,
+            controller,
+            peer,
+        })
+    }
+
+    /// Advance the pipe and run work_loop_iterations.
+    /// TODO: We just run a couple of times to "make sure" all pending work has
+    /// been processed. Ideally, we'd have some feedback from `work_loop_iter()`
+    /// to decide if need to run `advance()` / `work_loop_iter()` instead of
+    /// blindly calling it a couple of time...
+    pub fn advance_and_run_loop(&mut self) -> anyhow::Result<()> {
+        self.pipe.advance()?;
+        self.work_loop_iter()?;
+        self.pipe.advance()?;
+        self.work_loop_iter()?;
+        self.pipe.advance()?;
+        self.work_loop_iter()?;
+        self.pipe.advance()?;
+        Ok(())
+    }
+
+    /// call `on_conn_established()` on the driver and advance to pipe to
+    /// complete the H3 handshake
+    pub fn complete_handshake(&mut self) -> anyhow::Result<()> {
+        self.driver
+            .on_conn_established(
+                H::qconn(&mut self.pipe),
+                &HandshakeInfo::new(Instant::now(), None),
+            )
+            .map_err(anyhow::Error::from_boxed)
+            .context("on_conn_established")?;
+        // advance pipe to complete H3 handshake
+        self.pipe.advance().context("advance pipe")?;
+        self.driver.settings_received_and_forwarded = true;
+        Ok(())
+    }
+
+    /// call `forward_settings()` on the driver. This will enqueue an
+    /// IncomingSettings event for the controller
+    /// deal with IncomingSettings events
+    pub fn forward_settings(&mut self) -> anyhow::Result<()> {
+        Ok(self.driver.forward_settings()?)
+    }
+
+    /// Run one iteration of the work loop *without* advancing the pipe
+    pub fn work_loop_iter(&mut self) -> anyhow::Result<()> {
+        let qconn = H::qconn(&mut self.pipe);
+        self.driver
+            .process_reads(qconn)
+            .map_err(anyhow::Error::from_boxed)
+            .context("process_reads")?;
+        self.driver
+            .process_writes(qconn)
+            .map_err(anyhow::Error::from_boxed)
+            .context("process_writes")?;
+        tokio::task::unconstrained(self.driver.wait_for_data(qconn))
+            .now_or_never()
+            .unwrap_or(Ok(()))
+            .map_err(anyhow::Error::from_boxed)
+            .context("wait_for_data")?;
+        self.forward_settings()?;
+
+        Ok(())
+    }
+
+    /// process any commands the driver might have received, returns
+    /// the nubmer of commands processed
+    /// Note that commands will also be processed by
+    /// [`Self::work_loop_iter()`], but this function allows one to
+    /// only process the events.
+    pub fn process_commands(&mut self) -> anyhow::Result<u64> {
+        let mut iter = 0;
+        while let Ok(cmd) = self.driver.cmd_recv.try_recv() {
+            H::conn_command(&mut self.driver, H::qconn(&mut self.pipe), cmd)
+                .with_context(|| format!("H::conn_command iter={}", iter))?;
+            iter += 1;
+        }
+        Ok(iter)
+    }
+
+    /// Call [`h3::Connection::poll()`] on the peer
+    fn poll_peer(&mut self) -> h3::Result<(u64, h3::Event)> {
+        self.peer.poll(H::peer_qconn(&mut self.pipe))
+    }
+
+    /// Send a body from the peer
+    fn peer_send_body(
+        &mut self, stream_id: u64, body: &[u8], fin: bool,
+    ) -> h3::Result<usize> {
+        self.peer
+            .send_body(H::peer_qconn(&mut self.pipe), stream_id, body, fin)
+    }
+
+    /// Call `h3::Connection::recv_body()` on the peer and read at most
+    /// `max_read` bytes into a Vector, returns the Vec.
+    fn peer_recv_body_vec(
+        &mut self, stream_id: u64, max_read: usize,
+    ) -> h3::Result<Vec<u8>> {
+        let mut buf = vec![0; max_read];
+
+        let written = self.peer.recv_body(
+            H::peer_qconn(&mut self.pipe),
+            stream_id,
+            &mut buf,
+        )?;
+        buf.truncate(written);
+        Ok(buf)
+    }
+
+    // Repeately calls try_recv() on the given receiver and work_loop_iter()
+    // until the receiver returns an empty or disconnected.
+    // Merges all received parts into a single Vec.
+    pub fn driver_try_recv_body(
+        &mut self, recv: &mut InboundFrameStream,
+    ) -> (Vec<u8>, bool, TryRecvError) {
+        let mut buf = Vec::new();
+        let mut had_fin = false;
+        loop {
+            match recv.try_recv() {
+                Ok(InboundFrame::Body(pooled, fin)) => {
+                    if had_fin {
+                        panic!("Received data after fin");
+                    }
+                    buf.extend_from_slice(&pooled);
+                    had_fin = fin;
+                },
+                Ok(InboundFrame::Datagram(..)) => {
+                    panic!("Unexepected InboundFrame::Datagram");
+                },
+                Err(err) => return (buf, had_fin, err),
+            }
+            self.work_loop_iter().unwrap();
+        }
+    }
+}
+
+impl DriverTestHelper<ClientHooks> {
+    /// Sends a new client request, by enqueuing a `NewClientRequest`
+    /// command, processing it, and receiving the `NewOutboundRequest` from
+    /// the controllers. It returns `stream_id`.
+    ///
+    /// This function assumes that there are no commands or events queued
+    /// when called.
+    pub fn driver_send_request(
+        &mut self, headers: Vec<Header>, fin: bool,
+    ) -> anyhow::Result<u64> {
+        let body_writer_oneshot_tx = if fin {
+            None
+        } else {
+            let (tx, _) = oneshot::channel();
+            Some(tx)
+        };
+        self.driver_enqueue_request(1, headers, body_writer_oneshot_tx);
+        anyhow::ensure!(
+            self.process_commands()? == 1,
+            "More than one command processed"
+        );
+        match self.driver_recv_client_event() {
+            Ok(ClientH3Event::NewOutboundRequest {
+                stream_id,
+                request_id: 1,
+            }) => Ok(stream_id),
+            other => Err(anyhow::anyhow!("Unexpected result: {other:?}")),
+        }
+    }
+
+    /// enqueue a `NewClientRequest` command
+    pub fn driver_enqueue_request(
+        &mut self, request_id: u64, headers: Vec<Header>,
+        body_writer: Option<oneshot::Sender<OutboundFrameSender>>,
+    ) {
+        self.controller
+            .request_sender()
+            .send(NewClientRequest {
+                request_id,
+                headers: headers.clone(),
+                body_writer,
+            })
+            .unwrap();
+    }
+
+    /// Try to receive an event from the controller, returns an error if
+    /// the receive fails
+    pub fn driver_recv_core_event(&mut self) -> anyhow::Result<H3Event> {
+        match self.controller.event_receiver_mut().try_recv()? {
+            ClientH3Event::Core(h3_event) => Ok(h3_event),
+            ev => Err(anyhow::anyhow!("Not a core event: {ev:?}")),
+        }
+    }
+
+    /// Try to receive a `ClientH3Event` from the controller's event receiver
+    pub fn driver_recv_client_event(&mut self) -> anyhow::Result<ClientH3Event> {
+        Ok(self.controller.event_receiver_mut().try_recv()?)
+    }
+
+    /// Sends a response from server with default headers.
+    ///
+    /// On success it returns the headers.
+    pub fn peer_server_send_response(
+        &mut self, stream: u64, fin: bool,
+    ) -> h3::Result<Vec<Header>> {
+        let resp = vec![
+            Header::new(b":status", b"200"),
+            Header::new(b"server", b"quiche-test"),
+        ];
+
+        self.peer
+            .send_response(&mut self.pipe.server, stream, &resp, fin)?;
+
+        Ok(resp)
+    }
+
+    pub fn peer_server_poll(&mut self) -> h3::Result<(u64, h3::Event)> {
+        self.poll_peer()
+    }
+
+    /// Send a body from the server
+    pub fn peer_server_send_body(
+        &mut self, stream_id: u64, body: &[u8], fin: bool,
+    ) -> h3::Result<usize> {
+        self.peer_send_body(stream_id, body, fin)
+    }
+
+    /// Receive at most `max_read` body bytes and return the read
+    /// bytes as a `Vec`
+    pub fn peer_server_recv_body_vec(
+        &mut self, stream_id: u64, max_read: usize,
+    ) -> h3::Result<Vec<u8>> {
+        self.peer_recv_body_vec(stream_id, max_read)
+    }
+}
+
+impl DriverTestHelper<ServerHooks> {
+    /// Sends a new client request
+    pub fn peer_client_send_request(
+        &mut self, headers: Vec<Header>, fin: bool,
+    ) -> anyhow::Result<u64> {
+        Ok(self
+            .peer
+            .send_request(&mut self.pipe.client, &headers, fin)?)
+    }
+
+    /// Try to receive an event from the controller, returns an error if
+    /// the receive fails
+    pub fn driver_recv_core_event(&mut self) -> anyhow::Result<H3Event> {
+        match self.controller.event_receiver_mut().try_recv()? {
+            ServerH3Event::Core(h3_event) => Ok(h3_event),
+            ev => Err(anyhow::anyhow!("Not a core event: {ev:?}")),
+        }
+    }
+
+    /// Try to receive a `ServerH3Event` from the controller's event receiver
+    pub fn driver_recv_server_event(&mut self) -> anyhow::Result<ServerH3Event> {
+        Ok(self.controller.event_receiver_mut().try_recv()?)
+    }
+
+    pub fn peer_client_poll(&mut self) -> h3::Result<(u64, h3::Event)> {
+        self.poll_peer()
+    }
+
+    /// Send a body from the server
+    pub fn peer_client_send_body(
+        &mut self, stream_id: u64, body: &[u8], fin: bool,
+    ) -> h3::Result<usize> {
+        self.peer_send_body(stream_id, body, fin)
+    }
+
+    /// Receive at most `max_read` body bytes and return the read
+    /// bytes as a `Vec`
+    pub fn peer_client_recv_body_vec(
+        &mut self, stream_id: u64, max_read: usize,
+    ) -> h3::Result<Vec<u8>> {
+        self.peer_recv_body_vec(stream_id, max_read)
+    }
+}

--- a/tokio-quiche/src/http3/driver/tests.rs
+++ b/tokio-quiche/src/http3/driver/tests.rs
@@ -1,0 +1,1300 @@
+use crate::http3::driver::client::ClientHooks;
+use crate::http3::driver::server::ServerHooks;
+use assert_matches::assert_matches;
+
+use super::test_utils::*;
+use super::*;
+
+/// Tests that use an H3Driver for the client side. We mostly focus on testing
+/// the driver's handling of stream state, and data, rather than H3 semantics.
+/// Note that most of these tests could have just as easily been written for
+/// the server side.
+mod client_side_driver {
+    use super::*;
+
+    #[test]
+    fn client_fin_before_server_body() {
+        let mut helper = DriverTestHelper::<ClientHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a request
+        let stream_id = helper
+            .driver_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_server_poll().unwrap(),
+            (0, h3::Event::Headers { .. })
+        );
+        helper.peer_server_send_response(0, false).unwrap();
+
+        helper.advance_and_run_loop().unwrap();
+
+        // Client receives response headers
+        let resp = assert_matches!(
+            helper.driver_recv_core_event().unwrap(),
+            H3Event::IncomingHeaders(headers) => { headers }
+        );
+        assert_eq!(resp.stream_id, stream_id);
+        assert!(!resp.read_fin);
+        let to_server = resp.send.get_ref().unwrap().clone();
+        let mut from_server = resp.recv;
+        // client sends body
+        to_server
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[1; 5]),
+                false,
+            ))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // server receives client body
+        assert_eq!(helper.peer_server_poll(), Ok((0, h3::Event::Data)));
+        assert_eq!(helper.peer_server_poll(), Err(h3::Error::Done));
+        assert_eq!(helper.peer_server_recv_body_vec(0, 1024), Ok(vec![1; 5]));
+
+        // client sends fin, server sends body and fin
+        to_server
+            .try_send(OutboundFrame::Body(BufFactory::get_empty_buf(), true))
+            .unwrap();
+        helper.peer_server_send_body(0, &[2; 10], true).unwrap();
+
+        // Server reads fin
+        helper.advance_and_run_loop().unwrap();
+        // TODO: the server sees an h3::Event::Data, but it's for an empty buffer.
+        // Ideally, it wouldn't do that.
+        assert_eq!(helper.peer_server_poll(), Ok((0, h3::Event::Data)));
+        // No data to be read
+        assert_eq!(
+            helper.peer_server_recv_body_vec(0, 1024),
+            Err(h3::Error::Done)
+        );
+        assert_eq!(helper.peer_server_poll(), Ok((0, h3::Event::Finished)));
+        assert_eq!(helper.peer_server_poll(), Err(h3::Error::Done));
+        helper.advance_and_run_loop().unwrap();
+
+        // client receives the server body
+        assert_matches!(from_server.try_recv(), Ok(InboundFrame::Body(buf, fin)) => {
+            assert_eq!(buf.into_inner().into_vec(), vec![2; 10]);
+            // TODO: it would be nice if we could receive the fin here, but that's not
+            // how quiche::h3 works. Instead we need another receive call on the channel
+            assert!(!fin);
+        });
+        helper.work_loop_iter().unwrap();
+
+        // FIXME: This is an edge case. We should not see a `Disconnected` error
+        // here. The `from_server` / `InboudFrame` channel is set to 1 in tests.
+        // What happens, is the driver reads the previous body frame, then it
+        // sees an `Event::Finished` and calls `process_h3_fin`, which sets
+        // `ctx.fin_recv`. Then it processes the pending write that sends the fin
+        // from client to server. The driver now sees both ctx.fin_read &&
+        // ctx.fin_sent and drops the context and thus the channel. Application
+        // code (H3Body) is not affected by -- it treats a disconnected channel
+        // like receiving a fin. It's a different question if it should treat it
+        // as such
+
+        // assert_matches!(from_server.try_recv(), Ok(InboundFrame::Body(buf,
+        // fin)) => {
+        //    assert_eq!(buf.into_inner().into_vec().len(), 0);
+        //    assert!(fin);
+        //});
+        assert_matches!(from_server.try_recv(), Err(TryRecvError::Disconnected));
+        assert_eq!(helper.driver.stream_map.len(), 0);
+    }
+    /// Test that dropping the OutboundFrame channel causes the driver to
+    /// send a RESET_STREAM frame to the peer.
+    #[test]
+    fn client_send_reset_stream_when_outbound_frame_channel_drops() {
+        let mut helper = DriverTestHelper::<ClientHooks>::new().unwrap();
+        const REQUEST_CANCELED_ERR: u64 =
+            h3::WireErrorCode::RequestCancelled as u64;
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // The client uses H3Driver
+        // client sends a request
+        let stream_id = helper
+            .driver_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_server_poll().unwrap(),
+            (0, h3::Event::Headers { .. })
+        );
+        helper.peer_server_send_response(0, false).unwrap();
+
+        helper.advance_and_run_loop().unwrap();
+
+        // Client receives response headers
+        let resp = assert_matches!(
+            helper.driver_recv_core_event().unwrap(),
+            H3Event::IncomingHeaders(headers) => { headers }
+        );
+        assert_eq!(resp.stream_id, stream_id);
+        assert!(!resp.read_fin);
+        // the stream is waiting on writes
+        assert_eq!(helper.driver.waiting_streams.len(), 1);
+        // take the InboundFrame receiver and stats
+        let mut from_server = resp.recv;
+        let audit_stats = resp.h3_audit_stats.clone();
+        // ... and drop the outbound frame
+        drop(resp.send);
+
+        helper.advance_and_run_loop().unwrap();
+
+        // server receives the reset
+        assert_eq!(
+            helper.peer_server_poll(),
+            Ok((0, h3::Event::Reset(REQUEST_CANCELED_ERR)))
+        );
+        assert_eq!(helper.peer_server_poll(), Err(h3::Error::Done));
+
+        helper.peer_server_send_body(0, &[2; 10], true).unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client receives the server body
+        assert_matches!(from_server.try_recv(), Ok(InboundFrame::Body(buf, fin)) => {
+            assert_eq!(buf.into_inner().into_vec(), vec![2; 10]);
+            // TODO: it would be nice if we could receive the fin here, but that's not
+            // how quiche::h3 works. Instead we need another receive call on the channel
+            assert!(!fin);
+        });
+        helper.work_loop_iter().unwrap();
+        assert_eq!(helper.driver.stream_map.len(), 0);
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), -1);
+        assert_eq!(
+            audit_stats.sent_reset_stream_error_code(),
+            REQUEST_CANCELED_ERR as i64
+        );
+        assert_eq!(audit_stats.sent_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::None);
+        assert_eq!(audit_stats.downstream_bytes_recvd(), 10);
+        assert_eq!(audit_stats.downstream_bytes_sent(), 0);
+    }
+
+    /// Test that dropping the OutboundFrame channel causes the driver to
+    /// send a RESET_STREAM frame to the peer.
+    #[test]
+    fn client_send_reset_stream_when_outbound_frame_channel_drops_2() {
+        let mut helper = DriverTestHelper::<ClientHooks>::new().unwrap();
+        const REQUEST_CANCELED_ERR: u64 =
+            h3::WireErrorCode::RequestCancelled as u64;
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // The client uses H3Driver
+        // client sends a request
+        let stream_id = helper
+            .driver_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers, body, and fin
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_server_poll().unwrap(),
+            (0, h3::Event::Headers { .. })
+        );
+        helper.peer_server_send_response(0, false).unwrap();
+        helper.peer_server_send_body(0, &[2; 10], true).unwrap();
+
+        helper.advance_and_run_loop().unwrap();
+
+        // Client receives response headers
+        let mut resp = assert_matches!(
+            helper.driver_recv_core_event().unwrap(),
+            H3Event::IncomingHeaders(headers) => { headers }
+        );
+        assert_eq!(resp.stream_id, stream_id);
+        assert!(!resp.read_fin);
+        // take the InboundFrame receiver and stats
+        let mut from_server = resp.recv;
+        let audit_stats = resp.h3_audit_stats.clone();
+        let (body, fin, _) = helper.driver_try_recv_body(&mut from_server);
+        assert_eq!(body, vec![2; 10]);
+        assert!(fin);
+        helper.advance_and_run_loop().unwrap();
+
+        // clsoe the channel.
+        resp.send.close();
+
+        helper.advance_and_run_loop().unwrap();
+
+        // server receives the reset
+        assert_eq!(
+            helper.peer_server_poll(),
+            Ok((0, h3::Event::Reset(REQUEST_CANCELED_ERR)))
+        );
+        assert_eq!(helper.peer_server_poll(), Err(h3::Error::Done));
+
+        helper.advance_and_run_loop().unwrap();
+
+        assert_eq!(helper.driver.stream_map.len(), 0);
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), -1);
+        assert_eq!(
+            audit_stats.sent_reset_stream_error_code(),
+            REQUEST_CANCELED_ERR as i64
+        );
+        assert_eq!(audit_stats.sent_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::None);
+        assert_eq!(audit_stats.downstream_bytes_recvd(), 10);
+        assert_eq!(audit_stats.downstream_bytes_sent(), 0);
+    }
+
+    /// Send data until the stream is no longer writable, then drop the
+    /// OutboundFrame channel to trigger a RESET_STREAM
+    #[test]
+    fn client_send_reset_stream_with_full_stream() {
+        let mut config = default_quiche_config();
+        config.set_initial_max_stream_data_bidi_local(30);
+        config.set_initial_max_stream_data_bidi_remote(30);
+        let mut helper = DriverTestHelper::<ClientHooks>::with_pipe(
+            quiche::test_utils::Pipe::with_config(&mut config).unwrap(),
+        )
+        .unwrap();
+        const REQUEST_CANCELED_ERR: u64 =
+            h3::WireErrorCode::RequestCancelled as u64;
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // The client uses H3Driver
+        // client sends a request
+        let stream_id = helper
+            .driver_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers, and fin
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_server_poll().unwrap(),
+            (0, h3::Event::Headers { .. })
+        );
+        helper.peer_server_send_response(0, true).unwrap();
+
+        helper.advance_and_run_loop().unwrap();
+
+        // Client receives response headers
+        let resp = assert_matches!(
+            helper.driver_recv_core_event().unwrap(),
+            H3Event::IncomingHeaders(headers) => { headers }
+        );
+        assert_eq!(resp.stream_id, stream_id);
+        assert!(resp.read_fin);
+        let audit_stats = resp.h3_audit_stats.clone();
+        // send a body the to server, but not enough flow control for the full
+        // body
+        resp.send
+            .get_ref()
+            .unwrap()
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[23; 50]),
+                false,
+            ))
+            .unwrap();
+        assert_eq!(helper.driver.waiting_streams.len(), 1);
+        // run `work_loop_iter()` to write the body into quiche
+        helper.work_loop_iter().unwrap();
+        // make sure we couldn't write the full body
+        assert!(audit_stats.downstream_bytes_sent() < 50);
+        let written = audit_stats.downstream_bytes_sent();
+        // advance the pipe, the stream is writable again, but
+        // don't advance the work_loop yet.
+        helper.pipe.advance().unwrap();
+        while helper.peer_server_poll().is_ok() {}
+        assert_eq!(
+            helper.peer_server_recv_body_vec(0, 1024).unwrap().len(),
+            written as usize
+        );
+        helper.pipe.advance().unwrap();
+        assert_eq!(helper.driver.waiting_streams.len(), 0);
+        assert!(helper.driver.stream_map.get(&0).unwrap().recv.is_some());
+        assert!(helper
+            .driver
+            .stream_map
+            .get(&0)
+            .unwrap()
+            .queued_frame
+            .is_some());
+
+        // clsoe the channel.
+        drop(resp.send);
+
+        helper.work_loop_iter().unwrap();
+        assert_eq!(
+            audit_stats.sent_reset_stream_error_code(),
+            REQUEST_CANCELED_ERR as i64
+        );
+        helper.advance_and_run_loop().unwrap();
+
+        // server receives the reset
+        assert_eq!(
+            helper.peer_server_poll(),
+            Ok((0, h3::Event::Reset(REQUEST_CANCELED_ERR)))
+        );
+        assert_eq!(helper.peer_server_poll(), Err(h3::Error::Done));
+
+        helper.advance_and_run_loop().unwrap();
+
+        assert_eq!(helper.driver.stream_map.len(), 0);
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), -1);
+        assert_eq!(
+            audit_stats.sent_reset_stream_error_code(),
+            REQUEST_CANCELED_ERR as i64
+        );
+        assert_eq!(audit_stats.sent_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::None);
+    }
+
+    /// Test that dropping the OutboundFrame channel after we've send a fin
+    /// is a no-op.
+    #[test]
+    fn client_drop_outbound_frame_channel_after_fin_no_reset() {
+        let mut helper = DriverTestHelper::<ClientHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // The client uses H3Driver
+        // client sends a request
+        let stream_id = helper
+            .driver_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers, body, and fin
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_server_poll().unwrap(),
+            (0, h3::Event::Headers { .. })
+        );
+        helper.peer_server_send_response(0, false).unwrap();
+
+        helper.advance_and_run_loop().unwrap();
+
+        // Client receives response headers
+        let mut resp = assert_matches!(
+            helper.driver_recv_core_event().unwrap(),
+            H3Event::IncomingHeaders(headers) => { headers }
+        );
+        assert_eq!(resp.stream_id, stream_id);
+        assert!(!resp.read_fin);
+        // take the InboundFrame receiver and stats
+        let mut from_server = resp.recv;
+        let audit_stats = resp.h3_audit_stats.clone();
+        helper.advance_and_run_loop().unwrap();
+        resp.send
+            .get_ref()
+            .unwrap()
+            .try_send(OutboundFrame::Body(BufFactory::get_empty_buf(), true))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // clsoe the channel.
+        resp.send.close();
+
+        helper.advance_and_run_loop().unwrap();
+        assert_eq!(helper.peer_server_send_body(0, &[42], true), Ok(1));
+        helper.advance_and_run_loop().unwrap();
+
+        // server receives the fin
+        assert_eq!(helper.peer_server_poll(), Ok((0, h3::Event::Data)));
+        assert_eq!(
+            helper.peer_server_recv_body_vec(0, 1024),
+            Err(h3::Error::Done)
+        );
+        assert_eq!(helper.peer_server_poll(), Ok((0, h3::Event::Finished)));
+        assert_eq!(helper.peer_server_poll(), Err(h3::Error::Done));
+
+        helper.advance_and_run_loop().unwrap();
+
+        // client receives the body and fin
+        let (body, fin, _err) = helper.driver_try_recv_body(&mut from_server);
+        assert_eq!(body, &[42]);
+        assert!(fin);
+
+        assert_eq!(helper.driver.stream_map.len(), 0);
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.sent_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.sent_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.downstream_bytes_recvd(), 1);
+        assert_eq!(audit_stats.downstream_bytes_sent(), 0);
+    }
+}
+
+/// Tests that use an H3Driver for the server side. We mostly focus on testing
+/// the driver's handling of stream state, and data, rather than H3 semantics.
+/// Note that most of these tests could have just as easily been written for
+/// the client side.
+mod server_side_driver {
+    use super::*;
+
+    #[test]
+    fn client_fin_before_server_body() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        assert!(!req.read_fin);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let mut from_client = req.recv;
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+
+        // client reads response and sends body and fin
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_client_poll(),
+            Ok((0, h3::Event::Headers { .. }))
+        );
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(helper.peer_client_send_body(0, &[1; 5], true), Ok(5));
+        helper.advance_and_run_loop().unwrap();
+
+        // server receives body
+        let (body, fin, _err) = helper.driver_try_recv_body(&mut from_client);
+        assert_eq!(body, vec![1; 5]);
+        assert!(fin);
+
+        // server sends body and fin
+        to_client
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[42]),
+                true,
+            ))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Data)));
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(helper.peer_client_recv_body_vec(0, 1024), Ok(vec![42]));
+        assert_eq!(
+            helper.peer_client_recv_body_vec(0, 1024),
+            Err(h3::Error::Done)
+        );
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Finished)));
+
+        assert_eq!(helper.driver.stream_map.len(), 0);
+    }
+
+    // This test verifies https://github.com/cloudflare/quiche/pull/2162
+    #[test]
+    fn verify_pr_2162() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a request but NO FIN.
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        assert!(!req.read_fin);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let mut from_client = req.recv;
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+        helper.work_loop_iter().unwrap();
+        // server sends body and fin. This caused an infinite loop before #2162
+        to_client
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[42]),
+                true,
+            ))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends body and fin
+        helper.advance_and_run_loop().unwrap();
+        assert_eq!(helper.peer_client_send_body(0, &[1; 5], true), Ok(5));
+        helper.advance_and_run_loop().unwrap();
+
+        let (body, fin, _err) = helper.driver_try_recv_body(&mut from_client);
+        assert_eq!(body, &[1; 5]);
+        assert!(fin);
+
+        // Stream is done
+        assert_eq!(helper.driver.stream_map.len(), 0);
+    }
+
+    /// Test the case where the client sends a STOP_SENDING quiche frame.
+    #[test]
+    fn client_sends_stop_sending() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        assert!(!req.read_fin);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let mut from_client = req.recv;
+        let audit_stats = req.h3_audit_stats;
+
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+
+        // client sends a STOP_SENDING
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_client_poll(),
+            Ok((0, h3::Event::Headers { .. }))
+        );
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(
+            helper
+                .pipe
+                .client
+                .stream_shutdown(0, quiche::Shutdown::Read, 4242),
+            Ok(())
+        );
+        helper.advance_and_run_loop().unwrap();
+
+        // the client didn't send any additional data, a try_recv on the server
+        // returns empty
+        assert_matches!(from_client.try_recv(), Err(TryRecvError::Empty));
+        // The way quiche is implemented, we need to attempt a write to the stream
+        // to learn that it's closed. So we add an OutboundFrame to the
+        // channel and let the driver write it. The driver gets a
+        // StreamStopped back and closes the channel.
+        to_client
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[23; 10]),
+                false,
+            ))
+            .unwrap();
+        helper.work_loop_iter().unwrap();
+        assert!(to_client.is_closed());
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), 4242);
+        helper.work_loop_iter().unwrap();
+
+        // STOP_SENDING only closes one half of the stream. The client
+        // can still send data and it MUST send a `fin` to close the
+        // other half.
+        helper.peer_client_send_body(0, &[1, 2, 3], true).unwrap();
+        helper.advance_and_run_loop().unwrap();
+        let (body, fin, _err) = helper.driver_try_recv_body(&mut from_client);
+        assert_eq!(body, &[1, 2, 3]);
+        assert!(fin);
+
+        assert_eq!(helper.driver.stream_map.len(), 0);
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), 4242);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.sent_stop_sending_error_code(), -1);
+        // technically quiche will automatically respond to a STOP_SENDING
+        // frame with a STREAM_RESET echoing the error code, but the user
+        // didn't *actively* send a STREAM_RESET.
+        assert_eq!(audit_stats.sent_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::None);
+        assert_eq!(audit_stats.downstream_bytes_recvd(), 3);
+        assert_eq!(audit_stats.downstream_bytes_sent(), 0);
+    }
+
+    /// Test the case where the client sends a RESET_STREAM quiche frame.
+    /// The peer sends its reset before we send a fin
+    #[test]
+    fn client_sends_reset_stream_before_server_fin() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client (peer) sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        assert!(!req.read_fin);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let from_client = req.recv;
+        let audit_stats = req.h3_audit_stats;
+
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+
+        // client sends a RESET_STREAM frame
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_client_poll(),
+            Ok((0, h3::Event::Headers { .. }))
+        );
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(
+            helper
+                .pipe
+                .client
+                .stream_shutdown(0, quiche::Shutdown::Write, 4242),
+            Ok(())
+        );
+        helper.advance_and_run_loop().unwrap();
+
+        // The channel is closed because the peer send us the reset.
+        assert!(from_client.is_closed());
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), 4242);
+        assert_matches!(
+            helper.driver_recv_core_event(),
+            Ok(H3Event::ResetStream { stream_id: 0 })
+        );
+
+        // We can still write to the peer and in fact, we must eventually send a
+        // fin.
+        to_client
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[5; 4]),
+                false,
+            ))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+        to_client
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[6; 4]),
+                true,
+            ))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Data)));
+        assert_eq!(
+            helper.peer_client_recv_body_vec(0, 1024),
+            Ok(vec![5, 5, 5, 5, 6, 6, 6, 6])
+        );
+
+        assert_eq!(helper.driver.stream_map.len(), 0);
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), 4242);
+        assert_eq!(audit_stats.sent_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.sent_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::None);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.downstream_bytes_recvd(), 0);
+        assert_eq!(audit_stats.downstream_bytes_sent(), 8);
+    }
+
+    /// Test the case where the client sends a RESET_STREAM quiche frame.
+    /// We send a fin before the client sends reset
+    #[test]
+    fn client_sends_reset_stream_after_server_fin() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client (peer) sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        assert!(!req.read_fin);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let from_client = req.recv;
+        let audit_stats = req.h3_audit_stats;
+
+        // Send response, body, and fin to client
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+        helper.work_loop_iter().unwrap();
+        to_client
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(b"foobar 42"),
+                true,
+            ))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a RESET_STREAM frame
+        assert_matches!(
+            helper.peer_client_poll(),
+            Ok((0, h3::Event::Headers { .. }))
+        );
+        assert_matches!(helper.peer_client_poll(), Ok((0, h3::Event::Data)));
+        helper.peer_client_recv_body_vec(0, 1024).unwrap();
+        assert_eq!(
+            helper
+                .pipe
+                .client
+                .stream_shutdown(0, quiche::Shutdown::Write, 4242),
+            Ok(())
+        );
+        helper.advance_and_run_loop().unwrap();
+
+        // The channel is closed because the peer send us the reset.
+        assert!(from_client.is_closed());
+        assert_matches!(
+            helper.driver_recv_core_event(),
+            Ok(H3Event::ResetStream { stream_id: 0 })
+        );
+
+        assert_eq!(helper.driver.stream_map.len(), 0);
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), 4242);
+        assert_eq!(audit_stats.sent_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.sent_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::None);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.downstream_bytes_recvd(), 0);
+        assert_eq!(
+            audit_stats.downstream_bytes_sent(),
+            b"foobar 42".len() as u64
+        );
+    }
+
+    /// Test the case where the client sends a RESET_STREAM quiche frame while
+    /// we're in the middle of reading data. We want to excercise the
+    /// code-path where `upstream_ready` is called before `process_reads`.
+    /// If `process_reads()` is called first, it will get the Reset event.
+    /// If `upstream_ready()` is called first, it will attempt to read from
+    /// the h3::Connection and will get a
+    /// `TransportError(StreamReset(code))`
+    #[test]
+    fn client_sends_reset_stream_while_reading_wait_for_data() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client (peer) sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers and some body bytes
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        assert!(!req.read_fin);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let mut from_client = req.recv;
+        let audit_stats = req.h3_audit_stats;
+
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+        helper.work_loop_iter().unwrap();
+        to_client
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[1, 2, 3, 4]),
+                false,
+            ))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends data
+        assert_matches!(
+            helper.peer_client_poll(),
+            Ok((0, h3::Event::Headers { .. }))
+        );
+        assert_matches!(helper.peer_client_poll(), Ok((0, h3::Event::Data)));
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(helper.peer_client_send_body(0, &[1; 10], false), Ok(10));
+
+        // Advance the pipe and let the driver read a part of the body and
+        // put it into the `from_client` channel
+        helper.pipe.advance().unwrap();
+        // Limit the amount of data we read from the stream.
+        helper.driver.pooled_buf = BufFactory::buf_from_slice(&[0; 5]);
+        helper.work_loop_iter().unwrap();
+        assert_matches!(from_client.try_recv(), Ok(InboundFrame::Body(buf, fin)) => {
+            assert_eq!(buf.into_inner().into_vec(), &[1; 5]);
+            assert!(!fin);
+        });
+        assert_matches!(
+            helper.driver_recv_core_event(),
+            Ok(H3Event::BodyBytesReceived {
+                stream_id: 0,
+                num_bytes: 5,
+                fin: false
+            })
+        );
+        assert_matches!(
+            helper.controller.event_receiver_mut().try_recv(),
+            Err(TryRecvError::Empty)
+        );
+
+        // client sends a reset.
+        // TODO: This is a bit finnicky to test properly. We don't want to
+        // run a full `work_loop_iter()` because that would call `process_reads()`
+        // first.
+        helper.pipe.advance().unwrap();
+        assert_eq!(
+            helper
+                .pipe
+                .client
+                .stream_shutdown(0, quiche::Shutdown::Write, 4242),
+            Ok(())
+        );
+        helper.pipe.advance().unwrap();
+        tokio::task::unconstrained(
+            helper.driver.wait_for_data(&mut helper.pipe.server),
+        )
+        .now_or_never()
+        .unwrap_or(Ok(()))
+        .unwrap();
+
+        // The channel is closed because the peer send us the reset.
+        assert!(from_client.is_closed());
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), 4242);
+        assert_matches!(
+            helper.driver_recv_core_event(),
+            Ok(H3Event::ResetStream { stream_id: 0 })
+        );
+
+        // We can still write to the peer and in fact, we must eventually send a
+        // fin.
+        to_client
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[6; 4]),
+                true,
+            ))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        assert_eq!(
+            helper.peer_client_recv_body_vec(0, 1024),
+            Ok(vec![1, 2, 3, 4, 6, 6, 6, 6])
+        );
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Finished)));
+
+        assert_eq!(helper.driver.stream_map.len(), 0);
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), 4242);
+        assert_eq!(audit_stats.sent_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.sent_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::None);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.downstream_bytes_recvd(), 5);
+        assert_eq!(audit_stats.downstream_bytes_sent(), 8);
+    }
+
+    /// Test the case where the client sends a RESET_STREAM quiche frame while
+    /// we're in the middle of reading data. We want to excercise the
+    /// code-path where where we call `process_reads` before
+    /// `upstream_ready()`.
+    #[test]
+    fn server_sends_reset_stream_while_reading_process_reads() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client (peer) sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        assert!(!req.read_fin);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let mut from_client = req.recv;
+        let audit_stats = req.h3_audit_stats;
+
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends data
+        assert_matches!(
+            helper.peer_client_poll(),
+            Ok((0, h3::Event::Headers { .. }))
+        );
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(helper.peer_client_send_body(0, &[1; 10], false), Ok(10));
+
+        // Advance the pipe and let the driver read a part of the body and
+        // put it into the `from_client` channel
+        helper.pipe.advance().unwrap();
+        // Limit the amount of data we read from the stream.
+        helper.driver.pooled_buf = BufFactory::buf_from_slice(&[0; 5]);
+        helper.work_loop_iter().unwrap();
+        assert_matches!(from_client.try_recv(), Ok(InboundFrame::Body(buf, fin)) => {
+            assert_eq!(buf.into_inner().into_vec(), &[1; 5]);
+            assert!(!fin);
+        });
+        assert_matches!(
+            helper.driver_recv_core_event(),
+            Ok(H3Event::BodyBytesReceived {
+                stream_id: 0,
+                num_bytes: 5,
+                fin: false
+            })
+        );
+
+        // client sends a reset.
+        assert_eq!(
+            helper
+                .pipe
+                .client
+                .stream_shutdown(0, quiche::Shutdown::Write, 4242),
+            Ok(())
+        );
+        helper.advance_and_run_loop().unwrap();
+
+        // The channel is closed because the peer send us the reset.
+        assert!(from_client.is_closed());
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), 4242);
+        assert_matches!(
+            helper.driver_recv_core_event(),
+            Ok(H3Event::ResetStream { stream_id: 0 })
+        );
+
+        // send fin to client
+        to_client
+            .try_send(OutboundFrame::Body(BufFactory::get_empty_buf(), true))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        assert_eq!(
+            helper.peer_client_recv_body_vec(0, 1024),
+            Err(h3::Error::Done)
+        );
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Data)));
+        assert_eq!(
+            helper.peer_client_recv_body_vec(0, 1024),
+            Err(h3::Error::Done)
+        );
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Finished)));
+
+        assert_eq!(helper.driver.stream_map.len(), 0);
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), 4242);
+        assert_eq!(audit_stats.sent_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.sent_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::None);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.downstream_bytes_recvd(), 5);
+        assert_eq!(audit_stats.downstream_bytes_sent(), 0);
+    }
+
+    #[test]
+    fn server_driver_send_stop_sending_after_channel_drop() {
+        const REQUEST_CANCELED_ERR: u64 =
+            h3::WireErrorCode::RequestCancelled as u64;
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        let audit_stats = req.h3_audit_stats.clone();
+        assert_eq!(req.stream_id, stream_id);
+        assert!(!req.read_fin);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let mut from_client = req.recv;
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+
+        // client reads response and sends body without fin
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_client_poll(),
+            Ok((0, h3::Event::Headers { .. }))
+        );
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(helper.peer_client_send_body(0, &[1; 5], false), Ok(5));
+        helper.advance_and_run_loop().unwrap();
+
+        // server receives body
+        let (body, fin, _err) = helper.driver_try_recv_body(&mut from_client);
+        assert_eq!(body, vec![1; 5]);
+        assert!(!fin);
+
+        // peer (client) sends more data
+        assert_eq!(helper.peer_client_send_body(0, &[1; 6], false), Ok(6));
+        // advance the pipe only
+        helper.pipe.advance().unwrap();
+        // we drop the channel.
+        drop(from_client);
+        helper.advance_and_run_loop().unwrap();
+
+        assert_matches!(
+            helper.driver_recv_core_event(),
+            Ok(H3Event::BodyBytesReceived {
+                stream_id: 0,
+                num_bytes: 5,
+                fin: false
+            })
+        );
+        assert_matches!(
+            helper.controller.event_receiver_mut().try_recv(),
+            Err(TryRecvError::Empty)
+        );
+
+        // Make sure the peer has received our STOP_SENDING frame
+        assert_eq!(
+            helper.peer_client_send_body(0, &[1; 7], false),
+            Err(h3::Error::TransportError(quiche::Error::StreamStopped(
+                REQUEST_CANCELED_ERR
+            )))
+        );
+        helper.advance_and_run_loop().unwrap();
+
+        // we still need to send a fin
+        to_client
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[42]),
+                true,
+            ))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Data)));
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(helper.peer_client_recv_body_vec(0, 1024), Ok(vec![42]));
+        assert_eq!(
+            helper.peer_client_recv_body_vec(0, 1024),
+            Err(h3::Error::Done)
+        );
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Finished)));
+
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.sent_reset_stream_error_code(), -1);
+        assert_eq!(
+            audit_stats.sent_stop_sending_error_code(),
+            REQUEST_CANCELED_ERR as i64
+        );
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::None);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.downstream_bytes_recvd(), 5);
+        assert_eq!(audit_stats.downstream_bytes_sent(), 1);
+        assert_eq!(helper.driver.stream_map.len(), 0);
+    }
+
+    // Verify we don't send a STOP_SENDING frame if we've already processed a
+    // fin
+    #[test]
+    fn server_driver_drop_channel_after_fin() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        let audit_stats = req.h3_audit_stats.clone();
+        assert_eq!(req.stream_id, stream_id);
+        assert!(!req.read_fin);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let mut from_client = req.recv;
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+
+        // client reads response and sends body WITH fin
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_client_poll(),
+            Ok((0, h3::Event::Headers { .. }))
+        );
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(helper.peer_client_send_body(0, &[1; 5], true), Ok(5));
+        helper.advance_and_run_loop().unwrap();
+
+        // server receives body
+        let (body, fin, _err) = helper.driver_try_recv_body(&mut from_client);
+        assert_eq!(body, vec![1; 5]);
+        assert!(fin);
+
+        helper.advance_and_run_loop().unwrap();
+        // we drop the channel.
+        drop(from_client);
+        helper.advance_and_run_loop().unwrap();
+
+        // we still need to send a fin
+        to_client
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[42]),
+                true,
+            ))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Data)));
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(helper.peer_client_recv_body_vec(0, 1024), Ok(vec![42]));
+        assert_eq!(
+            helper.peer_client_recv_body_vec(0, 1024),
+            Err(h3::Error::Done)
+        );
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Finished)));
+
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.sent_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.sent_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.downstream_bytes_recvd(), 5);
+        assert_eq!(audit_stats.downstream_bytes_sent(), 1);
+        assert_eq!(helper.driver.stream_map.len(), 0);
+    }
+
+    // Test the edge case where the driver has read a fin from the stream but
+    // hasn't been able to deliver it before the channel is dropped.
+    #[test]
+    fn server_driver_drop_channel_after_fin_2() {
+        const REQUEST_CANCELED_ERR: u64 =
+            h3::WireErrorCode::RequestCancelled as u64;
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        // servers reads request and sends response headers
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        let audit_stats = req.h3_audit_stats.clone();
+        assert_eq!(req.stream_id, stream_id);
+        assert!(!req.read_fin);
+        let to_client = req.send.get_ref().unwrap().clone();
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+
+        // client reads response and sends body without fin
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_client_poll(),
+            Ok((0, h3::Event::Headers { .. }))
+        );
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(helper.peer_client_send_body(0, &[1; 5], false), Ok(5));
+        helper.advance_and_run_loop().unwrap();
+
+        // peer (client) sends more data and fin
+        assert_eq!(helper.peer_client_send_body(0, &[1; 6], true), Ok(6));
+        helper.advance_and_run_loop().unwrap();
+        // we drop the channel.
+        drop(req.recv);
+        helper.advance_and_run_loop().unwrap();
+
+        assert_matches!(
+            helper.driver_recv_core_event(),
+            Ok(H3Event::BodyBytesReceived {
+                stream_id: 0,
+                num_bytes: 5,
+                fin: false
+            })
+        );
+        assert_matches!(
+            helper.controller.event_receiver_mut().try_recv(),
+            Err(TryRecvError::Empty)
+        );
+
+        // we still need to send a fin
+        to_client
+            .try_send(OutboundFrame::Body(
+                BufFactory::buf_from_slice(&[42]),
+                true,
+            ))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Data)));
+        assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
+        assert_eq!(helper.peer_client_recv_body_vec(0, 1024), Ok(vec![42]));
+        assert_eq!(
+            helper.peer_client_recv_body_vec(0, 1024),
+            Err(h3::Error::Done)
+        );
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Finished)));
+
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), -1);
+        assert_eq!(audit_stats.recvd_reset_stream_error_code(), -1);
+        assert_eq!(audit_stats.sent_reset_stream_error_code(), -1);
+        assert_eq!(
+            audit_stats.sent_stop_sending_error_code(),
+            REQUEST_CANCELED_ERR as i64
+        );
+        assert_eq!(audit_stats.recvd_stream_fin(), StreamClosureKind::None);
+        assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::Explicit);
+        assert_eq!(audit_stats.downstream_bytes_recvd(), 5);
+        assert_eq!(audit_stats.downstream_bytes_sent(), 1);
+        assert_eq!(helper.driver.stream_map.len(), 0);
+    }
+}

--- a/tokio-quiche/tests/integration_tests/headers.rs
+++ b/tokio-quiche/tests/integration_tests/headers.rs
@@ -28,6 +28,7 @@ use crate::fixtures::*;
 
 use futures::SinkExt;
 
+use tokio_quiche::buf_factory::BufFactory;
 use tokio_quiche::http3::driver::H3Event;
 use tokio_quiche::http3::driver::IncomingH3Headers;
 use tokio_quiche::http3::driver::OutboundFrame;
@@ -75,6 +76,14 @@ async fn test_additional_headers() {
                         send.send(OutboundFrame::Headers(
                             vec![Header::new(b":status", b"200")],
                             None,
+                        ))
+                        .await
+                        .unwrap();
+
+                        // Send fin
+                        send.send(OutboundFrame::Body(
+                            BufFactory::get_empty_buf(),
+                            true,
                         ))
                         .await
                         .unwrap();


### PR DESCRIPTION
Alternative version to #2165 (This PR does not echo back a received RESET_FRAME or STOP_SENDING and instead lets the application close the other stream direction on its own. )

TL;DR:
* When receiving RESET_STREAM or STOP_SENDING, we mark the appropriate
  direction of the stream as closed.
* When InboundFrame or OutboundFrame channels are closed without a fin,
  send STOP_SENDING or RESET_STREAM to close that half of the stream.
* Add a testing framework similar to quiche::test_utils::Pipe to allow
  unit testing of H3Driver.

This contains two changes to tokio-quiche's handling of "abnormal" stream
termination via RESET_STREAM and STOP_SENDING. A stream is only fully
completed if its final size in both directions is know and the final size
is only communicated via a fin or RESET_STREAM frame. Note that quiche
will automatically reply with a RESET_STREAM when it receives a STOP_SENDING
frame.

That means that receiving a RESET_STREAM or STOP_SENDING only shuts down one
direction of the stream, so tokio-quiche must also close the other direction.
This PR does so by marking the appropriate direction of the stream closed when
receiving these frames. The other direction must still be closed (fin or reset).

When the H3Driver detects that either the InboundFrame or OutboundFrame channels
have been closed without a fin, the driver shuts down that direction by sending
STOP_SENDING or RESET STREAM. This is
necessary to allow quiche to release the streams resources (flow control credit).
Since the channel is gone, it's otherwise impossible to finish the stream.

