### PR TITLE
fuzz: determine path of certificate / key more robustly

### DIFF
--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,3 +1,6 @@
+use std::path::Path;
+use std::path::PathBuf;
+
 use quiche::h3::NameValue;
 
 pub struct PktsData<'a> {
@@ -46,6 +49,42 @@ pub fn reset_rand_for_fuzzing() {
     }
 
     unsafe { RAND_reset_for_fuzzing() };
+}
+
+/// Returns the path to the X.509 certificate and key.
+///
+/// If `QUICHE_FUZZ_CRT` and / or `QUICHE_FUZZ_KEY` are set, their value is
+/// used, otherwise in order to accomodate different fuzzing environments, this
+/// either returns relative paths (e.g. "fuzz/cert.crt") when running from a
+/// clone of the git repository, or absolute paths based on `argv[0]` when
+/// running bare executable (as used by OSS-Fuzz).
+pub fn get_cert_path() -> (String, String) {
+    let fuzz_dir = if Path::new("fuzz/").exists() {
+        PathBuf::from("fuzz/")
+    } else {
+        // Get directory the fuzzer is running from.
+        let mut fuzz_dir = PathBuf::from(std::env::args().next().unwrap());
+        // Remove executable file name.
+        fuzz_dir.pop();
+        // Add "fuzz" subdirectory.
+        fuzz_dir.push("fuzz");
+
+        fuzz_dir
+    };
+
+    let crt_path = std::env::var("QUICHE_FUZZ_CRT").unwrap_or_else(|_| {
+        let mut crt_path = fuzz_dir.clone();
+        crt_path.push("cert.crt");
+        crt_path.to_str().unwrap().to_string()
+    });
+
+    let key_path = std::env::var("QUICHE_FUZZ_KEY").unwrap_or_else(|_| {
+        let mut key_path = fuzz_dir.clone();
+        key_path.push("cert.key");
+        key_path.to_str().unwrap().to_string()
+    });
+
+    (crt_path, key_path)
 }
 
 pub fn server_process(

--- a/fuzz/src/packet_recv_server.rs
+++ b/fuzz/src/packet_recv_server.rs
@@ -27,10 +27,7 @@ fuzz_target!(|data: &[u8]| {
     let mut buf = data.to_vec();
 
     let config = CONFIG.get_or_init(|| {
-        let crt_path = std::env::var("QUICHE_FUZZ_CRT")
-            .unwrap_or_else(|_| "fuzz/cert.crt".to_string());
-        let key_path = std::env::var("QUICHE_FUZZ_KEY")
-            .unwrap_or_else(|_| "fuzz/cert.key".to_string());
+        let (crt_path, key_path) = quiche_fuzz::get_cert_path();
 
         let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
         config.load_cert_chain_from_pem_file(&crt_path).unwrap();

--- a/fuzz/src/packets_posths_server.rs
+++ b/fuzz/src/packets_posths_server.rs
@@ -27,10 +27,7 @@ fuzz_target!(|data: &[u8]| {
     let packets = quiche_fuzz::PktsData { data };
 
     let config = CONFIG.get_or_init(|| {
-        let crt_path = std::env::var("QUICHE_FUZZ_CRT")
-            .unwrap_or_else(|_| "fuzz/cert.crt".to_string());
-        let key_path = std::env::var("QUICHE_FUZZ_KEY")
-            .unwrap_or_else(|_| "fuzz/cert.key".to_string());
+        let (crt_path, key_path) = quiche_fuzz::get_cert_path();
 
         let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
         config.load_cert_chain_from_pem_file(&crt_path).unwrap();

--- a/fuzz/src/packets_recv_server.rs
+++ b/fuzz/src/packets_recv_server.rs
@@ -27,10 +27,7 @@ fuzz_target!(|data: &[u8]| {
     let packets = quiche_fuzz::PktsData { data };
 
     let config = CONFIG.get_or_init(|| {
-        let crt_path = std::env::var("QUICHE_FUZZ_CRT")
-            .unwrap_or_else(|_| "fuzz/cert.crt".to_string());
-        let key_path = std::env::var("QUICHE_FUZZ_KEY")
-            .unwrap_or_else(|_| "fuzz/cert.key".to_string());
+        let (crt_path, key_path) = quiche_fuzz::get_cert_path();
 
         let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
         config.load_cert_chain_from_pem_file(&crt_path).unwrap();


### PR DESCRIPTION
This is largely to accomodate OSS-Fuzz, where fuzzers are not supposed to make any assumptions about the current working directory, but should use the path from `argv[0]` instead:
https://google.github.io/oss-fuzz/further-reading/fuzzer-environment/#current-working-directory

The existing behaviour is also kept, as that is what is needed for running `cargo fuzz` manually: the decision is made based on whether the relative "fuzz/" directory exists or not.