### PR TITLE
h3i: add interactive mode to async client

### DIFF
--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -14,7 +14,7 @@ categories = { workspace = true }
 readme = "README.md"
 
 [features]
-async = ["dep:buffer-pool", "dep:tokio", "dep:tokio-quiche"]
+async = ["dep:buffer-pool", "dep:futures", "dep:tokio", "dep:tokio-quiche"]
 
 [dependencies]
 clap = "3"
@@ -35,5 +35,6 @@ url = { workspace = true }
 
 # Dependencies for async client
 buffer-pool = { optional = true, workspace = true }
+futures = { version = "0.3", optional = true }
 tokio = { version = "1.44", features = ["net", "sync", "time"], optional = true }
 tokio-quiche = { features = ["capture_keylogs", "quiche_internal"], optional = true, workspace = true }


### PR DESCRIPTION
Add H3iHandle and connect_interactive() to allow submitting actions one at a time via a channel, rather than providing all actions upfront.

Changes:
- Add H3iHandle struct with do_action() and finish() methods
- Add connect_interactive() function that returns an H3iHandle
- Refactor H3iDriver to use VecDeque action queue instead of Vec+index
- Add action_rx channel for receiving actions in interactive mode
- Move action processing from iterator-based to queue-based approach
- Process incoming actions in work_loop via select! macro

This enables use cases where actions need to be submitted dynamically based on server responses, rather than predetermined at connection time.