### PR TITLE
tokio-quiche: release 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ smallvec = { version = "1.10", default-features = false }
 task-killswitch = { version = "0.1.0", path = "./task-killswitch" }
 thiserror = { version = "1" }
 tokio = { version = "1.44", default-features = false }
-tokio-quiche = { version = "0.8.0", path = "./tokio-quiche" }
+tokio-quiche = { version = "0.9.0", path = "./tokio-quiche" }
 tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7.13" }
 triomphe = { version = "0.1" }

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-quiche"
-version = "0.8.0"
+version = "0.9.0"
 repository = { workspace = true }
 license = { workspace = true }
 description = "Asynchronous wrapper around quiche"


### PR DESCRIPTION
0.8.0 grabbed `datagram-socket 0.4.0`, since `0.5.0` wasn't published at the time that 0.8.0 was (even though `datagram-socket` is a workspace dependency)