### PR TITLE
Revert "tokio-quiche: attach additional context when logging errors"

### DIFF
--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -1177,14 +1177,7 @@ impl<H: DriverHooks> ApplicationOverQuic for H3Driver<H> {
                     // Don't bubble error up, instead keep the worker loop going
                     // until quiche reports the connection is
                     // closed.
-                    log::debug!(
-                        "connection closed due to h3 protocol error";
-                        "error"=>?err,
-                        "local_err"=>?qconn.local_error(),
-                        "peer_err"=>?qconn.peer_error(),
-                        "handshake_complete"=>qconn.is_established(),
-                        "idle_timeout"=>qconn.is_timed_out(),
-                    );
+                    log::debug!("connection closed due to h3 protocol error"; "error"=>?err);
                     return Ok(());
                 },
             };

--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -360,7 +360,7 @@ where
                     mut qconn,
                 }) => {
                     let hs_result = make_handshake_result(&work_loop_result);
-                    IoWorker::new(params, Close::new(work_loop_result))
+                    IoWorker::new(params, Close { work_loop_result })
                         .close(&mut qconn, &mut context)
                         .await;
                     hs_result
@@ -419,7 +419,7 @@ where
                 mut qconn,
             } = running_worker.run(qconn, context).await;
 
-            IoWorker::new(params, Close::new(work_loop_result))
+            IoWorker::new(params, Close { work_loop_result })
                 .close(&mut qconn, &mut context)
                 .await;
         };

--- a/tokio-quiche/src/result.rs
+++ b/tokio-quiche/src/result.rs
@@ -61,7 +61,3 @@ impl<T, E> QuicResultExt<T, E> for Result<T, E> {
         self.map_err(io::Error::other)
     }
 }
-
-pub fn to_box_error<T: ToString>(msg: T) -> BoxError {
-    msg.to_string().into()
-}

--- a/tokio-quiche/tests/integration_tests/connection_close.rs
+++ b/tokio-quiche/tests/integration_tests/connection_close.rs
@@ -94,7 +94,7 @@ async fn test_requests_per_connection_limit() -> QuicResult<()> {
 }
 
 #[tokio::test]
-async fn test_max_header_list_size_limit() {
+async fn test_max_header_list_size_limit() -> QuicResult<()> {
     let hook = TestConnectionHook::new();
     let url = start_server_with_settings(
         QuicSettings::default(),
@@ -138,6 +138,8 @@ async fn test_max_header_list_size_limit() {
         error.error_code,
         quiche::h3::WireErrorCode::ExcessiveLoad as u64
     );
+
+    Ok(())
 }
 
 #[tokio::test]


### PR DESCRIPTION
This reverts commit 04805cd27dc3dc21e34b44e508c019059dff0ce9.