### PR TITLE
[Example code] Improve error message when panicking due to not being able to find certificates

### DIFF
--- a/tokio-quiche/examples/async_http3_server/args.rs
+++ b/tokio-quiche/examples/async_http3_server/args.rs
@@ -54,10 +54,14 @@ fn default_private_key_path() -> String {
 }
 
 fn path_relative_to_manifest_dir(path: &str) -> String {
-    std::fs::canonicalize({
-        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
-    })
-    .unwrap()
-    .to_string_lossy()
-    .into_owned()
+    match std::fs::canonicalize(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(path)) {
+        Ok(result) => result.to_string_lossy().into_owned(),
+        Err(_) => {
+            panic!(
+                "Example certificates not found in {}/{}",
+                env!("CARGO_MANIFEST_DIR"),
+                path
+            )
+        }
+    }
 }


### PR DESCRIPTION
Before:
```
thread 'main' panicked at src/args.rs:58:10:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:
```
thread 'main' panicked at src/args.rs:60:13:
Example certificates not found in /Users/paul/gitseed/gitseed/listener/examples/cert.crt
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```