### PR TITLE
Defer log formatting until it's actually used

### DIFF
--- a/tokio-quiche/src/quic/router/mod.rs
+++ b/tokio-quiche/src/quic/router/mod.rs
@@ -695,7 +695,7 @@ where
                     buf.truncate(bytes);
 
                     let send_from = if let Some(dst_addr) = dst_addr_override {
-                        log::trace!("overriding local address"; "actual_local" => format!("{:?}", dst_addr), "configured_local" => format!("{:?}", server_addr));
+                        log::trace!("overriding local address"; "actual_local" => dst_addr, "configured_local" => server_addr);
                         dst_addr
                     } else {
                         server_addr


### PR DESCRIPTION
slog doesn't guard log statements by log-level. Instead it relies on arguments to its logging macros to defer work until needed.