### PR TITLE
qlog-dancer: improve conversion speed and disk usage and fix garbled output on Windows

### DIFF
--- a/qlog-dancer/src/reports/events.rs
+++ b/qlog-dancer/src/reports/events.rs
@@ -475,7 +475,7 @@ pub fn print_sqlog_events(events: &[qlog::reader::Event]) {
     );
     for p in &pp {
         println!(
-            "{:>12.2} | {:<10} | {:<25} | {}",
+            "{:>12.3} | {:<10} | {:<25} | {}",
             p.time, p.category, p.ty, p.details
         );
     }

--- a/qlog-dancer/src/reports/events.rs
+++ b/qlog-dancer/src/reports/events.rs
@@ -233,9 +233,9 @@ fn http_frame_to_string(frame: &Http3Frame) -> String {
     s
 }
 
-pub fn sqlog_event_list(
+fn build_event_list(
     events: &[qlog::reader::Event],
-) -> tabled::builder::Builder {
+) -> Vec<PrintableEvent> {
     let mut pp = vec![];
 
     for event in events {
@@ -457,5 +457,26 @@ pub fn sqlog_event_list(
         }
     }
 
-    Table::builder(pp)
+    pp
+}
+
+pub fn sqlog_event_list(
+    events: &[qlog::reader::Event],
+) -> tabled::builder::Builder {
+    Table::builder(build_event_list(events))
+}
+
+pub fn print_sqlog_events(events: &[qlog::reader::Event]) {
+    let pp = build_event_list(events);
+    println!("Qlog events");
+    println!(
+        "{:>12} | {:<10} | {:<25} | {}",
+        "time", "category", "Type", "details"
+    );
+    for p in &pp {
+        println!(
+            "{:>12.2} | {:<10} | {:<25} | {}",
+            p.time, p.category, p.ty, p.details
+        );
+    }
 }

--- a/qlog-dancer/src/reports/mod.rs
+++ b/qlog-dancer/src/reports/mod.rs
@@ -26,8 +26,7 @@
 
 //! Reporting (tables etc.)
 
-use events::sqlog_event_list;
-use tabled::settings::Style;
+use events::print_sqlog_events;
 
 use crate::config::AppConfig;
 use crate::LogFileParseResult;
@@ -55,10 +54,7 @@ pub fn report(log_file: &LogFileParseResult, config: &AppConfig) {
             match &data.raw {
                 crate::RawLogEvents::QlogJson { events: _ } => todo!(),
                 crate::RawLogEvents::QlogJsonSeq { events } => {
-                    let mut table = sqlog_event_list(events).build();
-                    table.with(Style::sharp());
-                    println!("Qlog events");
-                    println!("{}", table);
+                    print_sqlog_events(events);
                 },
                 crate::RawLogEvents::Netlog => todo!(),
             }

--- a/qlog-dancer/src/reports/text.rs
+++ b/qlog-dancer/src/reports/text.rs
@@ -86,6 +86,8 @@ pub fn request_timing_table(
         let style = Style::empty().vertical(',');
 
         table.with(style);
+    } else {
+        table.with(Style::ascii());
     }
 
     Some(table)


### PR DESCRIPTION
#### Issues:
1. On Windows, since `tabled`'s `sharp` style (UTF8 unicode) is used, when being pipe'd in powershell to a text file, the box-drawing characters are misinterpreted (as ASCII). e.g.
`Γöé 71060.11   Γöé transport Γöé packet_received          Γöé 1RTT pn=98831182,  ACK {6065814, 6065815, }`
2. The column width automatically adapts to the longest row which leads to massive amount of whitespaces getting printed in almost all rows in the event table. Because of this, the captured text file is unnecessarily large and the conversion consumes a huge amount of memory (converting a 2GB sqlog can crash the qlog-dancer process itself on my 32GB ram laptop). Also, the trailing whitespace makes it hard to share qlog on IMs.

#### This PR:
- replaces the tabled style from `sharp` to `ascii`.
- uses simple hand-rolled formatter for event table instead of tabled, which does not output trailing space and trailing separator.

#### Some benchmarks:
Before:
```
> time qlog-dancer ~/09899a18f8d329f608474eaec06105376d5ff993.sqlog --report-text > old.qlog
qlog-dancer ~/09899a18f8d329f608474eaec06105376d5ff993.sqlog  >   203.70s user 22.54s system 99% cpu 3:47.63 total

> ls -lsah old.qlog
17G -rw-rw-r-- 1 yi yi 17G Mar  1 14:06 old.qlog
```

After:
```
> time ./target/release/qlog-dancer ~/Downloads/09899a18f8d329f608474eaec06105376d5ff993.sqlog --report-text > new.qlog
./target/release/qlog-dancer  --report-text > new.qlog  38.82s user 10.46s system 98% cpu 49.975 total

> ls -lsah new.qlog
1.3G -rw-rw-r-- 1 yi yi 1.3G Mar  1 14:01 new.qlog
```

Time:  227s to 50s
Space: 17G to 1.3G

#### Preview of the new format:
```
    97157.73 | transport  | packet_received           | 1RTT pn=125962,  STREAM {id=2012, off=3685535, len=1303}
    97157.73 | transport  | packet_received           | 1RTT pn=125963,  STREAM {id=2004, off=3704992, len=871}
    97157.74 | transport  | packet_received           | 1RTT pn=125964,  STREAM_DATA_BLOCKED {id=2016, limit=3724965} STREAM {id=1992, off=4238236, len=1296}
    97157.75 | transport  | packet_received           | 1RTT pn=125965,  STREAM {id=1968, off=4737620, len=1303}
    97157.76 | transport  | packet_received           | 1RTT pn=125966,  STREAM {id=2060, off=2981977, len=1303}
    97157.77 | transport  | packet_received           | 1RTT pn=125967,  STREAM {id=2044, off=2995390, len=1303}
    97157.77 | transport  | packet_received           | 1RTT pn=125968,  STREAM {id=2016, off=3698712, len=1303}
    97157.78 | transport  | packet_received           | 1RTT pn=125969,  STREAM {id=1988, off=4191261, len=1303}
    97157.79 | transport  | packet_received           | 1RTT pn=125970,  STREAM {id=1980, off=4295003, len=1303}
    97157.84 | transport  | packet_received           | 1RTT pn=125971,  STREAM {id=2008, off=3687483, len=1303}
    97157.84 | transport  | packet_received           | 1RTT pn=125972,  STREAM {id=2052, off=3006628, len=1303}
    97157.86 | transport  | data_moved                | id=2044, off=2992784, len=3909, from=transport, to=application, 
    97157.88 | transport  | data_moved                | id=2016, off=3696106, len=3909, from=transport, to=application, 
    97157.89 | transport  | data_moved                | id=1988, off=4188655, len=3909, from=transport, to=application, 
    97157.90 | transport  | data_moved                | id=1980, off=4292397, len=3909, from=transport, to=application, 
    97157.91 | transport  | data_moved                | id=2008, off=3684877, len=3909, from=transport, to=application, 
    97160.64 | transport  | data_moved                | id=2052, off=3004022, len=3909, from=transport, to=application, 
    97160.66 | transport  | data_moved                | id=2012, off=3684232, len=2073, from=transport, to=application, 
    97160.66 | transport  | data_moved                | id=2012, off=3686305, len=1, from=transport, to=application, 
    97160.67 | transport  | data_moved                | id=2012, off=3686306, len=1, from=transport, to=application, 
    97160.68 | transport  | data_moved                | id=2012, off=3686307, len=3, from=transport, to=application,
```