### PR TITLE
Revert "Temporary patch to fix windows CI (#2285)"

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -202,13 +202,6 @@ jobs:
         with:
           args: install nasm
 
-      # https://github.com/rust-lang/cmake-rs/pull/259 breaks handling of long Windows paths
-      # https://github.com/cloudflare/boring/issues/414
-      # https://github.com/0x676e67/boring/commit/efacedb5bf409d0d773e8ce4f5080cb4b4c10f54
-      - name: Pin some dependencies, temporary patch for cmake breakage
-        run: |
-          cargo update --package cmake --precise 0.1.54
-
       - name: Run cargo build
         if: endsWith(matrix.target, '-gnu')
         run: cargo build --target=${{ matrix.target }} --verbose --all-targets ${{ env.DEFAULT_OPTIONS }} --exclude qlog-dancer --features=boringssl-boring-crate

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -64,7 +64,7 @@ features = ["boringssl-boring-crate", "qlog"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [build-dependencies]
-cmake = "0.1"
+cmake = "0.1.57"
 pkg-config = { version = "0.3", optional = true }
 cdylib-link-lines = { version = "0.1", optional = true }
 


### PR DESCRIPTION
The issue we had on Windows seems to have been fixed in version 0.1.57 https://github.com/rust-lang/cmake-rs/pull/267

This reverts commit 225b656742a07508236fbc420b5c44fa3cbdf55b.