### PR TITLE
Move Rust Version To 1.83 (Stable)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82 AS build
+FROM rust:1.83 AS build
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ is disabled by default), by passing ``--features ffi`` to ``cargo``.
 Building
 --------
 
-quiche requires Rust 1.82 or later to build. The latest stable Rust release can
+quiche requires Rust 1.83 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched

--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
   "Evan Rittenhouse <evanrittenhouse@gmail.com>",
 ]
 description = "Low-level HTTP/3 debugging and testing"
-rust-version = "1.82"
+rust-version = "1.83"
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.24.6"
 authors = ["Alessandro Ghedini <alessandro@ghedini.me>"]
 description = "🥧 Savoury implementation of the QUIC transport protocol and HTTP/3"
 build = "src/build.rs"
-rust-version = "1.82"
+rust-version = "1.83"
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -1190,7 +1190,7 @@ mod tests {
     fn loss_threshold() {
         let config = Config::new(crate::PROTOCOL_VERSION).unwrap();
         let recovery_config = RecoveryConfig::from_config(&config);
-        assert_eq!(recovery_config.enable_relaxed_loss_threshold, false);
+        assert!(!recovery_config.enable_relaxed_loss_threshold);
 
         let mut loss_thresh = LossThreshold::new(&recovery_config);
         assert_eq!(loss_thresh.time_thresh_overhead, None);

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -7996,7 +7996,7 @@ fn connection_id_retire_exotic_sequence(
         frame::Frame::NewConnectionId {
             seq_num: 1,
             retire_prior_to: 0,
-            conn_id: vec![02],
+            conn_id: vec![2],
             reset_token: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2],
         },
         frame::Frame::NewConnectionId {


### PR DESCRIPTION
@LPardue suggested that an update to the MSRV would be welcomed. So, here it goes! 