### PR TITLE
perf: avoid sending a redundant max-size probe when restarting PMTUD

### DIFF
--- a/quiche/src/pmtud.rs
+++ b/quiche/src/pmtud.rs
@@ -388,6 +388,12 @@ mod tests {
         // Simulate a failed probe that is less than the last successful probe
         pmtud.failed_probe(1300);
 
+        // The largest successful probe should be reset after restarting PMTUD
+        assert_eq!(pmtud.largest_successful_probe_size, None);
+
+        // The smallest failed probe should be recorded again after restarting PMTUD
+        assert_eq!(pmtud.smallest_failed_probe_size, Some(1300));
+
         // Run the PMTUD test runner to verify handling of inconsistent results
         pmtud_test_runner(&mut pmtud, 1250);
     }

--- a/quiche/src/pmtud.rs
+++ b/quiche/src/pmtud.rs
@@ -89,16 +89,16 @@ impl Pmtud {
 
                     self.restart_pmtud();
 
-                    // Record the failed probe again after restarting PMTUD
-                    // to ensure the next probe size is reduced (binary search down)
+                    // Record the failed probe again after restarting PMTUD to
+                    // ensure the next probe size is reduced (binary search down)
                     // instead of resetting to the maximum MTU.
                     //
-                    // NOTE: `failed_probe()` internally calls `update_probe_size()`,
-                    // so this is an intentional and bounded recursive call. After
-                    // `restart_pmtud()` the state is reset, and re-recording the
-                    // failed probe brings the PMTUD state back into a consistent
-                    // configuration for the next probe without causing unbounded
-                    // recursion.
+                    // NOTE: `failed_probe()` internally calls
+                    // `update_probe_size()`, so this is an intentional and
+                    // bounded recursive call. After `restart_pmtud()` the state
+                    // is reset, and re-recording the failed probe brings the
+                    // PMTUD state back into a consistent configuration for the
+                    // next probe without causing unbounded recursion.
                     self.failed_probe(failed_probe_size);
 
                     return;
@@ -398,7 +398,7 @@ mod tests {
         // The largest successful probe should be reset after restarting PMTUD
         assert_eq!(pmtud.largest_successful_probe_size, None);
 
-        // The smallest failed probe should be recorded again after restarting PMTUD
+        // The smallest failed probe should be recorded again
         assert_eq!(pmtud.smallest_failed_probe_size, Some(1300));
 
         // Run the PMTUD test runner to verify handling of inconsistent results

--- a/quiche/src/pmtud.rs
+++ b/quiche/src/pmtud.rs
@@ -92,6 +92,13 @@ impl Pmtud {
                     // Record the failed probe again after restarting PMTUD
                     // to ensure the next probe size is reduced (binary search down)
                     // instead of resetting to the maximum MTU.
+                    //
+                    // NOTE: `failed_probe()` internally calls `update_probe_size()`,
+                    // so this is an intentional and bounded recursive call. After
+                    // `restart_pmtud()` the state is reset, and re-recording the
+                    // failed probe brings the PMTUD state back into a consistent
+                    // configuration for the next probe without causing unbounded
+                    // recursion.
                     self.failed_probe(failed_probe_size);
 
                     return;


### PR DESCRIPTION
## Problem

Currently, when `update_probe_size` detects an inconsistency (where `failed_probe_size <= successful_probe_size`) and calls `restart_pmtud()`, the `probe_size` is reset to `maximum_supported_mtu`.

This behavior causes the next probe to be sent at `maximum_supported_mtu` immediately after the restart. In scenarios where the path MTU has actually decreased (causing the inconsistency), this probe is highly likely to fail again, resulting in a wasted packet and an unnecessary RTT before the algorithm begins to search downwards.

## Solution

This change records the failed probe size immediately after restarting PMTUD. By doing so, the next probe size is calculated based on the failure (searching downwards) instead of resetting to the maximum supported MTU. This avoids sending a probe that is known to likely fail.