### PR TITLE
extract pto duration calculation into helper function

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3400,7 +3400,7 @@ impl<F: BufFactory> Connection<F> {
                 crypto_open: open_prev,
                 pn_on_update: pn,
                 update_acked: false,
-                timer: now + (recv_path.recovery.pto() * 3),
+                timer: now + recv_path.recovery.pto_timeout(),
             });
 
             self.key_phase = !self.key_phase;
@@ -4936,8 +4936,8 @@ impl<F: BufFactory> Connection<F> {
                         };
 
                         if push_frame_to_pkt!(b, frames, frame, left) {
-                            let pto = path.recovery.pto();
-                            self.draining_timer = Some(now + (pto * 3));
+                            self.draining_timer =
+                                Some(now + path.recovery.pto_timeout());
 
                             ack_eliciting = true;
                             in_flight = true;
@@ -4952,8 +4952,8 @@ impl<F: BufFactory> Connection<F> {
                     };
 
                     if push_frame_to_pkt!(b, frames, frame, left) {
-                        let pto = path.recovery.pto();
-                        self.draining_timer = Some(now + (pto * 3));
+                        self.draining_timer =
+                            Some(now + path.recovery.pto_timeout());
 
                         ack_eliciting = true;
                         in_flight = true;
@@ -8684,7 +8684,7 @@ impl<F: BufFactory> Connection<F> {
                 });
 
                 let path = self.paths.get_active()?;
-                self.draining_timer = Some(now + (path.recovery.pto() * 3));
+                self.draining_timer = Some(now + path.recovery.pto_timeout());
             },
 
             frame::Frame::ApplicationClose { error_code, reason } => {
@@ -8695,7 +8695,7 @@ impl<F: BufFactory> Connection<F> {
                 });
 
                 let path = self.paths.get_active()?;
-                self.draining_timer = Some(now + (path.recovery.pto() * 3));
+                self.draining_timer = Some(now + path.recovery.pto_timeout());
             },
 
             frame::Frame::HandshakeDone => {

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -241,6 +241,12 @@ pub trait RecoveryOps {
 
     fn pto(&self) -> Duration;
 
+    /// Returns the PTO-based draining/closing timeout duration (3 * PTO),
+    /// as recommended in RFC 9000, Section 10.2.
+    fn pto_timeout(&self) -> Duration {
+        self.pto() * 3
+    }
+
     /// The most recent data delivery rate estimate.
     fn delivery_rate(&self) -> Bandwidth;
 


### PR DESCRIPTION
## summary
- added `pto_timeout()` default method on the `Recovery` trait that returns `self.pto() * 3`
- replaced all 5 occurrences of the duplicated `pto() * 3` expression in `lib.rs` with the new helper
- matches the RFC 9000 Section 10.2 recommendation for draining/closing period duration

## test plan
- ran full `cargo test -p quiche` - all 977 unit tests and 45 doc tests pass
- verified no remaining `pto * 3` or `pto() * 3` patterns in the codebase

fixes #2369