### PR TITLE
h3: clear streams when send finishes before recv

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -282,6 +282,7 @@
 //! [`send_response()`]: struct.Connection.html#method.send_response
 //! [`send_body()`]: struct.Connection.html#method.send_body
 
+use std::collections::hash_map;
 use std::collections::HashSet;
 use std::collections::VecDeque;
 
@@ -977,6 +978,10 @@ pub struct Connection {
 
     max_push_id: u64,
 
+    // Streams whose peer send side has finished and still need a Finished
+    // event. If the local send side is already done, poll() removes the H3
+    // stream state when returning the event. Otherwise the send path removes it
+    // when the local side finishes later.
     finished_streams: VecDeque<u64>,
 
     frames_greased: bool,
@@ -1496,12 +1501,10 @@ impl Connection {
             q.add_event_data_now(ev_data).ok();
         });
 
-        if let Some(s) = self.streams.get_mut(&stream_id) {
+        if fin {
+            self.finish_local_stream(conn, stream_id, true);
+        } else if let Some(s) = self.streams.get_mut(&stream_id) {
             s.initialize_local();
-        }
-
-        if fin && conn.stream_finished(stream_id) {
-            self.streams.remove(&stream_id);
         }
 
         Ok(())
@@ -1743,8 +1746,8 @@ impl Connection {
             let _ = conn.stream_writable(stream_id, overhead + 1);
         }
 
-        if fin && written == len && conn.stream_finished(stream_id) {
-            self.streams.remove(&stream_id);
+        if fin && written == len {
+            self.finish_local_stream(conn, stream_id, false);
         }
 
         Ok(ret)
@@ -2097,8 +2100,8 @@ impl Connection {
         }
 
         // Process finished streams list.
-        if let Some(finished) = self.finished_streams.pop_front() {
-            return Ok((finished, Event::Finished));
+        if let Some(ev) = self.pop_finished_stream(conn) {
+            return Ok(ev);
         }
 
         // Process HTTP/3 data from readable streams.
@@ -2112,8 +2115,11 @@ impl Connection {
 
                 // Return early if the stream was reset, to avoid returning
                 // a Finished event later as well.
-                Err(Error::TransportError(crate::Error::StreamReset(e))) =>
-                    return Ok((s, Event::Reset(e))),
+                Err(Error::TransportError(crate::Error::StreamReset(e))) => {
+                    self.remove_local_finished_stream(s);
+
+                    return Ok((s, Event::Reset(e)));
+                },
 
                 Err(e) => return Err(e),
             };
@@ -2131,17 +2137,8 @@ impl Connection {
         // Process finished streams list once again, to make sure `Finished`
         // events are returned when receiving empty stream frames with the fin
         // flag set.
-        if let Some(finished) = self.finished_streams.pop_front() {
-            if conn.stream_readable(finished) {
-                // The stream is finished, but is still readable, it may
-                // indicate that there is a pending error, such as reset.
-                if let Err(crate::Error::StreamReset(e)) =
-                    conn.stream_recv(finished, &mut [])
-                {
-                    return Ok((finished, Event::Reset(e)));
-                }
-            }
-            return Ok((finished, Event::Finished));
+        if let Some(ev) = self.pop_finished_stream(conn) {
+            return Ok(ev);
         }
 
         Err(Error::Done)
@@ -2890,6 +2887,58 @@ impl Connection {
 
             _ => (),
         };
+    }
+
+    fn finish_local_stream<F: BufFactory>(
+        &mut self, conn: &super::Connection<F>, stream_id: u64,
+        initialize_local: bool,
+    ) {
+        let hash_map::Entry::Occupied(mut stream) = self.streams.entry(stream_id)
+        else {
+            return;
+        };
+
+        {
+            let stream = stream.get_mut();
+
+            if initialize_local {
+                stream.initialize_local();
+            }
+
+            stream.finish_local();
+        }
+
+        if conn.stream_finished(stream_id) {
+            stream.remove();
+        }
+    }
+
+    fn remove_local_finished_stream(&mut self, stream_id: u64) {
+        if let hash_map::Entry::Occupied(stream) = self.streams.entry(stream_id) {
+            if stream.get().local_finished() {
+                stream.remove();
+            }
+        }
+    }
+
+    fn pop_finished_stream<F: BufFactory>(
+        &mut self, conn: &mut super::Connection<F>,
+    ) -> Option<(u64, Event)> {
+        let finished = self.finished_streams.pop_front()?;
+
+        self.remove_local_finished_stream(finished);
+
+        if conn.stream_readable(finished) {
+            // The stream is finished, but is still readable, it may indicate
+            // that there is a pending error, such as reset.
+            if let Err(crate::Error::StreamReset(e)) =
+                conn.stream_recv(finished, &mut [])
+            {
+                return Some((finished, Event::Reset(e)));
+            }
+        }
+
+        Some((finished, Event::Finished))
     }
 
     fn process_frame<F: BufFactory>(
@@ -7856,6 +7905,131 @@ mod tests {
         assert_eq!(s.poll_client(), Ok((stream, ev_headers)));
         assert_eq!(s.poll_client(), Ok((stream, Event::Finished)));
         assert_eq!(s.poll_client(), Err(Error::Done));
+    }
+
+    #[test]
+    fn collect_completed_streams() {
+        let mut s = Session::new().unwrap();
+        s.handshake().unwrap();
+
+        let init_streams_client = s.client.streams.len();
+        let init_streams_server = s.server.streams.len();
+
+        // Client sends HEADERS and doesn't fin
+        let (stream, req) = s.send_request(false).unwrap();
+
+        let ev_headers = Event::Headers {
+            list: req,
+            more_frames: true,
+        };
+
+        // Server receives headers.
+        assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        assert_eq!(s.client.streams.len(), init_streams_client + 1);
+        assert_eq!(s.server.streams.len(), init_streams_server + 1);
+
+        // Client sends body and fin
+        let body = s.send_body_client(stream, true).unwrap();
+
+        let mut recv_buf = vec![0; body.len()];
+
+        assert_eq!(s.poll_server(), Ok((stream, Event::Data)));
+        assert_eq!(s.recv_body_server(stream, &mut recv_buf), Ok(body.len()));
+
+        assert_eq!(s.poll_server(), Ok((stream, Event::Finished)));
+
+        assert_eq!(s.client.streams.len(), init_streams_client + 1);
+        assert_eq!(s.server.streams.len(), init_streams_server + 1);
+
+        // Server sends response and finishes the stream
+        let resp_headers = s.send_response(stream, false).unwrap();
+        s.send_body_server(stream, true).unwrap();
+
+        let ev_headers = Event::Headers {
+            list: resp_headers,
+            more_frames: true,
+        };
+
+        assert_eq!(s.poll_client(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_client(), Ok((stream, Event::Data)));
+        assert_eq!(s.recv_body_client(stream, &mut recv_buf), Ok(body.len()));
+
+        // The server stream should be gone now
+        assert_eq!(s.client.streams.len(), init_streams_client + 1);
+        assert_eq!(s.server.streams.len(), init_streams_server);
+
+        // Polling again should clean up the client
+        assert_eq!(s.poll_client(), Ok((stream, Event::Finished)));
+        assert_eq!(s.poll_client(), Err(Error::Done));
+
+        assert_eq!(s.client.streams.len(), init_streams_client);
+    }
+
+    #[test]
+    fn collect_reset_streams() {
+        let mut s = Session::new().unwrap();
+        s.handshake().unwrap();
+
+        let init_streams_client = s.client.streams.len();
+        let init_streams_server = s.server.streams.len();
+
+        // Client sends HEADERS and doesn't fin
+        let (stream, req) = s.send_request(false).unwrap();
+
+        let ev_headers = Event::Headers {
+            list: req,
+            more_frames: true,
+        };
+
+        // Server receives headers.
+        assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        assert_eq!(s.client.streams.len(), init_streams_client + 1);
+        assert_eq!(s.server.streams.len(), init_streams_server + 1);
+
+        // Client sends body and fin
+        let body = s.send_body_client(stream, true).unwrap();
+
+        let mut recv_buf = vec![0; body.len()];
+
+        assert_eq!(s.poll_server(), Ok((stream, Event::Data)));
+        assert_eq!(s.recv_body_server(stream, &mut recv_buf), Ok(body.len()));
+
+        assert_eq!(s.poll_server(), Ok((stream, Event::Finished)));
+
+        assert_eq!(s.client.streams.len(), init_streams_client + 1);
+        assert_eq!(s.server.streams.len(), init_streams_server + 1);
+
+        // Server sends response and resets the stream.
+        s.send_response(stream, false).unwrap();
+        s.pipe
+            .server
+            .stream_shutdown(stream, crate::Shutdown::Write, 0)
+            .unwrap();
+
+        s.advance().ok();
+
+        // TODO: need to notify resets better.
+        //
+        // This will trigger the h3 layer to check for the stream resets,
+        // otherwise it wouldn't know that a reset happened.
+        //
+        // We will need to figure out a way to do this automatically to avoid
+        // requiring applications to do this manually. For now just keep this
+        // for testing purposes.
+        let _ = s.send_body_server(stream, true);
+
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        assert_eq!(s.poll_client(), Ok((stream, Event::Reset(0))));
+        assert_eq!(s.poll_client(), Err(Error::Done));
+
+        // The server stream should be gone now
+        assert_eq!(s.client.streams.len(), init_streams_client);
+        assert_eq!(s.server.streams.len(), init_streams_server);
     }
 }
 

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -3201,13 +3201,11 @@ impl Connection {
                     return Err(Error::IdError);
                 }
 
-                // If the PRIORITY_UPDATE is valid, consider storing the latest
-                // contents. Due to reordering, it is possible that we might
-                // receive frames that reference streams that have not yet to
-                // been opened and that's OK because it's within our concurrency
-                // limit. However, we discard PRIORITY_UPDATE that refers to
-                // streams that we know have been collected.
-                if conn.streams.is_collected(prioritized_element_id) {
+                // PRIORITY_UPDATE can arrive before the request stream exists,
+                // so a missing transport stream is allowed. Ignore updates only
+                // once the transport stream was collected or both transport
+                // directions are finished.
+                if conn.stream_closed(prioritized_element_id) {
                     return Err(Error::Done);
                 }
 
@@ -5233,6 +5231,64 @@ mod tests {
 
         // No event generated at server
         assert_eq!(s.poll_server(), Err(Error::Done));
+    }
+
+    #[test]
+    /// Send a PRIORITY_UPDATE for a request stream after H3 has collected it,
+    /// but before the transport stream has been collected.
+    fn priority_update_request_after_h3_collection() {
+        let mut s = Session::new().unwrap();
+        s.handshake().unwrap();
+
+        let init_streams_server = s.server.streams.len();
+
+        let (stream, req) = s.send_request(true).unwrap();
+        let ev_headers = Event::Headers {
+            list: req,
+            more_frames: false,
+        };
+
+        assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_server(), Ok((stream, Event::Finished)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        let resp = vec![
+            Header::new(b":status", b"200"),
+            Header::new(b"server", b"quiche-test"),
+        ];
+
+        s.server
+            .send_response(&mut s.pipe.server, stream, &resp, true)
+            .unwrap();
+
+        // H3 no longer needs its stream state once it has sent the response
+        // FIN and consumed the request FIN. The QUIC stream remains until the
+        // response FIN is acknowledged by the peer.
+        assert_eq!(s.server.streams.len(), init_streams_server);
+        assert!(s.pipe.server.stream_finished(stream));
+        assert!(s.pipe.server.stream_closed(stream));
+
+        let stream_state = s.pipe.server.streams.get(stream).unwrap();
+        assert!(stream_state.recv.is_fin());
+        assert!(stream_state.send.is_fin());
+        assert!(!s.pipe.server.streams.is_collected(stream));
+
+        s.client
+            .send_priority_update_for_request(
+                &mut s.pipe.client,
+                stream,
+                &Priority {
+                    urgency: 3,
+                    incremental: false,
+                },
+            )
+            .unwrap();
+
+        let flight = crate::test_utils::emit_flight(&mut s.pipe.client).unwrap();
+        crate::test_utils::process_flight(&mut s.pipe.server, flight).unwrap();
+
+        assert_eq!(s.poll_server(), Err(Error::Done));
+        assert_eq!(s.server.streams.len(), init_streams_server);
     }
 
     #[test]

--- a/quiche/src/h3/stream.rs
+++ b/quiche/src/h3/stream.rs
@@ -153,6 +153,9 @@ pub struct Stream {
     /// Whether the stream has been locally initialized.
     local_initialized: bool,
 
+    /// Whether the local send-side of the stream has finished.
+    local_finished: bool,
+
     /// Whether a `Data` event has been triggered for this stream.
     data_event_triggered: bool,
 
@@ -204,8 +207,11 @@ impl Stream {
             frame_type: None,
 
             is_local,
+
             remote_initialized: false,
+
             local_initialized: false,
+            local_finished: false,
 
             data_event_triggered: false,
 
@@ -516,6 +522,16 @@ impl Stream {
     /// Whether the stream has been locally initialized.
     pub fn local_initialized(&self) -> bool {
         self.local_initialized
+    }
+
+    /// Finish the local part of the stream.
+    pub fn finish_local(&mut self) {
+        self.local_finished = true
+    }
+
+    /// Whether the local send-side of the stream has finished.
+    pub fn local_finished(&self) -> bool {
+        self.local_finished
     }
 
     pub fn increment_headers_received(&mut self) {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6542,6 +6542,36 @@ impl<F: BufFactory> Connection<F> {
         stream.recv.is_fin()
     }
 
+    /// Returns true if the specified stream is closed.
+    ///
+    /// For bidirectional streams this happens when both the receive and send
+    /// sides have signaled `fin`. For unidirectional streams only the
+    /// relevant direction is checked, depending on whether the stream was
+    /// created locally or not.
+    ///
+    /// This also returns true if the stream has already been collected, but
+    /// returns false if the stream was never opened.
+    #[inline]
+    pub fn stream_closed(&self, stream_id: u64) -> bool {
+        let Some(stream) = self.streams.get(stream_id) else {
+            return self.streams.is_collected(stream_id);
+        };
+
+        match (stream.bidi, stream.local) {
+            // For bidirectional streams both directions must have signaled
+            // FIN.
+            (true, _) => stream.recv.is_fin() && stream.send.is_fin(),
+
+            // For unidirectional streams created locally, only the send side
+            // is checked.
+            (false, true) => stream.send.is_fin(),
+
+            // For unidirectional streams created by the peer, only the
+            // receive side is checked.
+            (false, false) => stream.recv.is_fin(),
+        }
+    }
+
     /// Returns the number of bidirectional streams that can be created
     /// before the peer's stream count limit is reached.
     ///

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -1013,6 +1013,61 @@ fn streamio(#[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str) {
     assert!(pipe.server.stream_finished(4));
 }
 
+#[rstest]
+fn stream_closed_bidi(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    assert!(!pipe.client.stream_closed(0));
+    assert!(!pipe.server.stream_closed(0));
+
+    assert_eq!(pipe.client.stream_send(0, b"hello", true), Ok(5));
+    assert_eq!(pipe.advance(), Ok(()));
+
+    assert!(!pipe.client.stream_closed(0));
+    assert!(!pipe.server.stream_closed(0));
+
+    let mut buf = [0; 5];
+    assert_eq!(pipe.server.stream_recv(0, &mut buf), Ok((5, true)));
+
+    assert!(!pipe.server.stream_closed(0));
+
+    assert_eq!(pipe.server.stream_send(0, b"world", true), Ok(5));
+    assert!(pipe.server.stream_closed(0));
+
+    assert_eq!(pipe.advance(), Ok(()));
+
+    assert!(!pipe.client.stream_closed(0));
+    assert_eq!(pipe.client.stream_recv(0, &mut buf), Ok((5, true)));
+    assert!(pipe.client.stream_closed(0));
+}
+
+#[rstest]
+fn stream_closed_uni(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    assert!(!pipe.client.stream_closed(2));
+    assert!(!pipe.server.stream_closed(2));
+
+    assert_eq!(pipe.client.stream_send(2, b"hello", true), Ok(5));
+
+    assert!(pipe.client.stream_closed(2));
+
+    assert_eq!(pipe.advance(), Ok(()));
+
+    assert!(!pipe.server.stream_closed(2));
+
+    let mut buf = [0; 5];
+    assert_eq!(pipe.server.stream_recv(2, &mut buf), Ok((5, true)));
+
+    assert!(pipe.server.stream_closed(2));
+}
+
 /// Test receiving into `BufMut`
 #[rstest]
 fn stream_recv_buf(


### PR DESCRIPTION
h3 streams are meant to be dopped from the internal stream map when both the send and recv side of the stream are finished (this means both sending and received a `fin` for example).

However currently this only works if the recv side is finished first, and the clean-up happens on the next `send_body()` or `send_response()` call. When the opposite happens (e.g. `fin` is sent before receiving it) the the stream leaks.

This change adds logic to properly check for a stream being completed in that case as well, which involves tracking a "local finished" state for each stream.

When returning a `Finished` event, the corresponding stream is checked again and if its send-side is also finished then the stream's state is cleared.

Note that this change doesn't cover the case of stream being reset by the local application itself, as the h3 layer doesn't get any signal about that happening right now, so it will need follow-up changes to be fixed.