### PR TITLE
Revert recent changes to datagram-socket SocketStats

### DIFF
--- a/datagram-socket/src/socket_stats.rs
+++ b/datagram-socket/src/socket_stats.rs
@@ -66,10 +66,6 @@ pub struct SocketStats {
     pub delivery_rate: u64,
     pub max_bandwidth: Option<u64>,
     pub startup_exit: Option<StartupExit>,
-    pub data_blocked_sent_count: u64,
-    pub stream_data_blocked_sent_count: u64,
-    pub data_blocked_recv_count: u64,
-    pub stream_data_blocked_recv_count: u64,
     pub bytes_in_flight_duration_us: u64,
 }
 

--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -173,14 +173,6 @@ impl AsSocketStats for QuicConnectionStats {
                 .as_ref()
                 .and_then(|p| p.startup_exit)
                 .map(QuicConnectionStats::startup_exit_to_socket_stats),
-            data_blocked_sent_count: self.stats.data_blocked_sent_count,
-            stream_data_blocked_sent_count: self
-                .stats
-                .stream_data_blocked_sent_count,
-            data_blocked_recv_count: self.stats.data_blocked_recv_count,
-            stream_data_blocked_recv_count: self
-                .stats
-                .stream_data_blocked_recv_count,
             bytes_in_flight_duration_us: self
                 .stats
                 .bytes_in_flight_duration


### PR DESCRIPTION
The fields that I added to SocketStats are not needed since we decided to look at quiche Stats and PathStats directly.

Reverting these datagram-socket changes in order to avoid the need to bump datagram-socket as we do a tokio-quiche release.