### PR TITLE
Add stream reset and stopped counts to SocketStats

### DIFF
--- a/datagram-socket/src/socket_stats.rs
+++ b/datagram-socket/src/socket_stats.rs
@@ -67,6 +67,10 @@ pub struct SocketStats {
     pub max_bandwidth: Option<u64>,
     pub startup_exit: Option<StartupExit>,
     pub bytes_in_flight_duration_us: u64,
+    pub reset_stream_count_local: u64,
+    pub stopped_stream_count_local: u64,
+    pub reset_stream_count_remote: u64,
+    pub stopped_stream_count_remote: u64,
 }
 
 /// Statistics from when a CCA first exited the startup phase.

--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -177,6 +177,10 @@ impl AsSocketStats for QuicConnectionStats {
                 .stats
                 .bytes_in_flight_duration
                 .as_micros() as u64,
+            reset_stream_count_local: self.stats.reset_stream_count_local,
+            stopped_stream_count_local: self.stats.stopped_stream_count_local,
+            reset_stream_count_remote: self.stats.reset_stream_count_remote,
+            stopped_stream_count_remote: self.stats.stopped_stream_count_remote,
         }
     }
 }


### PR DESCRIPTION
We'ld like to track the number of remote RESET_STREAM and STOP_STREAM messages handled by the proxy.