### PR TITLE
h3i: use ring for RNG instead of rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ parking_lot = { version = "0.12.1", default-features = false }
 pin-project = { version = "1.0.12" }
 qlog = { version = "0.15.2", path = "./qlog" }
 quiche = { version = "0.24.6", path = "./quiche" }
-rand = { version = "0.8" }
 regex = { version = "1.4.2" }
 ring = { version = "0.17.8" }
 rstest = { version = "0.25.0" }

--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -27,7 +27,7 @@ multimap = "0.10"
 octets = { workspace = true }
 qlog = { workspace = true }
 quiche = { features = ["internal", "qlog"], workspace = true }
-rand = { workspace = true }
+ring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["macros", "std"] }

--- a/h3i/src/client/sync_client.rs
+++ b/h3i/src/client/sync_client.rs
@@ -30,6 +30,8 @@ use std::slice::Iter;
 use std::time::Duration;
 use std::time::Instant;
 
+use ring::rand::*;
+
 use crate::client::QUIC_VERSION;
 use crate::frame::H3iFrame;
 use crate::quiche;
@@ -159,7 +161,9 @@ pub fn connect(
 
     // Generate a random source connection ID for the connection.
     let mut scid = [0; quiche::MAX_CONN_ID_LEN];
-    rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut scid);
+
+    let rng = SystemRandom::new();
+    rng.fill(&mut scid[..]).unwrap();
 
     let scid = quiche::ConnectionId::from_ref(&scid);
 
@@ -488,11 +492,15 @@ fn check_duration_and_do_actions(
 
 /// Generate a new pair of Source Connection ID and reset token.
 pub fn generate_cid_and_reset_token() -> (quiche::ConnectionId<'static>, u128) {
+    let rng = SystemRandom::new();
+
     let mut scid = [0; quiche::MAX_CONN_ID_LEN];
-    rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut scid);
+    rng.fill(&mut scid[..]).unwrap();
     let scid = scid.to_vec().into();
+
     let mut reset_token = [0; 16];
-    rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut reset_token);
+    rng.fill(&mut reset_token[..]).unwrap();
+
     let reset_token = u128::from_be_bytes(reset_token);
     (scid, reset_token)
 }


### PR DESCRIPTION
We already use `ring` in apps anyway, so just do the same here rather than importing a whole new dependency just for h3i.