### PR TITLE
Allow updates to the recovery config after sending ACK-only packets.

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -7452,20 +7452,12 @@ impl<F: BufFactory> Connection<F> {
             Ok(_) => (),
 
             Err(Error::Done) => {
-                // Apply in-handshake configuration from callbacks before any
-                // packet with inflight data have been sent. The congestion
-                // controller doesn't track anything interesting until inflight
-                // data is sent. Handshake ACKs may be sent prior to arrival of
-                // the full client hello, but the send of ACK only packets
-                // shouldn't prevent the reinit of the recovery module.
+                // Apply in-handshake configuration from callbacks if the path's
+                // Recovery module can still be reinitilized.
                 if self
                     .paths
                     .get_active()
-                    .map(|p| {
-                        p.recovery.bytes_in_flight() == 0 &&
-                            p.recovery.bytes_in_flight_duration() ==
-                                Duration::ZERO
-                    })
+                    .map(|p| p.can_reinit_recovery())
                     .unwrap_or(false)
                 {
                     if ex_data.recovery_config != self.recovery_config {


### PR DESCRIPTION
This allows in-handshake config overrides to work reliably with multi-packet handshakes.