### PR TITLE
h3: remove duplicated stream type validation

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -2877,16 +2877,6 @@ impl Connection {
             },
 
             frame::Frame::Headers { header_block } => {
-                if Some(stream_id) == self.peer_control_stream_id {
-                    conn.close(
-                        true,
-                        Error::FrameUnexpected.to_wire(),
-                        b"HEADERS received on control stream",
-                    )?;
-
-                    return Err(Error::FrameUnexpected);
-                }
-
                 // Servers reject too many HEADERS frames.
                 if let Some(s) = self.streams.get_mut(&stream_id) {
                     if self.is_server && s.headers_received_count() == 2 {
@@ -2961,30 +2951,10 @@ impl Connection {
             },
 
             frame::Frame::Data { .. } => {
-                if Some(stream_id) == self.peer_control_stream_id {
-                    conn.close(
-                        true,
-                        Error::FrameUnexpected.to_wire(),
-                        b"DATA received on control stream",
-                    )?;
-
-                    return Err(Error::FrameUnexpected);
-                }
-
                 // Do nothing. The Data event is returned separately.
             },
 
             frame::Frame::GoAway { id } => {
-                if Some(stream_id) != self.peer_control_stream_id {
-                    conn.close(
-                        true,
-                        Error::FrameUnexpected.to_wire(),
-                        b"GOAWAY received on non-control stream",
-                    )?;
-
-                    return Err(Error::FrameUnexpected);
-                }
-
                 if !self.is_server && id % 4 != 0 {
                     conn.close(
                         true,
@@ -3013,16 +2983,6 @@ impl Connection {
             },
 
             frame::Frame::MaxPushId { push_id } => {
-                if Some(stream_id) != self.peer_control_stream_id {
-                    conn.close(
-                        true,
-                        Error::FrameUnexpected.to_wire(),
-                        b"MAX_PUSH_ID received on non-control stream",
-                    )?;
-
-                    return Err(Error::FrameUnexpected);
-                }
-
                 if !self.is_server {
                     conn.close(
                         true,
@@ -3071,16 +3031,6 @@ impl Connection {
             },
 
             frame::Frame::CancelPush { .. } => {
-                if Some(stream_id) != self.peer_control_stream_id {
-                    conn.close(
-                        true,
-                        Error::FrameUnexpected.to_wire(),
-                        b"CANCEL_PUSH received on non-control stream",
-                    )?;
-
-                    return Err(Error::FrameUnexpected);
-                }
-
                 // TODO: implement CANCEL_PUSH frame
             },
 
@@ -3093,16 +3043,6 @@ impl Connection {
                         true,
                         Error::FrameUnexpected.to_wire(),
                         b"PRIORITY_UPDATE received by client",
-                    )?;
-
-                    return Err(Error::FrameUnexpected);
-                }
-
-                if Some(stream_id) != self.peer_control_stream_id {
-                    conn.close(
-                        true,
-                        Error::FrameUnexpected.to_wire(),
-                        b"PRIORITY_UPDATE received on non-control stream",
                     )?;
 
                     return Err(Error::FrameUnexpected);
@@ -3165,16 +3105,6 @@ impl Connection {
                         true,
                         Error::FrameUnexpected.to_wire(),
                         b"PRIORITY_UPDATE received by client",
-                    )?;
-
-                    return Err(Error::FrameUnexpected);
-                }
-
-                if Some(stream_id) != self.peer_control_stream_id {
-                    conn.close(
-                        true,
-                        Error::FrameUnexpected.to_wire(),
-                        b"PRIORITY_UPDATE received on non-control stream",
                     )?;
 
                     return Err(Error::FrameUnexpected);

--- a/quiche/src/h3/stream.rs
+++ b/quiche/src/h3/stream.rs
@@ -349,6 +349,12 @@ impl Stream {
                         (frame::MAX_PUSH_FRAME_TYPE_ID, _) =>
                             return Err(Error::FrameUnexpected),
 
+                        (frame::PRIORITY_UPDATE_FRAME_REQUEST_TYPE_ID, _) =>
+                            return Err(Error::FrameUnexpected),
+
+                        (frame::PRIORITY_UPDATE_FRAME_PUSH_TYPE_ID, _) =>
+                            return Err(Error::FrameUnexpected),
+
                         // All other frames can be ignored regardless of stream
                         // state.
                         _ => (),


### PR DESCRIPTION
The `Stream::set_frame_type()` already checks whether a frame is allowed on a specific type of stream, so we don't have to check it again while processing the frame.