### PR TITLE
ci: update macOS image

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         target:
-          - "macos-13"     # Intel (x86_64)
+          - "macos-15-intel"     # Intel (x86_64)
           - "macos-latest" # Apple Silicon (M1)
     runs-on: ${{ matrix.target }}
     # Only run on "pull_request" event for external PRs. This is to avoid


### PR DESCRIPTION
macOS 13 is deprecated: https://github.com/actions/runner-images/issues/13046