### PR TITLE
fix race condition that caused the StreamStopped error to be lost

### DIFF
--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -677,11 +677,13 @@ impl HttpConn for Http09Conn {
         &mut self, conn: &mut quiche::Connection,
         partial_responses: &mut HashMap<u64, PartialResponse>, stream_id: u64,
     ) {
+        let stream_cap = conn.stream_capacity(stream_id);
+
         debug!(
             "{} response stream {} is writable with capacity {:?}",
             conn.trace_id(),
             stream_id,
-            conn.stream_capacity(stream_id)
+            stream_cap,
         );
 
         if !partial_responses.contains_key(&stream_id) {
@@ -1601,11 +1603,13 @@ impl HttpConn for Http3Conn {
         &mut self, conn: &mut quiche::Connection,
         partial_responses: &mut HashMap<u64, PartialResponse>, stream_id: u64,
     ) {
+        let stream_cap = conn.stream_capacity(stream_id);
+
         debug!(
             "{} response stream {} is writable with capacity {:?}",
             conn.trace_id(),
             stream_id,
-            conn.stream_capacity(stream_id)
+            stream_cap,
         );
 
         if !partial_responses.contains_key(&stream_id) {

--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -420,7 +420,7 @@ int quiche_conn_stream_shutdown(quiche_conn *conn, uint64_t stream_id,
                                 enum quiche_shutdown direction, uint64_t err);
 
 // Returns the stream's send capacity in bytes.
-ssize_t quiche_conn_stream_capacity(const quiche_conn *conn, uint64_t stream_id);
+ssize_t quiche_conn_stream_capacity(quiche_conn *conn, uint64_t stream_id);
 
 // Returns true if the stream has data that can be read.
 bool quiche_conn_stream_readable(const quiche_conn *conn, uint64_t stream_id);

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -925,7 +925,7 @@ pub extern "C" fn quiche_conn_stream_shutdown(
 
 #[no_mangle]
 pub extern "C" fn quiche_conn_stream_capacity(
-    conn: &Connection, stream_id: u64,
+    conn: &mut Connection, stream_id: u64,
 ) -> ssize_t {
     match conn.stream_capacity(stream_id) {
         Ok(v) => v as ssize_t,


### PR DESCRIPTION
Currently if a STOP_SENDING frame is received, a RESET_STREAM frame is sent in response and the corresponding stream is marked as writable so that the STOP_SENDING error can be forwarded to the application.

However, the stream's state is collected once the RESET_STREAM frame is acked, and if the application hasn't yet received the corresponding error, it will never get it again.

Instead of collecting the stream immediately on receiving the RESET_STREAM ack, wait until the `StreamStopped` error is returned to the application (i.e. on calling `stream_send()`, `stream_capacity()` or `stream_writable()`).

The downside is that because of the need to modify the connection state to collect a stream, `stream_capacity()` now needs a mutable reference to the connection object, which is a breaking change.