### PR TITLE
Fix StreamPriorityKey::cmp implementation

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -4134,6 +4134,47 @@ mod tests {
         assert_eq!(s.poll_client(), Ok((stream, Event::Finished)));
     }
 
+    /// A server polling concurrent requests sees the headers of every request
+    /// before the body of any of them, so it can route or reject on headers
+    /// alone instead of being made to consume one request's body first.
+    ///
+    /// The transport provides this: `stream_recv` cycles an incremental stream
+    /// to the back of its priority group each time it is serviced, and `poll()`
+    /// parses frames through `stream_recv`. HTTP/3 does not arrange the
+    /// interleaving itself.
+    ///
+    /// Asserted here rather than left to the transport tests because it is an
+    /// HTTP/3 property an application depends on, and because losing it is not
+    /// obvious from either layer alone: without the cycling this order becomes
+    /// per-stream FIFO, headers and body together, one request at a time.
+    #[test]
+    fn poll_yields_headers_of_all_requests_before_any_body() {
+        let mut s = Session::new().unwrap();
+        s.handshake().unwrap();
+
+        let mut streams = Vec::new();
+
+        for _ in 0..3 {
+            let (stream, _) = s.send_request(false).unwrap();
+            s.send_body_client(stream, true).unwrap();
+            streams.push(stream);
+        }
+
+        let mut headers = Vec::new();
+
+        for _ in 0..streams.len() {
+            match s.poll_server() {
+                Ok((stream, Event::Headers { .. })) => headers.push(stream),
+
+                other => panic!(
+                    "expected Headers for every request before any body, got {other:?}"
+                ),
+            }
+        }
+
+        assert_eq!(headers, streams);
+    }
+
     #[test]
     /// Send a request with multiple DATA frames, get a response with one DATA
     /// frame.

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -427,8 +427,8 @@ use crate::recovery::OnLossDetectionTimeoutOutcome;
 use crate::recovery::RecoveryOps;
 use crate::recovery::ReleaseDecision;
 
+use crate::stream::PriorityQueue;
 use crate::stream::RecvAction;
-use crate::stream::StreamPriorityKey;
 
 /// The current QUIC wire version.
 pub const PROTOCOL_VERSION: u32 = PROTOCOL_VERSION_V1;
@@ -5261,16 +5261,15 @@ impl<F: BufFactory> Connection<F> {
                     has_data = true;
                 }
 
-                let priority_key = Arc::clone(&stream.priority_key);
-                // If the stream is no longer flushable, remove it from the queue
+                // Reached through `peek_flushable`, so the stream is in the
+                // queue already and only needs taking out.
                 if !stream.is_flushable() {
+                    let priority_key = Arc::clone(&stream.priority_key);
                     self.streams.remove_flushable(&priority_key);
-                } else if stream.incremental {
-                    // Shuffle the incremental stream to the back of the
-                    // queue.
-                    self.streams.remove_flushable(&priority_key);
-                    self.streams.insert_flushable(&priority_key);
                 }
+
+                self.streams
+                    .cycle_priority(stream_id, PriorityQueue::Flushable);
 
                 // Update tx_buffered when data is emitted.
                 self.streams.sub_tx_buffered(len);
@@ -5823,7 +5822,12 @@ impl<F: BufFactory> Connection<F> {
             self.streams.insert_almost_full(stream_id);
         }
 
-        if !readable {
+        // The queue holds the streams that are eligible, so a stream that
+        // still has data belongs in it even if stream_readable_next() handed
+        // it out and took it back out.
+        if readable {
+            self.streams.insert_readable(&priority_key);
+        } else {
             self.streams.remove_readable(&priority_key);
         }
 
@@ -5851,11 +5855,8 @@ impl<F: BufFactory> Connection<F> {
             q.add_event_data_with_instant(ev_data, now).ok();
         });
 
-        if priority_key.incremental && readable {
-            // Shuffle the incremental stream to the back of the queue.
-            self.streams.remove_readable(&priority_key);
-            self.streams.insert_readable(&priority_key);
-        }
+        self.streams
+            .cycle_priority(stream_id, PriorityQueue::Readable);
 
         Ok((read, fin))
     }
@@ -6051,11 +6052,7 @@ impl<F: BufFactory> Connection<F> {
             return Err(Error::Done);
         }
 
-        let (cap, fin, blocked_by_cap) = if cap < len {
-            (cap, false, true)
-        } else {
-            (len, fin, false)
-        };
+        let (cap, fin) = if cap < len { (cap, false) } else { (len, fin) };
 
         let (sent, ret) = match write_fn(stream, buf, cap, fin) {
             Ok(v) => v,
@@ -6066,7 +6063,6 @@ impl<F: BufFactory> Connection<F> {
             },
         };
 
-        let incremental = stream.incremental;
         let priority_key = Arc::clone(&stream.priority_key);
 
         let flushable = stream.is_flushable();
@@ -6096,16 +6092,13 @@ impl<F: BufFactory> Connection<F> {
             self.streams.insert_flushable(&priority_key);
         }
 
-        if !writable {
-            self.streams.remove_writable(&priority_key);
-        } else if was_writable && blocked_by_cap {
-            // When `stream_writable_next()` returns a stream, the writable
-            // mark is removed, but because the stream is blocked by the
-            // connection-level send capacity it won't be marked as writable
-            // again once the capacity increases.
-            //
-            // Since the stream is writable already, mark it here instead.
+        // As above: a stream with capacity left belongs in the queue even if
+        // stream_writable_next() handed it out, which is also how it gets
+        // reported again once connection-level capacity increases.
+        if writable {
             self.streams.insert_writable(&priority_key);
+        } else {
+            self.streams.remove_writable(&priority_key);
         }
 
         self.tx_cap -= sent;
@@ -6138,11 +6131,8 @@ impl<F: BufFactory> Connection<F> {
             return Err(Error::Done);
         }
 
-        if incremental && writable {
-            // Shuffle the incremental stream to the back of the queue.
-            self.streams.remove_writable(&priority_key);
-            self.streams.insert_writable(&priority_key);
-        }
+        self.streams
+            .cycle_priority(stream_id, PriorityQueue::Writable);
 
         Ok(ret)
     }
@@ -6160,33 +6150,15 @@ impl<F: BufFactory> Connection<F> {
     ) -> Result<()> {
         // Get existing stream or create a new one, but if the stream
         // has already been closed and collected, ignore the prioritization.
-        let stream = match self.get_or_create_stream(stream_id, true) {
-            Ok(v) => v,
+        match self.get_or_create_stream(stream_id, true) {
+            Ok(_) => (),
 
             Err(Error::Done) => return Ok(()),
 
             Err(e) => return Err(e),
-        };
-
-        if stream.urgency == urgency && stream.incremental == incremental {
-            return Ok(());
         }
 
-        stream.urgency = urgency;
-        stream.incremental = incremental;
-
-        let new_priority_key = Arc::new(StreamPriorityKey {
-            urgency: stream.urgency,
-            incremental: stream.incremental,
-            id: stream_id,
-            ..Default::default()
-        });
-
-        let old_priority_key =
-            std::mem::replace(&mut stream.priority_key, new_priority_key.clone());
-
-        self.streams
-            .update_priority(&old_priority_key, &new_priority_key);
+        self.streams.set_priority(stream_id, urgency, incremental);
 
         Ok(())
     }
@@ -6357,10 +6329,9 @@ impl<F: BufFactory> Connection<F> {
     /// Returns the next stream that has data to read.
     ///
     /// Note that once returned by this method, a stream ID will not be returned
-    /// again until it is "re-armed".
-    ///
-    /// The application will need to read all of the pending data on the stream,
-    /// and new data has to be received before the stream is reported again.
+    /// again until it is "re-armed": either by reading from the stream while it
+    /// still holds data the application has not consumed, or, once it has been
+    /// drained, by new data arriving for it.
     ///
     /// This is unlike the [`readable()`] method, that returns the same list of
     /// readable streams when called multiple times in succession.
@@ -6438,21 +6409,19 @@ impl<F: BufFactory> Connection<F> {
 
         while let Some(priority_key) = cursor.clone_pointer() {
             if let Some(stream) = self.streams.get(priority_key.id) {
-                let cap = match stream.send.cap() {
-                    Ok(v) => v,
+                let ready = match stream.send.cap() {
+                    Ok(cap) => cmp::min(self.tx_cap, cap) >= stream.send_lowat,
 
                     // Return the stream to the application immediately if it's
                     // stopped.
-                    Err(_) =>
-                        return {
-                            self.streams.remove_writable(&priority_key);
-
-                            Some(priority_key.id)
-                        },
+                    Err(_) => true,
                 };
 
-                if cmp::min(self.tx_cap, cap) >= stream.send_lowat {
+                if ready {
                     self.streams.remove_writable(&priority_key);
+                    self.streams
+                        .cycle_priority(priority_key.id, PriorityQueue::Writable);
+
                     return Some(priority_key.id);
                 }
             }

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -26,6 +26,8 @@
 
 use std::cmp;
 
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use std::collections::hash_map;
@@ -110,6 +112,14 @@ type BuildStreamIdHasher = std::hash::BuildHasherDefault<StreamIdHasher>;
 
 pub type StreamIdHashMap<V> = HashMap<u64, V, BuildStreamIdHasher>;
 pub type StreamIdHashSet = HashSet<u64, BuildStreamIdHasher>;
+
+/// One of the priority queues a stream can be scheduled in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PriorityQueue {
+    Readable,
+    Writable,
+    Flushable,
+}
 
 /// Keeps track of QUIC streams and enforces stream limits.
 #[derive(Default)]
@@ -198,6 +208,26 @@ pub struct StreamMap<F: BufFactory = DefaultBufFactory> {
 
     /// Total number of bytes in send buffers across all streams.
     tx_buffered: usize,
+
+    /// Source of round-robin positions. A stream takes the next value when it
+    /// is created, and again each time it is cycled, which places it behind
+    /// the other streams in its priority group.
+    ///
+    /// Must not wrap: a stream ahead of the wrap would sit at the back of
+    /// every group, never picked and so never cycled back into rotation.
+    sequence_counter: SequenceCounter,
+}
+
+/// A distinct type so that taking a position borrows only the counter, leaving
+/// the stream map borrowable at the same time.
+#[derive(Default)]
+struct SequenceCounter(u64);
+
+impl SequenceCounter {
+    fn advance(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(1);
+        self.0
+    }
 }
 
 impl<F: BufFactory> StreamMap<F> {
@@ -338,6 +368,9 @@ impl<F: BufFactory> StreamMap<F> {
                 };
 
                 let initial_window = max_rx_data;
+
+                let sequence = self.sequence_counter.advance();
+
                 let s = Stream::new(
                     id,
                     max_rx_data,
@@ -346,6 +379,8 @@ impl<F: BufFactory> StreamMap<F> {
                     initial_window,
                     self.max_stream_window,
                 );
+
+                s.priority_key.set_sequences(sequence);
 
                 let is_writable = s.is_writable();
 
@@ -381,6 +416,8 @@ impl<F: BufFactory> StreamMap<F> {
 
         let mut c = {
             let ptr = Arc::as_ptr(priority_key);
+            // SAFETY: `priority_key` is the `Arc` this tree holds; see
+            // `StreamPriorityKey`.
             unsafe { self.readable.cursor_mut_from_ptr(ptr) }
         };
 
@@ -410,6 +447,8 @@ impl<F: BufFactory> StreamMap<F> {
 
         let mut c = {
             let ptr = Arc::as_ptr(priority_key);
+            // SAFETY: `priority_key` is the `Arc` this tree holds; see
+            // `StreamPriorityKey`.
             unsafe { self.writable.cursor_mut_from_ptr(ptr) }
         };
 
@@ -433,6 +472,8 @@ impl<F: BufFactory> StreamMap<F> {
 
         let mut c = {
             let ptr = Arc::as_ptr(priority_key);
+            // SAFETY: `priority_key` is the `Arc` this tree holds; see
+            // `StreamPriorityKey`.
             unsafe { self.flushable.cursor_mut_from_ptr(ptr) }
         };
 
@@ -444,7 +485,7 @@ impl<F: BufFactory> StreamMap<F> {
     }
 
     /// Updates the priorities of a stream.
-    pub fn update_priority(
+    fn update_priority(
         &mut self, old: &Arc<StreamPriorityKey>, new: &Arc<StreamPriorityKey>,
     ) {
         if old.readable.is_linked() {
@@ -461,6 +502,103 @@ impl<F: BufFactory> StreamMap<F> {
             self.remove_flushable(old);
             self.flushable.insert(Arc::clone(new));
         }
+    }
+
+    /// Records that a stream was serviced in one queue, moving it to the back
+    /// of its priority group there.
+    ///
+    /// Call this from every point that services a stream. Whether the service
+    /// left the stream in the queue, whether the stream still exists, and
+    /// whether it is incremental are all decided here, so a service point
+    /// needs no condition of its own. The stream's position in the other
+    /// queues is left alone.
+    ///
+    /// The new position is recorded even when the stream is not currently in
+    /// the queue, so that it re-enters at the back rather than where it left
+    /// off.
+    pub fn cycle_priority(&mut self, stream_id: u64, queue: PriorityQueue) {
+        let Some(stream) = self.streams.get(&stream_id) else {
+            return;
+        };
+
+        // A non-incremental stream has no round-robin position to move:
+        // `position` masks the sequence out for it.
+        if !stream.priority_key.incremental {
+            return;
+        }
+
+        let key = Arc::clone(&stream.priority_key);
+        let sequence = self.sequence_counter.advance();
+
+        // The queue is sorted by the value being changed, so unlink first.
+        let linked = self.remove_from(queue, &key);
+        key.set_sequence(queue, sequence);
+
+        if linked {
+            self.insert_into(queue, &key);
+        }
+    }
+
+    /// Removes the stream from `queue`, returning whether it was linked there.
+    fn remove_from(
+        &mut self, queue: PriorityQueue, key: &Arc<StreamPriorityKey>,
+    ) -> bool {
+        let linked = match queue {
+            PriorityQueue::Readable => key.readable.is_linked(),
+            PriorityQueue::Writable => key.writable.is_linked(),
+            PriorityQueue::Flushable => key.flushable.is_linked(),
+        };
+
+        match queue {
+            PriorityQueue::Readable => self.remove_readable(key),
+            PriorityQueue::Writable => self.remove_writable(key),
+            PriorityQueue::Flushable => self.remove_flushable(key),
+        }
+
+        linked
+    }
+
+    fn insert_into(
+        &mut self, queue: PriorityQueue, key: &Arc<StreamPriorityKey>,
+    ) {
+        match queue {
+            PriorityQueue::Readable => self.insert_readable(key),
+            PriorityQueue::Writable => self.insert_writable(key),
+            PriorityQueue::Flushable => self.insert_flushable(key),
+        }
+    }
+
+    /// Sets a stream's urgency and incremental flag.
+    ///
+    /// Urgency and the incremental flag apply to every queue, so the stream
+    /// moves to the back of its new priority group in all of them. The key is
+    /// replaced rather than edited in place because the queues order
+    /// themselves by its contents.
+    pub fn set_priority(
+        &mut self, stream_id: u64, urgency: u8, incremental: bool,
+    ) {
+        let Some(stream) = self.streams.get_mut(&stream_id) else {
+            return;
+        };
+
+        if stream.urgency == urgency && stream.incremental == incremental {
+            return;
+        }
+
+        stream.urgency = urgency;
+        stream.incremental = incremental;
+
+        let sequence = self.sequence_counter.advance();
+
+        let new = Arc::new(StreamPriorityKey::new(
+            stream_id,
+            urgency,
+            incremental,
+            sequence,
+        ));
+        let old = std::mem::replace(&mut stream.priority_key, Arc::clone(&new));
+
+        self.update_priority(&old, &new);
     }
 
     /// Adds the stream ID to the almost full streams set.
@@ -883,23 +1021,48 @@ pub fn is_bidi(stream_id: u64) -> bool {
     (stream_id & 0x2) == 0
 }
 
-#[derive(Clone, Debug)]
+/// A stream's entry in the three priority queues.
+///
+/// Each queue links this key rather than the stream, and removal is by raw
+/// pointer, so the `Arc` a queue holds must stay the one `Stream::priority_key`
+/// holds. Cycling reuses the key, and the only code that replaces it
+/// (`StreamMap::set_priority`) hands the old `Arc` to `update_priority` to
+/// relink every queue.
+#[derive(Debug)]
 pub struct StreamPriorityKey {
     pub urgency: u8,
     pub incremental: bool,
     pub id: u64,
+
+    /// Round-robin position within a priority group, one per queue. Each
+    /// queue reads only its own field, so servicing a stream in one queue does
+    /// not reorder it in the others.
+    ///
+    /// Atomic for interior mutability, not for concurrency: the key is shared
+    /// through an `Arc` with the queues, and it has to stay `Sync` to keep
+    /// `Connection` `Send`. Every access is made through `&StreamMap` or
+    /// `&mut StreamMap` from one thread, so `Relaxed` orders nothing that needs
+    /// ordering.
+    readable_sequence: AtomicU64,
+    writable_sequence: AtomicU64,
+    flushable_sequence: AtomicU64,
 
     pub readable: RBTreeAtomicLink,
     pub writable: RBTreeAtomicLink,
     pub flushable: RBTreeAtomicLink,
 }
 
-impl Default for StreamPriorityKey {
-    fn default() -> Self {
+impl StreamPriorityKey {
+    /// A key for a stream at the given priority, starting at `sequence` in
+    /// every queue and linked in none of them.
+    fn new(id: u64, urgency: u8, incremental: bool, sequence: u64) -> Self {
         Self {
-            urgency: DEFAULT_URGENCY,
-            incremental: true,
-            id: Default::default(),
+            id,
+            urgency,
+            incremental,
+            readable_sequence: AtomicU64::new(sequence),
+            writable_sequence: AtomicU64::new(sequence),
+            flushable_sequence: AtomicU64::new(sequence),
             readable: Default::default(),
             writable: Default::default(),
             flushable: Default::default(),
@@ -907,80 +1070,109 @@ impl Default for StreamPriorityKey {
     }
 }
 
-impl PartialEq for StreamPriorityKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+impl Default for StreamPriorityKey {
+    fn default() -> Self {
+        Self::new(0, DEFAULT_URGENCY, true, 0)
     }
 }
 
-impl Eq for StreamPriorityKey {}
-
-impl PartialOrd for StreamPriorityKey {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(other))
-    }
+/// A stream's position in one priority queue.
+///
+/// The derived ordering compares the fields in declaration order: urgency,
+/// then non-incremental ahead of incremental, then the queue's round-robin
+/// sequence, then stream ID. `sequence` is only meaningful for incremental
+/// streams, so it is masked out otherwise to keep non-incremental streams
+/// ordered by ID.
+///
+/// See [RFC 9218 Section 4] for urgency and incremental semantics.
+///
+/// [RFC 9218 Section 4]: https://www.rfc-editor.org/rfc/rfc9218.html#section-4
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StreamPriorityPosition {
+    urgency: u8,
+    incremental: bool,
+    sequence: u64,
+    id: u64,
 }
 
-impl Ord for StreamPriorityKey {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        // Ignore priority if ID matches.
-        if self.id == other.id {
-            return cmp::Ordering::Equal;
+impl StreamPriorityKey {
+    fn position(&self, sequence: u64) -> StreamPriorityPosition {
+        StreamPriorityPosition {
+            urgency: self.urgency,
+            incremental: self.incremental,
+            sequence: if self.incremental { sequence } else { 0 },
+            id: self.id,
         }
+    }
 
-        // First, order by urgency...
-        if self.urgency != other.urgency {
-            return self.urgency.cmp(&other.urgency);
-        }
+    fn readable_sequence(&self) -> u64 {
+        self.readable_sequence.load(Ordering::Relaxed)
+    }
 
-        // ...when the urgency is the same, and both are not incremental, order
-        // by stream ID...
-        if !self.incremental && !other.incremental {
-            return self.id.cmp(&other.id);
-        }
+    fn writable_sequence(&self) -> u64 {
+        self.writable_sequence.load(Ordering::Relaxed)
+    }
 
-        // ...non-incremental takes priority over incremental...
-        if self.incremental && !other.incremental {
-            return cmp::Ordering::Greater;
-        }
-        if !self.incremental && other.incremental {
-            return cmp::Ordering::Less;
-        }
+    fn flushable_sequence(&self) -> u64 {
+        self.flushable_sequence.load(Ordering::Relaxed)
+    }
 
-        // ...finally, when both are incremental, `other` takes precedence (so
-        // `self` is always sorted after other same-urgency incremental
-        // entries).
-        cmp::Ordering::Greater
+    /// Sets this stream's position in `queue`.
+    ///
+    /// Only sound while the stream is unlinked from `queue`: the queue orders
+    /// itself by this value, so changing it under a linked node would leave
+    /// the queue sorted by a stale key. The other queues read their own
+    /// fields and are unaffected.
+    fn set_sequence(&self, queue: PriorityQueue, sequence: u64) {
+        let (field, linked) = match queue {
+            PriorityQueue::Readable =>
+                (&self.readable_sequence, self.readable.is_linked()),
+            PriorityQueue::Writable =>
+                (&self.writable_sequence, self.writable.is_linked()),
+            PriorityQueue::Flushable =>
+                (&self.flushable_sequence, self.flushable.is_linked()),
+        };
+
+        debug_assert!(!linked, "stream {} is still linked in {queue:?}", self.id);
+
+        field.store(sequence, Ordering::Relaxed);
+    }
+
+    /// Sets this stream's position in every queue.
+    fn set_sequences(&self, sequence: u64) {
+        self.set_sequence(PriorityQueue::Readable, sequence);
+        self.set_sequence(PriorityQueue::Writable, sequence);
+        self.set_sequence(PriorityQueue::Flushable, sequence);
     }
 }
 
 intrusive_adapter!(pub StreamWritablePriorityAdapter = Arc<StreamPriorityKey>: StreamPriorityKey { writable: RBTreeAtomicLink });
 
 impl KeyAdapter<'_> for StreamWritablePriorityAdapter {
-    type Key = StreamPriorityKey;
+    type Key = StreamPriorityPosition;
 
     fn get_key(&self, s: &StreamPriorityKey) -> Self::Key {
-        s.clone()
+        s.position(s.writable_sequence())
     }
 }
 
 intrusive_adapter!(pub StreamReadablePriorityAdapter = Arc<StreamPriorityKey>: StreamPriorityKey { readable: RBTreeAtomicLink });
 
 impl KeyAdapter<'_> for StreamReadablePriorityAdapter {
-    type Key = StreamPriorityKey;
+    type Key = StreamPriorityPosition;
 
     fn get_key(&self, s: &StreamPriorityKey) -> Self::Key {
-        s.clone()
+        s.position(s.readable_sequence())
     }
 }
 
 intrusive_adapter!(pub StreamFlushablePriorityAdapter = Arc<StreamPriorityKey>: StreamPriorityKey { flushable: RBTreeAtomicLink });
 
 impl KeyAdapter<'_> for StreamFlushablePriorityAdapter {
-    type Key = StreamPriorityKey;
+    type Key = StreamPriorityPosition;
 
     fn get_key(&self, s: &StreamPriorityKey) -> Self::Key {
-        s.clone()
+        s.position(s.flushable_sequence())
     }
 }
 
@@ -1910,8 +2102,7 @@ mod tests {
     }
 
     fn cycle_stream_priority(stream_id: u64, streams: &mut StreamMap) {
-        let key = streams.get(stream_id).unwrap().priority_key.clone();
-        streams.update_priority(&key.clone(), &key);
+        streams.cycle_priority(stream_id, PriorityQueue::Writable);
     }
 
     #[test]
@@ -2013,55 +2204,21 @@ mod tests {
         ];
 
         for (id, urgency) in input.clone() {
-            // this duplicates some code from stream_priority in order to access
-            // streams and the collection they're in
-            let stream = streams
+            streams
                 .get_or_create(id, &local_tp, &peer_tp, false, true)
                 .unwrap();
-
-            stream.urgency = urgency;
-
-            let new_priority_key = Arc::new(StreamPriorityKey {
-                urgency: stream.urgency,
-                incremental: stream.incremental,
-                id,
-                ..Default::default()
-            });
-
-            let old_priority_key = std::mem::replace(
-                &mut stream.priority_key,
-                new_priority_key.clone(),
-            );
-
-            streams.update_priority(&old_priority_key, &new_priority_key);
+            streams.set_priority(id, urgency, true);
         }
 
         let walk_1: Vec<u64> = streams.writable().collect();
         assert_eq!(walk_1, vec![40, 36, 32, 28, 24, 20, 16, 12, 8, 4, 0]);
 
-        // Re-applying priority to a stream does not cause duplication.
+        // Re-applying priority to a stream does not cause duplication. Set a
+        // different urgency and back, since setting the urgency a stream
+        // already has does nothing.
         for (id, urgency) in input {
-            // this duplicates some code from stream_priority in order to access
-            // streams and the collection they're in
-            let stream = streams
-                .get_or_create(id, &local_tp, &peer_tp, false, true)
-                .unwrap();
-
-            stream.urgency = urgency;
-
-            let new_priority_key = Arc::new(StreamPriorityKey {
-                urgency: stream.urgency,
-                incremental: stream.incremental,
-                id,
-                ..Default::default()
-            });
-
-            let old_priority_key = std::mem::replace(
-                &mut stream.priority_key,
-                new_priority_key.clone(),
-            );
-
-            streams.update_priority(&old_priority_key, &new_priority_key);
+            streams.set_priority(id, urgency + 1, true);
+            streams.set_priority(id, urgency, true);
         }
 
         let walk_2: Vec<u64> = streams.writable().collect();
@@ -2115,27 +2272,10 @@ mod tests {
         ];
 
         for (id, urgency) in input.clone() {
-            // this duplicates some code from stream_priority in order to access
-            // streams and the collection they're in
-            let stream = streams
+            streams
                 .get_or_create(id, &local_tp, &peer_tp, false, true)
                 .unwrap();
-
-            stream.urgency = urgency;
-
-            let new_priority_key = Arc::new(StreamPriorityKey {
-                urgency: stream.urgency,
-                incremental: stream.incremental,
-                id,
-                ..Default::default()
-            });
-
-            let old_priority_key = std::mem::replace(
-                &mut stream.priority_key,
-                new_priority_key.clone(),
-            );
-
-            streams.update_priority(&old_priority_key, &new_priority_key);
+            streams.set_priority(id, urgency, true);
         }
 
         let walk_1: Vec<u64> = streams.writable().collect();
@@ -2192,27 +2332,23 @@ mod tests {
         assert_eq!(walk_10, vec![40, 4, 12, 36, 28, 32, 24, 16, 8, 0]);
 
         // Adding streams doesn't break expected ordering.
-        let stream = streams
+        streams
             .get_or_create(44, &local_tp, &peer_tp, false, true)
             .unwrap();
-
-        stream.urgency = 20;
-        stream.incremental = true;
-
-        let new_priority_key = Arc::new(StreamPriorityKey {
-            urgency: stream.urgency,
-            incremental: stream.incremental,
-            id: 44,
-            ..Default::default()
-        });
-
-        let old_priority_key =
-            std::mem::replace(&mut stream.priority_key, new_priority_key.clone());
-
-        streams.update_priority(&old_priority_key, &new_priority_key);
+        streams.set_priority(44, 20, true);
 
         let walk_11: Vec<u64> = streams.writable().collect();
         assert_eq!(walk_11, vec![40, 4, 12, 36, 44, 28, 32, 24, 16, 8, 0]);
+
+        // Re-applying the priority a stream already has must not move it. An
+        // application that reasserts unchanged priorities would otherwise
+        // reset the round-robin position of every stream it names.
+        for (id, urgency) in input {
+            streams.set_priority(id, urgency, true);
+        }
+
+        let walk_12: Vec<u64> = streams.writable().collect();
+        assert_eq!(walk_12, walk_11);
     }
 
     #[test]
@@ -2490,6 +2626,231 @@ mod tests {
         let dropped = stream.send.ack_and_drop(0, 5);
         assert_eq!(dropped, 5);
         assert_eq!(stream.send.buffered_bytes(), 0);
+    }
+
+    /// At equal urgency, non-incremental streams are served ahead of
+    /// incremental ones, and among themselves in stream ID order regardless of
+    /// when they were created or last serviced (RFC 9218 Section 4).
+    ///
+    /// A non-incremental stream has no round-robin position, so cycling must
+    /// not move it. This is what masking the sequence in `position` provides,
+    /// and what the field order of `StreamPriorityPosition` encodes.
+    #[test]
+    fn non_incremental_ahead_of_incremental() {
+        let local_tp = crate::TransportParams::default();
+        let peer_tp = crate::TransportParams {
+            initial_max_stream_data_bidi_local: 100,
+            initial_max_stream_data_uni: 100,
+            ..Default::default()
+        };
+
+        let mut streams: StreamMap = StreamMap::new(100, 100, 100);
+
+        // Created out of ID order, and the non-incremental ones last.
+        for (id, incremental) in [(8, true), (0, true), (12, false), (4, false)] {
+            streams
+                .get_or_create(id, &local_tp, &peer_tp, false, true)
+                .unwrap();
+            streams.set_priority(id, DEFAULT_URGENCY, incremental);
+        }
+
+        assert_eq!(streams.writable().collect::<Vec<u64>>(), vec![4, 12, 8, 0]);
+
+        // Cycling cannot move a non-incremental stream.
+        streams.cycle_priority(4, PriorityQueue::Writable);
+        assert_eq!(streams.writable().collect::<Vec<u64>>(), vec![4, 12, 8, 0]);
+
+        // An incremental stream cycles behind its incremental peers only.
+        streams.cycle_priority(8, PriorityQueue::Writable);
+        assert_eq!(streams.writable().collect::<Vec<u64>>(), vec![4, 12, 0, 8]);
+    }
+
+    /// Cycling a stream in one queue must not move it in the others, while
+    /// setting its priority must move it in all of them.
+    ///
+    /// A stream can sit in the flushable, readable and writable queues at
+    /// once. Reading from it reschedules only what is read next; it must not
+    /// reorder what is sent, which is scheduled from the client's priority
+    /// signals rather than from local read behaviour. Urgency and the
+    /// incremental flag, in contrast, select the priority group in every
+    /// queue.
+    #[test]
+    fn cycle_priority_is_per_queue() {
+        let local_tp = crate::TransportParams::default();
+        let peer_tp = crate::TransportParams {
+            initial_max_stream_data_bidi_local: 100,
+            initial_max_stream_data_uni: 100,
+            ..Default::default()
+        };
+
+        let mut streams: StreamMap = StreamMap::new(100, 100, 100);
+
+        for id in [4, 8, 12] {
+            streams
+                .get_or_create(id, &local_tp, &peer_tp, false, true)
+                .unwrap();
+            streams
+                .get_mut(id)
+                .unwrap()
+                .send
+                .write(b"data", false)
+                .unwrap();
+            let priority_key = Arc::clone(&streams.get(id).unwrap().priority_key);
+            streams.insert_flushable(&priority_key);
+            streams.insert_readable(&priority_key);
+            streams.insert_writable(&priority_key);
+        }
+
+        macro_rules! order {
+            ($tree:expr) => {{
+                let mut v = Vec::new();
+                let mut c = $tree.front();
+                while let Some(k) = c.get() {
+                    v.push(k.id);
+                    c.move_next();
+                }
+                v
+            }};
+        }
+
+        assert_eq!(order!(streams.flushable), vec![4, 8, 12]);
+        assert_eq!(order!(streams.readable), vec![4, 8, 12]);
+        assert_eq!(order!(streams.writable), vec![4, 8, 12]);
+
+        // A read moves the stream in the readable queue only.
+        streams.cycle_priority(4, PriorityQueue::Readable);
+        assert_eq!(order!(streams.readable), vec![8, 12, 4]);
+        assert_eq!(order!(streams.flushable), vec![4, 8, 12]);
+        assert_eq!(order!(streams.writable), vec![4, 8, 12]);
+
+        // A send moves it in the flushable queue only.
+        streams.cycle_priority(4, PriorityQueue::Flushable);
+        assert_eq!(order!(streams.flushable), vec![8, 12, 4]);
+        assert_eq!(order!(streams.readable), vec![8, 12, 4]);
+        assert_eq!(order!(streams.writable), vec![4, 8, 12]);
+
+        // And a write moves it in the writable queue only.
+        streams.cycle_priority(4, PriorityQueue::Writable);
+        assert_eq!(order!(streams.writable), vec![8, 12, 4]);
+        assert_eq!(order!(streams.flushable), vec![8, 12, 4]);
+        assert_eq!(order!(streams.readable), vec![8, 12, 4]);
+
+        // Setting a priority moves the stream in every queue. Set a different
+        // urgency and back, since setting the urgency a stream already has
+        // does nothing.
+        streams.set_priority(8, DEFAULT_URGENCY + 1, true);
+        streams.set_priority(8, DEFAULT_URGENCY, true);
+        assert_eq!(order!(streams.readable), vec![12, 4, 8]);
+        assert_eq!(order!(streams.writable), vec![12, 4, 8]);
+        assert_eq!(order!(streams.flushable), vec![12, 4, 8]);
+    }
+
+    /// A stream created after another has been serviced starts behind it.
+    ///
+    /// A new stream takes the current round-robin position in each queue. With
+    /// the default position it would sort ahead of every stream that has ever
+    /// been serviced, and so preempt streams that have been waiting since
+    /// before it existed.
+    #[test]
+    fn new_stream_starts_at_the_back() {
+        let local_tp = crate::TransportParams::default();
+        let peer_tp = crate::TransportParams {
+            initial_max_stream_data_bidi_local: 100,
+            initial_max_stream_data_uni: 100,
+            ..Default::default()
+        };
+
+        let mut streams: StreamMap = StreamMap::new(100, 100, 100);
+
+        let link = |streams: &mut StreamMap, id| {
+            streams
+                .get_or_create(id, &local_tp, &peer_tp, false, true)
+                .unwrap();
+            streams
+                .get_mut(id)
+                .unwrap()
+                .send
+                .write(b"data", false)
+                .unwrap();
+            let key = Arc::clone(&streams.get(id).unwrap().priority_key);
+            streams.insert_readable(&key);
+            streams.insert_flushable(&key);
+        };
+
+        link(&mut streams, 4);
+        link(&mut streams, 8);
+
+        // Service stream 4 in every queue, so it sits behind stream 8.
+        for queue in [
+            PriorityQueue::Readable,
+            PriorityQueue::Writable,
+            PriorityQueue::Flushable,
+        ] {
+            streams.cycle_priority(4, queue);
+        }
+
+        link(&mut streams, 12);
+
+        assert_eq!(streams.readable().collect::<Vec<u64>>(), vec![8, 4, 12]);
+        assert_eq!(streams.writable().collect::<Vec<u64>>(), vec![8, 4, 12]);
+        assert_eq!(
+            streams.flushable.iter().map(|k| k.id).collect::<Vec<u64>>(),
+            vec![8, 4, 12]
+        );
+    }
+
+    /// Cycling a queue the stream is not linked in must not add it there.
+    ///
+    /// Callers cycle a stream whenever they service it, including when that
+    /// service removed it from the queue, so `cycle_priority` is routinely
+    /// asked to cycle a queue the stream is absent from.
+    #[test]
+    fn cycle_priority_no_phantom_entries() {
+        let local_tp = crate::TransportParams::default();
+        let peer_tp = crate::TransportParams {
+            initial_max_stream_data_bidi_local: 100,
+            initial_max_stream_data_uni: 100,
+            ..Default::default()
+        };
+
+        let mut streams: StreamMap = StreamMap::new(100, 100, 100);
+
+        // get_or_create leaves the stream writable, so take it back out to
+        // leave it linked in the flushable queue alone.
+        streams
+            .get_or_create(4, &local_tp, &peer_tp, false, true)
+            .unwrap();
+        streams
+            .get_mut(4)
+            .unwrap()
+            .send
+            .write(b"data", false)
+            .unwrap();
+        let priority_key = Arc::clone(&streams.get(4).unwrap().priority_key);
+        streams.remove_writable(&priority_key);
+        streams.insert_flushable(&priority_key);
+
+        assert!(streams.readable().next().is_none());
+        assert!(streams.writable().next().is_none());
+        assert_eq!(streams.peek_flushable().unwrap().id, 4);
+
+        streams.cycle_priority(4, PriorityQueue::Readable);
+        streams.cycle_priority(4, PriorityQueue::Writable);
+
+        assert!(streams.readable().next().is_none());
+        assert!(streams.writable().next().is_none());
+
+        let before = streams.get(4).unwrap().priority_key.flushable_sequence();
+
+        streams.cycle_priority(4, PriorityQueue::Flushable);
+
+        // The stream moved rather than being left where it was.
+        assert_ne!(
+            streams.get(4).unwrap().priority_key.flushable_sequence(),
+            before
+        );
+
+        assert_eq!(streams.peek_flushable().unwrap().id, 4);
     }
 }
 

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -9685,10 +9685,17 @@ fn last_tx_data_larger_than_tx_data(
 
     pipe.server.on_timeout();
 
-    // Server sends PTO probe (not limited to cwnd),
-    // to update last_tx_data.
+    // Server sends PTO probe (not limited to cwnd), to update last_tx_data.
+    //
+    // The probe carries stream 8. Stream 4 was cycled to the back of the
+    // flushable queue on each of the packets that carried its 10000 bytes,
+    // while stream 8 has not been serviced at all, so round-robin picks
+    // stream 8 first. Only one STREAM frame goes in a packet, and connection
+    // flow control leaves stream 8 with 800 bytes buffered, so the length is
+    // 800 of stream data plus 48 of framing: a 5 byte STREAM header, 9 bytes
+    // of ACK and DATA_BLOCKED, an 18 byte short header, and a 16 byte tag.
     let (len, _) = pipe.server.send(&mut buf).unwrap();
-    assert_eq!(len, 1200);
+    assert_eq!(len, 848);
 
     // Client sends STOP_SENDING to decrease tx_data
     // by unsent data. It will make last_tx_data > tx_data
@@ -12929,4 +12936,357 @@ fn server_qlog() {
     } else {
         panic!("expected Qlog event");
     }
+}
+
+/// Incremental streams of equal urgency take turns on the wire: none of them
+/// sends a second time before every other stream with data has sent once.
+///
+/// This is what the round-robin sequence in the priority key exists to
+/// provide. Without it one stream monopolises the connection until it runs
+/// out of data.
+#[test]
+fn incremental_stream_round_robin() {
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config
+        .set_application_protos(&[b"proto1", b"proto2"])
+        .unwrap();
+    config.set_initial_max_data(100000);
+    config.set_initial_max_stream_data_bidi_local(10000);
+    config.set_initial_max_stream_data_bidi_remote(10000);
+    config.set_initial_max_streams_bidi(10);
+    config.verify_peer(false);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // More than one packet's worth on each stream, so the rotation has to
+    // come back around. All streams are incremental by default.
+    let data = vec![0u8; 2500];
+    for id in [4, 8, 12] {
+        assert_eq!(pipe.client.stream_send(id, &data, false), Ok(2500));
+    }
+
+    let mut buf = [0; 1350];
+    let mut send_order = Vec::new();
+
+    while let Ok((len, _)) = pipe.client.send(&mut buf) {
+        let frames =
+            test_utils::decode_pkt(&mut pipe.server, &mut buf[..len]).unwrap();
+
+        send_order.extend(frames.iter().filter_map(|f| match f {
+            frame::Frame::Stream { stream_id, .. } => Some(*stream_id),
+            _ => None,
+        }));
+    }
+
+    assert_eq!(send_order, vec![4, 8, 12, 4, 8, 12, 4, 8, 12]);
+}
+
+/// A stream that empties its send buffer leaves the flushable queue. When the
+/// application writes to it again it must re-enter at the back of its priority
+/// group, so that it cannot preempt a stream still waiting to be serviced.
+///
+/// Cycling on service rather than on queue membership is what provides this. If
+/// the cycle were skipped for a stream that just left the queue, the stream
+/// would keep its old position and could preempt the same peer on every refill.
+#[test]
+fn emptied_stream_reflushes_at_back() {
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config
+        .set_application_protos(&[b"proto1", b"proto2"])
+        .unwrap();
+    config.set_initial_max_data(100000);
+    config.set_initial_max_stream_data_bidi_local(50000);
+    config.set_initial_max_stream_data_bidi_remote(50000);
+    config.set_initial_max_streams_bidi(10);
+    config.verify_peer(false);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // Stream 4 fits in one packet; stream 8 needs several, so it stays queued
+    // and is never fully serviced below.
+    assert_eq!(pipe.client.stream_send(4, b"aaaaaaaaaa", false), Ok(10));
+    assert_eq!(pipe.client.stream_send(8, &[0; 5000], false), Ok(5000));
+
+    let mut buf = [0; 1350];
+    assert!(pipe.client.send(&mut buf).is_ok());
+
+    // Stream 4 emptied and left the queue.
+    assert_eq!(pipe.client.streams.peek_flushable().map(|k| k.id), Some(8));
+
+    // Stream 4 has more to send. Stream 8 has been waiting since before that
+    // first packet, so it keeps its place at the front.
+    assert_eq!(pipe.client.stream_send(4, b"bbbbbbbbbb", false), Ok(10));
+
+    assert_eq!(pipe.client.streams.peek_flushable().map(|k| k.id), Some(8));
+}
+
+/// A stream that is fully drained leaves the readable queue. When new data
+/// arrives it must re-enter at the back of its priority group rather than at
+/// the front, so that it does not preempt a stream that has never been
+/// serviced.
+#[test]
+fn drained_stream_reenters_at_back() {
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config
+        .set_application_protos(&[b"proto1", b"proto2"])
+        .unwrap();
+    config.set_initial_max_data(100000);
+    config.set_initial_max_stream_data_bidi_local(10000);
+    config.set_initial_max_stream_data_bidi_remote(10000);
+    config.set_initial_max_streams_bidi(10);
+    config.verify_peer(false);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // Streams 4 and 8 both have data pending; 8 is never serviced below.
+    assert_eq!(pipe.client.stream_send(4, b"aaaaaaaaaa", false), Ok(10));
+    assert_eq!(pipe.client.stream_send(8, b"bbbbbbbbbb", false), Ok(10));
+    assert_eq!(pipe.advance(), Ok(()));
+
+    assert_eq!(pipe.server.readable().collect::<Vec<u64>>(), vec![4, 8]);
+
+    // Drain stream 4 completely, so it leaves the readable queue.
+    let mut buf = [0; 100];
+    while pipe.server.stream_recv(4, &mut buf).is_ok() {}
+
+    assert_eq!(pipe.server.readable().collect::<Vec<u64>>(), vec![8]);
+
+    // More data arrives for stream 4. Stream 8 has been waiting the whole
+    // time and has never been read, so it must still be served first.
+    assert_eq!(pipe.client.stream_send(4, b"cccccccccc", false), Ok(10));
+    assert_eq!(pipe.advance(), Ok(()));
+
+    assert_eq!(pipe.server.readable().collect::<Vec<u64>>(), vec![8, 4]);
+}
+
+/// A stream that has written up to its flow control limit leaves the writable
+/// queue. When the peer extends the limit it must re-enter at the back of its
+/// priority group, so that an application which keeps one stream at its limit
+/// is still told about the streams queued behind it.
+#[test]
+fn blocked_stream_returns_writable_at_back() {
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config
+        .set_application_protos(&[b"proto1", b"proto2"])
+        .unwrap();
+    config.set_initial_max_data(100000);
+    config.set_initial_max_stream_data_bidi_local(10000);
+    config.set_initial_max_stream_data_bidi_remote(2000);
+    config.set_initial_max_streams_bidi(10);
+    config.verify_peer(false);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // Stream 4 uses all of its flow control capacity and leaves the queue.
+    // Stream 8 keeps capacity and is not written again below.
+    assert_eq!(pipe.client.stream_send(4, b"aaaaaaaaaa", false), Ok(10));
+    assert_eq!(pipe.client.stream_send(8, b"bbbbbbbbbb", false), Ok(10));
+
+    assert_eq!(pipe.client.writable().collect::<Vec<u64>>(), vec![4, 8]);
+
+    assert_eq!(pipe.client.stream_send(4, &[0; 1990], false), Ok(1990));
+
+    assert_eq!(pipe.client.writable().collect::<Vec<u64>>(), vec![8]);
+
+    // The peer consumes stream 4 and extends its limit. Stream 8 has been
+    // waiting since before stream 4 was last written, so it comes first.
+    assert_eq!(pipe.advance(), Ok(()));
+
+    let mut buf = [0; 2000];
+    while pipe.server.stream_recv(4, &mut buf).is_ok() {}
+
+    assert_eq!(pipe.advance(), Ok(()));
+
+    assert_eq!(pipe.client.writable().collect::<Vec<u64>>(), vec![8, 4]);
+}
+
+/// `stream_writable_next()` hands a stream to the application and takes it out
+/// of the writable queue, which is that queue's form of service. When
+/// `stream_writable()` puts it back it must re-enter at the back, so that an
+/// application which is handed a stream, cannot write to it, and re-arms does
+/// not keep being handed the same stream while another waits.
+#[test]
+fn writable_next_stream_rearms_at_back() {
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config
+        .set_application_protos(&[b"proto1", b"proto2"])
+        .unwrap();
+    // Connection capacity well below the stream limits, so re-arming for more
+    // than it holds leaves the stream writable but connection blocked.
+    config.set_initial_max_data(20);
+    config.set_initial_max_stream_data_bidi_local(10000);
+    config.set_initial_max_stream_data_bidi_remote(10000);
+    config.set_initial_max_streams_bidi(10);
+    config.verify_peer(false);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    assert_eq!(pipe.client.stream_send(4, b"a", false), Ok(1));
+    assert_eq!(pipe.client.stream_send(8, b"a", false), Ok(1));
+
+    assert_eq!(pipe.client.writable().collect::<Vec<u64>>(), vec![4, 8]);
+
+    // Stream 4 is handed out and leaves the queue.
+    assert_eq!(pipe.client.stream_writable_next(), Some(4));
+
+    assert_eq!(pipe.client.writable().collect::<Vec<u64>>(), vec![8]);
+
+    // Stream 4 re-arms for more capacity than the connection has, so it goes
+    // back in the queue. Stream 8 has not been handed out at all, so it keeps
+    // its place at the front.
+    assert_eq!(pipe.client.stream_writable(4, 100), Ok(false));
+
+    assert_eq!(pipe.client.writable().collect::<Vec<u64>>(), vec![8, 4]);
+}
+
+/// Buffered data is never invisible to the readable queue.
+///
+/// `stream_readable_next()` takes the stream out of the queue as it hands it to
+/// the application. If the application then reads only part of what is
+/// buffered, the stream still has data, so it belongs in the queue again: the
+/// queue holds the streams that are readable, not the streams that have not
+/// been offered yet. Nothing else puts it back, since a stream re-enters on
+/// becoming readable and this one never stopped being readable.
+///
+/// Both cases matter and they used to differ: the round-robin shuffle this
+/// replaces put an incremental stream back as a side effect and left a
+/// non-incremental one out.
+#[rstest]
+fn partially_read_stream_stays_readable(
+    #[values(true, false)] incremental: bool,
+) {
+    let mut pipe = test_utils::Pipe::new("cubic").unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    assert_eq!(pipe.client.stream_send(4, b"hello world", false), Ok(11));
+    assert_eq!(pipe.client.stream_send(8, b"hello world", false), Ok(11));
+    assert_eq!(pipe.advance(), Ok(()));
+
+    pipe.server.stream_priority(4, 127, incremental).unwrap();
+    pipe.server.stream_priority(8, 127, incremental).unwrap();
+
+    assert_eq!(pipe.server.stream_readable_next(), Some(4));
+    assert_eq!(pipe.server.readable().collect::<Vec<u64>>(), vec![8]);
+
+    let mut buf = [0; 2];
+    assert_eq!(pipe.server.stream_recv(4, &mut buf), Ok((2, false)));
+
+    // Stream 4 is back in the queue. A read is a service, so an incremental
+    // stream re-enters behind a stream that has never been read from; a
+    // non-incremental one has no round-robin position and stays in ID order.
+    let expected = if incremental { vec![8, 4] } else { vec![4, 8] };
+
+    assert_eq!(pipe.server.readable().collect::<Vec<u64>>(), expected);
+    assert_eq!(pipe.server.stream_readable_next(), Some(expected[0]));
+}
+
+/// The writable twin of `partially_read_stream_stays_readable`.
+///
+/// `stream_writable_next()` also takes the stream out of the queue as it hands
+/// it over, so a stream that still has capacity after being written to belongs
+/// back in it. As above, the shuffle this replaces did that only for
+/// incremental streams.
+#[rstest]
+fn partially_written_stream_stays_writable(
+    #[values(true, false)] incremental: bool,
+) {
+    let mut pipe = test_utils::Pipe::new("cubic").unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    assert_eq!(pipe.client.stream_send(4, b"a", false), Ok(1));
+    pipe.client.stream_priority(4, 127, incremental).unwrap();
+
+    assert_eq!(pipe.client.stream_writable_next(), Some(4));
+    assert!(pipe.client.writable().next().is_none());
+
+    // The stream keeps capacity after this write, so it is still writable.
+    assert_eq!(pipe.client.stream_send(4, b"b", false), Ok(1));
+
+    assert_eq!(pipe.client.writable().collect::<Vec<u64>>(), vec![4]);
+    assert_eq!(pipe.client.stream_writable_next(), Some(4));
+}
+
+/// Reading from a stream must not reorder what is sent on it.
+///
+/// The three queues carry a round-robin position each, so servicing a stream in
+/// one must leave the other two alone. Send scheduling follows the peer's
+/// priority signals, not how promptly the local application drains its receive
+/// buffers.
+///
+/// Asserted at the connection level because that is where the queue to cycle is
+/// chosen: a service point that names the wrong queue, or one that cycles a
+/// queue it did not service, is invisible to the `StreamMap` tests.
+#[test]
+fn reading_a_stream_does_not_reorder_sending() {
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config
+        .set_application_protos(&[b"proto1", b"proto2"])
+        .unwrap();
+    config.set_initial_max_data(100000);
+    config.set_initial_max_stream_data_bidi_local(50000);
+    config.set_initial_max_stream_data_bidi_remote(50000);
+    config.set_initial_max_streams_bidi(10);
+    config.verify_peer(false);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // The server sees streams 4 and 8 created in that order.
+    assert_eq!(pipe.client.stream_send(4, b"aaaaaaaaaa", false), Ok(10));
+    assert_eq!(pipe.client.stream_send(8, b"bbbbbbbbbb", false), Ok(10));
+    assert_eq!(pipe.advance(), Ok(()));
+
+    // Both have data to send, so both are queued to flush, 4 ahead of 8.
+    assert_eq!(pipe.server.stream_send(4, &[0; 4000], false), Ok(4000));
+    assert_eq!(pipe.server.stream_send(8, &[0; 4000], false), Ok(4000));
+
+    assert_eq!(pipe.server.streams.peek_flushable().map(|k| k.id), Some(4));
+
+    // The application drains stream 4's receive buffer. Nothing was sent on
+    // stream 4, so its place in the flushable queue must not move.
+    let mut buf = [0; 100];
+    assert_eq!(pipe.server.stream_recv(4, &mut buf), Ok((10, false)));
+
+    assert_eq!(pipe.server.streams.peek_flushable().map(|k| k.id), Some(4));
 }


### PR DESCRIPTION
Fix `StreamPriorityKey::cmp` implementation so it doesn't violate Rust's `Ord`
trait contract while keeping the intended round-robin behavior.

This is based on the discussion that was had in #2282. @antoniovicente had some
concerns about the implementation with respect to the `Ord` trait contract.

This is my attempt at fixing that and maintaining the round-robin requirement.

- Ordering comes from a derived `Ord` on a new position type, so the contract
  holds without a hand-written comparison.
- The sequence field is per queue, so reading from a stream doesn't reorder what
  we send on it.
- `cycle_flushable()` became `cycle_priority()`. It takes the queue that was
  serviced, and runs every time we service a stream rather than only when the
  stream stays queued.
- `stream_readable_next()` and `stream_writable_next()` take a stream off the
  queue as they hand it out. The old reinsert put it back by accident, and only
  for incremental streams, so membership follows eligibility now instead.
- Moved `stream_priority()` into `StreamMap::set_priority()`, so the priority
  tests don't need their own copy of it.

The h3 change is a test, see the comment on the thread.

The branch is rebased onto master and squashed, so the existing review threads
point at lines that no longer exist. Happy to re-open any of them.
