### PR TITLE
feat: emit path and cid specific invalid state error.

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -928,7 +928,7 @@ bool quiche_socket_addr_iter_next(quiche_socket_addr_iter *iter, struct sockaddr
 void quiche_socket_addr_iter_free(quiche_socket_addr_iter *iter);
 
 // Returns whether the network path with local address "from and remote address "to" has been validated.
-// If the 4-tuple does not exist over the connection, returns an InvalidState.
+// If the 4-tuple does not exist over the connection, returns an InvalidPathState.
 int quiche_conn_is_path_validated(const quiche_conn *conn, const struct sockaddr *from, size_t from_len, const struct sockaddr *to, size_t to_len);
 
 // Frees the connection object.

--- a/quiche/src/error.rs
+++ b/quiche/src/error.rs
@@ -115,6 +115,14 @@ pub enum Error {
 
     /// An invalid DCID was used when connecting to a remote peer.
     InvalidDcidInitialization,
+
+    /// The operation cannot be completed because the connection has an invalid
+    /// path state.
+    InvalidPathState,
+
+    /// The operation cannot be completed because the connection has an invalid
+    /// CID state.
+    InvalidCidState,
 }
 
 /// QUIC error codes sent on the wire.
@@ -227,6 +235,8 @@ impl Error {
             Error::InvalidAckRange => -21,
             Error::OptimisticAckDetected => -22,
             Error::InvalidDcidInitialization => -23,
+            Error::InvalidPathState => -24,
+            Error::InvalidCidState => -25,
         }
     }
 }

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -657,22 +657,22 @@ impl PathMap {
 
     /// Gets an immutable reference to the path identified by `path_id`. If the
     /// provided `path_id` does not identify any current `Path`, returns an
-    /// [`InvalidState`].
+    /// [`InvalidPathState`].
     ///
-    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    /// [`InvalidPathState`]: enum.Error.html#variant.InvalidPathState
     #[inline]
     pub fn get(&self, path_id: usize) -> Result<&Path> {
-        self.paths.get(path_id).ok_or(Error::InvalidState)
+        self.paths.get(path_id).ok_or(Error::InvalidPathState)
     }
 
     /// Gets a mutable reference to the path identified by `path_id`. If the
     /// provided `path_id` does not identify any current `Path`, returns an
-    /// [`InvalidState`].
+    /// [`InvalidPathState`].
     ///
-    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    /// [`InvalidPathState`]: enum.Error.html#variant.InvalidPathState
     #[inline]
     pub fn get_mut(&mut self, path_id: usize) -> Result<&mut Path> {
-        self.paths.get_mut(path_id).ok_or(Error::InvalidState)
+        self.paths.get_mut(path_id).ok_or(Error::InvalidPathState)
     }
 
     #[inline]
@@ -683,38 +683,38 @@ impl PathMap {
     }
 
     /// Gets an immutable reference to the active path with the lowest
-    /// identifier. If there is no active path, returns an [`InvalidState`].
+    /// identifier. If there is no active path, returns an [`InvalidPathState`].
     ///
-    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    /// [`InvalidPathState`]: enum.Error.html#variant.InvalidPathState
     #[inline]
     pub fn get_active(&self) -> Result<&Path> {
         self.get_active_with_pid()
             .map(|(_, p)| p)
-            .ok_or(Error::InvalidState)
+            .ok_or(Error::InvalidPathState)
     }
 
     /// Gets the lowest active path identifier. If there is no active path,
-    /// returns an [`InvalidState`].
+    /// returns an [`InvalidPathState`].
     ///
-    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    /// [`InvalidPathState`]: enum.Error.html#variant.InvalidPathState
     #[inline]
     pub fn get_active_path_id(&self) -> Result<usize> {
         self.get_active_with_pid()
             .map(|(pid, _)| pid)
-            .ok_or(Error::InvalidState)
+            .ok_or(Error::InvalidPathState)
     }
 
     /// Gets an mutable reference to the active path with the lowest identifier.
-    /// If there is no active path, returns an [`InvalidState`].
+    /// If there is no active path, returns an [`InvalidPathState`].
     ///
-    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
+    /// [`InvalidPathState`]: enum.Error.html#variant.InvalidPathState
     #[inline]
     pub fn get_active_mut(&mut self) -> Result<&mut Path> {
         self.paths
             .iter_mut()
             .map(|(_, p)| p)
             .find(|p| p.active())
-            .ok_or(Error::InvalidState)
+            .ok_or(Error::InvalidPathState)
     }
 
     /// Returns an iterator over all existing paths.

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -9104,8 +9104,8 @@ fn connection_id_handling(
 
     // Now tries to experience CID retirement. If the server tries to remove
     // non-existing DCIDs, it fails.
-    assert_eq!(pipe.server.retire_dcid(0), Err(Error::InvalidState));
-    assert_eq!(pipe.server.retire_dcid(3), Err(Error::InvalidState));
+    assert_eq!(pipe.server.retire_dcid(0), Err(Error::InvalidCidState));
+    assert_eq!(pipe.server.retire_dcid(3), Err(Error::InvalidCidState));
 
     // Now it removes DCID with sequence 1.
     assert_eq!(pipe.server.retire_dcid(1), Ok(()));
@@ -9210,11 +9210,11 @@ fn sending_duplicate_scids(
     assert_eq!(pipe.advance(), Ok(()));
 
     // Trying to send the same CID with a different reset token raises an
-    // InvalidState error.
+    // InvalidCidState error.
     let reset_token_2 = reset_token_1.wrapping_add(1);
     assert_eq!(
         pipe.client.new_scid(&scid_1, reset_token_2, false),
-        Err(Error::InvalidState),
+        Err(Error::InvalidCidState),
     );
 
     // Retrying to send the exact same CID with the same token returns the
@@ -9926,7 +9926,7 @@ fn send_on_path_test(
     let stats = pipe.server.stats();
     assert_eq!(stats.path_challenge_rx_count, 1);
 
-    // A non-existing 4-tuple raises an InvalidState.
+    // A non-existing 4-tuple raises an InvalidPathState.
     let client_addr_3 = "127.0.0.1:9012".parse().unwrap();
     let server_addr_2 = "127.0.0.1:9876".parse().unwrap();
     assert_eq!(
@@ -9935,7 +9935,7 @@ fn send_on_path_test(
             Some(client_addr_3),
             Some(server_addr)
         ),
-        Err(Error::InvalidState)
+        Err(Error::InvalidPathState)
     );
     assert_eq!(
         pipe.client.send_on_path(
@@ -9943,7 +9943,7 @@ fn send_on_path_test(
             Some(client_addr),
             Some(server_addr_2)
         ),
-        Err(Error::InvalidState)
+        Err(Error::InvalidPathState)
     );
 
     // Let's introduce some additional path challenges and data exchange.


### PR DESCRIPTION
**feat: emit path and cid specific invalid state error.**
quiche currently has a general InvalidState error which is emitted for
various reasons. This PR adds InvalidPathState and InvalidCidState
errors which provide a more specific error reason and can help with
reasoning about quiche behavior.