### PR TITLE
Add async InitialQuicConnection.start_with_result(app)

### DIFF
--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -492,7 +492,7 @@ where
                 Ok(q_conn)
             },
             Err(e) => {
-                log::error!("QUIC handshake failed in IQC::start"; "error" => e);
+                log::error!("QUIC handshake failed in IQC::start_with_result"; "error" => e);
                 Err(e) // Pass it upward
             }
         }

--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -470,6 +470,11 @@ where
         conn
     }
 
+    /// Drives a QUIC connection from handshake to close in separate tokio
+    /// tasks but returns a result by awaiting the [`InitialQuicConnection::handshake`] call.
+    ///
+    /// It combines [`InitialQuicConnection::handshake`] and
+    /// [`InitialQuicConnection::resume`] into a single call.
     pub async fn start_with_result<A: ApplicationOverQuic>(self, app: A) -> io::Result<QuicConnection> {
         let task_metrics = self.params.metrics.clone();
         let result = self.handshake(app).await;

--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -491,9 +491,9 @@ where
 
                 Ok(q_conn)
             },
-            Err(e) => {
-                log::error!("QUIC handshake failed in IQC::start_with_result"; "error" => e);
-                Err(e) // Pass it upward
+            Err(err) => {
+                log::error!("QUIC handshake failed in IQC::start_with_result"; "error" => &err);
+                Err(err) // Pass it upward
             }
         }
     }


### PR DESCRIPTION
- Propagate handshake errors upward
- Same logging behavior as start(app)

Fixes #2274