### PR TITLE
tokio-quiche: only close connection when H3Event receiver drops if no active streams/flows

### DIFF
--- a/tokio-quiche/src/http3/driver/hooks.rs
+++ b/tokio-quiche/src/http3/driver/hooks.rs
@@ -83,6 +83,12 @@ pub trait DriverHooks: Sized + Send + 'static {
         cmd: Self::Command,
     ) -> H3ConnectionResult<()>;
 
+    /// Whether the extended CONNECT protocol is enabled. Used to gate
+    /// datagram flow creation.
+    fn extended_connect_enabled(&self) -> bool {
+        false
+    }
+
     /// Determines whether the hook's `wait_for_action` future will be polled
     /// as part of `ApplicationOverQuic::wait_for_data`. Defaults to `false` and
     /// must be overridden if `wait_for_action` is overridden.

--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -362,6 +362,9 @@ pub struct H3Driver<H: DriverHooks> {
     /// Tracks whether we have forwarded the HTTP/3 SETTINGS frame
     /// to the [H3Controller] once.
     settings_received_and_forwarded: bool,
+    /// Tracks whether the H3 event receiver has been dropped.
+    /// Used to avoid busy-looping on `h3_event_sender.closed()`.
+    h3_event_receiver_dropped: bool,
 }
 
 impl<H: DriverHooks> H3Driver<H> {
@@ -397,6 +400,7 @@ impl<H: DriverHooks> H3Driver<H> {
                 waiting_streams: FuturesUnordered::new(),
 
                 settings_received_and_forwarded: false,
+                h3_event_receiver_dropped: false,
             },
             H3Controller {
                 cmd_sender,
@@ -920,6 +924,7 @@ impl<H: DriverHooks> H3Driver<H> {
                         },
                     )?;
                     self.flow_map.remove(&flow_id);
+                    self.close_if_idle(qconn);
                     break;
                 },
                 Ok(_) => unreachable!("Flows can't send frame of other types"),
@@ -993,7 +998,21 @@ impl<H: DriverHooks> H3Driver<H> {
                 .send(H3Event::StreamClosed { stream_id }.into());
         }
 
+        self.close_if_idle(qconn);
+
         Ok(())
+    }
+
+    /// Closes the connection with `NoError` if the H3 event receiver
+    /// has been dropped and there are no active streams or flows.
+    fn close_if_idle(&self, qconn: &mut QuicheConnection) {
+        if self.h3_event_receiver_dropped &&
+            self.stream_map.is_empty() &&
+            self.flow_map.is_empty()
+        {
+            let _ =
+                qconn.close(true, quiche::h3::WireErrorCode::NoError as u64, &[]);
+        }
     }
 
     /// Shuts down the indicated HTTP/3 stream by sending frames and cleaning
@@ -1082,9 +1101,13 @@ impl<H: DriverHooks> H3Driver<H> {
     ) -> H3ConnectionResult<()> {
         loop {
             match datagram::receive_h3_dgram(qconn) {
-                Ok((flow_id, dgram)) => {
+                Ok((flow_id, dgram))
+                    if !qconn.is_server() ||
+                        self.hooks.extended_connect_enabled() =>
+                {
                     self.get_or_insert_flow(flow_id)?.send_best_effort(dgram);
                 },
+                Ok(_) => {},
                 Err(quiche::Error::Done) => return Ok(()),
                 Err(err) => return Err(H3ConnectionError::from(err)),
             }
@@ -1324,6 +1347,11 @@ impl<H: DriverHooks> ApplicationOverQuic for H3Driver<H> {
             Some(dgram) = self.dgram_recv.recv() => self.dgram_ready(qconn, dgram),
             Some(cmd) = self.cmd_recv.recv() => H::conn_command(self, qconn, cmd),
             r = self.hooks.wait_for_action(qconn), if H::has_wait_action(self) => r,
+            _ = self.h3_event_sender.closed(), if !self.h3_event_receiver_dropped => {
+                self.h3_event_receiver_dropped = true;
+                self.close_if_idle(qconn);
+                Ok(())
+            }
         }?;
 
         // Make sure controller is not starved, but also not prioritized in the

--- a/tokio-quiche/src/http3/driver/server.rs
+++ b/tokio-quiche/src/http3/driver/server.rs
@@ -164,6 +164,9 @@ pub struct ServerHooks {
     /// Handle to the post-accept timeout entry. If present, the server must
     /// receive a HEADERS frame before this timeout.
     post_accept_timeout: Option<TimeoutKey>,
+    /// Whether the extended CONNECT protocol is enabled. When disabled,
+    /// skip DATAGRAM flow creation for `:protocol` requests.
+    extended_connect_enabled: bool,
 }
 
 impl ServerHooks {
@@ -191,11 +194,19 @@ impl ServerHooks {
         let (mut stream_ctx, send, recv) =
             StreamCtx::new(stream_id, STREAM_CAPACITY);
 
-        if let Some(flow_id) =
-            datagram::extract_quarter_stream_id(stream_id, &headers)
-        {
-            let _ = driver.get_or_insert_flow(flow_id)?;
-            stream_ctx.associated_dgram_flow_id = Some(flow_id);
+        // When Extended CONNECT is enabled, extract the datagram flow ID
+        // from the request headers and register it in flow_map. This
+        // allows incoming DATAGRAMs to be routed to the correct stream.
+        // Note: flow_map entries are considered active work, so the
+        // connection will not be closed in cleanup_stream() while
+        // flows remain.
+        if driver.hooks.extended_connect_enabled() {
+            if let Some(flow_id) =
+                datagram::extract_quarter_stream_id(stream_id, &headers)
+            {
+                let _ = driver.get_or_insert_flow(flow_id)?;
+                stream_ctx.associated_dgram_flow_id = Some(flow_id);
+            }
         }
 
         let latest_priority_update: Option<RawPriorityValue> = driver
@@ -253,7 +264,12 @@ impl DriverHooks for ServerHooks {
             settings_enforcer: settings.into(),
             requests: 0,
             post_accept_timeout: None,
+            extended_connect_enabled: settings.enable_extended_connect,
         }
+    }
+
+    fn extended_connect_enabled(&self) -> bool {
+        self.extended_connect_enabled
     }
 
     fn conn_established(

--- a/tokio-quiche/src/http3/driver/tests.rs
+++ b/tokio-quiche/src/http3/driver/tests.rs
@@ -1816,4 +1816,385 @@ mod server_side_driver {
         assert_eq!(helper.peer_client_recv_body_vec(0, 1024), Ok(vec![3; 10]));
         assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Finished)));
     }
+
+    // Test that dropping the H3 event receiver when there are no active streams
+    // and datagram flows causes the connection to close immediately.
+    #[test]
+    fn h3_controller_drop_closes_connection_when_maps_empty() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+
+        assert!(helper.driver.stream_map.is_empty());
+        assert!(helper.driver.flow_map.is_empty());
+        assert!(helper.pipe.server.local_error().is_none());
+
+        // drop the controller to trigger receiver drop detection
+        drop(helper.controller);
+
+        // run wait_for_data to detect the receiver drop
+        tokio::task::unconstrained(
+            helper.driver.wait_for_data(&mut helper.pipe.server),
+        )
+        .now_or_never();
+
+        // connection closed with H3 NoError
+        let local_error = helper
+            .pipe
+            .server
+            .local_error()
+            .expect("connection should be closing");
+        assert!(local_error.is_app, "should be application-level close");
+        assert_eq!(
+            local_error.error_code,
+            h3::WireErrorCode::NoError as u64,
+            "should close with H3 NoError"
+        );
+    }
+
+    // Test that dropping the H3Controller when there are active streams/flows
+    // does NOT close the connection immediately (e.g. tunnel scenarios).
+    #[test]
+    fn h3_controller_drop_keeps_connection_alive_when_streams_exist() {
+        let mut helper =
+            DriverTestHelper::<ServerHooks>::with_pipe_and_http3_settings(
+                quiche::test_utils::Pipe::with_config_and_buf(
+                    &mut default_quiche_config(),
+                )
+                .unwrap(),
+                Http3Settings {
+                    enable_extended_connect: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // CONNECT-UDP request creates both a stream and a datagram flow
+        let connect_headers = vec![
+            h3::Header::new(b":method", b"CONNECT-UDP"),
+            h3::Header::new(b":scheme", b"https"),
+            h3::Header::new(b":authority", b"quic.tech"),
+            h3::Header::new(b":path", b"/"),
+            h3::Header::new(b"datagram-flow-id", b"0"),
+        ];
+        helper
+            .peer_client_send_request(connect_headers, false)
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // Consume events to keep channels alive
+        assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Core(H3Event::NewFlow { .. })
+        );
+        assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers { .. }
+        );
+
+        assert_eq!(helper.driver.stream_map.len(), 1);
+        assert_eq!(helper.driver.flow_map.len(), 1);
+
+        drop(helper.controller);
+        tokio::task::unconstrained(
+            helper.driver.wait_for_data(&mut helper.pipe.server),
+        )
+        .now_or_never();
+
+        // Connection stays open (stream and flow still active)
+        assert!(helper.pipe.server.local_error().is_none());
+    }
+
+    /// Test that a CONNECT request with `:protocol` does NOT create a
+    /// datagram flow when extended CONNECT is disabled.
+    #[test]
+    fn protocol_without_extended_connect_closes_on_controller_drop() {
+        // Default settings have enable_extended_connect: false
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // CONNECT with :protocol, but extended CONNECT is disabled
+        let connect_headers = vec![
+            h3::Header::new(b":method", b"CONNECT"),
+            h3::Header::new(b":scheme", b"https"),
+            h3::Header::new(b":authority", b"quic.tech"),
+            h3::Header::new(b":path", b"/"),
+            h3::Header::new(b":protocol", b"webtransport"),
+        ];
+        helper
+            .peer_client_send_request(connect_headers, true)
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // No NewFlow event — flow was not created
+        assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers { .. }
+        );
+
+        assert_eq!(helper.driver.stream_map.len(), 1);
+        assert_eq!(helper.driver.flow_map.len(), 0);
+
+        // Drop controller, then run wait_for_data
+        drop(helper.controller);
+        tokio::task::unconstrained(
+            helper.driver.wait_for_data(&mut helper.pipe.server),
+        )
+        .now_or_never();
+        tokio::task::unconstrained(
+            helper.driver.wait_for_data(&mut helper.pipe.server),
+        )
+        .now_or_never();
+
+        // Connection closes because stream_map and flow_map are empty
+        let local_error = helper
+            .pipe
+            .server
+            .local_error()
+            .expect("connection should be closing");
+        assert!(local_error.is_app, "should be application-level close");
+        assert_eq!(
+            local_error.error_code,
+            h3::WireErrorCode::NoError as u64,
+            "should close with H3 NoError"
+        );
+    }
+
+    /// Drop the event receiver with an open stream, then close the
+    /// stream via client fin. Verify the connection closes.
+    #[test]
+    fn controller_drop_then_stream_close_triggers_connection_close() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // Client sends a request the stream stays open
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), false)
+            .unwrap();
+
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => {
+                incoming_headers
+            }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        let to_client = req.send.get_ref().unwrap().clone();
+
+        // Send response headers + body with fin
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+        to_client
+            .try_send(OutboundFrame::Body(Bytes::from_static(b"ok"), true))
+            .unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        assert_eq!(helper.driver.stream_map.len(), 1);
+
+        // Drop the stream channels so cleanup_stream can remove
+        // the stream from the map
+        drop(to_client);
+        drop(req);
+
+        // Client reads response and sends fin to close the stream
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_client_poll(),
+            Ok((0, h3::Event::Headers { .. }))
+        );
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Data)));
+        assert_eq!(
+            helper.peer_client_recv_body_vec(0, 1024),
+            Ok(vec![111, 107])
+        );
+        assert_eq!(helper.peer_client_poll(), Ok((0, h3::Event::Finished)));
+
+        // Drop the controller
+        drop(helper.controller);
+        tokio::task::unconstrained(
+            helper.driver.wait_for_data(&mut helper.pipe.server),
+        )
+        .now_or_never();
+
+        // Connection should NOT close yet (stream still open)
+        assert!(helper.pipe.server.local_error().is_none());
+
+        // Client sends fin to close the stream
+        assert_eq!(
+            helper
+                .peer
+                .send_body(&mut helper.pipe.client, 0, b"done", true,),
+            Ok(4)
+        );
+        // One IO worker iteration: deliver client fin, process it,
+        // and close the connection.
+        helper.pipe.advance().unwrap();
+        helper
+            .driver
+            .process_reads(&mut helper.pipe.server)
+            .unwrap();
+        helper
+            .driver
+            .process_writes(&mut helper.pipe.server)
+            .unwrap();
+        tokio::task::unconstrained(
+            helper.driver.wait_for_data(&mut helper.pipe.server),
+        )
+        .now_or_never();
+
+        assert_eq!(helper.driver.stream_map.len(), 0);
+
+        // Now the connection should close with NoError
+        let local_error = helper
+            .pipe
+            .server
+            .local_error()
+            .expect("connection should be closing");
+        assert!(local_error.is_app, "should be application-level close");
+        assert_eq!(
+            local_error.error_code,
+            h3::WireErrorCode::NoError as u64,
+            "should close with H3 NoError"
+        );
+    }
+
+    /// Drop the event receiver with an autonomous flow open (a flow
+    /// with no associated stream), then shut down the flow. Verify
+    /// the connection closes.
+    #[test]
+    fn controller_drop_then_autonomous_flow_shutdown_triggers_connection_close() {
+        let mut config = default_quiche_config();
+        config.enable_dgram(true, 100, 100);
+
+        let mut helper =
+            DriverTestHelper::<ServerHooks>::with_pipe_and_http3_settings(
+                quiche::test_utils::Pipe::with_config_and_buf(&mut config)
+                    .unwrap(),
+                Http3Settings {
+                    enable_extended_connect: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // Peer sends an H3 datagram for a flow_id with no associated
+        // CONNECT-UDP stream. Wire format: varint(flow_id) || payload.
+        let flow_id: u64 = 8;
+        let payload: &[u8] = b"hi";
+        let prefix_len = octets::varint_len(flow_id);
+        let mut wire = vec![0u8; prefix_len + payload.len()];
+        {
+            let mut enc = octets::OctetsMut::with_slice(&mut wire);
+            enc.put_varint(flow_id).unwrap();
+            enc.put_bytes(payload).unwrap();
+        }
+        helper.pipe.client.dgram_send(&wire).unwrap();
+
+        // process_available_dgrams creates an autonomous flow and
+        // emits NewFlow.
+        helper.advance_and_run_loop().unwrap();
+
+        let flow_send = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Core(H3Event::NewFlow { send, .. }) => send
+        );
+        let flow_sender = flow_send.get_ref().unwrap().clone();
+
+        assert!(helper.driver.stream_map.is_empty());
+        assert_eq!(helper.driver.flow_map.len(), 1);
+
+        // Drop the controller. closed() fires, sets the flag, but
+        // flow_map is non-empty so no close yet.
+        drop(helper.controller);
+        tokio::task::unconstrained(
+            helper.driver.wait_for_data(&mut helper.pipe.server),
+        )
+        .now_or_never();
+        assert!(helper.pipe.server.local_error().is_none());
+
+        // Send FlowShutdown via the per-flow channel.
+        flow_sender
+            .try_send(OutboundFrame::FlowShutdown {
+                flow_id,
+                stream_id: flow_id,
+            })
+            .unwrap();
+
+        // wait_for_data picks up the frame and calls dgram_ready.
+        // shutdown_stream returns early (no stream), so the close
+        // gate in cleanup_stream is never invoked.
+        tokio::task::unconstrained(
+            helper.driver.wait_for_data(&mut helper.pipe.server),
+        )
+        .now_or_never();
+        drop(flow_sender);
+        drop(flow_send);
+
+        assert!(helper.driver.stream_map.is_empty());
+        assert!(helper.driver.flow_map.is_empty());
+
+        // closed() is gated off; no other arm can drive a close.
+        tokio::task::unconstrained(
+            helper.driver.wait_for_data(&mut helper.pipe.server),
+        )
+        .now_or_never();
+
+        let local_error = helper
+            .pipe
+            .server
+            .local_error()
+            .expect("connection should be closing");
+        assert!(local_error.is_app, "should be application-level close");
+        assert_eq!(
+            local_error.error_code,
+            h3::WireErrorCode::NoError as u64,
+            "should close with H3 NoError"
+        );
+    }
+
+    /// Verify that datagrams are silently dropped and no flow is
+    /// created when extended connect is disabled.
+    #[test]
+    fn process_dgram_skips_flow_creation_when_extended_connect_disabled() {
+        let mut config = default_quiche_config();
+        config.enable_dgram(true, 100, 100);
+
+        // Default settings have enable_extended_connect: false
+        let mut helper =
+            DriverTestHelper::<ServerHooks>::with_pipe_and_http3_settings(
+                quiche::test_utils::Pipe::with_config_and_buf(&mut config)
+                    .unwrap(),
+                Http3Settings::default(),
+            )
+            .unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        let flow_id: u64 = 8;
+        let payload: &[u8] = b"hi";
+        let prefix_len = octets::varint_len(flow_id);
+        let mut wire = vec![0u8; prefix_len + payload.len()];
+        {
+            let mut enc = octets::OctetsMut::with_slice(&mut wire);
+            enc.put_varint(flow_id).unwrap();
+            enc.put_bytes(payload).unwrap();
+        }
+        helper.pipe.client.dgram_send(&wire).unwrap();
+
+        helper.advance_and_run_loop().unwrap();
+
+        // No flow should be created
+        assert!(
+            helper.driver.flow_map.is_empty(),
+            "flow_map should remain empty when extended connect is disabled"
+        );
+    }
 }


### PR DESCRIPTION
**tokio-quiche: only close connection when H3Event receiver drops if no active streams/flows**

Applications built on top of H3Driver process events via the H3Event
receiver. When they drop it, tokio-quiche should close the connection
promptly instead of spinning until idle timeout.

This change detects when the H3Event receiver is dropped (via
h3_event_sender.closed()) and closes the connection with NoError once
both stream_map and flow_map are empty.

The close is deferred when streams or flows are still active to support
tunnel scenarios (CONNECT-UDP/MASQUE) where the controller is
intentionally dropped after setup.

Close logic is extracted into close_if_idle() and called from
cleanup_stream, dgram_ready (after flow removal), and wait_for_data.

Additionally, datagram flow creation in process_available_dgrams and
headers_received is now gated on extended_connect_enabled to prevent
phantom flow entries when extended CONNECT is disabled.