### PR TITLE
Return task ID from spawn_with_killswitch

### DIFF
--- a/tokio-quiche/src/metrics/tokio_task.rs
+++ b/tokio-quiche/src/metrics/tokio_task.rs
@@ -192,8 +192,8 @@ where
     let ctx = TelemetryContext::current();
 
     if cfg!(feature = "tokio-task-metrics") {
-        killswitch_spawn(Instrumented::new(name, metrics, ctx.apply(future)))
+        killswitch_spawn(Instrumented::new(name, metrics, ctx.apply(future)));
     } else {
-        killswitch_spawn(ctx.apply(future))
+        killswitch_spawn(ctx.apply(future));
     }
 }


### PR DESCRIPTION
As part of the change to run Tokio task hooks in Oxy and FL2, we also need the task id within Oxy to map between tasks and the associated timing data. Therefore we need to have spawn_with_killswitch return the task_id from the spawned task.