### PR TITLE
tokio-quiche: keep early-data connections in handshake stage until established

### DIFF
--- a/tokio-quiche/src/quic/io/connection_stage.rs
+++ b/tokio-quiche/src/quic/io/connection_stage.rs
@@ -122,9 +122,9 @@ impl ConnectionStage for Handshake {
         &mut self, qconn: &mut QuicheConnection,
         _ctx: &mut ConnectionStageContext<A>,
     ) -> ControlFlow<QuicResult<()>> {
-        // Transition to RunningApplication if we have 1-RTT keys (handshake is
-        // complete) or if we have 0-RTT keys (in early data).
-        if qconn.is_established() || qconn.is_in_early_data() {
+        // Transition to RunningApplication only after the QUIC handshake is
+        // complete (1-RTT keys are available).
+        if qconn.is_established() {
             ControlFlow::Break(Ok(()))
         } else {
             ControlFlow::Continue(())


### PR DESCRIPTION
### Motivation
- Prevent a resource-exhaustion/DoS scenario where 0-RTT (early-data) causes the connection to leave the handshake stage and thereby bypass handshake timeout enforcement.

### Description
- Change `Handshake::on_flush` in `tokio-quiche/src/quic/io/connection_stage.rs` to transition to the `RunningApplication` stage only when `qconn.is_established()` is true and stop treating `qconn.is_in_early_data()` as sufficient for the transition, preserving handshake-timeout checks during early data.

### Testing
- Ran `cargo test -p tokio-quiche --no-run`, which completed successfully and produced the test binaries (compile-only run succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fa16e35c8323a54dd14cb4fa387c)