### PR TITLE
Clippy Fixes

### DIFF
--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -816,44 +816,41 @@ impl PartialEq for StreamPriorityKey {
 impl Eq for StreamPriorityKey {}
 
 impl PartialOrd for StreamPriorityKey {
-    // Priority ordering is complex, disable Clippy warning.
-    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        // Ignore priority if ID matches.
-        if self.id == other.id {
-            return Some(cmp::Ordering::Equal);
-        }
-
-        // First, order by urgency...
-        if self.urgency != other.urgency {
-            return self.urgency.partial_cmp(&other.urgency);
-        }
-
-        // ...when the urgency is the same, and both are not incremental, order
-        // by stream ID...
-        if !self.incremental && !other.incremental {
-            return self.id.partial_cmp(&other.id);
-        }
-
-        // ...non-incremental takes priority over incremental...
-        if self.incremental && !other.incremental {
-            return Some(cmp::Ordering::Greater);
-        }
-        if !self.incremental && other.incremental {
-            return Some(cmp::Ordering::Less);
-        }
-
-        // ...finally, when both are incremental, `other` takes precedence (so
-        // `self` is always sorted after other same-urgency incremental
-        // entries).
-        Some(cmp::Ordering::Greater)
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for StreamPriorityKey {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        // `partial_cmp()` never returns `None`, so this should be safe.
-        self.partial_cmp(other).unwrap()
+        // Ignore priority if ID matches.
+        if self.id == other.id {
+            return cmp::Ordering::Equal;
+        }
+
+        // First, order by urgency...
+        if self.urgency != other.urgency {
+            return self.urgency.cmp(&other.urgency);
+        }
+
+        // ...when the urgency is the same, and both are not incremental, order
+        // by stream ID...
+        if !self.incremental && !other.incremental {
+            return self.id.cmp(&other.id);
+        }
+
+        // ...non-incremental takes priority over incremental...
+        if self.incremental && !other.incremental {
+            return cmp::Ordering::Greater;
+        }
+        if !self.incremental && other.incremental {
+            return cmp::Ordering::Less;
+        }
+
+        // ...finally, when both are incremental, `other` takes precedence (so
+        // `self` is always sorted after other same-urgency incremental
+        // entries).
+        cmp::Ordering::Greater
     }
 }
 

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -2928,15 +2928,12 @@ fn stream_shutdown_read(
     let frames =
         test_utils::decode_pkt(&mut pipe.client, &mut dummy[..len]).unwrap();
     // make sure the pkt contains the expected StopSending frame
-    assert!(frames
-        .iter()
-        .find(|f| {
-            **f == frame::Frame::StopSending {
-                stream_id: 4,
-                error_code: 42,
-            }
-        })
-        .is_some(),);
+    assert!(frames.iter().any(|f| {
+        *f == frame::Frame::StopSending {
+            stream_id: 4,
+            error_code: 42,
+        }
+    }));
 
     assert_eq!(pipe.client_recv(&mut buf[..len]), Ok(len));
 

--- a/tokio-quiche/src/quic/io/utilization_estimator.rs
+++ b/tokio-quiche/src/quic/io/utilization_estimator.rs
@@ -147,9 +147,8 @@ impl PartialEq for Estimate {
 impl Eq for Estimate {}
 
 impl PartialOrd for Estimate {
-    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.bandwidth.partial_cmp(&other.bandwidth)
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
Clippy fixes for Rust 1.92

https://rust-lang.github.io/rust-clippy/stable/index.html#/non_canonical_partial_ord_impl