### PR TITLE
tokio-quiche: store latest PRIORITY_UPDATE value on incoming request

### DIFF
--- a/tokio-quiche/src/http3/driver/client.rs
+++ b/tokio-quiche/src/http3/driver/client.rs
@@ -223,6 +223,7 @@ impl ClientHooks {
             recv: pending_request.recv,
             read_fin: !has_body,
             h3_audit_stats: Arc::clone(&stream_ctx.audit_stats),
+            latest_priority_update: None,
         };
 
         driver

--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -46,6 +46,7 @@ use foundations::telemetry::log;
 use futures::FutureExt;
 use futures_util::stream::FuturesUnordered;
 use quiche::h3;
+use quiche::h3::Priority;
 use tokio::select;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
@@ -190,6 +191,9 @@ pub struct IncomingH3Headers {
     pub read_fin: bool,
     /// Handle to the [`H3AuditStats`] for the message's stream.
     pub h3_audit_stats: Arc<H3AuditStats>,
+    /// The latest PRIORITY_UPDATE frame value, if any. Always `None` for
+    /// clients.
+    pub latest_priority_update: Option<Priority>,
 }
 
 impl fmt::Debug for IncomingH3Headers {
@@ -199,6 +203,7 @@ impl fmt::Debug for IncomingH3Headers {
             .field("headers", &self.headers)
             .field("read_fin", &self.read_fin)
             .field("h3_audit_stats", &self.h3_audit_stats)
+            .field("latest_priority_update", &self.latest_priority_update)
             .finish()
     }
 }


### PR DESCRIPTION
Priority signals take the form of HTTP headers and/or frames. Some clients only send frames, while some clients can both. At the point in time a server reads request HEADERS, a client may sent a PRIORITY_UPDATE frame that should take precedence.

With this change, we read take the last PRIORITY_UPDATE processed by quiche, and attach it to the IncomingH3Headers so that Tokio-Quiche-based apps can use it if they wish.