### PR TITLE
Remove debug_assert! in process_write_frame

### DIFF
--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -703,11 +703,6 @@ impl<H: DriverHooks> H3Driver<H> {
         let Some(frame) = &mut ctx.queued_frame else {
             return Ok(());
         };
-        debug_assert!(
-            ctx.recv.is_some(),
-            "If we have a queued frame in the context, we MUST NOT be waiting
-             on data from the channel"
-        );
 
         let audit_stats = &ctx.audit_stats;
         let stream_id = audit_stats.stream_id();


### PR DESCRIPTION
This debug_assert was introduced in https://github.com/cloudflare/quiche/pull/2166 and can trigger if a stream's FIN frame can't be serialized immediately due to not having enough congestion window or flow control window.  Sending of the FIN stream next time window becomes available works correctly, the only problem is that this debug_assert triggers failures when running download stress tests in debug mode (in other words, when binaries are build without the --release flag)