### PR TITLE
qlog-dancer: fix and optimise stream metadata event handling

### DIFF
--- a/qlog-dancer/src/datastore.rs
+++ b/qlog-dancer/src/datastore.rs
@@ -47,6 +47,8 @@ use tabled::Tabled;
 use crate::request_stub::find_header_value;
 use crate::request_stub::HttpRequestStub;
 use crate::request_stub::NaOption;
+use crate::trackers::StreamBufferTracker;
+use crate::trackers::StreamMaxTracker;
 use crate::LogFileData;
 use crate::PacketType;
 use crate::QlogPointf32;
@@ -282,37 +284,27 @@ pub struct Datastore {
 
     pub received_max_data: Vec<QlogPointu64>,
 
-    pub received_stream_max_data: BTreeMap<u64, Vec<QlogPointu64>>,
-    // This stores just the last max, not every entry. This lets us easily
-    // calculate the cumulative value.
-    pub received_stream_max_data_flat: BTreeMap<u64, u64>,
-    pub sum_received_stream_max_data: Vec<QlogPointu64>,
+    /// Tracks per-stream max data: full history, current max, and cumulative
+    /// sum.
+    pub received_stream_max_data_tracker: StreamMaxTracker,
 
     pub sent_max_data: Vec<QlogPointu64>,
 
-    pub sent_stream_max_data: BTreeMap<u64, Vec<QlogPointu64>>,
-    // This stores just the last max, not every entry. This lets us easily
-    // calculate the cumulative value.
-    pub sent_stream_max_data_flat: BTreeMap<u64, u64>,
-    pub sum_sent_stream_max_data: Vec<QlogPointu64>,
+    /// Tracks per-stream max data: full history, current max, and cumulative
+    /// sum.
+    pub sent_stream_max_data_tracker: StreamMaxTracker,
 
-    pub stream_buffer_reads: BTreeMap<u64, Vec<(f32, StreamAccess)>>,
-    // This stores just the last max, not every entry. This lets us easily
-    // calculate the cumulative value.
-    pub stream_buffer_reads_flat: BTreeMap<u64, u64>,
-    pub sum_stream_buffer_reads: Vec<QlogPointu64>,
+    /// Tracks stream buffer reads: per-stream history, current max, and running
+    /// sum.
+    pub stream_buffer_reads_tracker: StreamBufferTracker,
 
-    pub stream_buffer_writes: BTreeMap<u64, Vec<(f32, StreamAccess)>>,
-    // This stores just the last max, not every entry. This lets us easily
-    // calculate the cumulative value.
-    pub stream_buffer_writes_flat: BTreeMap<u64, u64>,
-    pub sum_stream_buffer_writes: Vec<QlogPointu64>,
+    /// Tracks stream buffer writes: per-stream history, current max, and
+    /// running sum.
+    pub stream_buffer_writes_tracker: StreamBufferTracker,
 
-    pub stream_buffer_dropped: BTreeMap<u64, Vec<(f32, StreamAccess)>>,
-    // This stores just the last max, not every entry. This lets us easily
-    // calculate the cumulative value.
-    pub stream_buffer_dropped_flat: BTreeMap<u64, u64>,
-    pub sum_stream_buffer_dropped: Vec<QlogPointu64>,
+    /// Tracks stream buffer dropped: per-stream history, current max, and
+    /// running sum.
+    pub stream_buffer_dropped_tracker: StreamBufferTracker,
 
     pub received_reset_stream: BTreeMap<u64, Vec<QuicFrame>>,
     pub sent_reset_stream: BTreeMap<u64, Vec<QuicFrame>>,
@@ -343,8 +335,10 @@ pub struct Datastore {
     pub largest_data_frame_tx_length_global: u64,
 
     pub local_init_max_stream_data_bidi_local: u64,
+    pub local_init_max_stream_data_uni: u64,
     pub peer_init_max_stream_data_bidi_local: u64,
     pub peer_init_max_stream_data_bidi_remote: u64,
+    pub peer_init_max_stream_data_uni: u64,
 
     pub h2_recv_window_updates: BTreeMap<u32, Vec<(f32, i32)>>,
 
@@ -375,6 +369,10 @@ pub struct Datastore {
     pub h2_session_close: Option<H2SessionClose>,
 
     pub h2_concurrent_requests: u64,
+}
+
+fn is_bidi(stream_id: u64) -> bool {
+    (stream_id & 0x2) == 0
 }
 
 impl Datastore {
@@ -806,12 +804,13 @@ impl Datastore {
         let rel_event_time = (ev_hdr.time_num - session_start_time) as f32;
 
         match ev {
-            Http2SessionSendSettings(e) =>
+            Http2SessionSendSettings(e) => {
                 match Http2Settings::try_from(e.params.settings.as_slice()) {
                     Ok(v) => self.h2_client_settings = v,
 
                     Err(e) => error!("{}", e),
-                },
+                }
+            },
 
             Http2SessionRecvSetting(e) => {
                 let re = Regex::new(H2_RECV_SETTING_PATTERN).unwrap();
@@ -1186,6 +1185,10 @@ impl Datastore {
                 {
                     self.local_init_max_stream_data_bidi_local = max_stream_data;
                 }
+
+                if let Some(max_stream_data) = tp.initial_max_stream_data_uni {
+                    self.local_init_max_stream_data_uni = max_stream_data;
+                }
             },
 
             Some(TransportOwner::Remote) => {
@@ -1203,6 +1206,10 @@ impl Datastore {
                     tp.initial_max_stream_data_bidi_remote
                 {
                     self.peer_init_max_stream_data_bidi_remote = max_stream_data;
+                }
+
+                if let Some(max_stream_data) = tp.initial_max_stream_data_uni {
+                    self.peer_init_max_stream_data_uni = max_stream_data;
                 }
             },
 
@@ -1281,21 +1288,13 @@ impl Datastore {
                     },
 
                     QuicFrame::MaxStreamData { stream_id, maximum } => {
-                        let init_val = self.peer_init_max_stream_data_bidi_remote;
-                        let s: &mut Vec<(f32, u64)> = self
-                            .received_stream_max_data
-                            .entry(*stream_id)
-                            .or_insert_with(|| vec![(0.0, init_val)]);
-
-                        s.push((ev_time, *maximum));
-
-                        self.received_stream_max_data_flat
-                            .insert(*stream_id, *maximum);
-
-                        let sum =
-                            self.received_stream_max_data_flat.values().sum();
-
-                        self.sum_received_stream_max_data.push((ev_time, sum));
+                        let init_val = if is_bidi(*stream_id) {
+                            self.peer_init_max_stream_data_bidi_remote
+                        } else {
+                            self.peer_init_max_stream_data_uni
+                        };
+                        self.received_stream_max_data_tracker
+                            .update(*stream_id, *maximum, ev_time, init_val);
                     },
 
                     QuicFrame::ResetStream { stream_id, .. } => {
@@ -1381,20 +1380,13 @@ impl Datastore {
                     },
 
                     QuicFrame::MaxStreamData { stream_id, maximum } => {
-                        let init_val = self.local_init_max_stream_data_bidi_local;
-                        let s = self
-                            .sent_stream_max_data
-                            .entry(*stream_id)
-                            .or_insert_with(|| vec![(0.0, init_val)]);
-
-                        s.push((ev_time, *maximum));
-
-                        self.sent_stream_max_data_flat
-                            .insert(*stream_id, *maximum);
-
-                        let sum = self.sent_stream_max_data_flat.values().sum();
-
-                        self.sum_sent_stream_max_data.push((event_time, sum));
+                        let init_val = if is_bidi(*stream_id) {
+                            self.local_init_max_stream_data_bidi_local
+                        } else {
+                            self.local_init_max_stream_data_uni
+                        };
+                        self.sent_stream_max_data_tracker
+                            .update(*stream_id, *maximum, ev_time, init_val);
                     },
 
                     QuicFrame::ResetStream { stream_id, .. } => {
@@ -1451,41 +1443,23 @@ impl Datastore {
         &mut self, dm: &qlog::events::quic::DataMoved, ev_time: f32,
     ) {
         if let Some(recipient) = &dm.to {
-            let (data, data_flat, sum_data) = match recipient {
-                // stream read
-                qlog::events::DataRecipient::Application => (
-                    &mut self.stream_buffer_reads,
-                    &mut self.stream_buffer_reads_flat,
-                    &mut self.sum_stream_buffer_reads,
-                ),
-
-                // stream write
-                qlog::events::DataRecipient::Transport => (
-                    &mut self.stream_buffer_writes,
-                    &mut self.stream_buffer_writes_flat,
-                    &mut self.sum_stream_buffer_writes,
-                ),
-
-                // stream data dropped
-                qlog::events::DataRecipient::Dropped => (
-                    &mut self.stream_buffer_dropped,
-                    &mut self.stream_buffer_dropped_flat,
-                    &mut self.sum_stream_buffer_dropped,
-                ),
-
+            let tracker = match recipient {
+                qlog::events::DataRecipient::Application =>
+                    &mut self.stream_buffer_reads_tracker,
+                qlog::events::DataRecipient::Transport =>
+                    &mut self.stream_buffer_writes_tracker,
+                qlog::events::DataRecipient::Dropped =>
+                    &mut self.stream_buffer_dropped_tracker,
                 _ => todo!(),
             };
 
             if let Some(stream_id) = dm.stream_id {
-                let s = data.entry(stream_id).or_default();
-
                 if let (Some(offset), Some(length)) = (dm.offset, dm.length) {
-                    s.push((ev_time, StreamAccess { offset, length }));
-
-                    data_flat.insert(stream_id, offset + length);
-
-                    let sum = data_flat.values().sum();
-                    sum_data.push((ev_time, sum));
+                    tracker.update(
+                        stream_id,
+                        StreamAccess { offset, length },
+                        ev_time,
+                    );
                 }
             }
         }

--- a/qlog-dancer/src/lib.rs
+++ b/qlog-dancer/src/lib.rs
@@ -409,6 +409,7 @@ pub mod plots;
 pub mod reports;
 pub mod request_stub;
 pub mod seriesstore;
+pub mod trackers;
 #[cfg(target_arch = "wasm32")]
 pub mod web;
 pub mod wirefilter;

--- a/qlog-dancer/src/reports/text.rs
+++ b/qlog-dancer/src/reports/text.rs
@@ -145,7 +145,11 @@ fn print_sent_packet_stats(data_store: &Datastore) {
 
 fn print_rx_max_data_frames(data_store: &Datastore) {
     println!("### received MAX_DATA frames ###");
-    if data_store.received_stream_max_data.is_empty() {
+    if data_store
+        .received_stream_max_data_tracker
+        .per_stream
+        .is_empty()
+    {
         println!("    None")
     } else {
         println!(
@@ -168,10 +172,14 @@ fn print_tx_max_data_frames(data_store: &Datastore) {
 
 fn print_rx_max_stream_data_frames(data_store: &Datastore) {
     println!("### received MAX_STREAM_DATA frames ###");
-    if data_store.received_stream_max_data.is_empty() {
+    if data_store
+        .received_stream_max_data_tracker
+        .per_stream
+        .is_empty()
+    {
         println!("    None")
     } else {
-        for entry in &data_store.received_stream_max_data {
+        for entry in &data_store.received_stream_max_data_tracker.per_stream {
             println!(
                 "    stream={}, total_count={}, first={:?}, last={}",
                 entry.0,
@@ -185,10 +193,14 @@ fn print_rx_max_stream_data_frames(data_store: &Datastore) {
 
 fn print_tx_max_stream_data_frames(data_store: &Datastore) {
     println!("### sent MAX_STREAM_DATA frames ###");
-    if data_store.sent_stream_max_data.is_empty() {
+    if data_store
+        .sent_stream_max_data_tracker
+        .per_stream
+        .is_empty()
+    {
         println!("    None")
     } else {
-        for entry in &data_store.sent_stream_max_data {
+        for entry in &data_store.sent_stream_max_data_tracker.per_stream {
             println!(
                 "    stream={}, total_count={}, first={:?}, last={:?}",
                 entry.0,
@@ -236,10 +248,10 @@ fn print_rx_reset_stream_frames(data_store: &Datastore) {
 
 fn print_local_stream_buffer_reads(data_store: &Datastore) {
     println!("### local stream buffer reads ###");
-    if data_store.stream_buffer_reads.is_empty() {
+    if data_store.stream_buffer_reads_tracker.per_stream.is_empty() {
         println!("    None")
     } else {
-        for entry in &data_store.stream_buffer_reads {
+        for entry in &data_store.stream_buffer_reads_tracker.per_stream {
             println!(
                 "    stream={}, total_count={}, first=(offset={}, length={}), last=(offset={}, length={}), total_length={}",
                 entry.0,
@@ -256,10 +268,14 @@ fn print_local_stream_buffer_reads(data_store: &Datastore) {
 
 fn print_local_stream_buffer_writes(data_store: &Datastore) {
     println!("### local stream buffer writes ###");
-    if data_store.stream_buffer_writes.is_empty() {
+    if data_store
+        .stream_buffer_writes_tracker
+        .per_stream
+        .is_empty()
+    {
         println!("    None")
     } else {
-        for entry in &data_store.stream_buffer_writes {
+        for entry in &data_store.stream_buffer_writes_tracker.per_stream {
             println!(
                 "    stream={}, total_count={}, first=(offset={}, length={}), last=(offset={}, length={}), total_length={}",
                 entry.0,
@@ -276,10 +292,14 @@ fn print_local_stream_buffer_writes(data_store: &Datastore) {
 
 fn print_local_stream_buffer_dropped(data_store: &Datastore) {
     println!("### local stream buffer dropped ###");
-    if data_store.stream_buffer_writes.is_empty() {
+    if data_store
+        .stream_buffer_dropped_tracker
+        .per_stream
+        .is_empty()
+    {
         println!("    None")
     } else {
-        for entry in &data_store.stream_buffer_dropped {
+        for entry in &data_store.stream_buffer_dropped_tracker.per_stream {
             println!(
                 "    stream={}, total_count={}, first=(offset={}, length={}), last=(offset={}, length={}), total_length={}",
                 entry.0,

--- a/qlog-dancer/src/seriesstore.rs
+++ b/qlog-dancer/src/seriesstore.rs
@@ -222,7 +222,7 @@ impl SeriesStore {
     }
 
     fn sum_sent_stream_max_data(&mut self, data_store: &Datastore) {
-        for point in &data_store.sum_sent_stream_max_data {
+        for point in &data_store.sent_stream_max_data_tracker.sum_series {
             self.update_sent_x_axis_max(point.0);
             self.update_stream_recv_y_axis_max(point.1);
 
@@ -333,7 +333,9 @@ impl SeriesStore {
     }
 
     fn sent_stream_max_data(&mut self, data_store: &Datastore) {
-        for (stream, points) in &data_store.sent_stream_max_data {
+        for (stream, points) in
+            &data_store.sent_stream_max_data_tracker.per_stream
+        {
             let mut series_points = vec![];
 
             for point in points {
@@ -348,7 +350,9 @@ impl SeriesStore {
     }
 
     fn received_stream_max_data(&mut self, data_store: &Datastore) {
-        for (stream, points) in &data_store.received_stream_max_data {
+        for (stream, points) in
+            &data_store.received_stream_max_data_tracker.per_stream
+        {
             let mut series_points = vec![];
 
             for point in points {
@@ -363,7 +367,8 @@ impl SeriesStore {
     }
 
     fn stream_buffer_reads(&mut self, data_store: &Datastore) {
-        for (stream, points) in &data_store.stream_buffer_reads {
+        for (stream, points) in &data_store.stream_buffer_reads_tracker.per_stream
+        {
             let mut series_points = vec![];
 
             for point in points {
@@ -380,13 +385,15 @@ impl SeriesStore {
     }
 
     fn sum_stream_buffer_reads(&mut self, data_store: &Datastore) {
-        for point in &data_store.sum_stream_buffer_reads {
+        for point in &data_store.stream_buffer_reads_tracker.sum_series {
             push_interp(&mut self.sum_stream_buffer_reads, *point);
         }
     }
 
     fn stream_buffer_writes(&mut self, data_store: &Datastore) {
-        for (stream, points) in &data_store.stream_buffer_writes {
+        for (stream, points) in
+            &data_store.stream_buffer_writes_tracker.per_stream
+        {
             let mut series_points = vec![];
 
             for point in points {
@@ -403,17 +410,21 @@ impl SeriesStore {
     }
 
     fn sum_stream_buffer_writes(&mut self, data_store: &Datastore) {
-        for point in &data_store.sum_stream_buffer_writes {
+        for point in &data_store.stream_buffer_writes_tracker.sum_series {
             push_interp(&mut self.sum_stream_buffer_writes, *point);
         }
 
-        if let Some((_, y)) = data_store.sum_stream_buffer_writes.last() {
+        if let Some((_, y)) =
+            data_store.stream_buffer_writes_tracker.sum_series.last()
+        {
             self.update_stream_send_y_axis_max(*y);
         }
     }
 
     fn stream_buffer_dropped(&mut self, data_store: &Datastore) {
-        for (stream, points) in &data_store.stream_buffer_dropped {
+        for (stream, points) in
+            &data_store.stream_buffer_dropped_tracker.per_stream
+        {
             let mut series_points = vec![];
 
             for point in points {
@@ -430,11 +441,13 @@ impl SeriesStore {
     }
 
     fn sum_stream_buffer_dropped(&mut self, data_store: &Datastore) {
-        for point in &data_store.sum_stream_buffer_dropped {
+        for point in &data_store.stream_buffer_dropped_tracker.sum_series {
             push_interp(&mut self.sum_stream_buffer_dropped, *point);
         }
 
-        if let Some((_, y)) = data_store.sum_stream_buffer_dropped.last() {
+        if let Some((_, y)) =
+            data_store.stream_buffer_dropped_tracker.sum_series.last()
+        {
             self.update_stream_send_y_axis_max(*y);
         }
     }
@@ -667,7 +680,7 @@ impl SeriesStore {
     }
 
     fn sum_received_stream_max_data(&mut self, data_store: &Datastore) {
-        for point in &data_store.sum_received_stream_max_data {
+        for point in &data_store.received_stream_max_data_tracker.sum_series {
             push_interp(&mut self.sum_received_stream_max_data, *point);
         }
     }

--- a/qlog-dancer/src/trackers/mod.rs
+++ b/qlog-dancer/src/trackers/mod.rs
@@ -1,0 +1,31 @@
+// Copyright (C) 2026, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+pub mod stream_buffer_tracker;
+pub mod stream_max_tracker;
+
+pub use stream_buffer_tracker::StreamBufferTracker;
+pub use stream_max_tracker::StreamMaxTracker;

--- a/qlog-dancer/src/trackers/stream_buffer_tracker.rs
+++ b/qlog-dancer/src/trackers/stream_buffer_tracker.rs
@@ -1,0 +1,334 @@
+// Copyright (C) 2026, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::collections::BTreeMap;
+
+use crate::datastore::StreamAccess;
+
+/// Tracks monotonically increasing stream buffer positions with efficient sum
+/// calculation. Handles out-of-order events by taking max end position (offset
+/// + length) seen per stream.
+#[derive(Debug, Default)]
+pub struct StreamBufferTracker {
+    /// Full time series per stream with StreamAccess details.
+    pub per_stream: BTreeMap<u64, Vec<(f32, StreamAccess)>>,
+
+    /// Current maximum end position (offset + length) per stream.
+    pub flat: BTreeMap<u64, u64>,
+
+    /// Cumulative sum time series.
+    pub sum_series: Vec<(f32, u64)>,
+
+    /// Running sum for O(1) updates.
+    running_sum: u64,
+}
+
+impl StreamBufferTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Updates stream buffer position, returns Some((old_max, new_max)) if
+    /// changed.
+    pub fn update(
+        &mut self, stream_id: u64, access: StreamAccess, ev_time: f32,
+    ) -> Option<(u64, u64)> {
+        self.per_stream
+            .entry(stream_id)
+            .or_default()
+            .push((ev_time, access.clone()));
+
+        let new_end = access.offset + access.length;
+        let old_max = self.flat.get(&stream_id).copied().unwrap_or(0);
+        let new_max = old_max.max(new_end);
+
+        let result = if new_max > old_max {
+            self.flat.insert(stream_id, new_max);
+            self.running_sum += new_max - old_max;
+            Some((old_max, new_max))
+        } else {
+            None
+        };
+
+        self.sum_series.push((ev_time, self.running_sum));
+
+        result
+    }
+
+    pub fn get_stream_max(&self, stream_id: u64) -> Option<u64> {
+        self.flat.get(&stream_id).copied()
+    }
+
+    pub fn current_sum(&self) -> u64 {
+        self.running_sum
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tracker_empty() {
+        let tracker = StreamBufferTracker::new();
+        assert_eq!(tracker.current_sum(), 0);
+        assert_eq!(tracker.get_stream_max(0), None);
+        assert!(tracker.sum_series.is_empty());
+        assert!(tracker.flat.is_empty());
+    }
+
+    #[test]
+    fn test_tracker_single_stream_in_order() {
+        let mut tracker = StreamBufferTracker::new();
+
+        let result = tracker.update(
+            0,
+            StreamAccess {
+                offset: 0,
+                length: 1000,
+            },
+            10.0,
+        );
+        assert_eq!(result, Some((0, 1000)));
+        assert_eq!(tracker.get_stream_max(0), Some(1000));
+        assert_eq!(tracker.current_sum(), 1000);
+        assert_eq!(tracker.sum_series, vec![(10.0, 1000)]);
+
+        let result = tracker.update(
+            0,
+            StreamAccess {
+                offset: 1000,
+                length: 1000,
+            },
+            20.0,
+        );
+        assert_eq!(result, Some((1000, 2000)));
+        assert_eq!(tracker.get_stream_max(0), Some(2000));
+        assert_eq!(tracker.current_sum(), 2000);
+        assert_eq!(tracker.sum_series, vec![(10.0, 1000), (20.0, 2000)]);
+    }
+
+    #[test]
+    fn test_tracker_out_of_order_events() {
+        let mut tracker = StreamBufferTracker::new();
+
+        // Larger end position arrives first at t=20.
+        let result = tracker.update(
+            0,
+            StreamAccess {
+                offset: 1000,
+                length: 1000,
+            },
+            20.0,
+        );
+        assert_eq!(result, Some((0, 2000)));
+        assert_eq!(tracker.get_stream_max(0), Some(2000));
+        assert_eq!(tracker.current_sum(), 2000);
+
+        // Smaller end position arrives later at t=10 - should NOT update.
+        let result = tracker.update(
+            0,
+            StreamAccess {
+                offset: 0,
+                length: 1000,
+            },
+            10.0,
+        );
+        assert_eq!(result, None);
+        assert_eq!(tracker.get_stream_max(0), Some(2000));
+        assert_eq!(tracker.current_sum(), 2000);
+
+        assert_eq!(tracker.sum_series, vec![(20.0, 2000), (10.0, 2000)]);
+
+        // Later, larger position arrives.
+        let result = tracker.update(
+            0,
+            StreamAccess {
+                offset: 2000,
+                length: 1000,
+            },
+            30.0,
+        );
+        assert_eq!(result, Some((2000, 3000)));
+        assert_eq!(tracker.get_stream_max(0), Some(3000));
+        assert_eq!(tracker.current_sum(), 3000);
+    }
+
+    #[test]
+    fn test_tracker_multiple_streams() {
+        let mut tracker = StreamBufferTracker::new();
+
+        tracker.update(
+            0,
+            StreamAccess {
+                offset: 0,
+                length: 1000,
+            },
+            10.0,
+        );
+        assert_eq!(tracker.current_sum(), 1000);
+
+        tracker.update(
+            1,
+            StreamAccess {
+                offset: 0,
+                length: 500,
+            },
+            15.0,
+        );
+        assert_eq!(tracker.current_sum(), 1500);
+
+        tracker.update(
+            0,
+            StreamAccess {
+                offset: 1000,
+                length: 500,
+            },
+            20.0,
+        );
+        assert_eq!(tracker.current_sum(), 2000);
+
+        tracker.update(
+            2,
+            StreamAccess {
+                offset: 0,
+                length: 300,
+            },
+            25.0,
+        );
+        assert_eq!(tracker.current_sum(), 2300);
+
+        assert_eq!(tracker.get_stream_max(0), Some(1500));
+        assert_eq!(tracker.get_stream_max(1), Some(500));
+        assert_eq!(tracker.get_stream_max(2), Some(300));
+        assert_eq!(tracker.get_stream_max(999), None);
+    }
+
+    #[test]
+    fn test_tracker_duplicate_values() {
+        let mut tracker = StreamBufferTracker::new();
+
+        let result = tracker.update(
+            0,
+            StreamAccess {
+                offset: 0,
+                length: 1000,
+            },
+            10.0,
+        );
+        assert_eq!(result, Some((0, 1000)));
+
+        let result = tracker.update(
+            0,
+            StreamAccess {
+                offset: 0,
+                length: 1000,
+            },
+            20.0,
+        );
+        assert_eq!(result, None);
+
+        assert_eq!(tracker.get_stream_max(0), Some(1000));
+        assert_eq!(tracker.current_sum(), 1000);
+
+        assert_eq!(tracker.sum_series.len(), 2);
+        assert_eq!(tracker.sum_series, vec![(10.0, 1000), (20.0, 1000)]);
+    }
+
+    #[test]
+    fn test_tracker_running_sum_correctness() {
+        let mut tracker = StreamBufferTracker::new();
+
+        tracker.update(
+            0,
+            StreamAccess {
+                offset: 0,
+                length: 1000,
+            },
+            1.0,
+        );
+        tracker.update(
+            1,
+            StreamAccess {
+                offset: 0,
+                length: 2000,
+            },
+            2.0,
+        );
+        tracker.update(
+            2,
+            StreamAccess {
+                offset: 0,
+                length: 1500,
+            },
+            3.0,
+        );
+        tracker.update(
+            0,
+            StreamAccess {
+                offset: 1000,
+                length: 200,
+            },
+            4.0,
+        );
+
+        let manual_sum: u64 = tracker.flat.values().sum();
+
+        assert_eq!(tracker.current_sum(), manual_sum);
+        assert_eq!(tracker.current_sum(), 4700);
+    }
+
+    #[test]
+    fn test_tracker_preserves_stream_access() {
+        let mut tracker = StreamBufferTracker::new();
+
+        tracker.update(
+            0,
+            StreamAccess {
+                offset: 100,
+                length: 500,
+            },
+            10.0,
+        );
+        tracker.update(
+            0,
+            StreamAccess {
+                offset: 600,
+                length: 300,
+            },
+            20.0,
+        );
+
+        let stream_data = tracker.per_stream.get(&0).unwrap();
+        assert_eq!(stream_data.len(), 2);
+        assert_eq!(stream_data[0].1.offset, 100);
+        assert_eq!(stream_data[0].1.length, 500);
+        assert_eq!(stream_data[1].1.offset, 600);
+        assert_eq!(stream_data[1].1.length, 300);
+
+        assert_eq!(tracker.get_stream_max(0), Some(900));
+    }
+}

--- a/qlog-dancer/src/trackers/stream_max_tracker.rs
+++ b/qlog-dancer/src/trackers/stream_max_tracker.rs
@@ -1,0 +1,236 @@
+// Copyright (C) 2026, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::collections::BTreeMap;
+
+/// Tracks monotonically increasing per-stream values with efficient sum
+/// calculation. Handles out-of-order events by taking max value seen per
+/// stream.
+#[derive(Debug, Default)]
+pub struct StreamMaxTracker {
+    /// Full time series per stream.
+    pub per_stream: BTreeMap<u64, Vec<(f32, u64)>>,
+
+    /// Current maximum per stream.
+    pub flat: BTreeMap<u64, u64>,
+
+    /// Cumulative sum time series.
+    pub sum_series: Vec<(f32, u64)>,
+
+    /// Running sum for O(1) updates.
+    running_sum: u64,
+}
+
+impl StreamMaxTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Updates stream value, returns Some((old_max, new_max)) if changed.
+    pub fn update(
+        &mut self, stream_id: u64, new_value: u64, ev_time: f32, init_val: u64,
+    ) -> Option<(u64, u64)> {
+        let entry = self
+            .per_stream
+            .entry(stream_id)
+            .or_insert_with(|| vec![(0.0, init_val)]);
+        entry.push((ev_time, new_value));
+
+        let old_max = self.flat.get(&stream_id).copied().unwrap_or(0);
+        let new_max = old_max.max(new_value);
+
+        let result = if new_max > old_max {
+            self.flat.insert(stream_id, new_max);
+            self.running_sum += new_max - old_max;
+            Some((old_max, new_max))
+        } else {
+            None
+        };
+
+        self.sum_series.push((ev_time, self.running_sum));
+
+        result
+    }
+
+    pub fn get_stream_max(&self, stream_id: u64) -> Option<u64> {
+        self.flat.get(&stream_id).copied()
+    }
+
+    pub fn current_sum(&self) -> u64 {
+        self.running_sum
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tracker_empty() {
+        let tracker = StreamMaxTracker::new();
+        assert_eq!(tracker.current_sum(), 0);
+        assert_eq!(tracker.get_stream_max(0), None);
+        assert!(tracker.sum_series.is_empty());
+        assert!(tracker.flat.is_empty());
+    }
+
+    #[test]
+    fn test_tracker_single_stream_in_order() {
+        let mut tracker = StreamMaxTracker::new();
+
+        let result = tracker.update(0, 1000, 10.0, 0);
+        assert_eq!(result, Some((0, 1000)));
+        assert_eq!(tracker.get_stream_max(0), Some(1000));
+        assert_eq!(tracker.current_sum(), 1000);
+        assert_eq!(tracker.sum_series, vec![(10.0, 1000)]);
+
+        let result = tracker.update(0, 2000, 20.0, 0);
+        assert_eq!(result, Some((1000, 2000)));
+        assert_eq!(tracker.get_stream_max(0), Some(2000));
+        assert_eq!(tracker.current_sum(), 2000);
+        assert_eq!(tracker.sum_series, vec![(10.0, 1000), (20.0, 2000)]);
+    }
+
+    #[test]
+    fn test_tracker_out_of_order_events() {
+        let mut tracker = StreamMaxTracker::new();
+
+        let result = tracker.update(0, 2000, 20.0, 0);
+        assert_eq!(result, Some((0, 2000)));
+        assert_eq!(tracker.get_stream_max(0), Some(2000));
+        assert_eq!(tracker.current_sum(), 2000);
+
+        let result = tracker.update(0, 1000, 10.0, 0);
+        assert_eq!(result, None);
+        assert_eq!(tracker.get_stream_max(0), Some(2000));
+        assert_eq!(tracker.current_sum(), 2000);
+
+        assert_eq!(tracker.sum_series, vec![(20.0, 2000), (10.0, 2000)]);
+
+        let result = tracker.update(0, 3000, 30.0, 0);
+        assert_eq!(result, Some((2000, 3000)));
+        assert_eq!(tracker.get_stream_max(0), Some(3000));
+        assert_eq!(tracker.current_sum(), 3000);
+    }
+
+    #[test]
+    fn test_tracker_multiple_streams() {
+        let mut tracker = StreamMaxTracker::new();
+
+        tracker.update(0, 1000, 10.0, 0);
+        assert_eq!(tracker.current_sum(), 1000);
+
+        tracker.update(1, 500, 15.0, 0);
+        assert_eq!(tracker.current_sum(), 1500);
+
+        tracker.update(0, 1500, 20.0, 0);
+        assert_eq!(tracker.current_sum(), 2000);
+
+        tracker.update(2, 300, 25.0, 0);
+        assert_eq!(tracker.current_sum(), 2300);
+
+        assert_eq!(tracker.get_stream_max(0), Some(1500));
+        assert_eq!(tracker.get_stream_max(1), Some(500));
+        assert_eq!(tracker.get_stream_max(2), Some(300));
+        assert_eq!(tracker.get_stream_max(999), None);
+    }
+
+    #[test]
+    fn test_tracker_duplicate_values() {
+        let mut tracker = StreamMaxTracker::new();
+
+        let result = tracker.update(0, 1000, 10.0, 0);
+        assert_eq!(result, Some((0, 1000)));
+
+        let result = tracker.update(0, 1000, 20.0, 0);
+        assert_eq!(result, None);
+
+        assert_eq!(tracker.get_stream_max(0), Some(1000));
+        assert_eq!(tracker.current_sum(), 1000);
+
+        assert_eq!(tracker.sum_series.len(), 2);
+        assert_eq!(tracker.sum_series, vec![(10.0, 1000), (20.0, 1000)]);
+    }
+
+    #[test]
+    fn test_tracker_running_sum_correctness() {
+        let mut tracker = StreamMaxTracker::new();
+
+        tracker.update(0, 1000, 1.0, 0);
+        tracker.update(1, 2000, 2.0, 0);
+        tracker.update(2, 1500, 3.0, 0);
+        tracker.update(0, 1200, 4.0, 0);
+
+        let manual_sum: u64 = tracker.flat.values().sum();
+
+        assert_eq!(tracker.current_sum(), manual_sum);
+        assert_eq!(tracker.current_sum(), 4700);
+    }
+
+    #[test]
+    fn test_tracker_complex_interleaving() {
+        let mut tracker = StreamMaxTracker::new();
+
+        let updates = vec![
+            (0, 1000, 10.0),
+            (1, 500, 12.0),
+            (0, 800, 8.0),
+            (2, 2000, 15.0),
+            (1, 1000, 18.0),
+            (0, 1500, 20.0),
+        ];
+
+        for (stream_id, value, time) in updates {
+            tracker.update(stream_id, value, time, 0);
+        }
+
+        assert_eq!(tracker.get_stream_max(0), Some(1500));
+        assert_eq!(tracker.get_stream_max(1), Some(1000));
+        assert_eq!(tracker.get_stream_max(2), Some(2000));
+        assert_eq!(tracker.current_sum(), 4500);
+
+        assert_eq!(tracker.sum_series.len(), 6);
+    }
+
+    #[test]
+    fn test_tracker_init_value() {
+        let mut tracker = StreamMaxTracker::new();
+
+        tracker.update(0, 1000, 10.0, 500);
+
+        let stream_data = tracker.per_stream.get(&0).unwrap();
+        assert_eq!(stream_data.len(), 2);
+        assert_eq!(stream_data[0], (0.0, 500));
+        assert_eq!(stream_data[1], (10.0, 1000));
+
+        tracker.update(0, 1500, 20.0, 500);
+        let stream_data = tracker.per_stream.get(&0).unwrap();
+        assert_eq!(stream_data.len(), 3);
+        assert_eq!(stream_data[0], (0.0, 500));
+        assert_eq!(stream_data[1], (10.0, 1000));
+        assert_eq!(stream_data[2], (20.0, 1500));
+    }
+}


### PR DESCRIPTION
The handling of events related to MAX_STREAM_DATA or qlog data_moved
events was quite verbose and repetitive. It also had two bugs:

* Stream data always assumed an initial value at t=0.0 based on a
  transport parameter. The value should have considered the stream
  type but always assumed the bidirectional limit.
* Max data values always increment. The value storage did not consider
  the possibility of out-of-order events (either reorderd packets
  , unsorted qlogs etc.

This change implements two tracker structures to fix the bugs and
reduce duplication. Tests are added to ensure behaviour matches
expectations.
