### PR TITLE
octets: fix slice_last() with non-zero offset

### DIFF
--- a/octets/src/lib.rs
+++ b/octets/src/lib.rs
@@ -332,8 +332,8 @@ impl<'a> Octets<'a> {
             return Err(BufferTooShortError);
         }
 
-        let cap = self.cap();
-        Ok(&self.buf[cap - len..])
+        let end = self.buf.len();
+        Ok(&self.buf[end - len..end])
     }
 
     /// Advances the buffer's offset.
@@ -747,8 +747,8 @@ impl<'a> OctetsMut<'a> {
             return Err(BufferTooShortError);
         }
 
-        let cap = self.cap();
-        Ok(&mut self.buf[cap - len..])
+        let end = self.buf.len();
+        Ok(&mut self.buf[end - len..end])
     }
 
     /// Advances the buffer's offset.
@@ -1489,6 +1489,13 @@ mod tests {
         }
 
         {
+            let mut b = Octets::with_slice(&d);
+            b.get_bytes(5).unwrap();
+            let exp = b"orld".to_vec();
+            assert_eq!(b.slice_last(4), Ok(&exp[..]));
+        }
+
+        {
             let b = Octets::with_slice(&d);
             let exp = b"d".to_vec();
             assert_eq!(b.slice_last(1), Ok(&exp[..]));
@@ -1518,6 +1525,13 @@ mod tests {
 
         {
             let mut b = OctetsMut::with_slice(&mut d);
+            let mut exp = b"orld".to_vec();
+            assert_eq!(b.slice_last(4), Ok(&mut exp[..]));
+        }
+
+        {
+            let mut b = OctetsMut::with_slice(&mut d);
+            b.get_bytes(5).unwrap();
             let mut exp = b"orld".to_vec();
             assert_eq!(b.slice_last(4), Ok(&mut exp[..]));
         }


### PR DESCRIPTION
## Summary

Fix `Octets::slice_last()` and `OctetsMut::slice_last()` returning an incorrect tail slice when the internal offset has been advanced.

These helpers previously used `cap()` (remaining bytes after `off`) to compute the start index, but then applied that index to the full underlying buffer (`self.buf[...]`). When `off > 0`, this could include already-consumed bytes and return the wrong region.

## Reproduction

```rust
let mut b = Octets::with_slice(b"helloworld");
b.get_bytes(5).unwrap(); // advance offset past "hello"
assert_eq!(b.slice_last(4).unwrap(), b"orld");
```

Before this change, slice_last(4) could return the wrong region (e.g. starting at index 1), because cap() was treated as an absolute index into the full buffer.

## Fix

Compute `end` as `self.buf.len()` and slice `self.buf[end - len..end]` (and the mutable equivalent). The existing `len <= self.cap()` guard ensures `end - len >= off`, so the returned slice stays within the remaining window.

## Tests

Add regression cases that advance the offset via `get_bytes()` and then assert `slice_last()` returns the correct tail bytes for both `Octets` and `OctetsMut`.

Tested with:
- \ cargo test -p octets