### PR TITLE
qlog: align ErrorSpace with qlog spec

### DIFF
--- a/h3i/src/prompts/h3/errors.rs
+++ b/h3i/src/prompts/h3/errors.rs
@@ -84,12 +84,12 @@ pub const APPLICATION: &str = "application";
 pub fn prompt_transport_or_app_error() -> InquireResult<(ErrorSpace, u64)> {
     let trans_or_app = prompt_transport_or_app()?;
     let space = if trans_or_app == TRANSPORT {
-        ErrorSpace::TransportError
+        ErrorSpace::Transport
     } else {
-        ErrorSpace::ApplicationError
+        ErrorSpace::Application
     };
 
-    let error_code = if matches!(space, ErrorSpace::TransportError) {
+    let error_code = if matches!(space, ErrorSpace::Transport) {
         let error_code = Text::new("error code:")
             .with_validator(validate_transport_error_code)
             .with_autocomplete(&transport_error_code_suggestor)

--- a/h3i/src/prompts/h3/mod.rs
+++ b/h3i/src/prompts/h3/mod.rs
@@ -467,7 +467,7 @@ pub fn prompt_connection_close() -> InquireResult<Action> {
 
     Ok(Action::ConnectionClose {
         error: ConnectionError {
-            is_app: matches!(error_space, ErrorSpace::ApplicationError),
+            is_app: matches!(error_space, ErrorSpace::Application),
             error_code,
             reason: reason.as_bytes().to_vec(),
         },

--- a/h3i/src/recordreplay/qlog.rs
+++ b/h3i/src/recordreplay/qlog.rs
@@ -295,9 +295,9 @@ impl From<&Action> for QlogEvents {
 
             Action::ConnectionClose { error } => {
                 let error_space = if error.is_app {
-                    ErrorSpace::ApplicationError
+                    ErrorSpace::Application
                 } else {
-                    ErrorSpace::TransportError
+                    ErrorSpace::Transport
                 };
 
                 let reason = if error.reason.is_empty() {
@@ -422,7 +422,7 @@ impl From<&PacketSent> for H3Actions {
                             error_space.as_ref().expect(
                                 "invalid CC frame in qlog input, no error space"
                             ),
-                            ErrorSpace::ApplicationError
+                            ErrorSpace::Application
                         );
 
                         actions.push(Action::ConnectionClose {

--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -199,8 +199,8 @@ pub enum StreamState {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorSpace {
-    TransportError,
-    ApplicationError,
+    Transport,
+    Application,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]

--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -1044,7 +1044,7 @@ impl Frame {
                 error: Some(ConnectionClosedFrameError::TransportError(
                     qlog::events::quic::TransportError::Unknown,
                 )),
-                error_space: Some(ErrorSpace::TransportError),
+                error_space: Some(ErrorSpace::Transport),
                 error_code: Some(*error_code),
                 reason: Some(String::from_utf8_lossy(reason).into_owned()),
                 reason_bytes: None,
@@ -1056,7 +1056,7 @@ impl Frame {
                     error: Some(ConnectionClosedFrameError::ApplicationError(
                         qlog::events::ApplicationError::Unknown,
                     )),
-                    error_space: Some(ErrorSpace::ApplicationError),
+                    error_space: Some(ErrorSpace::Application),
                     error_code: Some(*error_code),
                     reason: Some(String::from_utf8_lossy(reason).into_owned()),
                     reason_bytes: None,


### PR DESCRIPTION
This updates qlog `ErrorSpace` enum variants and call sites to match the [spec](https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-quic-events.html) (all versions) which uses `"transport"` and `"application"` instead of `"transport_error"` and `"application_error"`.