### PR TITLE
tokio-quiche: release 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ smallvec = { version = "1.10", default-features = false }
 task-killswitch = { version = "0.1.1", path = "./task-killswitch" }
 thiserror = { version = "2" }
 tokio = { version = "1.44", default-features = false }
-tokio-quiche = { version = "0.10.0", path = "./tokio-quiche" }
+tokio-quiche = { version = "0.11.0", path = "./tokio-quiche" }
 tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7.13" }
 triomphe = { version = "0.1" }

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-quiche"
-version = "0.10.0"
+version = "0.11.0"
 description = "Asynchronous wrapper around quiche"
 repository = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
Changes:
* Cargo.toml: fix `readme` field and re-order (#2229)
* Add TimeHistogram for time spent in the sendmsg loop (#2223)
* test: expose functionality to pass/retrieve in session info (#2219)
* tokio-quiche: boost the priority of server streams prior to writing response headers (#2215)
* tokio-quiche: better RESET_STREAM and STOP_SENDING handling (#2166)