### PR TITLE
task-killswitch: operation queue metrics

### DIFF
--- a/task-killswitch/Cargo.toml
+++ b/task-killswitch/Cargo.toml
@@ -8,7 +8,11 @@ keywords = { workspace = true }
 categories = { workspace = true }
 description = "Abort all tokio tasks at once"
 
+[features]
+metrics = ["dep:foundations"]
+
 [dependencies]
+foundations = { workspace = true, optional = true, features = ["metrics"] }
 parking_lot = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync"] }
 

--- a/task-killswitch/src/metrics.rs
+++ b/task-killswitch/src/metrics.rs
@@ -1,0 +1,35 @@
+use crate::ActiveTaskOp;
+use foundations::telemetry::metrics::metrics;
+use foundations::telemetry::metrics::Counter;
+use foundations::telemetry::metrics::Gauge;
+
+pub const OP_KIND_ADD: &str = "add";
+pub const OP_KIND_REMOVE: &str = "remove";
+
+#[metrics]
+pub mod killswitch_queue {
+    /// Length of task-killswitch's operation queue.
+    pub fn length() -> Gauge;
+
+    /// Number of operations of each `kind` that have been sent on the channel.
+    pub fn ops_sent(kind: &'static str) -> Counter;
+
+    /// Number of operations of each `kind` that have been received on the
+    /// channel.
+    pub fn ops_received(kind: &'static str) -> Counter;
+}
+
+pub fn count_ops_received(ops: &[ActiveTaskOp]) {
+    let mut add = 0;
+    let mut remove = 0;
+
+    for op in ops {
+        match op {
+            ActiveTaskOp::Add { .. } => add += 1,
+            ActiveTaskOp::Remove { .. } => remove += 1,
+        }
+    }
+
+    self::killswitch_queue::ops_received(OP_KIND_ADD).inc_by(add);
+    self::killswitch_queue::ops_received(OP_KIND_REMOVE).inc_by(remove);
+}


### PR DESCRIPTION
### task-killswitch: Add optional metrics to monitor operation queue

The `metrics` feature enables metrics collection via foundations.