### PR TITLE
fix: zero-initialize msghdr first for musl lib build compatibility 

### DIFF
--- a/datagram-socket/src/mmsg.rs
+++ b/datagram-socket/src/mmsg.rs
@@ -25,9 +25,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::io::IoSlice;
-use std::io::{
-    self,
-};
+use std::io::{self};
 use std::os::fd::AsRawFd;
 use std::os::fd::BorrowedFd;
 
@@ -55,16 +53,17 @@ pub fn recvmmsg(fd: BorrowedFd, bufs: &mut [ReadBuf<'_>]) -> io::Result<usize> {
 
             slices.push(IoSlice::new(b));
 
+            let mut msg_hdr: libc::msghdr = unsafe { std::mem::zeroed() };
+            msg_hdr.msg_name = std::ptr::null_mut();
+            msg_hdr.msg_namelen = 0;
+            msg_hdr.msg_iov = slices.last_mut().unwrap() as *mut _ as *mut _;
+            msg_hdr.msg_iovlen = 1;
+            msg_hdr.msg_control = std::ptr::null_mut();
+            msg_hdr.msg_controllen = 0;
+            msg_hdr.msg_flags = 0;
+
             msgvec.push(libc::mmsghdr {
-                msg_hdr: libc::msghdr {
-                    msg_name: std::ptr::null_mut(),
-                    msg_namelen: 0,
-                    msg_iov: slices.last_mut().unwrap() as *mut _ as *mut _,
-                    msg_iovlen: 1,
-                    msg_control: std::ptr::null_mut(),
-                    msg_controllen: 0,
-                    msg_flags: 0,
-                },
+                msg_hdr,
                 msg_len: buf.capacity().try_into().unwrap(),
             });
         }
@@ -115,16 +114,17 @@ pub fn sendmmsg(fd: BorrowedFd, bufs: &[ReadBuf<'_>]) -> io::Result<usize> {
         for buf in bufs.iter() {
             slices.push(IoSlice::new(buf.filled()));
 
+            let mut msg_hdr: libc::msghdr = unsafe { std::mem::zeroed() };
+            msg_hdr.msg_name = std::ptr::null_mut();
+            msg_hdr.msg_namelen = 0;
+            msg_hdr.msg_iov = slices.last_mut().unwrap() as *mut _ as *mut _;
+            msg_hdr.msg_iovlen = 1;
+            msg_hdr.msg_control = std::ptr::null_mut();
+            msg_hdr.msg_controllen = 0;
+            msg_hdr.msg_flags = 0;
+
             msgvec.push(libc::mmsghdr {
-                msg_hdr: libc::msghdr {
-                    msg_name: std::ptr::null_mut(),
-                    msg_namelen: 0,
-                    msg_iov: slices.last_mut().unwrap() as *mut _ as *mut _,
-                    msg_iovlen: 1,
-                    msg_control: std::ptr::null_mut(),
-                    msg_controllen: 0,
-                    msg_flags: 0,
-                },
+                msg_hdr,
                 msg_len: buf.capacity().try_into().unwrap(),
             });
         }

--- a/datagram-socket/src/mmsg.rs
+++ b/datagram-socket/src/mmsg.rs
@@ -25,7 +25,9 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::io::IoSlice;
-use std::io::{self};
+use std::io::{
+    self,
+};
 use std::os::fd::AsRawFd;
 use std::os::fd::BorrowedFd;
 

--- a/datagram-socket/src/mmsg.rs
+++ b/datagram-socket/src/mmsg.rs
@@ -54,13 +54,14 @@ pub fn recvmmsg(fd: BorrowedFd, bufs: &mut [ReadBuf<'_>]) -> io::Result<usize> {
             slices.push(IoSlice::new(b));
 
             let mut msg_hdr: libc::msghdr = unsafe { std::mem::zeroed() };
-            msg_hdr.msg_name = std::ptr::null_mut();
-            msg_hdr.msg_namelen = 0;
             msg_hdr.msg_iov = slices.last_mut().unwrap() as *mut _ as *mut _;
             msg_hdr.msg_iovlen = 1;
-            msg_hdr.msg_control = std::ptr::null_mut();
-            msg_hdr.msg_controllen = 0;
-            msg_hdr.msg_flags = 0;
+            // Fields below are already zero-initialized by std::mem::zeroed().
+            // msg_hdr.msg_name = std::ptr::null_mut();
+            // msg_hdr.msg_namelen = 0;
+            // msg_hdr.msg_control = std::ptr::null_mut();
+            // msg_hdr.msg_controllen = 0;
+            // msg_hdr.msg_flags = 0;
 
             msgvec.push(libc::mmsghdr {
                 msg_hdr,
@@ -115,13 +116,14 @@ pub fn sendmmsg(fd: BorrowedFd, bufs: &[ReadBuf<'_>]) -> io::Result<usize> {
             slices.push(IoSlice::new(buf.filled()));
 
             let mut msg_hdr: libc::msghdr = unsafe { std::mem::zeroed() };
-            msg_hdr.msg_name = std::ptr::null_mut();
-            msg_hdr.msg_namelen = 0;
             msg_hdr.msg_iov = slices.last_mut().unwrap() as *mut _ as *mut _;
             msg_hdr.msg_iovlen = 1;
-            msg_hdr.msg_control = std::ptr::null_mut();
-            msg_hdr.msg_controllen = 0;
-            msg_hdr.msg_flags = 0;
+            // Fields below are already zero-initialized by std::mem::zeroed().
+            // msg_hdr.msg_name = std::ptr::null_mut();
+            // msg_hdr.msg_namelen = 0;
+            // msg_hdr.msg_control = std::ptr::null_mut();
+            // msg_hdr.msg_controllen = 0;
+            // msg_hdr.msg_flags = 0;
 
             msgvec.push(libc::mmsghdr {
                 msg_hdr,


### PR DESCRIPTION
Hey there!

fixes #2222 
Like @strophy pointed out, there's an issue where **msghdr** can't be created directly on **musl** systems. The problem is that the musl libc has a couple extra private padding fields in the struct that aren't accessible.

#### Fix
This PR uses [std::mem::zeroed()](https://doc.rust-lang.org/std/mem/fn.zeroed.html) to initialize `msghdr` by just setting everything to `0`. This way quiche builds fine on musl-based distros.
If we take a look at the [msghdr](https://docs.rs/libc/latest/libc/struct.msghdr.html) struct, it's basically just **raw pointers** and **numbers**. By zeroing everything out (including those hidden padding fields), we are able to satisfy the kernel.

The original code **manually** set many fields to null pointers and `0`. With `zeroed()` doing this automatically, those manual assignments were commented out. (kept for reference)

#### Safety
Now, `std::mem::zeroed()` can be dangerous if used on the wrong types - like anything that can't be null or zero because that creates [undefined behavior](https://doc.rust-lang.org/reference/behavior-considered-undefined.html#invalid-values). 

But as mentioned before it's fine here since `msghdr` is just raw pointers and numeric types, which can all safely be `0`.

#### Performance
Ran some benchmarks with **criterion.rs** to compare how fast safe vs unsafe initialization of  msghdr struct are.
Optimizations stayed enabled since the goal was to test under realistic conditions.

The safe constructor (which doesn't work with musl) was indeed slower, but the difference wasn't as big as mentioned [here](https://github.com/anza-xyz/agave/pull/4760#issue-2828227375).
On average the unsafe approach is about **1.5-2%** faster than the version without `zeroed()`.
Between having redundant assignments vs just using `zeroed()`, the performance is virtually **identical**.
