### PR TITLE
Fix cargo doc warnings

### DIFF
--- a/qlog-dancer/src/plots/colors.rs
+++ b/qlog-dancer/src/plots/colors.rs
@@ -43,7 +43,7 @@ pub const TEAL: RGBColor = RGBColor(0, 128, 128);
 /// Cycle through a set of colors
 ///
 /// By default, the set is based on a modified version of the set from
-/// https://stackoverflow.com/a/13781114
+/// <https://stackoverflow.com/a/13781114>
 pub struct ColorCycle {
     pub colors: Vec<RGBColor>,
     pub initial_index: usize,

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1745,12 +1745,13 @@ pub fn connect_with_buffer_factory<F: BufFactory>(
 
 /// Creates a new client-side connection, with a custom buffer generation
 /// method using the given dcid initially.
-/// Be aware the RFC places requirements for unpredictability and length
-/// on the client DCID field.
-/// [`RFC9000`]:  https://datatracker.ietf.org/doc/html/rfc9000#section-7.2-3
+/// Be aware the [RFC9000, Section 7.2.3] places requirements for
+/// unpredictability and length on the client DCID field.
 ///
 /// The buffers generated can be anything that can be drereferenced as a byte
 /// slice. See [`connect`] and [`BufFactory`] for more info.
+///
+/// [RFC9000, Section 7.2.3]: https://datatracker.ietf.org/doc/html/rfc9000#section-7.2-3
 #[cfg(feature = "custom-client-dcid")]
 #[cfg_attr(docsrs, doc(cfg(feature = "custom-client-dcid")))]
 pub fn connect_with_dcid_and_buffer_factory<F: BufFactory>(


### PR DESCRIPTION
When running `cargo doc --workspace --all-features --no-deps`  it prints out plenty of warnings about invalid hyperlinks. This series fixes them all.

Maybe we should add documentation generation to the pipeline so we do not have broken links in the documentation? 