### PR TITLE
fix: MAX_DATA frames were not retransmitted when lost

### DIFF
--- a/quiche/src/flowcontrol.rs
+++ b/quiche/src/flowcontrol.rs
@@ -127,7 +127,8 @@ impl FlowControl {
     /// the current window.
     pub fn ensure_window_lower_bound(&mut self, min_window: u64) {
         if min_window > self.window {
-            self.window = min_window;
+            // ... we still need to clamp to `max_window`
+            self.window = std::cmp::min(min_window, self.max_window);
         }
     }
 }

--- a/quiche/src/test_utils.rs
+++ b/quiche/src/test_utils.rs
@@ -36,7 +36,7 @@ pub struct Pipe {
 }
 
 impl Pipe {
-    pub fn new(cc_algorithm_name: &str) -> Result<Pipe> {
+    pub fn default_config(cc_algorithm_name: &str) -> Result<Config> {
         let mut config = Config::new(PROTOCOL_VERSION)?;
         assert_eq!(config.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
         config.load_cert_chain_from_pem_file("examples/cert.crt")?;
@@ -51,7 +51,11 @@ impl Pipe {
         config.set_max_idle_timeout(180_000);
         config.verify_peer(false);
         config.set_ack_delay_exponent(8);
+        Ok(config)
+    }
 
+    pub fn new(cc_algorithm_name: &str) -> Result<Pipe> {
+        let mut config = Self::default_config(cc_algorithm_name)?;
         Pipe::with_config(&mut config)
     }
 


### PR DESCRIPTION
The retransmission for MAX_DATA frames was broken. When a MAX_DATA frame was lost, we set `self.almost_full = true`. In `send_single()` we there is also a check for `flow_control.max_data() < flow_control.max_data_next()`. If the application has not read from the recv buffer, this check is false and the MAX_DATA will not be sent. We've seen this issue happen in real traffic.

I've removed `almost_full` and instead do the check for `should_update_max_data()` directly. That seems a lot cleaner than than setting the flag in several places. And I've added a flag to force-send a max-data frame.