### PR TITLE
Example of using a custom generic structure to wrap extension fields

### DIFF
--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -56,7 +56,7 @@ ffi = ["dep:cdylib-link-lines"]
 internal = []
 
 # Enable qlog support with serde_json for extension data
-qlog = ["dep:qlog", "dep:serde_json"]
+qlog = ["dep:qlog", "dep:serde", "dep:serde_json", "dep:serde_with"]
 
 [package.metadata.release]
 tag-prefix = ""
@@ -81,7 +81,9 @@ libm = "0.2"
 log = { workspace = true, features = ["std"] }
 octets = { workspace = true, features = ["huffman_hpack"] }
 qlog = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 serde_json = { version = "1.0", optional = true }
+serde_with = { workspace = true, features = ["macros"], optional = true }
 sfv = { version = "0.9", optional = true }
 slab = "0.4"
 smallvec = { workspace = true, features = ["union"] }


### PR DESCRIPTION
The generic type should probably be defined outside of the recovery module, but this was just an example to help further the discussions