### PR TITLE
lib: Ensure bidi stream limit consistency when TLS handshake callback is used

### DIFF
--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -534,6 +534,7 @@ impl<F: BufFactory> StreamMap<F> {
     pub fn set_max_streams_bidi(&mut self, max: u64) {
         self.local_max_streams_bidi = max;
         self.local_max_streams_bidi_next = max;
+        self.initial_max_streams_bidi = max;
     }
 
     /// Returns the current max_streams_bidi limit.

--- a/quiche/src/test_utils.rs
+++ b/quiche/src/test_utils.rs
@@ -54,6 +54,24 @@ impl Pipe {
         Ok(config)
     }
 
+    #[cfg(feature = "boringssl-boring-crate")]
+    pub fn default_tls_ctx_builder() -> boring::ssl::SslContextBuilder {
+        let mut ctx_builder =
+            boring::ssl::SslContextBuilder::new(boring::ssl::SslMethod::tls())
+                .unwrap();
+        ctx_builder
+            .set_certificate_chain_file("examples/cert.crt")
+            .unwrap();
+        ctx_builder
+            .set_private_key_file(
+                "examples/cert.key",
+                boring::ssl::SslFiletype::PEM,
+            )
+            .unwrap();
+
+        ctx_builder
+    }
+
     pub fn new(cc_algorithm_name: &str) -> Result<Pipe> {
         let mut config = Self::default_config(cc_algorithm_name)?;
         Pipe::with_config(&mut config)


### PR DESCRIPTION
This changes ensures the internal bidi stream limit used by the local
endpoint is consistent with the advertised value. Without this, MAX_STREAM
updates don't behave as anticipated when the value has been customized
via TLS handshake callback.
