### PR TITLE
Fix: Write stdout directly to avoid time comsumption without --dump-response option

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -764,6 +764,7 @@ pub struct Http3Conn {
     dump_json: bool,
     dgram_sender: Option<Http3DgramSender>,
     output_sink: Rc<RefCell<dyn FnMut(String)>>,
+    stdout_writer: std::io::BufWriter<std::io::Stdout>,
 }
 
 impl Http3Conn {
@@ -857,6 +858,7 @@ impl Http3Conn {
             dump_json: dump_json.is_some(),
             dgram_sender,
             output_sink,
+            stdout_writer: std::io::BufWriter::new(std::io::stdout()),
         };
 
         Box::new(h_conn)
@@ -889,6 +891,7 @@ impl Http3Conn {
             dump_json: false,
             dgram_sender,
             output_sink,
+            stdout_writer: std::io::BufWriter::new(std::io::stdout()),
         };
 
         Ok(Box::new(h_conn))
@@ -1270,11 +1273,7 @@ impl HttpConn for Http3Conn {
 
                             None =>
                                 if !self.dump_json {
-                                    self.output_sink.borrow_mut()(unsafe {
-                                        String::from_utf8_unchecked(
-                                            buf[..read].to_vec(),
-                                        )
-                                    });
+                                    self.stdout_writer.write_all(&buf[..read]).ok();
                                 },
                         }
                     }


### PR DESCRIPTION
Hello team.

This PR Closes https://github.com/cloudflare/quiche/issues/2220

I've changed response writing logic without dump option to write down stdout directly without copying and converting types.

Now there are no dramatic timp delay between the two operations.

```sh
time cargo run --bin quiche-client -- \
https://127.0.0.1:4433/1GB.bin --no-verify
   Compiling quiche_apps v0.1.0 (/Users/ohyeong-geun/rust/quiche/apps)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.57s
     Running `target/debug/quiche-client 'https://127.0.0.1:4433/1GB.bin' --no-verify`
cargo run --bin quiche-client -- https://127.0.0.1:4433/1GB.bin --no-verify  0.15s user 0.07s system 21% cpu 0.993 total
```

```sh
time cargo run --bin quiche-client -- \
https://127.0.0.1:4433/1GB.bin --no-verify \
--dump-responses /tmp
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/quiche-client 'https://127.0.0.1:4433/1GB.bin' --no-verify --dump-responses /tmp`
cargo run --bin quiche-client -- https://127.0.0.1:4433/1GB.bin --no-verify    0.15s user 0.06s system 41% cpu 0.489 total
```

Additionally, I've used BufWriter to minimize system calls (If we use ``std::io::stdout().write_all()`, there might be a x8 syscalls).

Please check and leave any comments.

Thanks.