### PR TITLE
qlog-dancer: Connection overview chart improvements

### DIFF
--- a/qlog-dancer/src/plots/congestion_control.rs
+++ b/qlog-dancer/src/plots/congestion_control.rs
@@ -64,7 +64,7 @@ pub fn draw_congestion_plot<'a, DB: DrawingBackend + 'a>(
         &params.colors,
         "Relative time (ms)",
         "Data (bytes)",
-        params.display_minor_lines,
+        false,
         &mut plot,
     );
 

--- a/qlog-dancer/src/plots/conn_overview.rs
+++ b/qlog-dancer/src/plots/conn_overview.rs
@@ -24,8 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::collections::BTreeMap;
-
 use full_palette::PURPLE_500;
 use minmax::XMinMax;
 use plotters::coord::types::RangedCoordf32;
@@ -35,7 +33,6 @@ use plotters::prelude::*;
 
 use crate::plots::colors::*;
 use crate::plots::*;
-use crate::QlogPointu64;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::datastore::Datastore;
@@ -110,39 +107,45 @@ impl From<OverviewChartOutputType> for ChartOutputType {
 }
 
 fn draw_sent_max_data<DB: DrawingBackend>(
-    data: &[(f32, u64)],
-    stream_chart: &mut ChartContext<
-        DB,
-        Cartesian2d<RangedCoordf32, RangedCoordu64>,
-    >,
-) {
-    draw_line(data, Some("sent MAX_DATA"), BLACK, stream_chart);
-}
-
-fn draw_cumulative_sent_max_data<DB: DrawingBackend>(
-    data: &[(f32, u64)],
+    ss: &SeriesStore,
     stream_chart: &mut ChartContext<
         DB,
         Cartesian2d<RangedCoordf32, RangedCoordu64>,
     >,
 ) {
     draw_line(
-        data,
-        Some("cumulative sent MAX_STREAM_DATA"),
+        &ss.sent_max_data,
+        Some("Sent MAX_DATA"),
+        BLACK,
+        stream_chart,
+    );
+}
+
+fn draw_cumulative_sent_max_data<DB: DrawingBackend>(
+    ss: &SeriesStore,
+    stream_chart: &mut ChartContext<
+        DB,
+        Cartesian2d<RangedCoordf32, RangedCoordu64>,
+    >,
+) {
+    draw_line(
+        &ss.sum_sent_stream_max_data,
+        Some("Cumulative sent MAX_STREAM_DATA"),
         CYAN,
         stream_chart,
     );
 }
 
 fn draw_sent_max_stream_data<DB: DrawingBackend>(
-    streams: &BTreeMap<u64, Vec<QlogPointu64>>,
+    ss: &SeriesStore,
     stream_chart: &mut ChartContext<
         DB,
         Cartesian2d<RangedCoordf32, RangedCoordu64>,
     >,
 ) {
-    let mut label = Some("sent MAX_STREAM_DATA");
+    let mut label = Some("Sent MAX_STREAM_DATA");
 
+    let streams = &ss.sent_stream_max_data;
     for series in streams {
         draw_line(series.1, label, BLUE, stream_chart);
         label = None;
@@ -150,14 +153,15 @@ fn draw_sent_max_stream_data<DB: DrawingBackend>(
 }
 
 fn draw_buffer_reads<DB: DrawingBackend>(
-    streams: &BTreeMap<u64, Vec<QlogPointu64>>,
+    ss: &SeriesStore,
     stream_chart: &mut ChartContext<
         DB,
         Cartesian2d<RangedCoordf32, RangedCoordu64>,
     >,
 ) {
-    let mut label = Some("stream buffer read");
+    let mut label = Some("Stream buffer read");
 
+    let streams = &ss.stream_buffer_reads;
     for series in streams {
         draw_line(series.1, label, FOREST_GREEN, stream_chart);
         label = None;
@@ -165,59 +169,88 @@ fn draw_buffer_reads<DB: DrawingBackend>(
 }
 
 fn draw_cumulative_buffer_reads<DB: DrawingBackend>(
-    data: &[(f32, u64)],
+    ss: &SeriesStore,
     stream_chart: &mut ChartContext<
         DB,
         Cartesian2d<RangedCoordf32, RangedCoordu64>,
     >,
 ) {
     draw_line(
-        data,
-        Some("cumulative stream buffer read"),
+        &ss.sum_stream_buffer_reads,
+        Some("Cumulative stream buffer read"),
         GREEN,
         stream_chart,
     );
 }
 
 fn draw_buffer_writes<DB: DrawingBackend>(
-    streams: &BTreeMap<u64, Vec<QlogPointu64>>,
+    ss: &SeriesStore,
     stream_chart: &mut ChartContext<
         DB,
         Cartesian2d<RangedCoordf32, RangedCoordu64>,
     >,
 ) {
-    let mut label = Some("stream buffer write");
+    let mut label = Some("Stream buffer write");
 
+    let streams = &ss.stream_buffer_writes;
     for series in streams {
         draw_line(series.1, label, MAGENTA, stream_chart);
         label = None;
     }
 }
 
-fn draw_buffer_dropped<DB: DrawingBackend>(
-    streams: &BTreeMap<u64, Vec<QlogPointu64>>,
+fn draw_cumulative_buffer_writes<DB: DrawingBackend>(
+    ss: &SeriesStore,
     stream_chart: &mut ChartContext<
         DB,
         Cartesian2d<RangedCoordf32, RangedCoordu64>,
     >,
 ) {
-    let mut label = Some("stream buffer dropped");
+    let data = &ss.sum_stream_buffer_writes;
+    let label = Some("Cumulative stream buffer writes");
 
+    draw_line(data, label, RGBColor(255, 0, 0), stream_chart);
+}
+
+fn draw_buffer_dropped<DB: DrawingBackend>(
+    ss: &SeriesStore,
+    stream_chart: &mut ChartContext<
+        DB,
+        Cartesian2d<RangedCoordf32, RangedCoordu64>,
+    >,
+) {
+    let mut label = Some("Stream buffer dropped");
+
+    let streams = &ss.stream_buffer_dropped;
     for series in streams {
         draw_line(series.1, label, ORANGE, stream_chart);
         label = None;
     }
 }
 
-fn draw_sent_stream_data<DB: DrawingBackend>(
-    streams: &BTreeMap<u64, Vec<QlogPointu64>>,
+fn draw_cumulative_buffer_dropped<DB: DrawingBackend>(
+    ss: &SeriesStore,
     stream_chart: &mut ChartContext<
         DB,
         Cartesian2d<RangedCoordf32, RangedCoordu64>,
     >,
 ) {
-    let mut label = Some("sent stream data");
+    let data = &ss.sum_stream_buffer_dropped;
+    let label = Some("Cumulative stream buffer dropped");
 
+    draw_line(data, label, RGBColor(0, 0, 255), stream_chart);
+}
+
+fn draw_sent_stream_data<DB: DrawingBackend>(
+    ss: &SeriesStore,
+    stream_chart: &mut ChartContext<
+        DB,
+        Cartesian2d<RangedCoordf32, RangedCoordu64>,
+    >,
+) {
+    let mut label = Some("Sent stream data");
+
+    let streams = &ss.sent_stream_frames_series;
     for series in streams {
         draw_line(series.1, label, PURPLE_500, stream_chart);
         label = None;
@@ -225,35 +258,36 @@ fn draw_sent_stream_data<DB: DrawingBackend>(
 }
 
 fn draw_received_max_data<DB: DrawingBackend>(
-    data: &[(f32, u64)],
+    ss: &SeriesStore,
     stream_chart: &mut ChartContext<
         DB,
         Cartesian2d<RangedCoordf32, RangedCoordu64>,
     >,
 ) {
     draw_line(
-        data,
-        Some("cumulative received MAX_DATA"),
+        &ss.received_max_data,
+        Some("Cumulative received MAX_DATA"),
         MID_GREY,
         stream_chart,
     );
 }
 
 fn draw_cumulative_received_stream_max_data<DB: DrawingBackend>(
-    data: &[(f32, u64)],
+    ss: &SeriesStore,
     stream_chart: &mut ChartContext<
         DB,
         Cartesian2d<RangedCoordf32, RangedCoordu64>,
     >,
 ) {
     draw_line(
-        data,
-        Some("cumulative received MAX_STREAM_DATA"),
+        &ss.sum_received_stream_max_data,
+        Some("Cumulative received MAX_STREAM_DATA"),
         MUSTARD,
         stream_chart,
     );
 }
 
+#[cfg(target_arch = "wasm32")]
 fn draw_main_plot<'a, DB: DrawingBackend + 'a>(
     filename: &str, params: &PlotParameters, axis: XYMinMax, ss: &SeriesStore,
     plot: &plotters::drawing::DrawingArea<DB, Shift>,
@@ -280,19 +314,119 @@ fn draw_main_plot<'a, DB: DrawingBackend + 'a>(
         &mut chart,
     );
 
-    draw_sent_max_data(&ss.sent_max_data, &mut chart);
-    draw_cumulative_sent_max_data(&ss.sum_sent_stream_max_data, &mut chart);
-    draw_sent_max_stream_data(&ss.sent_stream_max_data, &mut chart);
-    draw_buffer_reads(&ss.stream_buffer_reads, &mut chart);
-    draw_cumulative_buffer_reads(&ss.sum_stream_buffer_reads, &mut chart);
-    draw_buffer_writes(&ss.stream_buffer_writes, &mut chart);
-    draw_buffer_dropped(&ss.stream_buffer_dropped, &mut chart);
-    draw_sent_stream_data(&ss.sent_stream_frames_series, &mut chart);
-    draw_received_max_data(&ss.received_max_data, &mut chart);
+    draw_sent_max_data(ss, &mut chart);
+    draw_cumulative_sent_max_data(ss, &mut chart);
+    draw_sent_max_stream_data(ss, &mut chart);
+    draw_buffer_reads(ss, &mut chart);
+    draw_cumulative_buffer_reads(ss, &mut chart);
+    draw_buffer_writes(ss, &mut chart);
+    draw_cumulative_buffer_writes(ss, &mut chart);
+    draw_buffer_dropped(ss, &mut chart);
+    draw_cumulative_buffer_dropped(ss, &mut chart);
+    draw_sent_stream_data(ss, &mut chart);
+    draw_received_max_data(ss, &mut chart);
     draw_cumulative_received_stream_max_data(
         &ss.sum_received_stream_max_data,
         &mut chart,
     );
+
+    if params.display_legend {
+        chart
+            .configure_series_labels()
+            .label_font(chart_label_style(&params.colors.caption))
+            .background_style(params.colors.fill.mix(0.8))
+            .border_style(params.colors.axis)
+            .position(SeriesLabelPosition::UpperLeft)
+            .draw()
+            .unwrap();
+    }
+
+    chart
+}
+
+fn draw_stream_send_plot<'a, DB: DrawingBackend + 'a>(
+    params: &PlotParameters, axis: XYMinMax, ss: &SeriesStore,
+    plot: &plotters::drawing::DrawingArea<DB, Shift>,
+) -> ChartContext<'a, DB, Cartesian2d<RangedCoordf32, RangedCoordu64>> {
+    let mut builder = ChartBuilder::on(plot);
+    builder
+        .x_label_area_size(params.area_margin.x)
+        .y_label_area_size(params.area_margin.y);
+
+    if params.display_chart_title {
+        builder.caption(
+            "Stream sends",
+            chart_subtitle_style(&params.colors.caption),
+        );
+    }
+
+    let mut chart = builder
+        .build_cartesian_2d(axis.x.range(), axis.y_range())
+        .unwrap();
+
+    draw_mesh(
+        &params.colors,
+        "Relative time (ms)",
+        "Data (bytes)",
+        false,
+        &mut chart,
+    );
+
+    draw_cumulative_buffer_writes(ss, &mut chart);
+    draw_cumulative_buffer_dropped(ss, &mut chart);
+    draw_buffer_writes(ss, &mut chart);
+    draw_buffer_dropped(ss, &mut chart);
+    draw_sent_stream_data(ss, &mut chart);
+    draw_received_max_data(ss, &mut chart);
+    draw_cumulative_received_stream_max_data(ss, &mut chart);
+
+    if params.display_legend {
+        chart
+            .configure_series_labels()
+            .label_font(chart_label_style(&params.colors.caption))
+            .background_style(params.colors.fill.mix(0.8))
+            .border_style(params.colors.axis)
+            .position(SeriesLabelPosition::UpperLeft)
+            .draw()
+            .unwrap();
+    }
+
+    chart
+}
+
+fn draw_stream_recv_plot<'a, DB: DrawingBackend + 'a>(
+    params: &PlotParameters, axis: XYMinMax, ss: &SeriesStore,
+    plot: &plotters::drawing::DrawingArea<DB, Shift>,
+) -> ChartContext<'a, DB, Cartesian2d<RangedCoordf32, RangedCoordu64>> {
+    let mut builder = ChartBuilder::on(plot);
+    builder
+        .x_label_area_size(params.area_margin.x)
+        .y_label_area_size(params.area_margin.y);
+
+    if params.display_chart_title {
+        builder.caption(
+            "Stream receives",
+            chart_subtitle_style(&params.colors.caption),
+        );
+    }
+
+    let mut chart = builder
+        .build_cartesian_2d(axis.x.range(), axis.y_range())
+        .unwrap();
+
+    draw_mesh(
+        &params.colors,
+        "Relative time (ms)",
+        "Data (bytes)",
+        false,
+        &mut chart,
+    );
+
+    draw_sent_max_data(ss, &mut chart);
+    draw_cumulative_sent_max_data(ss, &mut chart);
+    draw_sent_max_stream_data(ss, &mut chart);
+    draw_buffer_reads(ss, &mut chart);
+    draw_cumulative_buffer_reads(ss, &mut chart);
 
     if params.display_legend {
         chart
@@ -334,16 +468,27 @@ pub fn plot_connection_overview(
         params.chart_margin,
     );
 
-    let (stream_plot, remainder) = root.split_vertically((60).percent());
-    let (congestion_plot, rtt_plot) = remainder.split_vertically((60).percent());
+    let (top_margin, bottom) = root.split_vertically((5).percent());
+    let (stream_plots, cwnd_rtt_area) = bottom.split_vertically((60).percent());
+    let (stream_send_plot, stream_recv_plot) =
+        stream_plots.split_vertically((50).percent());
+    let (congestion_plot, rtt_plot) =
+        cwnd_rtt_area.split_vertically((60).percent());
 
-    let stream_y_max = if let Some(y_max) = params.clamp.stream_y_max {
+    let stream_send_y_max = if let Some(y_max) = params.clamp.stream_y_max {
         y_max
     } else {
-        ss.y_max_stream_plot
+        ss.y_max_stream_send_plot
     };
 
-    let stream_axis = XYMinMax::init(params, ss, stream_y_max);
+    let stream_recv_y_max = if let Some(y_max) = params.clamp.stream_y_max {
+        y_max
+    } else {
+        ss.y_max_stream_recv_plot
+    };
+
+    let stream_send_axis = XYMinMax::init(params, ss, stream_send_y_max);
+    let stream_recv_axis = XYMinMax::init(params, ss, stream_recv_y_max);
 
     let cwnd_y_max = if let Some(y_max) = params.cwnd_y_max {
         y_max
@@ -359,7 +504,15 @@ pub fn plot_connection_overview(
         0..cwnd_y_max,
     );
 
-    draw_main_plot(filename, params, stream_axis, ss, &stream_plot);
+    top_margin
+        .draw_text(
+            format!("{} Connection overview", filename).as_str(),
+            &chart_title_style(&params.colors.caption),
+            (0, 0),
+        )
+        .unwrap();
+    draw_stream_send_plot(params, stream_send_axis, ss, &stream_send_plot);
+    draw_stream_recv_plot(params, stream_recv_axis, ss, &stream_recv_plot);
     draw_congestion_plot(params, &common_axis, ss, ds, &congestion_plot);
     draw_rtt_plot(params, &common_axis, ss, &rtt_plot);
 }

--- a/qlog-dancer/src/plots/stream_sparks.rs
+++ b/qlog-dancer/src/plots/stream_sparks.rs
@@ -1113,10 +1113,15 @@ pub fn plot_sparks(
             &mut rel_dl_chart,
         );
 
+        let y_max = match ds.vantage_point {
+            VantagePoint::Client => ss.y_max_stream_recv_plot,
+            VantagePoint::Server => ss.y_max_stream_send_plot,
+        };
+
         draw_request_timing_lines(
             ds,
             *stream_id,
-            ss.y_max_stream_plot,
+            y_max,
             &mut abs_dl_chart,
             &mut rel_dl_chart,
         );


### PR DESCRIPTION
The connection overview attempts to give a high-level view of events related
to connection data, stream data, congestion control, and RTT.

Previously, the top panel combined all connection and stream events, making
it difficult to assess when send and write operations are large and/or
asymmetric.

This change splits out thecombined  plot into separate send and receive
plots. In addition, the send plot gets two new series: cumulative buffer
write, and cumulative buffer drop.
