### PR TITLE
Expose `load_verify_locations_from_file` and `load_verify_locations_from_directory` to tokio-quiche QuicSettings

### DIFF
--- a/tokio-quiche/src/quic/mod.rs
+++ b/tokio-quiche/src/quic/mod.rs
@@ -241,6 +241,17 @@ where
         }
     }
 
+    if let Some(verify_file) = &params.settings.verify_file {
+        log::info!("setting up verify_file"; "verify_file"=>verify_file);
+        &client_config.quiche_config.load_verify_locations_from_file(verify_file);
+    }
+
+    if let Some(verify_directory) = &params.settings.verify_directory {
+        log::info!("setting up verify_directory"; "verify_directory"=>verify_directory);
+        &client_config.quiche_config.load_verify_locations_from_directory(verify_directory);
+    }
+
+
     // Set the keylog file here for the same reason
     if let Some(keylog_file) = &client_config.keylog_file {
         log::info!("setting up keylog file");

--- a/tokio-quiche/src/quic/mod.rs
+++ b/tokio-quiche/src/quic/mod.rs
@@ -251,7 +251,6 @@ where
         &client_config.quiche_config.load_verify_locations_from_directory(verify_directory);
     }
 
-
     // Set the keylog file here for the same reason
     if let Some(keylog_file) = &client_config.keylog_file {
         log::info!("setting up keylog file");
@@ -302,7 +301,17 @@ where
         "O_NONBLOCK should be set for the listening socket"
     );
 
-    let config = Config::new(params, socket.capabilities).into_io()?;
+    let mut config = Config::new(params, socket.capabilities).into_io()?;
+
+    if let Some(verify_file) = &params.settings.verify_file {
+        log::info!("setting up verify_file"; "verify_file"=>verify_file);
+        &config.quiche_config.load_verify_locations_from_file(verify_file);
+    }
+
+    if let Some(verify_directory) = &params.settings.verify_directory {
+        log::info!("setting up verify_directory"; "verify_directory"=>verify_directory);
+        &config.quiche_config.load_verify_locations_from_directory(verify_directory);
+    }
 
     let local_addr = socket.socket.local_addr()?;
     let socket_tx = Arc::new(socket.socket);

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -146,6 +146,26 @@ pub struct QuicSettings {
     /// Path to a directory where QLOG files will be saved.
     pub qlog_dir: Option<String>,
 
+    /// Specifies a file where trusted CA certificates are stored for the
+    /// purposes of certificate verification.
+    ///
+    /// The content of `file` is parsed as a PEM-encoded certificate chain.
+    ///
+    /// See [`load_verify_locations_from_file()`]
+    /// 
+    /// [`load_verify_locations_from_file()`]: https://docs.quic.tech/quiche/struct.Config.html#method.load_verify_locations_from_file
+    pub verify_file: Option<String>,
+
+    /// Specifies a directory where trusted CA certificates are stored for the
+    /// purposes of certificate verification.
+    ///
+    /// The content of `dir` a set of PEM-encoded certificate chains.
+    /// 
+    /// See [`load_verify_locations_from_directory()`]
+    /// 
+    /// [`load_verify_locations_from_directory()`]: https://docs.quic.tech/quiche/struct.Config.html#method.load_verify_locations_from_directory
+    pub verify_directory: Option<String>,
+
     /// Congestion control algorithm to use.
     ///
     /// For available values, see


### PR DESCRIPTION
Fixes #2271.

I'm new to contributing here so I'm not sure if I need to make a test case for this. Please let me know and for any other deficiencies