### PR TITLE
lib: Ensure RESET_STREAM frames are retransmitted even after a stream is collected

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4061,11 +4061,10 @@ impl<F: BufFactory> Connection<F> {
                         stream_id,
                         error_code,
                         final_size,
-                    } =>
-                        if self.streams.get(stream_id).is_some() {
-                            self.streams
-                                .insert_reset(stream_id, error_code, final_size);
-                        },
+                    } => {
+                        self.streams
+                            .insert_reset(stream_id, error_code, final_size);
+                    },
 
                     // Retransmit HANDSHAKE_DONE only if it hasn't been acked at
                     // least once already.


### PR DESCRIPTION
Depending on the sequence of events, a quiche stream might be collected from the
internal map by the time a sender detects packet loss that would trigger retransmission.

This fix removes the check on the stream collection when dealing with lost packets,
which is safe because the use of insert_reset() controls only state related to reset
streams, which is consumed later in send_single() to prepare a RESET_STREAM frame.

In order to make testing retransmission issues like this easier, a
trigger_ack_based_loss() function is added to test_util.rs. This is required because
PTO does not trigger loss detection and retransmission of all frame types.
