### PR TITLE
fix conn err metrics on conn close

### DIFF
--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -1282,11 +1282,11 @@ impl<H: DriverHooks> ApplicationOverQuic for H3Driver<H> {
             .maximum_writable_streams()
             .observe(max_stream_seen as f64);
 
+        Self::record_quiche_error(quiche_conn, metrics);
+
         let Err(work_loop_error) = work_loop_result else {
             return;
         };
-
-        Self::record_quiche_error(quiche_conn, metrics);
 
         let Some(h3_err) = work_loop_error.downcast_ref::<H3ConnectionError>()
         else {

--- a/tokio-quiche/src/http3/driver/test_utils.rs
+++ b/tokio-quiche/src/http3/driver/test_utils.rs
@@ -1,8 +1,14 @@
+use std::net::IpAddr;
+use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Context;
 use bytes::BufMut;
 use bytes::BytesMut;
+use foundations::telemetry::metrics::Counter;
+use foundations::telemetry::metrics::Gauge;
+use foundations::telemetry::metrics::Histogram;
+use foundations::telemetry::metrics::TimeHistogram;
 use futures::FutureExt as _;
 use quiche::h3;
 use quiche::h3::Header;
@@ -23,6 +29,8 @@ use crate::http3::driver::NewClientRequest;
 use crate::http3::driver::OutboundFrameSender;
 use crate::http3::driver::ServerH3Event;
 use crate::http3::settings::Http3Settings;
+use crate::metrics::labels;
+use crate::metrics::Metrics;
 use crate::quic::HandshakeInfo;
 use crate::quic::QuicheConnection;
 use crate::ApplicationOverQuic as _;
@@ -410,5 +418,140 @@ impl DriverTestHelper<ServerHooks> {
         &mut self, stream_id: u64, max_read: usize,
     ) -> h3::Result<Vec<u8>> {
         self.peer_recv_body_vec(stream_id, max_read)
+    }
+}
+
+/// Minimal [`Metrics`] impl for unit tests. Tracks connection close error
+/// counters; all other metrics are discarded.
+#[derive(Clone)]
+pub struct TestMetrics {
+    pub local_h3: Counter,
+    pub local_quic: Counter,
+    pub peer_h3: Counter,
+    pub peer_quic: Counter,
+}
+
+impl Default for TestMetrics {
+    fn default() -> Self {
+        Self {
+            local_h3: Counter::default(),
+            local_quic: Counter::default(),
+            peer_h3: Counter::default(),
+            peer_quic: Counter::default(),
+        }
+    }
+}
+
+impl Metrics for TestMetrics {
+    fn local_h3_conn_close_error_count(
+        &self, _reason: labels::H3Error,
+    ) -> Counter {
+        self.local_h3.clone()
+    }
+
+    fn local_quic_conn_close_error_count(
+        &self, _reason: labels::QuicError,
+    ) -> Counter {
+        self.local_quic.clone()
+    }
+
+    fn peer_h3_conn_close_error_count(
+        &self, _reason: labels::H3Error,
+    ) -> Counter {
+        self.peer_h3.clone()
+    }
+
+    fn peer_quic_conn_close_error_count(
+        &self, _reason: labels::QuicError,
+    ) -> Counter {
+        self.peer_quic.clone()
+    }
+
+    // -- everything below is unused by the code under test --
+
+    fn connections_in_memory(&self) -> Gauge {
+        Gauge::default()
+    }
+
+    fn maximum_writable_streams(&self) -> Histogram {
+        Histogram::new(std::iter::empty())
+    }
+
+    fn handshake_time_seconds(
+        &self, _: labels::QuicHandshakeStage,
+    ) -> TimeHistogram {
+        TimeHistogram::new(std::iter::empty())
+    }
+
+    fn write_errors(&self, _: labels::QuicWriteError) -> Counter {
+        Counter::default()
+    }
+
+    fn send_to_wouldblock_duration_s(&self) -> TimeHistogram {
+        TimeHistogram::new(std::iter::empty())
+    }
+
+    fn skipped_mid_handshake_flush_count(&self) -> Counter {
+        Counter::default()
+    }
+
+    fn invalid_cid_packet_count(&self, _: crate::BoxError) -> Counter {
+        Counter::default()
+    }
+
+    fn accepted_initial_packet_count(&self) -> Counter {
+        Counter::default()
+    }
+
+    fn expensive_accepted_initial_packet_count(&self, _: IpAddr) -> Counter {
+        Counter::default()
+    }
+
+    fn rejected_initial_packet_count(
+        &self, _: labels::QuicInvalidInitialPacketError,
+    ) -> Counter {
+        Counter::default()
+    }
+
+    fn expensive_rejected_initial_packet_count(
+        &self, _: labels::QuicInvalidInitialPacketError, _: IpAddr,
+    ) -> Counter {
+        Counter::default()
+    }
+
+    fn utilized_bandwidth(&self) -> Gauge {
+        Gauge::default()
+    }
+
+    fn max_bandwidth_mbps(&self) -> Histogram {
+        Histogram::new(std::iter::empty())
+    }
+
+    fn max_loss_pct(&self) -> Histogram {
+        Histogram::new(std::iter::empty())
+    }
+
+    fn udp_drop_count(&self) -> Counter {
+        Counter::default()
+    }
+
+    fn failed_handshakes(&self, _: labels::HandshakeError) -> Counter {
+        Counter::default()
+    }
+
+    fn tokio_runtime_task_schedule_delay_histogram(
+        &self, _: &Arc<str>,
+    ) -> TimeHistogram {
+        TimeHistogram::new(std::iter::empty())
+    }
+
+    fn tokio_runtime_task_poll_duration_histogram(
+        &self, _: &Arc<str>,
+    ) -> TimeHistogram {
+        TimeHistogram::new(std::iter::empty())
+    }
+
+    fn tokio_runtime_task_total_poll_time_micros(&self, _: &Arc<str>) -> Counter {
+        Counter::default()
     }
 }

--- a/tokio-quiche/src/http3/driver/tests.rs
+++ b/tokio-quiche/src/http3/driver/tests.rs
@@ -5,6 +5,90 @@ use assert_matches::assert_matches;
 use super::test_utils::*;
 use super::*;
 
+/// Tests for connection close error metrics recorded by
+/// [`H3Driver::on_conn_close`].
+mod conn_close_metrics {
+    use crate::ApplicationOverQuic as _;
+
+    use super::*;
+
+    /// Peer sends a QUIC-level CONNECTION_CLOSE and the work loop
+    /// completes with Ok. Verifies the peer QUIC error counter is
+    /// incremented.
+    #[test]
+    fn peer_quic_error_on_ok_result() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+
+        // Peer (client) closes with a QUIC-level error
+        helper
+            .pipe
+            .client
+            .close(false, 0x1, b"internal error")
+            .unwrap();
+        helper.pipe.advance().unwrap();
+
+        let metrics = TestMetrics::default();
+        helper
+            .driver
+            .on_conn_close(&mut helper.pipe.server, &metrics, &Ok(()));
+
+        assert_eq!(metrics.peer_quic.get(), 1);
+        assert_eq!(metrics.peer_h3.get(), 0);
+        assert_eq!(metrics.local_quic.get(), 0);
+        assert_eq!(metrics.local_h3.get(), 0);
+    }
+
+    /// Peer sends an APPLICATION_CLOSE (H3-level) and the work loop
+    /// completes with Ok. Verifies the peer H3 error counter is
+    /// incremented.
+    #[test]
+    fn peer_h3_error_on_ok_result() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+
+        // Peer (client) closes with an H3-level error (is_app = true)
+        helper.pipe.client.close(true, 0x100, b"no error").unwrap();
+        helper.pipe.advance().unwrap();
+
+        let metrics = TestMetrics::default();
+        helper
+            .driver
+            .on_conn_close(&mut helper.pipe.server, &metrics, &Ok(()));
+
+        assert_eq!(metrics.peer_h3.get(), 1);
+        assert_eq!(metrics.peer_quic.get(), 0);
+        assert_eq!(metrics.local_quic.get(), 0);
+        assert_eq!(metrics.local_h3.get(), 0);
+    }
+
+    /// Work loop returns an error and the local side has a QUIC-level
+    /// error set. Verifies the local QUIC error counter is incremented.
+    #[test]
+    fn local_quic_error_on_err_result() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+
+        // Local side (server) closes with a QUIC-level error
+        helper
+            .pipe
+            .server
+            .close(false, 0x1, b"internal error")
+            .unwrap();
+
+        let err: crate::QuicResult<()> = Err(H3ConnectionError::GoAway.into());
+        let metrics = TestMetrics::default();
+        helper
+            .driver
+            .on_conn_close(&mut helper.pipe.server, &metrics, &err);
+
+        assert_eq!(metrics.local_quic.get(), 1);
+        assert_eq!(metrics.local_h3.get(), 0);
+        assert_eq!(metrics.peer_quic.get(), 0);
+        assert_eq!(metrics.peer_h3.get(), 0);
+    }
+}
+
 /// Tests that use an H3Driver for the client side. We mostly focus on testing
 /// the driver's handling of stream state, and data, rather than H3 semantics.
 /// Note that most of these tests could have just as easily been written for


### PR DESCRIPTION
Fixes connection error code metric emmission for tokio-quiche. We need
to unconditionally emit these metrics regardless of work loop result or
we lose metrics for some scenarios.