### PR TITLE
tests: ensure test-related items have #[cfg(test)]

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -3150,6 +3150,7 @@ pub fn grease_value() -> u64 {
 }
 
 #[doc(hidden)]
+#[cfg(any(test, feature = "internal"))]
 pub mod testing {
     use super::*;
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -9004,6 +9004,7 @@ impl std::fmt::Debug for Stats {
 }
 
 #[doc(hidden)]
+#[cfg(any(test, feature = "internal"))]
 pub mod test_utils;
 
 #[cfg(test)]

--- a/quiche/src/ranges.rs
+++ b/quiche/src/ranges.rs
@@ -136,6 +136,7 @@ impl RangeSet {
 
     /// Iterate over every single [`u64`] value covered by the ranges in this
     /// [`RangeSet`] in incremental order.
+    #[cfg(test)]
     pub fn flatten(&self) -> impl DoubleEndedIterator<Item = u64> + '_ {
         match self {
             RangeSet::BTree(set) =>
@@ -147,6 +148,7 @@ impl RangeSet {
     }
 
     /// The smallest value covered by ranges in this collection.
+    #[cfg(test)]
     pub fn first(&self) -> Option<u64> {
         match self {
             RangeSet::Inline(set) => set.inner.first().map(|(s, _)| *s),


### PR DESCRIPTION
While attempting to use a quiche library function that was behind
a #[cfg(test), I noticed builds would break.

Placing test_utils behind #[cfg(test)] identifies that HTTP/3
tests have also been unilaterally built, and sticking them
behind #[cfg(test)] then highlighted some other functions
that are currently only used in tests.

While sorting that, I then hit an issue with h3i and tokio-quiche
tests. They need some bits from quiche's testing internals, so
expose that via the `internal` feature.
