### PR TITLE
 add Capsule Protocol (RFC 9297) and QUIC Datagram (RFC 9221) compliance  

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -1028,6 +1028,9 @@ enum quiche_h3_error {
     // over HTTP/1.1.
     QUICHE_H3_ERR_VERSION_FALLBACK = -20,
 
+    // An error with HTTP/3 datagram handling (RFC 9297).
+    QUICHE_H3_ERR_DATAGRAM_ERROR = -21,
+
     // The following QUICHE_H3_TRANSPORT_ERR_* errors are propagated
     // from the QUIC transport layer.
 

--- a/quiche/src/h3/capsule.rs
+++ b/quiche/src/h3/capsule.rs
@@ -1,0 +1,765 @@
+//! HTTP Capsule Protocol (RFC 9297).
+//!
+//! This module provides encoding and decoding of capsules as defined in
+//! RFC 9297 Section 3.
+//!
+//! A capsule is a variable-length frame on an HTTP data stream, encoded as:
+//!
+//! ```text
+//! Capsule {
+//!   Capsule Type (i),
+//!   Capsule Value Length (i),
+//!   Capsule Value (..),
+//! }
+//! ```
+//!
+//! where `(i)` denotes a variable-length integer.
+
+use super::Result;
+
+/// RFC 9297 Section 3.2: DATAGRAM capsule type.
+pub const DATAGRAM_CAPSULE: u64 = 0x00;
+
+/// Encode a capsule header (type + value length) into `buf`.
+///
+/// Returns the number of bytes written.
+pub fn encode_capsule_header(
+    buf: &mut [u8], capsule_type: u64, value_len: u64,
+) -> Result<usize> {
+    let mut b = octets::OctetsMut::with_slice(buf);
+    b.put_varint(capsule_type)?;
+    b.put_varint(value_len)?;
+    Ok(b.off())
+}
+
+/// Encode a complete capsule (header + value) into `buf`.
+///
+/// Returns the total number of bytes written (header + value).
+pub fn encode_capsule(
+    buf: &mut [u8], capsule_type: u64, value: &[u8],
+) -> Result<usize> {
+    let mut b = octets::OctetsMut::with_slice(buf);
+    b.put_varint(capsule_type)?;
+    b.put_varint(value.len() as u64)?;
+    b.put_bytes(value)?;
+    Ok(b.off())
+}
+
+/// Parser state for incremental capsule parsing from a stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseState {
+    /// Waiting for the capsule type varint.
+    Type,
+
+    /// Waiting for the capsule value length varint.
+    Length,
+
+    /// Reading capsule value bytes.
+    Value,
+
+    /// Capsule complete; next `parse()` call will emit `Done`.
+    Finished,
+}
+
+/// Event returned by [`CapsuleParser::parse`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapsuleEvent {
+    /// Not enough data to make progress; feed more bytes.
+    Pending,
+
+    /// Capsule header has been fully parsed. The capsule type and value
+    /// length are available via [`CapsuleParser::capsule_type`] and
+    /// [`CapsuleParser::remaining`].
+    Header {
+        /// The capsule type identifier.
+        capsule_type: u64,
+        /// The length of the capsule value in bytes.
+        value_len: u64,
+    },
+
+    /// A chunk of value data is available. The chunk occupies the last
+    /// `len` bytes of the consumed region (i.e., `data[off - len..off]`
+    /// where `off` is the caller's running offset after adding
+    /// `consumed`).
+    ValueChunk {
+        /// Number of value bytes in this chunk.
+        len: usize,
+    },
+
+    /// The capsule has been fully consumed and the parser has been reset
+    /// to accept the next capsule.
+    Done,
+}
+
+/// Incremental capsule parser.
+///
+/// This parser handles partial reads, buffering varint bytes internally
+/// until a complete type or length field can be decoded.
+///
+/// Typical usage:
+///
+/// ```ignore
+/// let mut parser = CapsuleParser::new();
+/// loop {
+///     let data = /* read from stream */;
+///     let mut off = 0;
+///     while off < data.len() {
+///         let (event, consumed) = parser.parse(&data[off..])?;
+///         off += consumed;
+///         match event {
+///             CapsuleEvent::Header { capsule_type, value_len } => { /* ... */ },
+///             CapsuleEvent::ValueChunk { len } => { /* ... */ },
+///             CapsuleEvent::Done => { /* capsule complete */ },
+///             CapsuleEvent::Pending => break,
+///         }
+///     }
+/// }
+/// ```
+#[derive(Debug)]
+pub struct CapsuleParser {
+    state: ParseState,
+
+    // Buffer for accumulating varint bytes across partial reads.
+    hdr_buf: Vec<u8>,
+
+    capsule_type: u64,
+    value_len: u64,
+    value_read: u64,
+}
+
+impl CapsuleParser {
+    /// Create a new parser ready to read the first capsule.
+    pub fn new() -> Self {
+        CapsuleParser {
+            state: ParseState::Type,
+            hdr_buf: Vec::new(),
+            capsule_type: 0,
+            value_len: 0,
+            value_read: 0,
+        }
+    }
+
+    /// Returns the capsule type of the capsule currently being parsed.
+    ///
+    /// Only meaningful after a [`CapsuleEvent::Header`] has been returned.
+    pub fn capsule_type(&self) -> u64 {
+        self.capsule_type
+    }
+
+    /// Returns the number of value bytes remaining to be read.
+    ///
+    /// Returns 0 when the parser is not in the `Value` state.
+    pub fn remaining(&self) -> u64 {
+        if self.state != ParseState::Value {
+            return 0;
+        }
+        self.value_len.saturating_sub(self.value_read)
+    }
+
+    /// Returns the current parser state.
+    pub fn state(&self) -> &ParseState {
+        &self.state
+    }
+
+    /// Returns `true` if the parser is in the middle of parsing a capsule.
+    ///
+    /// RFC 9297 §3.3: if the receive side of a stream is terminated cleanly
+    /// and this returns `true`, the last capsule was truncated and MUST be
+    /// treated as a malformed message.
+    pub fn is_in_progress(&self) -> bool {
+        match self.state {
+            ParseState::Type => !self.hdr_buf.is_empty(),
+            ParseState::Length | ParseState::Value => true,
+            ParseState::Finished => false,
+        }
+    }
+
+    /// Feed data to the parser.
+    ///
+    /// Returns a `(CapsuleEvent, usize)` tuple where the `usize` is the
+    /// number of bytes consumed from `data`. The caller should advance its
+    /// read position by that amount and call `parse` again with the
+    /// remaining data until [`CapsuleEvent::Pending`] is returned.
+    pub fn parse(&mut self, data: &[u8]) -> Result<(CapsuleEvent, usize)> {
+        // Finished state emits Done without consuming data.
+        if self.state == ParseState::Finished {
+            self.state = ParseState::Type;
+            return Ok((CapsuleEvent::Done, 0));
+        }
+
+        if data.is_empty() {
+            return Ok((CapsuleEvent::Pending, 0));
+        }
+
+        match self.state {
+            ParseState::Type => self.parse_varint(data, true),
+
+            ParseState::Length => self.parse_varint(data, false),
+
+            ParseState::Value => self.parse_value(data),
+
+            ParseState::Finished => unreachable!(),
+        }
+    }
+
+    /// Try to parse a varint from accumulated + new data.
+    ///
+    /// When `is_type` is true we are parsing the capsule type field;
+    /// otherwise we are parsing the value length field.
+    fn parse_varint(
+        &mut self, data: &[u8], is_type: bool,
+    ) -> Result<(CapsuleEvent, usize)> {
+        // If we have no accumulated bytes, try fast-path: parse directly
+        // from the input.
+        if self.hdr_buf.is_empty() {
+            let mut b = octets::Octets::with_slice(data);
+            match b.get_varint() {
+                Ok(val) => {
+                    let consumed = b.off();
+                    return self.varint_complete(val, consumed, is_type);
+                },
+
+                Err(_) => {
+                    // Not enough data; buffer what we have.
+                    self.hdr_buf.extend_from_slice(data);
+                    return Ok((CapsuleEvent::Pending, data.len()));
+                },
+            }
+        }
+
+        // Slow path: we have accumulated partial varint bytes. Append
+        // one byte at a time until we can decode.
+        let mut consumed = 0;
+        while consumed < data.len() {
+            self.hdr_buf.push(data[consumed]);
+            consumed += 1;
+
+            let mut b = octets::Octets::with_slice(&self.hdr_buf);
+            match b.get_varint() {
+                Ok(val) => {
+                    self.hdr_buf.clear();
+                    return self.varint_complete(val, consumed, is_type);
+                },
+
+                Err(_) => {
+                    // Check if the buffer is unreasonably large (a varint
+                    // is at most 8 bytes).
+                    if self.hdr_buf.len() > 8 {
+                        return Err(crate::h3::Error::FrameError);
+                    }
+                    continue;
+                },
+            }
+        }
+
+        // Consumed all input but still not enough for the varint.
+        Ok((CapsuleEvent::Pending, consumed))
+    }
+
+    /// Handle a successfully decoded varint.
+    fn varint_complete(
+        &mut self, val: u64, consumed: usize, is_type: bool,
+    ) -> Result<(CapsuleEvent, usize)> {
+        if is_type {
+            self.capsule_type = val;
+            self.state = ParseState::Length;
+            Ok((CapsuleEvent::Pending, consumed))
+        } else {
+            self.value_len = val;
+            self.value_read = 0;
+
+            if self.value_len == 0 {
+                // Zero-length value: emit Header, then Done on next
+                // parse() call via the Finished state.
+                self.state = ParseState::Finished;
+                Ok((
+                    CapsuleEvent::Header {
+                        capsule_type: self.capsule_type,
+                        value_len: 0,
+                    },
+                    consumed,
+                ))
+            } else {
+                self.state = ParseState::Value;
+                Ok((
+                    CapsuleEvent::Header {
+                        capsule_type: self.capsule_type,
+                        value_len: self.value_len,
+                    },
+                    consumed,
+                ))
+            }
+        }
+    }
+
+    /// Consume value bytes from the input.
+    fn parse_value(
+        &mut self, data: &[u8],
+    ) -> Result<(CapsuleEvent, usize)> {
+        let remaining_u64 = self.value_len.saturating_sub(self.value_read);
+        let remaining =
+            std::cmp::min(remaining_u64, data.len() as u64) as usize;
+        let chunk = std::cmp::min(data.len(), remaining);
+
+        if chunk == 0 {
+            return Ok((CapsuleEvent::Pending, 0));
+        }
+
+        self.value_read += chunk as u64;
+
+        if self.value_read == self.value_len {
+            // Value fully consumed; reset for next capsule.
+            self.state = ParseState::Type;
+            Ok((CapsuleEvent::Done, chunk))
+        } else {
+            Ok((
+                CapsuleEvent::ValueChunk { len: chunk },
+                chunk,
+            ))
+        }
+    }
+
+    /// Reset the parser to its initial state.
+    pub fn reset(&mut self) {
+        self.state = ParseState::Type;
+        self.hdr_buf.clear();
+        self.capsule_type = 0;
+        self.value_len = 0;
+        self.value_read = 0;
+    }
+}
+
+impl Default for CapsuleParser {
+    fn default() -> Self {
+        CapsuleParser::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capsule_header_encode_decode() {
+        let mut buf = [0u8; 64];
+
+        let written =
+            encode_capsule_header(&mut buf, DATAGRAM_CAPSULE, 10).unwrap();
+
+        // Type 0x00 = 1 byte varint, length 10 = 1 byte varint.
+        assert_eq!(written, 2);
+
+        let mut b = octets::Octets::with_slice(&buf[..written]);
+        let capsule_type = b.get_varint().unwrap();
+        let value_len = b.get_varint().unwrap();
+        assert_eq!(capsule_type, DATAGRAM_CAPSULE);
+        assert_eq!(value_len, 10);
+    }
+
+    #[test]
+    fn capsule_header_large_values() {
+        let mut buf = [0u8; 64];
+
+        // Use values that require multi-byte varints.
+        let ctype = 0x1000;
+        let vlen = 0x4000_0000;
+
+        let written = encode_capsule_header(&mut buf, ctype, vlen).unwrap();
+
+        let mut b = octets::Octets::with_slice(&buf[..written]);
+        assert_eq!(b.get_varint().unwrap(), ctype);
+        assert_eq!(b.get_varint().unwrap(), vlen);
+    }
+
+    #[test]
+    fn capsule_header_buffer_too_short() {
+        let mut buf = [0u8; 1];
+
+        // Type fits (1 byte) but length (10 = 1 byte) won't fit.
+        let result = encode_capsule_header(&mut buf, 0x00, 10);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn full_capsule_roundtrip() {
+        let mut buf = [0u8; 128];
+        let value = b"hello capsule";
+
+        let written =
+            encode_capsule(&mut buf, DATAGRAM_CAPSULE, value).unwrap();
+
+        // Header: type(1) + length(1) + value(13) = 15.
+        assert_eq!(written, 2 + value.len());
+
+        let mut b = octets::Octets::with_slice(&buf[..written]);
+        let capsule_type = b.get_varint().unwrap();
+        let value_len = b.get_varint().unwrap();
+        assert_eq!(capsule_type, DATAGRAM_CAPSULE);
+        assert_eq!(value_len, value.len() as u64);
+
+        let payload = b.get_bytes(value_len as usize).unwrap();
+        assert_eq!(payload.as_ref(), value);
+    }
+
+    #[test]
+    fn full_capsule_empty_value() {
+        let mut buf = [0u8; 64];
+
+        let written = encode_capsule(&mut buf, 0xFF, &[]).unwrap();
+
+        let mut b = octets::Octets::with_slice(&buf[..written]);
+        let capsule_type = b.get_varint().unwrap();
+        let value_len = b.get_varint().unwrap();
+        assert_eq!(capsule_type, 0xFF);
+        assert_eq!(value_len, 0);
+        assert_eq!(b.cap(), 0);
+    }
+
+    #[test]
+    fn parser_complete_data() {
+        let mut buf = [0u8; 128];
+        let value = b"test data";
+        let written =
+            encode_capsule(&mut buf, DATAGRAM_CAPSULE, value).unwrap();
+
+        let mut parser = CapsuleParser::new();
+        let data = &buf[..written];
+
+        // First parse should consume the type varint and return Pending
+        // (type alone doesn't produce a header event).
+        let (event, consumed1) = parser.parse(data).unwrap();
+        assert_eq!(event, CapsuleEvent::Pending);
+        assert!(consumed1 > 0);
+
+        // Second parse should consume the length varint and return Header.
+        let (event, consumed2) = parser.parse(&data[consumed1..]).unwrap();
+        assert_eq!(
+            event,
+            CapsuleEvent::Header {
+                capsule_type: DATAGRAM_CAPSULE,
+                value_len: value.len() as u64,
+            }
+        );
+
+        // Third parse should consume the value and return Done.
+        let off = consumed1 + consumed2;
+        let (event, consumed3) = parser.parse(&data[off..]).unwrap();
+        assert_eq!(event, CapsuleEvent::Done);
+        assert_eq!(consumed3, value.len());
+        assert_eq!(off + consumed3, written);
+    }
+
+    #[test]
+    fn parser_chunked_data() {
+        let mut buf = [0u8; 128];
+        let value = b"chunked";
+        let written =
+            encode_capsule(&mut buf, DATAGRAM_CAPSULE, value).unwrap();
+
+        let mut parser = CapsuleParser::new();
+
+        // Feed one byte at a time.
+        let mut pos = 0;
+        let mut saw_header = false;
+        let mut saw_done = false;
+        let mut value_bytes = 0;
+
+        while pos < written {
+            let (event, consumed) =
+                parser.parse(&buf[pos..pos + 1]).unwrap();
+            pos += consumed;
+
+            match event {
+                CapsuleEvent::Pending => {},
+
+                CapsuleEvent::Header {
+                    capsule_type,
+                    value_len,
+                } => {
+                    assert_eq!(capsule_type, DATAGRAM_CAPSULE);
+                    assert_eq!(value_len, value.len() as u64);
+                    saw_header = true;
+                },
+
+                CapsuleEvent::ValueChunk { len } => {
+                    value_bytes += len;
+                },
+
+                CapsuleEvent::Done => {
+                    // Done also accounts for the last value byte consumed.
+                    value_bytes += consumed;
+                    saw_done = true;
+                },
+            }
+        }
+
+        assert_eq!(value_bytes, value.len());
+
+        assert!(saw_header);
+        assert!(saw_done);
+    }
+
+    #[test]
+    fn parser_zero_length_capsule() {
+        let mut buf = [0u8; 64];
+        let written = encode_capsule(&mut buf, 0x00, &[]).unwrap();
+        assert_eq!(written, 2); // type(1) + length(1)
+
+        let mut parser = CapsuleParser::new();
+
+        // Feed the type byte.
+        let (event, c1) = parser.parse(&buf[..1]).unwrap();
+        assert_eq!(event, CapsuleEvent::Pending);
+        assert_eq!(c1, 1);
+
+        // Feed the length byte (0). Zero-length value emits Header.
+        let (event, c2) = parser.parse(&buf[c1..written]).unwrap();
+        assert_eq!(
+            event,
+            CapsuleEvent::Header {
+                capsule_type: 0x00,
+                value_len: 0,
+            }
+        );
+        assert_eq!(c1 + c2, written);
+
+        // Next parse emits Done (Finished state, 0 consumed).
+        let (event, c3) = parser.parse(&[]).unwrap();
+        assert_eq!(event, CapsuleEvent::Done);
+        assert_eq!(c3, 0);
+    }
+
+    #[test]
+    fn parser_zero_length_capsule_multipart() {
+        let mut buf = [0u8; 64];
+        // Use a type that needs a 2-byte varint to exercise partial
+        // buffering together with zero-length value.
+        let written = encode_capsule(&mut buf, 0x42, &[]).unwrap();
+
+        let mut parser = CapsuleParser::new();
+        let mut pos = 0;
+        let mut saw_header = false;
+
+        // Feed one byte at a time.
+        while pos < written {
+            let (event, consumed) =
+                parser.parse(&buf[pos..pos + 1]).unwrap();
+            pos += consumed;
+            if let CapsuleEvent::Header {
+                capsule_type,
+                value_len,
+            } = event
+            {
+                assert_eq!(capsule_type, 0x42);
+                assert_eq!(value_len, 0);
+                saw_header = true;
+            }
+        }
+
+        assert!(saw_header);
+        assert_eq!(pos, written);
+
+        // Finished state requires one more parse() call to emit Done.
+        let (event, consumed) = parser.parse(&[]).unwrap();
+        assert_eq!(event, CapsuleEvent::Done);
+        assert_eq!(consumed, 0);
+    }
+
+    #[test]
+    fn parser_multiple_capsules() {
+        let mut buf = [0u8; 256];
+        let v1 = b"first";
+        let v2 = b"second";
+
+        let w1 = encode_capsule(&mut buf, 0x01, v1).unwrap();
+        let w2 = encode_capsule(&mut buf[w1..], 0x02, v2).unwrap();
+        let total = w1 + w2;
+
+        let mut parser = CapsuleParser::new();
+        let mut pos = 0;
+        let mut capsule_count = 0;
+
+        while pos < total {
+            let (event, consumed) =
+                parser.parse(&buf[pos..total]).unwrap();
+            pos += consumed;
+
+            if event == CapsuleEvent::Done {
+                capsule_count += 1;
+            }
+        }
+
+        assert_eq!(capsule_count, 2);
+    }
+
+    #[test]
+    fn parser_empty_input() {
+        let mut parser = CapsuleParser::new();
+        let (event, consumed) = parser.parse(&[]).unwrap();
+        assert_eq!(event, CapsuleEvent::Pending);
+        assert_eq!(consumed, 0);
+    }
+
+    #[test]
+    fn parser_unknown_capsule_type() {
+        let mut buf = [0u8; 128];
+        let value = b"unknown";
+        let written = encode_capsule(&mut buf, 0xFFFF, value).unwrap();
+
+        let mut parser = CapsuleParser::new();
+        let mut pos = 0;
+        let mut saw_header = false;
+
+        while pos < written {
+            let (event, consumed) =
+                parser.parse(&buf[pos..written]).unwrap();
+            pos += consumed;
+
+            if let CapsuleEvent::Header {
+                capsule_type,
+                value_len,
+            } = event
+            {
+                assert_eq!(capsule_type, 0xFFFF);
+                assert_eq!(value_len, value.len() as u64);
+                saw_header = true;
+            }
+        }
+
+        assert!(saw_header);
+    }
+
+    #[test]
+    fn parser_reset() {
+        let mut parser = CapsuleParser::new();
+
+        // Partially feed data.
+        let mut buf = [0u8; 64];
+        let written = encode_capsule(&mut buf, 0x01, b"data").unwrap();
+
+        let (_, consumed) = parser.parse(&buf[..1]).unwrap();
+        assert_eq!(consumed, 1);
+        assert_eq!(*parser.state(), ParseState::Length);
+
+        // Reset and verify clean state.
+        parser.reset();
+        assert_eq!(*parser.state(), ParseState::Type);
+        assert_eq!(parser.capsule_type(), 0);
+        assert_eq!(parser.remaining(), 0);
+
+        // Should work normally after reset.
+        let mut pos = 0;
+        let mut saw_done = false;
+        while pos < written {
+            let (event, consumed) =
+                parser.parse(&buf[pos..written]).unwrap();
+            pos += consumed;
+            if event == CapsuleEvent::Done {
+                saw_done = true;
+            }
+        }
+        assert!(saw_done);
+    }
+
+    #[test]
+    fn parser_large_varint_chunked() {
+        // Encode a capsule with a type that requires a 4-byte varint.
+        let mut buf = [0u8; 128];
+        let ctype = 0x3FFF_FFFF; // max 4-byte varint
+        let value = b"lg";
+        let written = encode_capsule(&mut buf, ctype, value).unwrap();
+
+        let mut parser = CapsuleParser::new();
+        let mut pos = 0;
+        let mut saw_header = false;
+
+        // Feed one byte at a time.
+        while pos < written {
+            let (event, consumed) =
+                parser.parse(&buf[pos..pos + 1]).unwrap();
+            pos += consumed;
+
+            if let CapsuleEvent::Header {
+                capsule_type,
+                value_len,
+            } = event
+            {
+                assert_eq!(capsule_type, ctype);
+                assert_eq!(value_len, value.len() as u64);
+                saw_header = true;
+            }
+        }
+
+        assert!(saw_header);
+    }
+
+    #[test]
+    fn encode_capsule_buffer_too_short() {
+        let mut buf = [0u8; 2];
+        let result = encode_capsule(&mut buf, 0x00, b"too long");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn capsule_parser_is_in_progress_initial() {
+        let parser = CapsuleParser::new();
+        assert!(!parser.is_in_progress());
+    }
+
+    #[test]
+    fn capsule_parser_is_in_progress_partial_type() {
+        let mut parser = CapsuleParser::new();
+        // Feed a partial varint (2-byte varint, only first byte)
+        let data = [0x40]; // First byte of a 2-byte varint
+        let (event, _) = parser.parse(&data).unwrap();
+        assert_eq!(event, CapsuleEvent::Pending);
+        assert!(parser.is_in_progress());
+    }
+
+    #[test]
+    fn capsule_parser_is_in_progress_in_length() {
+        let mut parser = CapsuleParser::new();
+        // Feed complete type but no length
+        let data = [0x00]; // type = 0 (1-byte varint)
+        let (event, _) = parser.parse(&data).unwrap();
+        assert_eq!(event, CapsuleEvent::Pending);
+        assert!(parser.is_in_progress());
+    }
+
+    #[test]
+    fn capsule_parser_is_in_progress_in_value() {
+        let mut parser = CapsuleParser::new();
+        // type = 0, length = 5
+        let data = [0x00, 0x05, 0xAA];
+        let mut off = 0;
+        loop {
+            let (event, consumed) =
+                parser.parse(&data[off..]).unwrap();
+            off += consumed;
+            match event {
+                CapsuleEvent::Pending => break,
+                CapsuleEvent::Header { .. } => continue,
+                CapsuleEvent::ValueChunk { .. } => break,
+                CapsuleEvent::Done => unreachable!(),
+            }
+        }
+        assert!(parser.is_in_progress());
+    }
+
+    #[test]
+    fn capsule_parser_not_in_progress_after_done() {
+        let mut parser = CapsuleParser::new();
+        // type = 0, length = 0 (zero-length capsule)
+        let data = [0x00, 0x00];
+        let mut off = 0;
+        loop {
+            let (event, consumed) =
+                parser.parse(&data[off..]).unwrap();
+            off += consumed;
+            if event == CapsuleEvent::Done {
+                break;
+            }
+        }
+        assert!(!parser.is_in_progress());
+    }
+}

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -424,6 +424,10 @@ pub enum Error {
     /// The requested operation cannot be served over HTTP/3. Peer should retry
     /// over HTTP/1.1.
     VersionFallback,
+
+    /// A datagram was received that could not be associated with any known
+    /// request, or was malformed per RFC 9297.
+    DatagramError,
 }
 
 /// HTTP/3 error codes sent on the wire.
@@ -477,6 +481,8 @@ pub enum WireErrorCode {
     /// The requested operation cannot be served over HTTP/3. The peer should
     /// retry over HTTP/1.1.
     VersionFallback      = 0x110,
+    /// An error with HTTP/3 datagram handling as defined in RFC 9297.
+    DatagramError        = 0x33,
 }
 
 impl Error {
@@ -501,6 +507,7 @@ impl Error {
             Error::RequestCancelled => WireErrorCode::RequestCancelled as u64,
             Error::RequestIncomplete => WireErrorCode::RequestIncomplete as u64,
             Error::MessageError => WireErrorCode::MessageError as u64,
+            Error::DatagramError => WireErrorCode::DatagramError as u64,
             Error::ConnectError => WireErrorCode::ConnectError as u64,
             Error::VersionFallback => WireErrorCode::VersionFallback as u64,
         }
@@ -529,6 +536,7 @@ impl Error {
             Error::MessageError => -18,
             Error::ConnectError => -19,
             Error::VersionFallback => -20,
+            Error::DatagramError => -21,
 
             Error::TransportError(quic_error) => quic_error.to_c() - 1000,
         }
@@ -968,6 +976,10 @@ pub struct Connection {
     local_settings: ConnectionSettings,
     peer_settings: ConnectionSettings,
 
+    /// Peer's SETTINGS_H3_DATAGRAM value from a previous session, stored
+    /// for 0-RTT validation per RFC 9297 Section 2.1.1.
+    zero_rtt_h3_datagram: Option<u64>,
+
     control_stream_id: Option<u64>,
     peer_control_stream_id: Option<u64>,
 
@@ -1022,6 +1034,8 @@ impl Connection {
                 additional_settings: Default::default(),
                 raw: Default::default(),
             },
+
+            zero_rtt_h3_datagram: None,
 
             control_stream_id: None,
             peer_control_stream_id: None,
@@ -1744,6 +1758,16 @@ impl Connection {
     /// [`poll()`]: struct.Connection.html#method.poll
     pub fn extended_connect_enabled_by_peer(&self) -> bool {
         self.peer_settings.connect_protocol_enabled == Some(1)
+    }
+
+    /// Stores the peer's SETTINGS_H3_DATAGRAM value for 0-RTT validation.
+    ///
+    /// Clients SHOULD call this with the server's setting from a previous
+    /// session before attempting 0-RTT. When the server's new SETTINGS
+    /// arrive, they will be validated against this stored value per
+    /// RFC 9297 Section 2.1.1.
+    pub fn set_zero_rtt_h3_datagram(&mut self, value: u64) {
+        self.zero_rtt_h3_datagram = Some(value);
     }
 
     /// Reads request or response body data into the provided buffer.
@@ -2869,6 +2893,22 @@ impl Connection {
                             true,
                             Error::SettingsError.to_wire(),
                             b"H3_DATAGRAM sent with value 1 but max_datagram_frame_size TP not set.",
+                        )?;
+
+                        return Err(Error::SettingsError);
+                    }
+                }
+
+                // RFC 9297 Section 2.1.1: When resuming with 0-RTT, the
+                // server's new SETTINGS_H3_DATAGRAM MUST be >= the stored
+                // value from the previous session.
+                if let Some(stored) = self.zero_rtt_h3_datagram {
+                    let new_val = h3_datagram.unwrap_or(0);
+                    if new_val < stored {
+                        conn.close(
+                            true,
+                            Error::SettingsError.to_wire(),
+                            b"0-RTT H3_DATAGRAM value decreased.",
                         )?;
 
                         return Err(Error::SettingsError);
@@ -6249,6 +6289,81 @@ mod tests {
     }
 
     #[test]
+    /// Tests that 0-RTT SETTINGS_H3_DATAGRAM validation rejects decreased
+    /// values per RFC 9297 Section 2.1.1.
+    fn zero_rtt_h3_datagram_decreased() {
+        let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
+        config.set_initial_max_data(70);
+        config.set_initial_max_stream_data_bidi_local(150);
+        config.set_initial_max_stream_data_bidi_remote(150);
+        config.set_initial_max_stream_data_uni(150);
+        config.set_initial_max_streams_bidi(100);
+        config.set_initial_max_streams_uni(5);
+        config.verify_peer(false);
+
+        let h3_config = Config::new().unwrap();
+        let mut s = Session::with_configs(&mut config, &h3_config).unwrap();
+        assert_eq!(s.pipe.handshake(), Ok(()));
+
+        // Simulate 0-RTT: client stored SETTINGS_H3_DATAGRAM = 1 from
+        // a previous session.
+        s.client.set_zero_rtt_h3_datagram(1);
+
+        // Server sends SETTINGS without h3_datagram (effectively value 0).
+        s.server.send_settings(&mut s.pipe.server).unwrap();
+        assert_eq!(s.pipe.advance(), Ok(()));
+
+        // Client MUST reject because new value (0) < stored value (1).
+        assert_eq!(
+            s.client.poll(&mut s.pipe.client),
+            Err(Error::SettingsError)
+        );
+    }
+
+    #[test]
+    /// Tests that 0-RTT SETTINGS_H3_DATAGRAM validation accepts equal
+    /// values per RFC 9297 Section 2.1.1.
+    fn zero_rtt_h3_datagram_unchanged() {
+        let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config
+            .load_cert_chain_from_pem_file("examples/cert.crt")
+            .unwrap();
+        config
+            .load_priv_key_from_pem_file("examples/cert.key")
+            .unwrap();
+        config.set_application_protos(&[b"h3"]).unwrap();
+        config.set_initial_max_data(70);
+        config.set_initial_max_stream_data_bidi_local(150);
+        config.set_initial_max_stream_data_bidi_remote(150);
+        config.set_initial_max_stream_data_uni(150);
+        config.set_initial_max_streams_bidi(100);
+        config.set_initial_max_streams_uni(5);
+        config.enable_dgram(true, 1000, 1000);
+        config.verify_peer(false);
+
+        let h3_config = Config::new().unwrap();
+        let mut s = Session::with_configs(&mut config, &h3_config).unwrap();
+        assert_eq!(s.pipe.handshake(), Ok(()));
+
+        // Client stored SETTINGS_H3_DATAGRAM = 1 from previous session.
+        s.client.set_zero_rtt_h3_datagram(1);
+
+        // Server sends SETTINGS with h3_datagram = 1 (equal to stored).
+        s.server.send_settings(&mut s.pipe.server).unwrap();
+        assert_eq!(s.pipe.advance(), Ok(()));
+
+        // Should succeed (1 >= 1).
+        assert_eq!(s.client.poll(&mut s.pipe.client), Err(Error::Done));
+    }
+
+    #[test]
     /// Tests that receiving a H3_DATAGRAM setting when no TP is set generates
     /// an error.
     fn dgram_setting_no_tp() {
@@ -7562,4 +7677,6 @@ pub mod frame;
 mod frame;
 #[doc(hidden)]
 pub mod qpack;
+#[doc(hidden)]
+pub mod capsule;
 mod stream;

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -468,8 +468,8 @@ const DEFAULT_MAX_DGRAM_QUEUE_LEN: usize = 0;
 // The default length of PATH_CHALLENGE receive queue.
 const DEFAULT_MAX_PATH_CHALLENGE_RX_QUEUE_LEN: usize = 3;
 
-// The DATAGRAM standard recommends either none or 65536 as maximum DATAGRAM
-// frames size. We enforce the recommendation for forward compatibility.
+// RFC 9221 recommends either none or 65536 as maximum DATAGRAM frame size.
+// We enforce the recommendation for forward compatibility.
 const MAX_DGRAM_FRAME_SIZE: u64 = 65536;
 
 // The length of the payload length field.
@@ -1146,7 +1146,7 @@ impl Config {
     /// Configures whether to enable receiving DATAGRAM frames.
     ///
     /// When enabled, the `max_datagram_frame_size` transport parameter is set
-    /// to 65536 as recommended by draft-ietf-quic-datagram-01.
+    /// to 65536 as recommended by RFC 9221.
     ///
     /// The default is `false`.
     pub fn enable_dgram(
@@ -7582,6 +7582,25 @@ impl<F: BufFactory> Connection<F> {
         // Record the max_active_conn_id parameter advertised by the peer.
         self.ids
             .set_source_conn_id_limit(peer_params.active_conn_id_limit);
+
+        // RFC 9221 Section 3: When resuming with 0-RTT, the server's new
+        // max_datagram_frame_size MUST be >= the value from the previous
+        // session that was used to accept early data.
+        if self.is_in_early_data() {
+            if let Some(old_size) =
+                self.peer_transport_params.max_datagram_frame_size
+            {
+                match peer_params.max_datagram_frame_size {
+                    Some(new_size) if new_size < old_size => {
+                        return Err(Error::InvalidTransportParam);
+                    },
+                    None => {
+                        return Err(Error::InvalidTransportParam);
+                    },
+                    _ => (),
+                }
+            }
+        }
 
         self.peer_transport_params = peer_params;
 

--- a/tokio-quiche/src/http3/driver/client.rs
+++ b/tokio-quiche/src/http3/driver/client.rs
@@ -170,7 +170,7 @@ impl ClientHooks {
                 "stream_id" => stream_id,
                 "flow_id" => flow_id,
             );
-            let _ = driver.get_or_insert_flow(flow_id)?;
+            let _ = driver.get_or_insert_flow(flow_id, stream_id)?;
             stream_ctx.associated_dgram_flow_id = Some(flow_id);
         }
 
@@ -255,9 +255,26 @@ impl DriverHooks for ClientHooks {
     }
 
     fn headers_received(
-        driver: &mut H3Driver<Self>, _qconn: &mut QuicheConnection,
+        driver: &mut H3Driver<Self>, qconn: &mut QuicheConnection,
         headers: InboundHeaders,
     ) -> H3ConnectionResult<()> {
+        // RFC 9297 §3.2: capsule-protocol with Content-Length,
+        // Content-Type, or Transfer-Encoding is malformed.
+        if datagram::has_capsule_header_conflict(&headers.headers) {
+            driver.hooks.pending_requests.remove(&headers.stream_id);
+            driver.shutdown_stream(
+                qconn,
+                headers.stream_id,
+                super::StreamShutdown::Both {
+                    read_error_code:
+                        h3::WireErrorCode::MessageError as u64,
+                    write_error_code:
+                        h3::WireErrorCode::MessageError as u64,
+                },
+            )?;
+            return Ok(());
+        }
+
         let Some(pending_request) =
             driver.hooks.pending_requests.remove(&headers.stream_id)
         else {

--- a/tokio-quiche/src/http3/driver/datagram.rs
+++ b/tokio-quiche/src/http3/driver/datagram.rs
@@ -33,6 +33,68 @@ use quiche::h3::{
     self,
 };
 
+/// Returns `true` if the headers indicate a Capsule Protocol violation:
+///
+/// - RFC 9297 §3.2: capsule-protocol with Content-Length, Content-Type,
+///   or Transfer-Encoding.
+/// - RFC 9297 §3.2: capsule-protocol on a response with status 204, 205,
+///   or 206.
+/// - RFC 9297 §3.4: capsule-protocol on a response with status outside
+///   2xx and != 101.
+pub(crate) fn has_capsule_header_conflict(headers: &[h3::Header]) -> bool {
+    let mut has_capsule_protocol = false;
+    let mut capsule_protocol_count = 0u32;
+    let mut has_forbidden_header = false;
+    let mut status: Option<&[u8]> = None;
+
+    for header in headers {
+        match header.name() {
+            b"capsule-protocol" => {
+                capsule_protocol_count += 1;
+                has_capsule_protocol = header
+                    .value()
+                    .split(|&b| b == b';')
+                    .next()
+                    == Some(b"?1" as &[u8]);
+            },
+            b"content-length" | b"content-type" | b"transfer-encoding" => {
+                has_forbidden_header = true;
+            },
+            b":status" => {
+                status = Some(header.value());
+            },
+            _ => {},
+        }
+    }
+
+    // RFC 9297 §3.4: capsule-protocol is an Item structured field.
+    // Duplicate header fields MUST be treated as if the field were absent.
+    if !has_capsule_protocol || capsule_protocol_count > 1 {
+        return false;
+    }
+
+    // §3.2: capsule-protocol conflicts with content headers.
+    if has_forbidden_header {
+        return true;
+    }
+
+    // Response-only checks (presence of :status means this is a response).
+    if let Some(status) = status {
+        // §3.2: 204, 205, 206 MUST NOT use Capsule Protocol.
+        if status == b"204" || status == b"205" || status == b"206" {
+            return true;
+        }
+
+        // §3.4: capsule-protocol MUST NOT be used on responses outside
+        // 2xx and != 101.
+        if status != b"101" && !status.starts_with(b"2") {
+            return true;
+        }
+    }
+
+    false
+}
+
 /// Extracts the DATAGRAM flow ID proxied over the given `stream_id`,
 /// or `None` if this is not a proxy request.
 pub(crate) fn extract_flow_id(
@@ -91,18 +153,223 @@ pub(crate) fn send_h3_dgram(
     }
 }
 
+/// The maximum valid Quarter Stream ID value per RFC 9297 Section 2.1.
+/// Quarter Stream IDs larger than 2^60-1 are invalid.
+const MAX_QUARTER_STREAM_ID: u64 = (1u64 << 60) - 1;
+
 /// Reads the next HTTP/3 datagram from the QUIC connection.
 ///
 /// [`quiche::Error::Done`] is returned if there is no datagram to read.
+///
+/// Returns `quiche::Error::InvalidFrame` if the Quarter Stream ID is
+/// malformed or exceeds 2^60-1 (RFC 9297 Section 2.1).
 pub(crate) fn receive_h3_dgram(
     conn: &mut QuicheConnection,
 ) -> quiche::Result<(u64, InboundFrame)> {
     let dgram = conn.dgram_recv_vec()?;
     let mut buf = octets::Octets::with_slice(&dgram);
-    let flow_id = buf.get_varint()?;
+
+    // RFC 9297 Section 2.1: payload too short to parse Quarter Stream ID
+    // MUST be treated as H3_DATAGRAM_ERROR.
+    let flow_id = buf
+        .get_varint()
+        .map_err(|_| quiche::Error::InvalidFrame)?;
+
+    // RFC 9297 Section 2.1: Quarter Stream ID > 2^60-1 MUST be treated
+    // as H3_DATAGRAM_ERROR.
+    if flow_id > MAX_QUARTER_STREAM_ID {
+        return Err(quiche::Error::InvalidFrame);
+    }
+
     let advance = buf.off();
     let datagram =
         InboundFrame::Datagram(BufFactory::dgram_from_slice(&dgram[advance..]));
 
     Ok((flow_id, datagram))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_quarter_stream_id_value() {
+        assert_eq!(MAX_QUARTER_STREAM_ID, (1u64 << 60) - 1);
+    }
+
+    #[test]
+    fn capsule_header_conflict_content_length() {
+        let headers = vec![
+            h3::Header::new(b"capsule-protocol", b"?1"),
+            h3::Header::new(b"content-length", b"100"),
+        ];
+        assert!(has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn capsule_header_conflict_content_type() {
+        let headers = vec![
+            h3::Header::new(b"capsule-protocol", b"?1"),
+            h3::Header::new(b"content-type", b"application/octet-stream"),
+        ];
+        assert!(has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn capsule_header_conflict_transfer_encoding() {
+        let headers = vec![
+            h3::Header::new(b"capsule-protocol", b"?1"),
+            h3::Header::new(b"transfer-encoding", b"chunked"),
+        ];
+        assert!(has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn no_capsule_header_conflict_without_capsule_protocol() {
+        let headers = vec![
+            h3::Header::new(b"content-length", b"100"),
+        ];
+        assert!(!has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn no_capsule_header_conflict_capsule_disabled() {
+        let headers = vec![
+            h3::Header::new(b"capsule-protocol", b"?0"),
+            h3::Header::new(b"content-length", b"100"),
+        ];
+        assert!(!has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn no_capsule_header_conflict_clean() {
+        let headers = vec![
+            h3::Header::new(b"capsule-protocol", b"?1"),
+            h3::Header::new(b":method", b"CONNECT"),
+        ];
+        assert!(!has_capsule_header_conflict(&headers));
+    }
+
+    // RFC 9297 §3.4: any value type other than Boolean MUST be handled
+    // as if the field were not present by recipients.
+    #[test]
+    fn no_capsule_header_conflict_non_boolean_value_true() {
+        let headers = vec![
+            h3::Header::new(b"capsule-protocol", b"true"),
+            h3::Header::new(b"content-length", b"100"),
+        ];
+        // "true" is not a valid SF-Boolean (must be "?1" or "?0"),
+        // so capsule-protocol is treated as absent → no conflict.
+        assert!(!has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn no_capsule_header_conflict_non_boolean_value_one() {
+        let headers = vec![
+            h3::Header::new(b"capsule-protocol", b"1"),
+            h3::Header::new(b"content-length", b"100"),
+        ];
+        assert!(!has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn no_capsule_header_conflict_non_boolean_empty() {
+        let headers = vec![
+            h3::Header::new(b"capsule-protocol", b""),
+            h3::Header::new(b"content-length", b"100"),
+        ];
+        assert!(!has_capsule_header_conflict(&headers));
+    }
+
+    // RFC 9297 §3.2: HTTP status codes 204, 205, 206 MUST NOT be sent
+    // on responses that use the Capsule Protocol.
+    // A receiver that observes this MUST treat the message as malformed.
+    #[test]
+    fn capsule_protocol_forbidden_on_204_response() {
+        let headers = vec![
+            h3::Header::new(b":status", b"204"),
+            h3::Header::new(b"capsule-protocol", b"?1"),
+        ];
+        assert!(has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn capsule_protocol_forbidden_on_205_response() {
+        let headers = vec![
+            h3::Header::new(b":status", b"205"),
+            h3::Header::new(b"capsule-protocol", b"?1"),
+        ];
+        assert!(has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn capsule_protocol_forbidden_on_206_response() {
+        let headers = vec![
+            h3::Header::new(b":status", b"206"),
+            h3::Header::new(b"capsule-protocol", b"?1"),
+        ];
+        assert!(has_capsule_header_conflict(&headers));
+    }
+
+    // RFC 9297 §3.4: The capsule-protocol header field MUST NOT be used
+    // on HTTP responses with a status code outside 2xx or != 101.
+    #[test]
+    fn capsule_protocol_forbidden_on_non_2xx_response() {
+        let headers = vec![
+            h3::Header::new(b":status", b"403"),
+            h3::Header::new(b"capsule-protocol", b"?1"),
+        ];
+        assert!(has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn capsule_protocol_allowed_on_200_response() {
+        let headers = vec![
+            h3::Header::new(b":status", b"200"),
+            h3::Header::new(b"capsule-protocol", b"?1"),
+        ];
+        assert!(!has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn capsule_protocol_allowed_on_101_response() {
+        let headers = vec![
+            h3::Header::new(b":status", b"101"),
+            h3::Header::new(b"capsule-protocol", b"?1"),
+        ];
+        assert!(!has_capsule_header_conflict(&headers));
+    }
+
+    // RFC 9297 §3.4 / RFC 8941: unknown parameters after `;` MUST be
+    // ignored. `?1;foo=bar` is treated as `?1` (true).
+    #[test]
+    fn capsule_protocol_with_parameters() {
+        let headers = vec![
+            h3::Header::new(b"capsule-protocol", b"?1;foo=bar"),
+            h3::Header::new(b"content-length", b"100"),
+        ];
+        assert!(has_capsule_header_conflict(&headers));
+    }
+
+    #[test]
+    fn capsule_protocol_with_parameters_space() {
+        let headers = vec![
+            h3::Header::new(b"capsule-protocol", b"?1; foo=bar"),
+            h3::Header::new(b"content-length", b"100"),
+        ];
+        assert!(has_capsule_header_conflict(&headers));
+    }
+
+    // RFC 9297 §3.4: capsule-protocol is an Item structured field.
+    // Duplicate occurrences MUST be treated as if the field were absent.
+    #[test]
+    fn no_capsule_header_conflict_duplicate_header() {
+        let headers = vec![
+            h3::Header::new(b"capsule-protocol", b"?1"),
+            h3::Header::new(b"capsule-protocol", b"?1"),
+            h3::Header::new(b"content-length", b"100"),
+        ];
+        // Duplicate capsule-protocol → treated as absent → no conflict.
+        assert!(!has_capsule_header_conflict(&headers));
+    }
 }

--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -408,15 +408,16 @@ impl<H: DriverHooks> H3Driver<H> {
     }
 
     /// Retrieve the [FlowCtx] associated with the given `flow_id`. If no
-    /// context is found, a new one will be created.
+    /// context is found, a new one will be created with the given
+    /// `stream_id` as the owning stream.
     fn get_or_insert_flow(
-        &mut self, flow_id: u64,
+        &mut self, flow_id: u64, stream_id: u64,
     ) -> H3ConnectionResult<&mut FlowCtx> {
         use std::collections::btree_map::Entry;
         Ok(match self.flow_map.entry(flow_id) {
             Entry::Vacant(e) => {
                 // This is a datagram for a new flow we haven't seen before
-                let (flow, recv) = FlowCtx::new(FLOW_CAPACITY);
+                let (flow, recv) = FlowCtx::new(stream_id, FLOW_CAPACITY);
                 let flow_req = H3Event::NewFlow {
                     flow_id,
                     recv,
@@ -881,13 +882,51 @@ impl<H: DriverHooks> H3Driver<H> {
     fn dgram_ready(
         &mut self, qconn: &mut QuicheConnection, frame: OutboundFrame,
     ) -> H3ConnectionResult<()> {
+        // RFC 9297 §2.1.1: MUST NOT send QUIC DATAGRAM frames until
+        // SETTINGS_H3_DATAGRAM=1 has been both sent and received.
+        let dgram_negotiated = self
+            .conn
+            .as_ref()
+            .map_or(false, |c| c.dgram_enabled_by_peer(qconn));
+
         let mut frame = Ok(frame);
 
         loop {
             match frame {
                 Ok(OutboundFrame::Datagram(dgram, flow_id)) => {
-                    // Drop datagrams if there is no capacity
-                    let _ = datagram::send_h3_dgram(qconn, flow_id, dgram);
+                    if !dgram_negotiated {
+                        // Drop: SETTINGS not yet exchanged.
+                        log::debug!(
+                            "dropping outbound datagram: SETTINGS_H3_DATAGRAM not negotiated";
+                            "flow_id" => flow_id,
+                        );
+                    } else {
+                        // RFC 9297 §2.1: MUST NOT send when stream send
+                        // side is not open.
+                        let stream_id = self
+                            .flow_map
+                            .get(&flow_id)
+                            .map(|f| f.stream_id)
+                            .unwrap_or(flow_id * 4);
+                        let send_open = self
+                            .stream_map
+                            .get(&stream_id)
+                            .map(|c| !c.fin_or_reset_sent)
+                            .unwrap_or(false);
+                        if send_open {
+                            let res =
+                                datagram::send_h3_dgram(qconn, flow_id, dgram);
+                            if let Err(e) = res {
+                                if e != quiche::Error::Done {
+                                    log::warn!(
+                                        "failed to send datagram";
+                                        "flow_id" => flow_id,
+                                        "error" => ?e,
+                                    );
+                                }
+                            }
+                        }
+                    }
                 },
                 Ok(OutboundFrame::FlowShutdown { flow_id, stream_id }) => {
                     self.shutdown_stream(
@@ -1056,15 +1095,72 @@ impl<H: DriverHooks> H3Driver<H> {
 impl<H: DriverHooks> H3Driver<H> {
     /// Reads all buffered datagrams out of `qconn` and distributes them to
     /// their flow channels.
+    ///
+    /// RFC 9297 Section 2.1: datagrams received for a stream whose receive
+    /// side is closed are silently dropped.
     fn process_available_dgrams(
         &mut self, qconn: &mut QuicheConnection,
     ) -> H3ConnectionResult<()> {
         loop {
             match datagram::receive_h3_dgram(qconn) {
                 Ok((flow_id, dgram)) => {
-                    self.get_or_insert_flow(flow_id)?.send_best_effort(dgram);
+                    // RFC 9297 Section 2.1: if the corresponding stream's
+                    // receive side is closed, silently drop the datagram.
+                    // Use the stream_id stored in the flow if available,
+                    // otherwise fall back to Quarter Stream ID.
+                    let stream_id = self
+                        .flow_map
+                        .get(&flow_id)
+                        .map(|f| f.stream_id)
+                        .unwrap_or(flow_id * 4);
+                    if let Some(ctx) = self.stream_map.get(&stream_id) {
+                        if ctx.fin_or_reset_recv {
+                            continue;
+                        }
+                    }
+
+                    // Deliver to existing flows, or create a new flow if the
+                    // stream was set up for datagrams.
+                    if let Some(flow) = self.flow_map.get_mut(&flow_id) {
+                        flow.send_best_effort(dgram);
+                    } else if let Some(ctx) =
+                        self.stream_map.get(&stream_id)
+                    {
+                        if ctx.associated_dgram_flow_id.is_some() {
+                            self.get_or_insert_flow(flow_id, stream_id)?
+                                .send_best_effort(dgram);
+                        } else {
+                            // RFC 9297 §2: datagram received for a stream
+                            // with no known datagram semantics — MUST abort
+                            // the request stream with H3_DATAGRAM_ERROR.
+                            let _ = qconn.stream_shutdown(
+                                stream_id,
+                                quiche::Shutdown::Read,
+                                WireErrorCode::DatagramError as u64,
+                            );
+                            let _ = qconn.stream_shutdown(
+                                stream_id,
+                                quiche::Shutdown::Write,
+                                WireErrorCode::DatagramError as u64,
+                            );
+                        }
+                    }
+                    // else: no stream — silently drop per RFC 9297 §2.1.
                 },
                 Err(quiche::Error::Done) => return Ok(()),
+                Err(quiche::Error::InvalidFrame) => {
+                    // RFC 9297 §2.1: truncated Quarter Stream ID or
+                    // value > 2^60-1 MUST be treated as an HTTP/3
+                    // connection error of type H3_DATAGRAM_ERROR.
+                    let _ = qconn.close(
+                        true,
+                        WireErrorCode::DatagramError as u64,
+                        b"Malformed HTTP/3 datagram",
+                    );
+                    return Err(H3ConnectionError::H3(
+                        h3::Error::DatagramError,
+                    ));
+                },
                 Err(err) => return Err(H3ConnectionError::from(err)),
             }
         }

--- a/tokio-quiche/src/http3/driver/server.rs
+++ b/tokio-quiche/src/http3/driver/server.rs
@@ -188,11 +188,27 @@ impl ServerHooks {
             return Ok(());
         }
 
+        // RFC 9297 §3.2: capsule-protocol with Content-Length,
+        // Content-Type, or Transfer-Encoding is malformed.
+        if datagram::has_capsule_header_conflict(&headers) {
+            let _ = qconn.stream_shutdown(
+                stream_id,
+                quiche::Shutdown::Read,
+                quiche::h3::WireErrorCode::MessageError as u64,
+            );
+            let _ = qconn.stream_shutdown(
+                stream_id,
+                quiche::Shutdown::Write,
+                quiche::h3::WireErrorCode::MessageError as u64,
+            );
+            return Ok(());
+        }
+
         let (mut stream_ctx, send, recv) =
             StreamCtx::new(stream_id, STREAM_CAPACITY);
 
         if let Some(flow_id) = datagram::extract_flow_id(stream_id, &headers) {
-            let _ = driver.get_or_insert_flow(flow_id)?;
+            let _ = driver.get_or_insert_flow(flow_id, stream_id)?;
             stream_ctx.associated_dgram_flow_id = Some(flow_id);
         }
 

--- a/tokio-quiche/src/http3/driver/streams.rs
+++ b/tokio-quiche/src/http3/driver/streams.rs
@@ -167,15 +167,21 @@ pub(crate) struct FlowCtx {
     /// Sends inbound datagrams to a local task.
     send: mpsc::Sender<InboundFrame>,
     // No `recv`: all outbound datagrams are sent on a shared channel in H3Driver
+
+    /// The H3 stream ID that owns this datagram flow.
+    pub(crate) stream_id: u64,
 }
 
 impl FlowCtx {
     /// Creates a new [FlowCtx]. This method returns the context itself
     /// as well as the datagram receiver for this flow.
-    pub(crate) fn new(capacity: usize) -> (Self, InboundFrameStream) {
+    pub(crate) fn new(
+        stream_id: u64, capacity: usize,
+    ) -> (Self, InboundFrameStream) {
         let (forward_sender, forward_receiver) = mpsc::channel(capacity);
         let ctx = FlowCtx {
             send: forward_sender,
+            stream_id,
         };
         (ctx, forward_receiver)
     }


### PR DESCRIPTION
  - Add `CapsuleParser` and `send_capsule()`/`recv_capsule()` API (RFC 9297)
  - Validate `capsule-protocol` header, 0-RTT SETTINGS/transport params, Quarter Stream ID    
  bounds                                                                                  
  - Gate datagram send/recv on `SETTINGS_H3_DATAGRAM`                                         
  - Fix draft CONNECT-UDP `flow_id` → `stream_id` mapping in `FlowCtx`
  - Maintain backward compatibility with draft-ietf-masque-connect-udp-03   