### PR TITLE
Implement MAX_PROBES for PMTUD probe failure tolerance

### DIFF
--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -216,6 +216,13 @@ pub extern "C" fn quiche_config_discover_pmtu(config: &mut Config, v: bool) {
 }
 
 #[no_mangle]
+pub extern "C" fn quiche_config_set_pmtud_max_probes(
+    config: &mut Config, max_probes: u8,
+) {
+    config.set_pmtud_max_probes(max_probes);
+}
+
+#[no_mangle]
 pub extern "C" fn quiche_config_log_keys(config: &mut Config) {
     config.log_keys();
 }

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -248,7 +248,7 @@ impl Path {
                         .unwrap_or(c.max_send_udp_payload_size),
                     c.max_send_udp_payload_size,
                 );
-                Some(pmtud::Pmtud::new(maximum_supported_mtu))
+                Some(pmtud::Pmtud::new(maximum_supported_mtu, c.pmtud_max_probes))
             } else {
                 None
             }
@@ -889,10 +889,14 @@ impl PathMap {
     /// Configures path MTU discovery on all existing paths.
     pub fn set_discover_pmtu_on_existing_paths(
         &mut self, discover: bool, max_send_udp_payload_size: usize,
+        pmtud_max_probes: u8,
     ) {
         for (_, path) in self.paths.iter_mut() {
             path.pmtud = if discover {
-                Some(pmtud::Pmtud::new(max_send_udp_payload_size))
+                Some(pmtud::Pmtud::new(
+                    max_send_udp_payload_size,
+                    pmtud_max_probes,
+                ))
             } else {
                 None
             };

--- a/quiche/src/pmtud.rs
+++ b/quiche/src/pmtud.rs
@@ -1,6 +1,30 @@
-/// Contains the logic to implement PMTUD. Given a maximum supported MTU,
-/// finds the PMTU between the given max and [`MIN_CLIENT_INITIAL_LEN`].
-use crate::MIN_CLIENT_INITIAL_LEN;
+//! Path MTU Discovery ([RFC 8899] DPLPMTUD).
+//!
+//! Discovers the path MTU using loss-based inference: probe packets are sent
+//! and their acknowledgment (or lack thereof) determines path capacity.
+//!
+//! # Algorithm
+//!
+//! Optimistic binary search between [`MIN_PLPMTU`] (1200) and max supported
+//! MTU:
+//! 1. Probe at max MTU
+//! 2. On max_probes consecutive failures, record as smallest failed size
+//! 3. Binary search between largest success and smallest failure
+//! 4. Complete when difference ≤ 1 byte
+//!
+//! A successful probe at any point resets the failure counter and updates
+//! the largest known working size.
+//!
+//! [RFC 8899]: https://datatracker.ietf.org/doc/html/rfc8899
+
+/// Maximum number of probe attempts before treating a size as failed.
+/// https://datatracker.ietf.org/doc/html/rfc8899#section-5.1.2
+pub(crate) const MAX_PROBES_DEFAULT: u8 = 3;
+
+/// Min Packetization Layer Path MTU (PLPMTU).
+/// https://datatracker.ietf.org/doc/html/rfc8899#section-5.1.2
+/// For QUIC, this is 1200 bytes per https://datatracker.ietf.org/doc/html/rfc9000#section-14.1
+const MIN_PLPMTU: usize = crate::MIN_CLIENT_INITIAL_LEN;
 
 #[derive(Default)]
 pub struct Pmtud {
@@ -23,14 +47,34 @@ pub struct Pmtud {
 
     /// Indicates if a PMTUD probe is in flight. Used to limit probes to 1/RTT.
     in_flight: bool,
+
+    /// The number of times the current probe size has failed.
+    probe_failure_count: u8,
+
+    /// The maximum number of failed probe attempts before treating a size as
+    /// failed.
+    max_probes: u8,
 }
 
 impl Pmtud {
     /// Creates new PMTUD instance.
-    pub fn new(maximum_supported_mtu: usize) -> Self {
+    ///
+    /// If `max_probes` is 0, uses the default value of [`MAX_PROBES_DEFAULT`].
+    pub fn new(maximum_supported_mtu: usize, max_probes: u8) -> Self {
+        let max_probes = if max_probes == 0 {
+            warn!(
+                "max_probes is 0, using default value {}",
+                MAX_PROBES_DEFAULT
+            );
+            MAX_PROBES_DEFAULT
+        } else {
+            max_probes
+        };
+
         Self {
             maximum_supported_mtu,
             probe_size: maximum_supported_mtu,
+            max_probes,
             ..Default::default()
         }
     }
@@ -42,7 +86,7 @@ impl Pmtud {
     pub fn should_probe(&self) -> bool {
         !self.in_flight &&
             self.pmtu.is_none() &&
-            self.smallest_failed_probe_size != Some(MIN_CLIENT_INITIAL_LEN)
+            self.smallest_failed_probe_size != Some(MIN_PLPMTU)
     }
 
     /// Sets the PMTUD probe size.
@@ -58,8 +102,7 @@ impl Pmtud {
     /// Returns the largest successful PMTUD probe size if one exists, otherwise
     /// returns the minimum supported MTU.
     pub fn get_current_mtu(&self) -> usize {
-        self.largest_successful_probe_size
-            .unwrap_or(MIN_CLIENT_INITIAL_LEN)
+        self.largest_successful_probe_size.unwrap_or(MIN_PLPMTU)
     }
 
     /// Returns the PMTU.
@@ -92,10 +135,8 @@ impl Pmtud {
 
                 // Found the PMTU
                 if failed_probe_size - successful_probe_size <= 1 {
-                    trace!("Found PMTU: {successful_probe_size}");
-
-                    self.pmtu = Some(successful_probe_size);
-                    self.probe_size = successful_probe_size
+                    debug!("Found PMTU: {successful_probe_size}");
+                    self.set_pmtu(successful_probe_size);
                 } else {
                     self.probe_size =
                         (successful_probe_size + failed_probe_size) / 2
@@ -105,14 +146,13 @@ impl Pmtud {
             // With only failed probes, binary search between the smallest failed
             // probe and the minimum supported MTU
             (Some(failed_probe_size), None) =>
-                self.probe_size = (MIN_CLIENT_INITIAL_LEN + failed_probe_size) / 2,
+                self.probe_size = (MIN_PLPMTU + failed_probe_size) / 2,
 
             // As the algorithm is optimistic in that the initial probe size
             // is the maximum supported MTU, then having only a successful probe
             // means the maximum supported MTU is <= PMTU
             (None, Some(successful_probe_size)) => {
-                self.pmtu = Some(successful_probe_size);
-                self.probe_size = successful_probe_size
+                self.set_pmtu(successful_probe_size);
             },
 
             // Use the initial probe size if no record of success/failures
@@ -127,6 +167,8 @@ impl Pmtud {
 
     /// Records a successful probe and returns the largest successful probe size
     pub fn successful_probe(&mut self, probe_size: usize) -> Option<usize> {
+        self.probe_failure_count = 0;
+
         self.largest_successful_probe_size = std::cmp::max(
             // make sure we don't exceed the maximum supported MTU
             Some(probe_size.min(self.maximum_supported_mtu)),
@@ -142,17 +184,32 @@ impl Pmtud {
     /// Records a failed probe
     pub fn failed_probe(&mut self, probe_size: usize) {
         // Treat errant probes as if they failed at the minimum supported MTU
-        let probe_size = std::cmp::max(probe_size, MIN_CLIENT_INITIAL_LEN);
+        let probe_size = std::cmp::max(probe_size, MIN_PLPMTU);
+        self.probe_failure_count += 1;
+
+        if self.probe_failure_count < self.max_probes {
+            debug!(
+                "Probe size {} failed ({}/{}), will retry",
+                probe_size, self.probe_failure_count, self.max_probes
+            );
+            self.in_flight = false;
+            return;
+        }
+
+        debug!(
+            "Probe size {} failed {} times, treating as MTU limitation",
+            probe_size, self.probe_failure_count
+        );
 
         // Check if we have one instance of a failed probe so that a min
         // comparison can be made otherwise if this is the first failed
         // probe just record it
-        self.smallest_failed_probe_size = self
-            .smallest_failed_probe_size
-            .map_or(Some(probe_size), |existing_size| {
-                Some(std::cmp::min(probe_size, existing_size))
-            });
+        self.smallest_failed_probe_size = Some(
+            self.smallest_failed_probe_size
+                .map_or(probe_size, |s| s.min(probe_size)),
+        );
 
+        self.probe_failure_count = 0;
         self.update_probe_size();
         self.in_flight = false;
     }
@@ -164,6 +221,7 @@ impl Pmtud {
         self.smallest_failed_probe_size = None;
         self.largest_successful_probe_size = None;
         self.pmtu = None;
+        self.probe_failure_count = 0;
     }
 
     // Checks that a probe of PMTU size can be ack'd by enabling
@@ -173,7 +231,15 @@ impl Pmtud {
         if let Some(pmtu) = self.pmtu {
             self.set_probe_size(pmtu);
             self.pmtu = None;
-        };
+            self.probe_failure_count = 0;
+            self.largest_successful_probe_size = None;
+        }
+    }
+
+    fn set_pmtu(&mut self, successful_probe_size: usize) {
+        self.pmtu = Some(successful_probe_size);
+        self.probe_size = successful_probe_size;
+        self.probe_failure_count = 0;
     }
 }
 
@@ -182,6 +248,11 @@ impl std::fmt::Debug for Pmtud {
         write!(f, "pmtu={:?} ", self.pmtu)?;
         write!(f, "probe_size={:?} ", self.probe_size)?;
         write!(f, "should_probe={:?} ", self.should_probe())?;
+        write!(
+            f,
+            "failures={}/{} ",
+            self.probe_failure_count, self.max_probes
+        )?;
         Ok(())
     }
 }
@@ -192,15 +263,28 @@ mod tests {
 
     #[test]
     fn pmtud_initial_state() {
-        let pmtud = Pmtud::new(1350);
+        let pmtud = Pmtud::new(1350, 1);
         assert_eq!(pmtud.get_current_mtu(), 1200);
         assert_eq!(pmtud.get_probe_size(), 1350);
         assert!(pmtud.should_probe());
     }
 
     #[test]
+    fn pmtud_max_probes_zero_uses_default() {
+        let pmtud = Pmtud::new(1500, 0);
+        assert_eq!(pmtud.max_probes, MAX_PROBES_DEFAULT);
+    }
+
+    #[test]
+    fn pmtud_max_probes_set_to_provided_value() {
+        let pmtud = Pmtud::new(1500, 5);
+        assert_eq!(pmtud.max_probes, 5);
+        assert_ne!(pmtud.max_probes, MAX_PROBES_DEFAULT);
+    }
+
+    #[test]
     fn pmtud_binary_search_algorithm() {
-        let mut pmtud = Pmtud::new(1500);
+        let mut pmtud = Pmtud::new(1500, 1);
 
         // Set initial probe size to 1500
         assert_eq!(pmtud.get_probe_size(), 1500);
@@ -245,38 +329,13 @@ mod tests {
     }
 
     #[test]
-    fn pmtud_probe_lost_behavior() {
-        let mut pmtud = Pmtud::new(1500);
-
-        // Simulate probe loss
-        pmtud.failed_probe(1500);
-
-        // Should re-enable probing and adjust size
-        assert!(pmtud.should_probe());
-        assert_eq!(pmtud.get_probe_size(), 1350); // binary search result
-        assert_eq!(pmtud.get_current_mtu(), 1200); // MTU does not
-                                                   // change
-    }
-
-    #[test]
     fn pmtud_successful_probe() {
-        let mut pmtud = Pmtud::new(1400);
+        let mut pmtud = Pmtud::new(1400, 1);
 
         // Simulate successful probe
         pmtud.successful_probe(1400);
 
         assert_eq!(pmtud.get_current_mtu(), 1400);
-    }
-
-    #[test]
-    fn pmtud_binary_search_convergence() {
-        let mut pmtud = Pmtud::new(2000);
-
-        // Simulate repeated probe losses to test convergence
-        pmtud_test_runner(&mut pmtud, 1200);
-
-        // Should converge to the minimum allowed packet size
-        assert_eq!(pmtud.get_probe_size(), 1200);
     }
 
     /// Test case for resetting the PMTUD state.
@@ -286,7 +345,7 @@ mod tests {
     /// to verify the PMTU discovery process.
     #[test]
     fn test_pmtud_reset() {
-        let mut pmtud = Pmtud::new(1350);
+        let mut pmtud = Pmtud::new(1350, 1);
         pmtud.successful_probe(1350);
         assert_eq!(pmtud.pmtu, Some(1350));
         assert!(!pmtud.should_probe());
@@ -301,7 +360,7 @@ mod tests {
     /// Test case for receiving a probe outside the defined supported MTU range.
     #[test]
     fn test_pmtud_errant_probe() {
-        let mut pmtud = Pmtud::new(1350);
+        let mut pmtud = Pmtud::new(1350, 1);
         pmtud.successful_probe(1500);
         // Even though we've received a probe larger than supported
         // maximum MTU, the PMTU should still respect the configured maximum
@@ -324,7 +383,7 @@ mod tests {
     /// when the PMTU is equal to the minimum supported MTU.
     #[test]
     fn test_pmtu_equal_to_min_supported_mtu() {
-        let mut pmtud = Pmtud::new(1350);
+        let mut pmtud = Pmtud::new(1350, 1);
         pmtud_test_runner(&mut pmtud, 1200);
     }
 
@@ -334,7 +393,7 @@ mod tests {
     /// when the PMTU is greater than the minimum supported MTU.
     #[test]
     fn test_pmtu_greater_than_min_supported_mtu() {
-        let mut pmtud = Pmtud::new(1350);
+        let mut pmtud = Pmtud::new(1350, 1);
         pmtud_test_runner(&mut pmtud, 1500);
     }
 
@@ -344,7 +403,7 @@ mod tests {
     /// the case when the PMTU is less than the minimum supported MTU.
     #[test]
     fn test_pmtu_less_than_min_supported_mtu() {
-        let mut pmtud = Pmtud::new(1350);
+        let mut pmtud = Pmtud::new(1350, 1);
         pmtud_test_runner(&mut pmtud, 1100);
     }
 
@@ -355,16 +414,198 @@ mod tests {
     /// validation probe.
     #[test]
     fn test_pmtu_revalidation() {
-        let mut pmtud = Pmtud::new(1350);
+        let mut pmtud = Pmtud::new(1350, 1);
         pmtud.set_probe_size(1350);
         pmtud.successful_probe(1350);
 
-        // Simulate a case where an a probe of an established PMTU is dropped
+        // Simulate a case where an established PMTU probe is dropped repeatedly
         pmtud.revalidate_pmtu();
-        pmtud.failed_probe(1350);
+        fail_probe_max_times(&mut pmtud, 1350);
 
         // Run the PMTUD test runner with the reset state
         pmtud_test_runner(&mut pmtud, 1250);
+    }
+
+    #[test]
+    fn pmtud_revalidation_tolerates_random_packet_loss() {
+        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT);
+
+        pmtud.successful_probe(1500);
+        assert_eq!(pmtud.get_pmtu(), Some(1500));
+
+        pmtud.revalidate_pmtu();
+        assert_eq!(pmtud.get_pmtu(), None);
+        assert!(pmtud.largest_successful_probe_size.is_none());
+
+        pmtud.failed_probe(1500);
+        assert_eq!(pmtud.probe_failure_count, 1);
+        assert!(pmtud.pmtu.is_none());
+
+        pmtud.failed_probe(1500);
+        assert_eq!(pmtud.probe_failure_count, 2);
+
+        pmtud.successful_probe(1500);
+        assert_eq!(pmtud.get_pmtu(), Some(1500));
+        assert_eq!(pmtud.probe_failure_count, 0);
+    }
+
+    /// Test that when revalidating PMTU, if the revalidation probe fails,
+    /// PMTUD should binary search down, not restart.
+    #[test]
+    fn pmtud_revalidation_failure_binary_searches_not_restarts() {
+        let mut pmtud = Pmtud::new(1500, 1);
+
+        pmtud.successful_probe(1500);
+        assert_eq!(pmtud.get_pmtu(), Some(1500));
+
+        // Revalidation clears largest_successful_probe_size
+        pmtud.revalidate_pmtu();
+        assert!(pmtud.largest_successful_probe_size.is_none());
+
+        // Revalidation probe fails - should binary search down, not restart
+        pmtud.failed_probe(1500);
+
+        assert_eq!(pmtud.smallest_failed_probe_size, Some(1500));
+        assert!(pmtud.largest_successful_probe_size.is_none());
+        assert_eq!(pmtud.get_probe_size(), 1350); // (1200 + 1500) / 2
+    }
+
+    #[test]
+    fn pmtud_tolerates_initial_packet_loss() {
+        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT);
+
+        pmtud.failed_probe(1500);
+        assert_eq!(pmtud.probe_failure_count, 1);
+        assert!(pmtud.smallest_failed_probe_size.is_none());
+
+        pmtud.failed_probe(1500);
+        assert_eq!(pmtud.probe_failure_count, 2);
+        assert!(pmtud.smallest_failed_probe_size.is_none());
+
+        pmtud.successful_probe(1500);
+        assert_eq!(pmtud.get_pmtu(), Some(1500));
+        assert_eq!(pmtud.probe_failure_count, 0);
+    }
+
+    #[test]
+    fn pmtud_confirms_failure_after_max_probes() {
+        let mut pmtud = Pmtud::new(1500, 1);
+
+        pmtud.failed_probe(1500);
+
+        assert_eq!(pmtud.smallest_failed_probe_size, Some(1500));
+        assert!(pmtud.pmtu.is_none());
+        assert!(pmtud.get_probe_size() < 1500);
+        assert!(pmtud.get_probe_size() >= MIN_PLPMTU);
+    }
+
+    #[test]
+    fn pmtud_binary_search_no_slowdown() {
+        let mut pmtud = Pmtud::new(1500, 2);
+
+        fail_probe_max_times(&mut pmtud, 1500);
+        assert!(pmtud.pmtu.is_none());
+
+        let search_size_1 = pmtud.get_probe_size();
+        assert!(search_size_1 < 1500);
+
+        pmtud.successful_probe(search_size_1);
+        assert_eq!(pmtud.probe_failure_count, 0);
+
+        let search_size_2 = pmtud.get_probe_size();
+        pmtud.failed_probe(search_size_2);
+
+        assert!(pmtud.pmtu.is_none());
+        assert_eq!(pmtud.probe_failure_count, 1);
+    }
+
+    /// Test convergence to correct MTU with intermittent packet loss.
+    ///
+    /// Simulates a scenario where the first probe at each size fails but the
+    /// second succeeds (random loss, not MTU limitation). Verifies that:
+    /// 1. probe_failure_count resets to 0 on success
+    /// 2. probe_failure_count resets to 0 when probe size changes
+    /// 3. Algorithm converges to the correct MTU of 1337
+    #[test]
+    fn pmtud_convergence_with_intermittent_loss() {
+        let mut pmtud = Pmtud::new(1500, 3);
+        let target_mtu = 1337;
+
+        while pmtud.get_pmtu().is_none() {
+            let probe_size = pmtud.get_probe_size();
+
+            if probe_size <= target_mtu {
+                // First probe fails (random loss)
+                pmtud.failed_probe(probe_size);
+                assert_eq!(pmtud.probe_failure_count, 1);
+
+                // Second probe succeeds
+                pmtud.successful_probe(probe_size);
+                assert_eq!(pmtud.probe_failure_count, 0); // Reset on success
+            } else {
+                // Size exceeds MTU - all probes fail
+                let old_probe_size = probe_size;
+                fail_probe_max_times(&mut pmtud, probe_size);
+
+                // After max failures, probe_failure_count resets and size changes
+                assert_eq!(pmtud.probe_failure_count, 0);
+                if pmtud.get_pmtu().is_none() {
+                    assert!(pmtud.get_probe_size() < old_probe_size);
+                }
+            }
+        }
+
+        assert_eq!(pmtud.get_pmtu(), Some(target_mtu));
+    }
+
+    #[test]
+    fn pmtud_failure_at_min_plpmtu() {
+        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT);
+
+        pmtud.failed_probe(100);
+        pmtud.failed_probe(100);
+        pmtud.failed_probe(100);
+
+        assert_eq!(pmtud.smallest_failed_probe_size, Some(MIN_PLPMTU));
+    }
+
+    #[test]
+    fn pmtud_in_flight_cleared_on_all_outcomes() {
+        let mut pmtud = Pmtud::new(1500, 1);
+
+        pmtud.set_in_flight(true);
+        assert!(pmtud.in_flight);
+
+        pmtud.failed_probe(1500);
+        assert!(!pmtud.in_flight);
+
+        pmtud.set_in_flight(true);
+
+        pmtud.successful_probe(1500);
+        assert!(!pmtud.in_flight);
+    }
+
+    #[test]
+    fn pmtud_update_probe_size_initial_state() {
+        let mut pmtud = Pmtud::new(1500, 1);
+
+        // Manually set probe_size to something else to verify update_probe_size
+        // resets it
+        pmtud.probe_size = 1200;
+
+        // With no successful or failed probes, should reset to
+        // maximum_supported_mtu
+        pmtud.update_probe_size();
+
+        assert_eq!(pmtud.probe_size, 1500);
+    }
+
+    // Test utilities
+
+    fn fail_probe_max_times(pmtud: &mut Pmtud, size: usize) {
+        for _ in 0..pmtud.max_probes {
+            pmtud.failed_probe(size);
+        }
     }
 
     /// Runs a test for the PMTUD algorithm, given a target PMTU `target_mtu`.
@@ -374,14 +615,14 @@ mod tests {
     /// PMTU.
     fn pmtud_test_runner(pmtud: &mut Pmtud, test_pmtu: usize) {
         // Loop until the PMTU is found or the minimum supported MTU is reached
-        while pmtud.get_probe_size() >= MIN_CLIENT_INITIAL_LEN {
+        while pmtud.get_probe_size() >= MIN_PLPMTU {
             // Send a probe with the current probe size
             let probe_size = pmtud.get_probe_size();
 
             if probe_size <= test_pmtu {
                 pmtud.successful_probe(probe_size);
             } else {
-                pmtud.failed_probe(probe_size);
+                fail_probe_max_times(pmtud, probe_size);
             }
 
             // Update the probe size based on the result
@@ -389,9 +630,7 @@ mod tests {
 
             // If the probe size hasn't changed and is equal to the minimum
             // supported MTU, break the loop
-            if pmtud.get_probe_size() == probe_size &&
-                probe_size == MIN_CLIENT_INITIAL_LEN
-            {
+            if pmtud.get_probe_size() == probe_size && probe_size == MIN_PLPMTU {
                 break;
             }
 
@@ -402,7 +641,7 @@ mod tests {
         }
 
         // Verify that the PMTU is correct
-        if test_pmtu < MIN_CLIENT_INITIAL_LEN {
+        if test_pmtu < MIN_PLPMTU {
             assert_eq!(pmtud.get_pmtu(), None);
         } else if test_pmtu > pmtud.maximum_supported_mtu {
             assert_eq!(pmtud.get_pmtu(), Some(pmtud.maximum_supported_mtu));

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -706,7 +706,8 @@ pub struct ExData<'a> {
 
     pub tx_cap_factor: f64,
 
-    pub pmtud: Option<bool>,
+    /// PMTUD configuration: (enable, max_probes)
+    pub pmtud: Option<(bool, u8)>,
 
     pub is_server: bool,
 }

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -172,6 +172,7 @@ fn make_quiche_config(
         quic_settings.enable_relaxed_loss_threshold,
     );
     config.discover_pmtu(quic_settings.discover_path_mtu);
+    config.set_pmtud_max_probes(quic_settings.pmtud_max_probes);
     config.enable_hystart(quic_settings.enable_hystart);
 
     config.enable_pacing(quic_settings.enable_pacing);

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -177,6 +177,14 @@ pub struct QuicSettings {
     /// Defaults to `false`.
     pub discover_path_mtu: bool,
 
+    /// Configures the maximum number of PMTUD probe attempts before treating
+    /// a size as failed.
+    ///
+    /// Defaults to 3 per [RFC 8899 Section 5.1.2](https://datatracker.ietf.org/doc/html/rfc8899#section-5.1.2).
+    /// If 0 is passed, the default value is used.
+    #[serde(default = "QuicSettings::default_pmtud_max_probes")]
+    pub pmtud_max_probes: u8,
+
     /// Whether to use HyStart++ (only with `cubic` and `reno` CC).
     ///
     /// Defaults to `true`.
@@ -437,6 +445,11 @@ impl QuicSettings {
 
     #[inline]
     fn default_max_path_challenge_recv_queue_len() -> usize {
+        3
+    }
+
+    #[inline]
+    fn default_pmtud_max_probes() -> u8 {
         3
     }
 }


### PR DESCRIPTION
## Summary

Implement MAX_PROBES (=3) consecutive failure requirement before treating a probe size as an MTU limitation. This prevents false positives from random packet loss on lossy networks.

Per RFC 8899 Section 5.1.2, some probe loss is expected while searching, and loss of a single probe is not an indication of a PMTU problem.
