### PR TITLE
chore: Add missing apt-get update call prior to package install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,9 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install qlog-dancer dependencies
-        run: sudo apt-get install libexpat1-dev libfreetype6-dev libfontconfig1-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libexpat1-dev libfreetype6-dev libfontconfig1-dev
 
       - name: Run cargo doc
         run: cargo doc --no-deps --all-features

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,9 @@ jobs:
           toolchain: ${{ env.RUSTTOOLCHAIN }}
 
       - name: Install qlog-dancer dependencies
-        run: sudo apt-get install libexpat1-dev libfreetype6-dev libfontconfig1-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libexpat1-dev libfreetype6-dev libfontconfig1-dev
 
       - name: Run cargo test
         run: cargo test --verbose --all-targets --features=boringssl-boring-crate,${{ env.FEATURES }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -41,7 +41,9 @@ jobs:
           components: clippy
 
       - name: Install qlog-dancer dependencies
-        run: sudo apt-get install libexpat1-dev libfreetype6-dev libfontconfig1-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libexpat1-dev libfreetype6-dev libfontconfig1-dev
 
       - name: Unused dependency check
         if: ${{ matrix.tls-feature == '' }}


### PR DESCRIPTION
Without updating the apt repositories, apt may try to install an outdated package version that is not available on mirrors anymore.