### PR TITLE
feat[tokio-quiche]: implement server-side support for 0-RTT

### DIFF
--- a/h3i/src/config.rs
+++ b/h3i/src/config.rs
@@ -63,6 +63,8 @@ pub struct Config {
     pub max_stream_window: u64,
     /// Set the session to attempt resumption.
     pub session: Option<Vec<u8>>,
+    /// Enables sending or receiving early data.
+    pub enable_early_data: bool,
     /// Whether to enable datagram sending.
     pub enable_dgram: bool,
     /// Datagram receive queue length.
@@ -194,6 +196,7 @@ impl Config {
             max_window: self.max_window,
             max_stream_window: self.max_stream_window,
             session: None,
+            enable_early_data: self.enable_early_data,
             enable_dgram: self.enable_dgram,
             dgram_recv_queue_len: self.dgram_recv_queue_len,
             dgram_send_queue_len: self.dgram_send_queue_len,
@@ -220,6 +223,7 @@ impl Default for Config {
             max_window: 25165824,
             max_stream_window: 16777216,
             session: None,
+            enable_early_data: false,
             enable_dgram: true,
             dgram_recv_queue_len: 65536,
             dgram_send_queue_len: 65536,

--- a/h3i/src/main.rs
+++ b/h3i/src/main.rs
@@ -326,6 +326,7 @@ fn config_from_clap() -> std::result::Result<Config, String> {
         max_window,
         max_stream_window,
         session: None,
+        enable_early_data: false,
         enable_dgram,
         dgram_recv_queue_len,
         dgram_send_queue_len,

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -7072,6 +7072,17 @@ impl<F: BufFactory> Connection<F> {
         self.handshake.is_in_early_data()
     }
 
+    /// Returns the early data reason for the connection.
+    ///
+    /// This status can be useful for logging and debugging. See [BoringSSL]
+    /// documentation for a definition of the reasons.
+    ///
+    /// [BoringSSL]: https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#ssl_early_data_reason_t
+    #[inline]
+    pub fn early_data_reason(&self) -> u32 {
+        self.handshake.early_data_reason()
+    }
+
     /// Returns whether there is stream or DATAGRAM data available to read.
     #[inline]
     pub fn is_readable(&self) -> bool {

--- a/quiche/src/tls/boringssl.rs
+++ b/quiche/src/tls/boringssl.rs
@@ -274,6 +274,12 @@ impl Handshake {
     pub fn is_in_early_data(&self) -> bool {
         unsafe { SSL_in_early_data(self.as_ptr()) == 1 }
     }
+
+    pub fn early_data_reason(&self) -> u32 {
+        let reuse_reason_status =
+            unsafe { SSL_get_early_data_reason(self.as_ptr()) };
+        reuse_reason_status.0
+    }
 }
 
 pub(super) fn get_session_bytes(session: *mut SSL_SESSION) -> Result<Vec<u8>> {
@@ -293,6 +299,10 @@ pub(super) fn get_session_bytes(session: *mut SSL_SESSION) -> Result<Vec<u8>> {
 }
 pub(super) const TLS_ERROR: c_int = 3;
 
+#[allow(non_camel_case_types)]
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct ssl_early_data_reason_t(pub ::std::os::raw::c_uint);
 extern "C" {
     // SSL_METHOD specific for boringssl.
     pub(super) fn SSL_CTX_set_tlsext_ticket_keys(
@@ -340,6 +350,8 @@ extern "C" {
     fn SSL_reset_early_data_reject(ssl: *mut SSL);
 
     fn SSL_in_early_data(ssl: *const SSL) -> c_int;
+
+    fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 
     fn SSL_SESSION_to_bytes(
         session: *const SSL_SESSION, out: *mut *mut u8, out_len: *mut usize,

--- a/quiche/src/tls/openssl_quictls.rs
+++ b/quiche/src/tls/openssl_quictls.rs
@@ -141,6 +141,10 @@ impl Handshake {
         false
     }
 
+    pub fn early_data_reason(&self) -> u32 {
+        0
+    }
+
     pub fn set_session(&mut self, session: &[u8]) -> Result<()> {
         unsafe {
             let ctx = SSL_get_SSL_CTX(self.as_ptr());

--- a/tokio-quiche/examples/async_http3_server/server.rs
+++ b/tokio-quiche/examples/async_http3_server/server.rs
@@ -147,6 +147,7 @@ where
             ServerH3Event::Headers {
                 incoming_headers,
                 priority,
+                is_in_early_data: _,
             } => {
                 // Received headers for a new stream from the H3Driver.
                 self.handle_incoming_headers(incoming_headers, priority)

--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -88,6 +88,7 @@ pub use self::client::ClientH3Driver;
 pub use self::client::ClientH3Event;
 pub use self::client::ClientRequestSender;
 pub use self::client::NewClientRequest;
+pub use self::server::IsInEarlyData;
 pub use self::server::RawPriorityValue;
 pub use self::server::ServerEventStream;
 pub use self::server::ServerH3Command;

--- a/tokio-quiche/src/quic/io/connection_stage.rs
+++ b/tokio-quiche/src/quic/io/connection_stage.rs
@@ -123,7 +123,9 @@ impl ConnectionStage for Handshake {
         &mut self, qconn: &mut QuicheConnection,
         _ctx: &mut ConnectionStageContext<A>,
     ) -> ControlFlow<QuicResult<()>> {
-        if qconn.is_established() {
+        // Transition to RunningApplication if we have 1-RTT keys (handshake is
+        // complete) or if we have 0-RTT keys (in early data).
+        if qconn.is_established() || qconn.is_in_early_data() {
             ControlFlow::Break(Ok(()))
         } else {
             ControlFlow::Continue(())

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -203,6 +203,9 @@ fn make_quiche_config(
             track_unknown_transport_params,
         );
     }
+    if params.settings.enable_early_data {
+        config.enable_early_data();
+    }
 
     if should_log_keys {
         config.log_keys();

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -59,6 +59,12 @@ pub struct QuicSettings {
     #[serde(default = "QuicSettings::default_dgram_max_queue_len")]
     pub dgram_send_max_queue_len: usize,
 
+    /// Configures whether to enable early data (0-RTT) support. Currently only
+    /// supported for servers.
+    ///
+    /// Defaults to `false`.
+    pub enable_early_data: bool,
+
     /// Sets the `initial_max_data` transport parameter.
     ///
     /// Defaults to 10 MB.

--- a/tokio-quiche/tests/fixtures/h3i_fixtures.rs
+++ b/tokio-quiche/tests/fixtures/h3i_fixtures.rs
@@ -61,10 +61,14 @@ pub fn h3i_config(url: &str) -> h3i::config::Config {
 }
 
 pub fn default_headers() -> Vec<Header> {
+    default_headers_with_authority("test.com")
+}
+
+pub fn default_headers_with_authority(host: &str) -> Vec<Header> {
     vec![
         Header::new(b":method", b"GET"),
         Header::new(b":scheme", b"https"),
-        Header::new(b":authority", b"test.com"),
+        Header::new(b":authority", host.as_bytes()),
         Header::new(b":path", b"/"),
     ]
 }

--- a/tokio-quiche/tests/integration_tests/mod.rs
+++ b/tokio-quiche/tests/integration_tests/mod.rs
@@ -46,6 +46,7 @@ pub mod connection_close;
 pub mod headers;
 pub mod migration;
 pub mod timeouts;
+pub mod zero_rtt;
 
 #[tokio::test]
 async fn echo() {

--- a/tokio-quiche/tests/integration_tests/zero_rtt.rs
+++ b/tokio-quiche/tests/integration_tests/zero_rtt.rs
@@ -1,0 +1,233 @@
+// Copyright (C) 2025, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::integration_tests::h3i_fixtures;
+use crate::integration_tests::start_server_with_settings;
+use crate::integration_tests::Http3Settings;
+use crate::integration_tests::QuicSettings;
+use crate::integration_tests::TestConnectionHook;
+use futures::SinkExt;
+use h3i;
+use h3i::actions::h3::send_headers_frame;
+use h3i::actions::h3::Action;
+use h3i::actions::h3::StreamEvent;
+use h3i::actions::h3::StreamEventType;
+use h3i::actions::h3::WaitType;
+use h3i::client::connection_summary::ConnectionSummary;
+use quiche::h3::NameValue;
+use quiche::ConnectionError;
+use quiche::WireErrorCode;
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::Mutex;
+use tokio_quiche::buf_factory::BufFactory;
+use tokio_quiche::http3::driver::H3Event;
+use tokio_quiche::http3::driver::IncomingH3Headers;
+use tokio_quiche::http3::driver::OutboundFrame;
+use tokio_quiche::http3::driver::ServerH3Event;
+use tokio_quiche::quiche::h3::Header;
+use tokio_quiche::ServerH3Connection;
+
+#[derive(Debug, Default, Clone)]
+struct TestContext {
+    did_recv_early_data_request: bool,
+    requests_handled_count: usize,
+    hosts_seen: Vec<String>,
+}
+
+#[tokio::test]
+async fn handle_0_rtt_request() {
+    let context = Arc::new(Mutex::new(TestContext::default()));
+    let early_stream_id = 0;
+    let stream_id = 4;
+
+    let context_clone = context.clone();
+    let mut quic_settings = QuicSettings::default();
+    quic_settings.enable_early_data = true;
+    let url = start_server_with_settings(
+        quic_settings,
+        Http3Settings::default(),
+        TestConnectionHook::new(),
+        move |h3_conn| helper_server_handler(h3_conn, &context_clone),
+    );
+
+    let nst_data = {
+        let summary = {
+            let h3i_config = h3i_fixtures::h3i_config(&url);
+            helper_connect_with_early_data(
+                h3i_config,
+                None,
+                helper_frame_actions(stream_id),
+            )
+            .await
+        };
+
+        {
+            let context = context.lock().unwrap();
+            assert_eq!(context.hosts_seen.len(), 1);
+            assert!(context.hosts_seen.contains(&"test.com".to_string()));
+            assert_eq!(context.requests_handled_count, 1);
+            assert_eq!(context.did_recv_early_data_request, false);
+        }
+
+        // Get Session data from this connection to resume the 0-RTT connection.
+        summary.conn_close_details.session.unwrap()
+    };
+
+    helper_reset_test(&context);
+
+    {
+        let early_frame_actions = vec![
+            send_headers_frame(
+                early_stream_id,
+                false,
+                h3i_fixtures::default_headers_with_authority("early.test.com"),
+            ),
+            Action::FlushPackets,
+        ];
+
+        let mut h3i_config = h3i_fixtures::h3i_config(&url);
+        // Provide session to the client to enable resumption.
+        h3i_config.session = Some(nst_data);
+        h3i_config.enable_early_data = true;
+        let _summary = helper_connect_with_early_data(
+            h3i_config,
+            Some(early_frame_actions),
+            helper_frame_actions(stream_id),
+        )
+        .await;
+
+        {
+            let context = context.lock().unwrap();
+            assert_eq!(context.hosts_seen.len(), 2);
+            assert_eq!(context.hosts_seen, vec!["early.test.com", "test.com"]);
+            assert_eq!(context.requests_handled_count, 2);
+            assert_eq!(context.did_recv_early_data_request, true);
+        }
+    }
+}
+
+pub async fn helper_connect_with_early_data(
+    h3i_config: h3i::config::Config, early_actions: Option<Vec<Action>>,
+    actions: Vec<Action>,
+) -> ConnectionSummary {
+    tokio::task::spawn_blocking(move || {
+        h3i::client::sync_client::connect_with_early_data(
+            h3i_config,
+            early_actions,
+            actions,
+            None,
+        )
+        .unwrap()
+    })
+    .await
+    .unwrap()
+}
+
+fn helper_reset_test(context: &Arc<Mutex<TestContext>>) {
+    let mut context = context.lock().unwrap();
+    *context = TestContext::default();
+}
+
+fn helper_frame_actions(stream_id: u64) -> Vec<Action> {
+    vec![
+        send_headers_frame(stream_id, true, h3i_fixtures::default_headers()),
+        Action::FlushPackets,
+        Action::Wait {
+            wait_type: WaitType::StreamEvent(StreamEvent {
+                stream_id,
+                event_type: StreamEventType::Finished,
+            }),
+        },
+        Action::ConnectionClose {
+            error: ConnectionError {
+                is_app: true,
+                error_code: WireErrorCode::NoError as _,
+                reason: Vec::new(),
+            },
+        },
+    ]
+}
+
+fn helper_server_handler(
+    mut h3_conn: ServerH3Connection, context: &Arc<Mutex<TestContext>>,
+) -> impl Future<Output = ()> {
+    let context = context.clone();
+
+    async move {
+        let event_rx = h3_conn.h3_controller.event_receiver_mut();
+
+        while let Some(event) = event_rx.recv().await {
+            match event {
+                ServerH3Event::Core(event) => match event {
+                    H3Event::ConnectionShutdown(_) => break,
+
+                    _ => (),
+                },
+
+                ServerH3Event::Headers {
+                    incoming_headers,
+                    is_in_early_data,
+                    ..
+                } => {
+                    let IncomingH3Headers {
+                        mut send, headers, ..
+                    } = incoming_headers;
+
+                    let authority = headers
+                        .iter()
+                        .find(|v| v.name().eq(":authority".as_bytes()))
+                        .unwrap();
+
+                    {
+                        let mut context = context.lock().unwrap();
+                        context.requests_handled_count += 1;
+                        context.did_recv_early_data_request |= *is_in_early_data;
+                        let host = str::from_utf8(authority.value())
+                            .unwrap()
+                            .to_string();
+                        context.hosts_seen.push(host);
+                    }
+
+                    // Send headers.
+                    send.send(OutboundFrame::Headers(
+                        vec![Header::new(b":status", b"200")],
+                        None,
+                    ))
+                    .await
+                    .unwrap();
+
+                    send.send(OutboundFrame::Body(
+                        BufFactory::get_empty_buf(),
+                        true,
+                    ))
+                    .await
+                    .unwrap();
+                },
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds server support for 0-RTT. This is done by transitioning the Handshake to Application when we have 0-RTT keys. The PR also adds an extension header IsInEarlyData to forward the early data request status so application can detect when a request was received with 0-RTT keys (and take appropriate security precautions).