### PR TITLE
tokio-quiche: add ServerH3Event::Headers

### DIFF
--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -84,6 +84,7 @@ pub use self::client::ClientH3Driver;
 pub use self::client::ClientH3Event;
 pub use self::client::ClientRequestSender;
 pub use self::client::NewClientRequest;
+pub use self::server::RawPriorityValue;
 pub use self::server::ServerEventStream;
 pub use self::server::ServerH3Command;
 pub use self::server::ServerH3Controller;


### PR DESCRIPTION
Priority signals take the form of HTTP headers and/or frames. Some clients only send frames, while some clients can both. At the point in time a server reads request HEADERS, a client may sent a PRIORITY_UPDATE frame that should take precedence.

With this change, we read take the last PRIORITY_UPDATE processed by quiche, and pass it alongside IncomingH3Headers in a new ServerH3Event:Headers event o that Tokio-Quiche-based server can use it if they wish.

This is the alternative design proposed by @evanrittenhouse on https://github.com/cloudflare/quiche/pull/2189/files#r2430013438