### PR TITLE
tokio-quiche: set sent error codes in audit stats

### DIFF
--- a/tokio-quiche/src/quic/io/worker.rs
+++ b/tokio-quiche/src/quic/io/worker.rs
@@ -972,6 +972,20 @@ where
             }
         }
 
+        if let Some(err) = qconn.local_error() {
+            if err.is_app {
+                self.audit_log_stats
+                    .set_sent_conn_close_application_error_code(
+                        err.error_code as _,
+                    );
+            } else {
+                self.audit_log_stats
+                    .set_sent_conn_close_transport_error_code(
+                        err.error_code as _,
+                    );
+            }
+        }
+
         self.close_connection(qconn);
 
         if let Err(work_loop_error) = self.conn_stage.work_loop_result {

--- a/tokio-quiche/tests/integration_tests/async_callbacks.rs
+++ b/tokio-quiche/tests/integration_tests/async_callbacks.rs
@@ -79,7 +79,7 @@ async fn test_hello_world_async_callbacks() {
     let hook = Arc::new(TestAsyncCallbackConnectionHook {
         was_called: Arc::new(AtomicBool::new(false)),
     });
-    let url = start_server_with_settings(
+    let (url, _) = start_server_with_settings(
         QuicSettings::default(),
         Http3Settings::default(),
         hook.clone(),
@@ -139,7 +139,7 @@ async fn test_async_callbacks_fail_after_initial_send() {
     }
 
     let hook = Arc::new(TestAsyncCallbackConnectionHook {});
-    let url = start_server_with_settings(
+    let (url, _) = start_server_with_settings(
         QuicSettings::default(),
         Http3Settings::default(),
         hook.clone(),

--- a/tokio-quiche/tests/integration_tests/headers.rs
+++ b/tokio-quiche/tests/integration_tests/headers.rs
@@ -39,7 +39,7 @@ use tokio_quiche::quiche::h3::Header;
 async fn test_additional_headers() {
     let hook = TestConnectionHook::new();
 
-    let url = start_server_with_settings(
+    let (url, _) = start_server_with_settings(
         QuicSettings::default(),
         Http3Settings::default(),
         hook,

--- a/tokio-quiche/tests/integration_tests/migration.rs
+++ b/tokio-quiche/tests/integration_tests/migration.rs
@@ -68,7 +68,7 @@ async fn run_migration_test(active: bool, base_port: u16) {
     quic_settings.disable_active_migration = !active;
     quic_settings.disable_dcid_reuse = false;
 
-    let url = start_server_with_settings(
+    let (url, _) = start_server_with_settings(
         quic_settings,
         Http3Settings::default(),
         TestConnectionHook::new(),

--- a/tokio-quiche/tests/integration_tests/mod.rs
+++ b/tokio-quiche/tests/integration_tests/mod.rs
@@ -52,7 +52,7 @@ async fn echo() {
     const CONN_COUNT: usize = 5;
 
     let req_count = |conn_num| conn_num * 100;
-    let (url, hook) = start_server();
+    let (url, hook, _) = start_server();
     let mut reqs = vec![];
 
     for i in 1..=CONN_COUNT {
@@ -77,7 +77,7 @@ async fn echo() {
 
 #[tokio::test]
 async fn e2e() {
-    let (url, hook) = start_server();
+    let (url, hook, _) = start_server();
     let url = format!("{url}/1");
 
     let res = request(url, 1).await.unwrap();
@@ -100,7 +100,7 @@ async fn e2e_client_ip_validation_disabled() {
 
     let hook = TestConnectionHook::new();
 
-    let url = start_server_with_settings(
+    let (url, _) = start_server_with_settings(
         quic_settings,
         Http3Settings::default(),
         hook.clone(),
@@ -126,7 +126,7 @@ async fn quiche_logs_forwarded_server_side(cx: TestTelemetryContext) {
 
     let hook = TestConnectionHook::new();
 
-    let url = start_server_with_settings(
+    let (url, _) = start_server_with_settings(
         quic_settings,
         Http3Settings::default(),
         hook,
@@ -204,53 +204,8 @@ async fn test_ioworker_state_machine_pause() {
 
 #[tokio::test]
 #[cfg(target_os = "linux")]
-async fn test_so_mark_receieve_data() {
-    use datagram_socket::QuicAuditStats;
-    use std::sync::Arc;
-    use std::sync::RwLock;
-
-    let socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
-    let url = format!("http://127.0.0.1:{}", socket.local_addr().unwrap().port());
-
-    let tls_cert_settings = TlsCertificatePaths {
-        cert: TEST_CERT_FILE,
-        private_key: TEST_KEY_FILE,
-        kind: tokio_quiche::settings::CertificateKind::X509,
-    };
-
-    let hooks = Hooks {
-        connection_hook: Some(TestConnectionHook::new()),
-    };
-
-    let params = ConnectionParams::new_server(
-        QuicSettings::default(),
-        tls_cert_settings,
-        hooks,
-    );
-    let mut stream = listen(vec![socket], params, DefaultMetrics)
-        .unwrap()
-        .remove(0);
-
-    let audit_log: Arc<RwLock<Option<Arc<QuicAuditStats>>>> =
-        Arc::new(RwLock::new(None));
-    let clone = Arc::clone(&audit_log);
-
-    let _ = tokio::spawn(async move {
-        let (h3_driver, h3_controller) =
-            ServerH3Driver::new(Http3Settings::default());
-        let conn = stream.next().await.unwrap().unwrap();
-
-        let quic_connection = conn.start(h3_driver);
-        let h3_over_quic =
-            ServerH3Connection::new(quic_connection, h3_controller);
-
-        let audit_stats = Arc::clone(h3_over_quic.audit_log_stats());
-        *clone.write().unwrap() = Some(audit_stats);
-        let _ = tokio::spawn(async move {
-            handle_connection(h3_over_quic).await;
-        })
-        .await;
-    });
+async fn test_so_mark_receive_data() {
+    let (url, _, mut audit_stats_rx) = start_server();
 
     let url = format!("{url}/1");
     let summary = timeout(Duration::from_secs(2), h3i_fixtures::request(&url, 1))
@@ -260,8 +215,8 @@ async fn test_so_mark_receieve_data() {
 
     assert!(received_status_code_on_stream(&summary, 0, 200));
 
-    let audit_log = audit_log.read().unwrap();
-    let so_mark_data = audit_log.as_ref().unwrap().initial_so_mark_data();
+    let audit_stats = audit_stats_rx.recv().await.expect("should receive stats");
+    let so_mark_data = audit_stats.initial_so_mark_data();
     // We don't actually set SO_MARK anywhere, so we just want to ensure that the
     // data is `Some`, indicating that we at least received the cmsg from the
     // socket.

--- a/tokio-quiche/tests/integration_tests/timeouts.rs
+++ b/tokio-quiche/tests/integration_tests/timeouts.rs
@@ -102,7 +102,7 @@ async fn test_handshake_duration_ioworker() {
     quic_settings.max_idle_timeout = Some(Duration::from_secs(5));
     quic_settings.handshake_timeout = Some(HANDSHAKE_TIMEOUT);
 
-    let url = start_server_with_settings(
+    let (url, _) = start_server_with_settings(
         quic_settings,
         Http3Settings {
             post_accept_timeout: Some(HANDSHAKE_TIMEOUT),
@@ -137,7 +137,7 @@ async fn test_handshake_timeout_with_one_client_flight() {
     let mut quic_settings = QuicSettings::default();
     quic_settings.handshake_timeout = Some(HANDSHAKE_TIMEOUT);
 
-    let url = start_server_with_settings(
+    let (url, _) = start_server_with_settings(
         quic_settings,
         Http3Settings::default(),
         hook.clone(),
@@ -235,7 +235,7 @@ async fn test_post_accept_timeout() {
     // post-accept timeout rather than Quiche's idle timeout.
     quic_settings.max_idle_timeout = Some(Duration::from_secs(5));
 
-    let url = start_server_with_settings(
+    let (url, _) = start_server_with_settings(
         quic_settings,
         Http3Settings {
             post_accept_timeout: Some(POST_ACCEPT_TIMEOUT),
@@ -295,7 +295,7 @@ async fn test_post_accept_timeout_is_reset() {
     // post-accept timeout rather than Quiche's idle timeout.
     quic_settings.max_idle_timeout = Some(Duration::from_secs(5));
 
-    let url = start_server_with_settings(
+    let (url, _) = start_server_with_settings(
         quic_settings,
         Http3Settings {
             post_accept_timeout: Some(POST_ACCEPT_TIMEOUT),

--- a/tokio-quiche/tests/integration_tests/zero_rtt.rs
+++ b/tokio-quiche/tests/integration_tests/zero_rtt.rs
@@ -67,7 +67,7 @@ async fn handle_0_rtt_request() {
     let context_clone = context.clone();
     let mut quic_settings = QuicSettings::default();
     quic_settings.enable_early_data = true;
-    let url = start_server_with_settings(
+    let (url, _) = start_server_with_settings(
         quic_settings,
         Http3Settings::default(),
         TestConnectionHook::new(),


### PR DESCRIPTION
The new test fails without the changes to IoWorker. We add a QuicAuditStats receiver so that future tests can access them if need be.