### PR TITLE
tokio-quiche: Expose missing quiche::Config entries

### DIFF
--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -168,6 +168,9 @@ fn make_quiche_config(
     config.set_initial_congestion_window_packets(
         quic_settings.initial_congestion_window_packets,
     );
+    config.set_enable_relaxed_loss_threshold(
+        quic_settings.enable_relaxed_loss_threshold,
+    );
     config.discover_pmtu(quic_settings.discover_path_mtu);
     config.enable_hystart(quic_settings.enable_hystart);
 
@@ -184,6 +187,7 @@ fn make_quiche_config(
     config.set_max_stream_window(quic_settings.max_stream_window);
     config.grease(quic_settings.grease);
     config.set_max_amplification_factor(quic_settings.max_amplification_factor);
+    config.set_send_capacity_factor(quic_settings.send_capacity_factor);
     config.set_ack_delay_exponent(quic_settings.ack_delay_exponent);
     config.set_max_ack_delay(quic_settings.max_ack_delay);
     config.set_path_challenge_recv_max_queue_len(

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -161,6 +161,11 @@ pub struct QuicSettings {
     #[serde(default = "QuicSettings::default_initial_congestion_window_packets")]
     pub initial_congestion_window_packets: usize,
 
+    /// Configures whether to enable relaxed loss detection on spurious loss.
+    ///
+    /// Defaults to `false`.
+    pub enable_relaxed_loss_threshold: bool,
+
     /// Configures whether to do path MTU discovery.
     ///
     /// Defaults to `false`.
@@ -250,6 +255,16 @@ pub struct QuicSettings {
     /// Defaults to 3.
     #[serde(default = "QuicSettings::default_amplification_factor")]
     pub max_amplification_factor: usize,
+
+    /// Sets the send capacity factor.
+    ///
+    /// A factor greater than 1 allows the connection to buffer more outbound
+    /// data than can be sent at this moment. This can improve throughput by
+    /// reducing time spent waiting for new data.
+    ///
+    /// Defaults to 1.
+    #[serde(default = "QuicSettings::default_send_capacity_factor")]
+    pub send_capacity_factor: f64,
 
     /// Sets the `ack_delay_exponent` transport parameter.
     ///
@@ -392,6 +407,11 @@ impl QuicSettings {
     #[inline]
     fn default_amplification_factor() -> usize {
         3
+    }
+
+    #[inline]
+    fn default_send_capacity_factor() -> f64 {
+        1.0
     }
 
     #[inline]


### PR DESCRIPTION
tokio-quiche is missing some `quiche::Config` entries that were added after tokio-quiche development began. This adds the two missing fields that I noticed:

- `enable_relaxed_loss_threshold`
- `send_capacity_factor`