### PR TITLE
Add the intended send_time arg to send_on_path to fix packet send times when pacing to fix RTT calculation when using BBR

### DIFF
--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -33,8 +33,6 @@ use std::rc::Rc;
 
 use std::cell::RefCell;
 
-use std::time::Instant;
-
 use ring::rand::*;
 
 const MAX_DATAGRAM_SIZE: usize = 1350;
@@ -499,13 +497,10 @@ pub fn connect(
 
             for peer_addr in conn.paths_iter(local_addr) {
                 loop {
-                    let now = Instant::now();
                     let (write, send_info) = match conn.send_on_path(
                         &mut out,
                         Some(local_addr),
                         Some(peer_addr),
-                        &quiche::TimeSent::new(&None, now),
-                        now,
                     ) {
                         Ok(v) => v,
 

--- a/h3i/src/client/sync_client.rs
+++ b/h3i/src/client/sync_client.rs
@@ -384,13 +384,10 @@ pub fn connect(
 
             for peer_addr in conn.paths_iter(local_addr) {
                 loop {
-                    let now = Instant::now();
                     let (write, send_info) = match conn.send_on_path(
                         &mut out,
                         Some(local_addr),
                         Some(peer_addr),
-                        &quiche::TimeSent::new(&None, now),
-                        now,
                     ) {
                         Ok(v) => v,
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -828,8 +828,7 @@ pub extern "C" fn quiche_conn_send_on_path(
     let to = optional_std_addr_from_c(to, to_len);
     let out = unsafe { slice::from_raw_parts_mut(out, out_len) };
 
-    let now = Instant::now();
-    match conn.send_on_path(out, from, to, &TimeSent::new(&None, now), now) {
+    match conn.send_on_path(out, from, to) {
         Ok((v, info)) => {
             out_info.from_len = std_addr_to_c(&info.from, &mut out_info.from);
             out_info.to_len = std_addr_to_c(&info.to, &mut out_info.to);

--- a/quiche/src/test_utils.rs
+++ b/quiche/src/test_utils.rs
@@ -364,14 +364,7 @@ pub fn emit_flight_with_max_buffer(
     loop {
         let mut out = vec![0u8; out_size];
 
-        let now = Instant::now();
-        let info = match conn.send_on_path(
-            &mut out,
-            from,
-            to,
-            &TimeSent::new(&None, now),
-            now,
-        ) {
+        let info = match conn.send_on_path(&mut out, from, to) {
             Ok((written, info)) => {
                 out.truncate(written);
                 info

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -8896,28 +8896,16 @@ fn send_on_path_test(
 
     let mut buf = [0; 65535];
     // There is nothing to send on the initial path.
-    let now = Instant::now();
     assert_eq!(
-        pipe.client.send_on_path(
-            &mut buf,
-            Some(client_addr),
-            Some(server_addr),
-            &TimeSent::new(&None, now),
-            now
-        ),
+        pipe.client
+            .send_on_path(&mut buf, Some(client_addr), Some(server_addr)),
         Err(Error::Done)
     );
 
     // Client should send padded PATH_CHALLENGE.
     let (sent, si) = pipe
         .client
-        .send_on_path(
-            &mut buf,
-            Some(client_addr_2),
-            Some(server_addr),
-            &TimeSent::new(&None, now),
-            now,
-        )
+        .send_on_path(&mut buf, Some(client_addr_2), Some(server_addr))
         .expect("No error");
     assert_eq!(sent, MIN_CLIENT_INITIAL_LEN);
     assert_eq!(si.from, client_addr_2);
@@ -8939,9 +8927,7 @@ fn send_on_path_test(
         pipe.client.send_on_path(
             &mut buf,
             Some(client_addr_3),
-            Some(server_addr),
-            &TimeSent::new(&None, now),
-            now
+            Some(server_addr)
         ),
         Err(Error::InvalidState)
     );
@@ -8949,9 +8935,7 @@ fn send_on_path_test(
         pipe.client.send_on_path(
             &mut buf,
             Some(client_addr),
-            Some(server_addr_2),
-            &TimeSent::new(&None, now),
-            now
+            Some(server_addr_2)
         ),
         Err(Error::InvalidState)
     );
@@ -8965,13 +8949,7 @@ fn send_on_path_test(
     // PATH_CHALLENGE
     let (sent, si) = pipe
         .client
-        .send_on_path(
-            &mut buf,
-            Some(client_addr),
-            None,
-            &TimeSent::new(&None, now),
-            now,
-        )
+        .send_on_path(&mut buf, Some(client_addr), None)
         .expect("No error");
     assert_eq!(sent, MIN_CLIENT_INITIAL_LEN);
     assert_eq!(si.from, client_addr);
@@ -8989,13 +8967,7 @@ fn send_on_path_test(
     // STREAM frame on active path.
     let (sent, si) = pipe
         .client
-        .send_on_path(
-            &mut buf,
-            Some(client_addr),
-            None,
-            &TimeSent::new(&None, now),
-            now,
-        )
+        .send_on_path(&mut buf, Some(client_addr), None)
         .expect("No error");
     assert_eq!(si.from, client_addr);
     assert_eq!(si.to, server_addr);
@@ -9012,13 +8984,7 @@ fn send_on_path_test(
     // PATH_CHALLENGE
     let (sent, si) = pipe
         .client
-        .send_on_path(
-            &mut buf,
-            None,
-            Some(server_addr),
-            &TimeSent::new(&None, now),
-            now,
-        )
+        .send_on_path(&mut buf, None, Some(server_addr))
         .expect("No error");
     assert_eq!(sent, MIN_CLIENT_INITIAL_LEN);
     assert_eq!(si.from, client_addr_3);
@@ -9036,13 +9002,7 @@ fn send_on_path_test(
     // STREAM frame on active path.
     let (sent, si) = pipe
         .client
-        .send_on_path(
-            &mut buf,
-            None,
-            Some(server_addr),
-            &TimeSent::new(&None, now),
-            now,
-        )
+        .send_on_path(&mut buf, None, Some(server_addr))
         .expect("No error");
     assert_eq!(si.from, client_addr);
     assert_eq!(si.to, server_addr);
@@ -9055,23 +9015,11 @@ fn send_on_path_test(
 
     // No more data to exchange leads to Error::Done.
     assert_eq!(
-        pipe.client.send_on_path(
-            &mut buf,
-            Some(client_addr),
-            None,
-            &TimeSent::new(&None, now),
-            now
-        ),
+        pipe.client.send_on_path(&mut buf, Some(client_addr), None),
         Err(Error::Done)
     );
     assert_eq!(
-        pipe.client.send_on_path(
-            &mut buf,
-            None,
-            Some(server_addr),
-            &TimeSent::new(&None, now),
-            now
-        ),
+        pipe.client.send_on_path(&mut buf, None, Some(server_addr)),
         Err(Error::Done)
     );
 

--- a/tokio-quiche/src/quic/io/gso.rs
+++ b/tokio-quiche/src/quic/io/gso.rs
@@ -46,31 +46,6 @@ mod linux_imports {
 #[cfg(all(target_os = "linux", not(feature = "fuzzing")))]
 use self::linux_imports::*;
 
-// Maximum number of packets can be sent in UDP GSO.
-pub(crate) const UDP_MAX_SEGMENT_COUNT: usize = 64;
-
-#[cfg(not(feature = "gcongestion"))]
-/// Returns a new max send buffer size to avoid the fragmentation
-/// at the end. Maximum send buffer size is min(MAX_SEND_BUF_SIZE,
-/// connection's send_quantum).
-/// For example,
-///
-/// - max_send_buf = 1000 and mss = 100, return 1000
-/// - max_send_buf = 1000 and mss = 90, return 990
-///
-/// not to have last 10 bytes packet.
-pub(crate) fn tune_max_send_size(
-    segment_size: Option<usize>, send_quantum: usize, max_capacity: usize,
-) -> usize {
-    let max_send_buf_size = send_quantum.min(max_capacity);
-
-    if let Some(mss) = segment_size {
-        max_send_buf_size / mss * mss
-    } else {
-        max_send_buf_size
-    }
-}
-
 // https://wiki.cfdata.org/pages/viewpage.action?pageId=436188159
 pub(crate) const UDP_MAX_GSO_PACKET_SIZE: usize = 65507;
 


### PR DESCRIPTION
The packet send time is computed deep in on_packet_sent, and this time differs from the one passed to the GSO burst which is based on the first packet in the train.  When ReleaseDecision.can_burst() returns true, the difference between the real send time and the one stored in the recovery module can grow arbitrarily large resulting in very low RTT estimates which BBR holds onto as minRTT from there on.  Incorrect RTT will result in the congestion window being set to artificially small values because of incorrect BDP calculations since BDP = minRTT * BW_estimate