### PR TITLE
tokio-quiche: drain coalesced QUIC packets on recv

### DIFF
--- a/tokio-quiche/src/quic/io/worker.rs
+++ b/tokio-quiche/src/quic/io/worker.rs
@@ -617,12 +617,15 @@ where
             to: pkt.local_addr,
         };
 
+        // A single UDP datagram may contain multiple coalesced QUIC packets
+        // (e.g. Initial + Handshake). `quiche::recv` only processes one packet
+        // per call, so loop until it signals Done to drain the whole datagram.
         if let Some(gro) = pkt.gro {
             for dgram in pkt.buf.chunks_mut(gro as usize) {
-                qconn.recv(dgram, recv_info)?;
+                recv_coalesced(qconn, dgram, recv_info)?;
             }
         } else {
-            qconn.recv(&mut pkt.buf, recv_info)?;
+            recv_coalesced(qconn, &mut pkt.buf, recv_info)?;
         }
 
         Ok(())
@@ -934,4 +937,25 @@ fn min_of_some<T: Ord>(v1: Option<T>, v2: Option<T>) -> Option<T> {
         (Some(v), _) | (_, Some(v)) => Some(v),
         (None, None) => None,
     }
+}
+
+/// Feed `buf` into `qconn.recv` repeatedly until quiche has consumed every
+/// coalesced QUIC packet in the datagram. `quiche::Connection::recv` only
+/// processes one packet per call; without this loop, any packets coalesced
+/// after the first (e.g. a server's Initial+Handshake) are silently dropped.
+fn recv_coalesced(
+    qconn: &mut QuicheConnection, buf: &mut [u8], recv_info: quiche::RecvInfo,
+) -> QuicResult<()> {
+    let mut rest: &mut [u8] = buf;
+    while !rest.is_empty() {
+        match qconn.recv(rest, recv_info) {
+            Ok(n) => {
+                let (_, tail) = std::mem::take(&mut rest).split_at_mut(n);
+                rest = tail;
+            },
+            Err(quiche::Error::Done) => break,
+            Err(err) => return Err(err.into()),
+        }
+    }
+    Ok(())
 }

--- a/tokio-quiche/src/quic/router/connector.rs
+++ b/tokio-quiche/src/quic/router/connector.rs
@@ -307,7 +307,13 @@ fn recv_coalesced(
                 rest = tail;
             },
             Err(quiche::Error::Done) => break,
-            Err(_) => break,
+            Err(err) => {
+                log::debug!(
+                    "client connector recv error from {}: {err:?}",
+                    recv_info.from
+                );
+                break;
+            },
         }
     }
 }

--- a/tokio-quiche/src/quic/router/connector.rs
+++ b/tokio-quiche/src/quic/router/connector.rs
@@ -155,14 +155,15 @@ where
             to: incoming.local_addr,
         };
 
+        // A single UDP datagram may contain multiple coalesced QUIC packets
+        // (e.g. a server can coalesce Initial + Handshake). `quiche::recv`
+        // only processes one packet per call, so loop until it signals Done.
         if let Some(gro) = incoming.gro {
             for dgram in incoming.buf.chunks_mut(gro as usize) {
-                // Log error here if recv fails
-                let _ = conn.recv(dgram, recv_info);
+                recv_coalesced(&mut conn, dgram, recv_info);
             }
         } else {
-            // Log error here if recv fails
-            let _ = conn.recv(&mut incoming.buf, recv_info);
+            recv_coalesced(&mut conn, &mut incoming.buf, recv_info);
         }
 
         // disarm the timer since we're either going to immediately rearm it or
@@ -287,6 +288,26 @@ fn simple_conn_send<Tx: DatagramSocketSend + Send + Sync + 'static>(
                 log::error!("error writing packets to quiche's internal buffer"; "scid" => ?scid, "error" => error.to_string());
                 break Err(std::io::Error::other(error));
             },
+        }
+    }
+}
+
+/// Feed `buf` into `conn.recv` repeatedly until quiche has consumed every
+/// coalesced QUIC packet in the datagram. `quiche::Connection::recv` only
+/// processes one packet per call; without this loop, any packets coalesced
+/// after the first (e.g. a server's Initial+Handshake) are silently dropped.
+fn recv_coalesced(
+    conn: &mut QuicheConnection, buf: &mut [u8], recv_info: quiche::RecvInfo,
+) {
+    let mut rest: &mut [u8] = buf;
+    while !rest.is_empty() {
+        match conn.recv(rest, recv_info) {
+            Ok(n) => {
+                let (_, tail) = std::mem::take(&mut rest).split_at_mut(n);
+                rest = tail;
+            },
+            Err(quiche::Error::Done) => break,
+            Err(_) => break,
         }
     }
 }


### PR DESCRIPTION
quiche::Connection::recv only processes one QUIC packet per call, but a single UDP datagram can contain several coalesced packets (a server commonly coalesces Initial + Handshake, and loopback MTU=65536 makes this common in local tests). The existing call sites in ClientConnector and IoWorker invoked recv once per buffer, so any packet coalesced after the first was silently discarded -- handshakes stall waiting for a Handshake-level frame that was already delivered.

Introduce a recv_coalesced helper at each call site that loops over conn.recv until it returns Done, advancing the buffer by the number of bytes quiche consumed.