### PR TITLE
Remove debug_assert! from handle_recvd_stop_sending

### DIFF
--- a/tokio-quiche/src/http3/driver/streams.rs
+++ b/tokio-quiche/src/http3/driver/streams.rs
@@ -133,7 +133,6 @@ impl StreamCtx {
         // Drop any pending data and close the write side.
         // We can't accept additional frames
         self.queued_frame = None;
-        debug_assert!(self.recv.is_some());
         self.recv = None;
     }
 


### PR DESCRIPTION
The fix for FIN handling in 54cefab sets recv = None but doesn't set fin_or_reset_sent = true until on_fin_sent is called after a fin is successfully sent.