### PR TITLE
quiche : add H3Controller::shutdown_stream() API

### DIFF
--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -50,6 +50,7 @@ use foundations::telemetry::log;
 use futures::FutureExt;
 use futures_util::stream::FuturesUnordered;
 use quiche::h3;
+use quiche::h3::WireErrorCode;
 use tokio::select;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
@@ -544,7 +545,7 @@ impl<H: DriverHooks> H3Driver<H> {
         match status {
             StreamStatus::Done { close } => {
                 if close {
-                    return self.finish_stream(qconn, stream_id, None, None);
+                    return self.cleanup_stream(qconn, stream_id);
                 }
 
                 // The QUIC stream is finished, manually invoke `process_h3_fin`
@@ -566,7 +567,7 @@ impl<H: DriverHooks> H3Driver<H> {
                     .send(H3Event::ResetStream { stream_id }.into())
                     .map_err(|_| H3ConnectionError::ControllerWentAway)?;
                 if ctx.both_directions_done() {
-                    return self.finish_stream(qconn, stream_id, None, None);
+                    return self.cleanup_stream(qconn, stream_id);
                 }
             },
             StreamStatus::Blocked => {
@@ -653,7 +654,7 @@ impl<H: DriverHooks> H3Driver<H> {
                         .send(H3Event::ResetStream { stream_id }.into())
                         .map_err(|_| H3ConnectionError::ControllerWentAway)?;
                     if ctx.both_directions_done() {
-                        return self.finish_stream(qconn, stream_id, None, None);
+                        return self.cleanup_stream(qconn, stream_id);
                     }
                 }
 
@@ -889,11 +890,13 @@ impl<H: DriverHooks> H3Driver<H> {
                     let _ = datagram::send_h3_dgram(qconn, flow_id, dgram);
                 },
                 Ok(OutboundFrame::FlowShutdown { flow_id, stream_id }) => {
-                    self.finish_stream(
+                    self.shutdown_stream(
                         qconn,
                         stream_id,
-                        Some(quiche::h3::WireErrorCode::NoError as u64),
-                        Some(quiche::h3::WireErrorCode::NoError as u64),
+                        StreamShutdown::Both {
+                            read_error_code: WireErrorCode::NoError as u64,
+                            write_error_code: WireErrorCode::NoError as u64,
+                        },
                     )?;
                     self.flow_map.remove(&flow_id);
                     break;
@@ -925,29 +928,17 @@ impl<H: DriverHooks> H3Driver<H> {
         H3ConnectionError::H3(h3::Error::TransportError(quiche::Error::TlsFail))
     }
 
-    /// Removes a stream from the stream map if it exists. Also optionally sends
-    /// `RESET` or `STOP_SENDING` frames if `write` or `read` is set to an
-    /// error code, respectively.
-    fn finish_stream(
+    /// Cleans up internal state for the indicated HTTP/3 stream.
+    ///
+    /// This function removes the stream from the stream map, closes any pending
+    /// futures, removes associated DATAGRAM flows, and sends a
+    /// [`H3Event::StreamClosed`] event (for servers).
+    fn cleanup_stream(
         &mut self, qconn: &mut QuicheConnection, stream_id: u64,
-        read: Option<u64>, write: Option<u64>,
     ) -> H3ConnectionResult<()> {
         let Some(stream_ctx) = self.stream_map.remove(&stream_id) else {
             return Ok(());
         };
-
-        let audit_stats = &stream_ctx.audit_stats;
-
-        if let Some(err) = read {
-            audit_stats.set_sent_stop_sending_error_code(err as _);
-            let _ = qconn.stream_shutdown(stream_id, quiche::Shutdown::Read, err);
-        }
-
-        if let Some(err) = write {
-            audit_stats.set_sent_reset_stream_error_code(err as _);
-            let _ =
-                qconn.stream_shutdown(stream_id, quiche::Shutdown::Write, err);
-        }
 
         // Find if the stream also has any pending futures associated with it
         for pending in self.waiting_streams.iter_mut() {
@@ -984,6 +975,60 @@ impl<H: DriverHooks> H3Driver<H> {
         Ok(())
     }
 
+    /// Shuts down the indicated HTTP/3 stream by sending frames and cleaning
+    /// up then cleans up internal state by calling
+    /// [`Self::cleanup_stream`].
+    fn shutdown_stream(
+        &mut self, qconn: &mut QuicheConnection, stream_id: u64,
+        shutdown: StreamShutdown,
+    ) -> H3ConnectionResult<()> {
+        let Some(stream_ctx) = self.stream_map.get(&stream_id) else {
+            return Ok(());
+        };
+
+        let audit_stats = &stream_ctx.audit_stats;
+
+        match shutdown {
+            StreamShutdown::Read { error_code } => {
+                audit_stats.set_sent_stop_sending_error_code(error_code as _);
+                let _ = qconn.stream_shutdown(
+                    stream_id,
+                    quiche::Shutdown::Read,
+                    error_code,
+                );
+            },
+            StreamShutdown::Write { error_code } => {
+                audit_stats.set_sent_reset_stream_error_code(error_code as _);
+                let _ = qconn.stream_shutdown(
+                    stream_id,
+                    quiche::Shutdown::Write,
+                    error_code,
+                );
+            },
+            StreamShutdown::Both {
+                read_error_code,
+                write_error_code,
+            } => {
+                audit_stats
+                    .set_sent_stop_sending_error_code(read_error_code as _);
+                let _ = qconn.stream_shutdown(
+                    stream_id,
+                    quiche::Shutdown::Read,
+                    read_error_code,
+                );
+                audit_stats
+                    .set_sent_reset_stream_error_code(write_error_code as _);
+                let _ = qconn.stream_shutdown(
+                    stream_id,
+                    quiche::Shutdown::Write,
+                    write_error_code,
+                );
+            },
+        }
+
+        self.cleanup_stream(qconn, stream_id)
+    }
+
     /// Handles a regular [`H3Command`]. May be called internally by
     /// [DriverHooks] for non-endpoint-specific [`H3Command`]s.
     fn handle_core_command(
@@ -996,6 +1041,12 @@ impl<H: DriverHooks> H3Driver<H> {
                 self.conn_mut()
                     .expect("connection should be established")
                     .send_goaway(qconn, max_id)?;
+            },
+            H3Command::ShutdownStream {
+                stream_id,
+                shutdown,
+            } => {
+                self.shutdown_stream(qconn, stream_id, shutdown)?;
             },
         }
         Ok(())
@@ -1037,11 +1088,13 @@ impl<H: DriverHooks> H3Driver<H> {
                 Ok(()) => ctx.queued_frame = None,
                 Err(h3::Error::StreamBlocked | h3::Error::Done) => break,
                 Err(h3::Error::MessageError) => {
-                    return self.finish_stream(
+                    return self.shutdown_stream(
                         qconn,
                         stream_id,
-                        Some(quiche::h3::WireErrorCode::MessageError as u64),
-                        Some(quiche::h3::WireErrorCode::MessageError as u64),
+                        StreamShutdown::Both {
+                            read_error_code: WireErrorCode::MessageError as u64,
+                            write_error_code: WireErrorCode::MessageError as u64,
+                        },
                     );
                 },
                 Err(h3::Error::TransportError(quiche::Error::StreamStopped(
@@ -1049,7 +1102,7 @@ impl<H: DriverHooks> H3Driver<H> {
                 ))) => {
                     ctx.handle_recvd_stop_sending(e);
                     if ctx.both_directions_done() {
-                        return self.finish_stream(qconn, stream_id, None, None);
+                        return self.cleanup_stream(qconn, stream_id);
                     } else {
                         return Ok(());
                     }
@@ -1057,10 +1110,10 @@ impl<H: DriverHooks> H3Driver<H> {
                 Err(h3::Error::TransportError(
                     quiche::Error::InvalidStreamState(stream),
                 )) => {
-                    return self.finish_stream(qconn, stream, None, None);
+                    return self.cleanup_stream(qconn, stream);
                 },
                 Err(_) => {
-                    return self.finish_stream(qconn, stream_id, None, None);
+                    return self.cleanup_stream(qconn, stream_id);
                 },
             }
 
@@ -1102,8 +1155,7 @@ impl<H: DriverHooks> H3Driver<H> {
                         );
                         ctx.handle_sent_reset(err);
                         if ctx.both_directions_done() {
-                            return self
-                                .finish_stream(qconn, stream_id, None, None);
+                            return self.cleanup_stream(qconn, stream_id);
                         }
                     }
                     break;
@@ -1228,8 +1280,7 @@ impl<H: DriverHooks> ApplicationOverQuic for H3Driver<H> {
 
         if matches!(h3_err, H3ConnectionError::ControllerWentAway) {
             // Inform client that we won't (can't) respond anymore
-            let _ =
-                quiche_conn.close(true, h3::WireErrorCode::NoError as u64, &[]);
+            let _ = quiche_conn.close(true, WireErrorCode::NoError as u64, &[]);
             return;
         }
 
@@ -1288,6 +1339,42 @@ pub enum H3Command {
     /// Send a GOAWAY frame to the peer to initiate a graceful connection
     /// shutdown.
     GoAway,
+    /// Shuts down a stream in the specified direction(s) and removes it from
+    /// local state.
+    ///
+    /// This removes the stream from local state and sends a `RESET_STREAM`
+    /// frame (for write direction) and/or a `STOP_SENDING` frame (for read
+    /// direction) to the peer. See [`quiche::Connection::stream_shutdown`]
+    /// for details.
+    ShutdownStream {
+        stream_id: u64,
+        shutdown: StreamShutdown,
+    },
+}
+
+/// Specifies which direction(s) of a stream to shut down.
+///
+/// Used with [`H3Controller::shutdown_stream`] and the internal
+/// `shutdown_stream` function to control whether to send a `STOP_SENDING` frame
+/// (read direction), and/or a `RESET_STREAM` frame (write direction)
+///
+/// Note: Despite its name, "shutdown" here refers to signaling the peer about
+/// stream termination, not sending a FIN flag. `STOP_SENDING` asks the peer to
+/// stop sending data, while `RESET_STREAM` abruptly terminates the write side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamShutdown {
+    /// Shut down only the read direction (sends `STOP_SENDING` frame with the
+    /// given error code).
+    Read { error_code: u64 },
+    /// Shut down only the write direction (sends `RESET_STREAM` frame with the
+    /// given error code).
+    Write { error_code: u64 },
+    /// Shut down both directions (sends both `STOP_SENDING` and `RESET_STREAM`
+    /// frames).
+    Both {
+        read_error_code: u64,
+        write_error_code: u64,
+    },
 }
 
 /// Sends [`H3Command`]s to an [H3Driver]. The sender is typed and internally
@@ -1359,5 +1446,29 @@ impl<H: DriverHooks> H3Controller<H> {
     /// Sends a GOAWAY frame to initiate a graceful connection shutdown.
     pub fn send_goaway(&self) {
         let _ = self.cmd_sender.send(H3Command::GoAway.into());
+    }
+
+    /// Creates an [`H3Command`] sender for the paired [H3Driver].
+    pub fn h3_cmd_sender(&self) -> RequestSender<H::Command, H3Command> {
+        RequestSender {
+            sender: self.cmd_sender.clone(),
+            _r: Default::default(),
+        }
+    }
+
+    /// Shuts down a stream in the specified direction(s) and removes it from
+    /// local state.
+    ///
+    /// This removes the stream from local state and sends a `RESET_STREAM`
+    /// frame (for write direction) and/or a `STOP_SENDING` frame (for read
+    /// direction) to the peer, depending on the [`StreamShutdown`] variant.
+    pub fn shutdown_stream(&self, stream_id: u64, shutdown: StreamShutdown) {
+        let _ = self.cmd_sender.send(
+            H3Command::ShutdownStream {
+                stream_id,
+                shutdown,
+            }
+            .into(),
+        );
     }
 }


### PR DESCRIPTION
**Summary**

Add `H3Controller::shutdown_stream()` API to explicitly shut down HTTP/3 streams in specific directions by sending `RESET_STREAM` and/or `STOP_SENDING` frames.

**Changes**
- Add StreamShutdown enum with three variants:
  - Read { error_code } - sends STOP_SENDING
  - Write { error_code } - sends RESET_STREAM
  - Both { read_error_code, write_error_code } - sends both frames
- Add H3Controller::shutdown_stream(stream_id, shutdown) public method
- Refactor internal stream management into two functions:
  - cleanup_stream - internal state cleanup only (no frames sent)
  - shutdown_stream - sends frames and calls cleanup_stream
- Add tests for all three StreamShutdown variants