### PR TITLE
tokio-quiche: opt-in QLOG compression (gzip, zstd)

### DIFF
--- a/qlog/Cargo.toml
+++ b/qlog/Cargo.toml
@@ -10,11 +10,48 @@ keywords = { workspace = true }
 categories = { workspace = true }
 readme = "README.md"
 
+[features]
+# Enable gzip compression / decompression of qlog streams via
+# [`flate2`]. Used by [`writer::make_qlog_writer`] and
+# [`reader::QlogSeqReader::with_file`].
+gzip = ["dep:flate2"]
+
+# Enable zstd compression / decompression of qlog streams via
+# [`zstd`]. Pulls in `zstd-sys` (C dependency). Used by
+# [`writer::make_qlog_writer`] and
+# [`reader::QlogSeqReader::with_file`].
+zstd = ["dep:zstd"]
+
+# Expose a `foundations::settings::Settings` impl for
+# [`writer::QlogCompression`] so it can be embedded as a field in a
+# `foundations`-annotated settings struct. Enabled by consumers that
+# use `foundations` (e.g. tokio-quiche); not pulled in by default so
+# the qlog crate stays lightweight for consumers that do not use
+# `foundations`.
+foundations = ["dep:foundations"]
+
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 humantime = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_with = { workspace = true, features = ["macros"] }
 
+# Optional: gzip backend for the `gzip` feature. Uses `flate2`'s
+# default backend (pure-Rust `miniz_oxide`); consumers can select a
+# different backend by depending on `flate2` themselves.
+flate2 = { version = "1", optional = true }
+
+# Optional: zstd backend for the `zstd` feature. Depends on
+# `zstd-sys` (C).
+zstd = { version = "0.13", default-features = false, optional = true }
+
+# Optional: used only to implement `foundations::settings::Settings`
+# for [`writer::QlogCompression`] when the `foundations` feature is
+# enabled.
+foundations = { workspace = true, optional = true, default-features = false, features = [
+  "settings",
+] }
+
 [dev-dependencies]
 pretty_assertions = "1.4"
+tempfile = "3"

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -439,6 +439,19 @@ impl std::convert::From<std::io::Error> for Error {
 pub const QLOGFILE_URI: &str = "urn:ietf:params:qlog:file:contained";
 pub const QLOGFILESEQ_URI: &str = "urn:ietf:params:qlog:file:sequential";
 
+/// File extension for an uncompressed qlog stream (JSON-SEQ).
+///
+/// Includes the leading dot so it can be concatenated as a suffix
+/// (`format!("{id}{SQLOG_EXT}")`) and matched as a path suffix
+/// (`name.ends_with(SQLOG_EXT)`).
+pub const SQLOG_EXT: &str = ".sqlog";
+
+/// File extension for a gzip-compressed qlog stream.
+pub const SQLOG_GZ_EXT: &str = ".sqlog.gz";
+
+/// File extension for a zstd-compressed qlog stream.
+pub const SQLOG_ZST_EXT: &str = ".sqlog.zst";
+
 pub type Bytes = String;
 pub type StatelessResetToken = Bytes;
 
@@ -661,6 +674,7 @@ pub mod reader;
 pub mod streamer;
 #[doc(hidden)]
 pub mod testing;
+pub mod writer;
 
 #[cfg(test)]
 mod tests {

--- a/qlog/src/reader.rs
+++ b/qlog/src/reader.rs
@@ -24,7 +24,14 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+
 use crate::QlogSeq;
+use crate::SQLOG_EXT;
+use crate::SQLOG_GZ_EXT;
+use crate::SQLOG_ZST_EXT;
 
 /// Represents the format of the read event.
 #[allow(clippy::large_enum_variant)]
@@ -64,6 +71,92 @@ impl<'a> QlogSeqReader<'a> {
 
             Err(e) => Err(e.into()),
         }
+    }
+
+    /// Convenience constructor that opens `path` and picks a streaming
+    /// decoder based on the file's compound extension:
+    ///
+    /// * `*.sqlog` -> raw JSON-SEQ (always available).
+    /// * `*.sqlog.gz` -> gzip via `flate2` (requires the `gzip` feature).
+    /// * `*.sqlog.zst` -> zstd via `zstd` (requires the `zstd` feature).
+    ///
+    /// The dispatch tests the *compound* suffix (`.sqlog.gz`,
+    /// `.sqlog.zst`, `.sqlog`) on the full filename, in that order.
+    /// This rejects bare `.gz` or `.zst` names that do not also carry
+    /// the `.sqlog` segment, and avoids the trap where
+    /// [`Path::extension`] strips only the last component (which
+    /// would silently accept `something.tar.gz`).
+    ///
+    /// Unknown extensions, or compressed extensions whose matching
+    /// feature is not enabled, return an [`std::io::ErrorKind::Unsupported`]
+    /// error with a message pointing at the feature that is needed.
+    ///
+    /// This is the intended single entry point for reading a qlog
+    /// file regardless of compression.
+    pub fn with_file(
+        path: impl AsRef<Path>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let path = path.as_ref();
+        let file = File::open(path)?;
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+
+        // Order matters: `.sqlog.gz` and `.sqlog.zst` must be tested
+        // before `.sqlog` (every compressed suffix also ends with
+        // `.sqlog` if you only look at the last extension).
+        //
+        // Each compound suffix is matched exactly once. The
+        // `#[cfg(feature = "...")]` lives inside the `if` body so the
+        // disabled-feature path can return a helpful error rather
+        // than falling through to the unknown-extension branch.
+        if name.ends_with(SQLOG_GZ_EXT) {
+            #[cfg(feature = "gzip")]
+            {
+                let reader: Box<dyn std::io::BufRead + Send + Sync> =
+                    Box::new(BufReader::new(flate2::read::GzDecoder::new(file)));
+                return Self::new(reader);
+            }
+            #[cfg(not(feature = "gzip"))]
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                format!(
+                    "qlog file {name:?} requires the `gzip` feature on \
+                     the qlog crate to decode"
+                ),
+            )
+            .into());
+        }
+        if name.ends_with(SQLOG_ZST_EXT) {
+            #[cfg(feature = "zstd")]
+            {
+                let decoder = zstd::Decoder::new(file)?;
+                let reader: Box<dyn std::io::BufRead + Send + Sync> =
+                    Box::new(BufReader::new(decoder));
+                return Self::new(reader);
+            }
+            #[cfg(not(feature = "zstd"))]
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                format!(
+                    "qlog file {name:?} requires the `zstd` feature on \
+                     the qlog crate to decode"
+                ),
+            )
+            .into());
+        }
+        if name.ends_with(SQLOG_EXT) {
+            let reader: Box<dyn std::io::BufRead + Send + Sync> =
+                Box::new(BufReader::new(file));
+            return Self::new(reader);
+        }
+
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            format!(
+                "qlog file {name:?} does not match a known qlog \
+                 extension ({SQLOG_EXT}, {SQLOG_GZ_EXT}, {SQLOG_ZST_EXT})"
+            ),
+        )
+        .into())
     }
 
     fn read_record(

--- a/qlog/src/writer.rs
+++ b/qlog/src/writer.rs
@@ -1,0 +1,245 @@
+// Copyright (C) 2026, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! QLOG file writer plumbing -- compression-aware companion to
+//! [`crate::reader`].
+//!
+//! This module owns the writer-side surface for emitting JSON-SEQ
+//! qlog streams, optionally wrapped in a streaming compressor. It is
+//! a deliberate exception to the qlog crate's otherwise pure-data
+//! posture: the writer helpers, the compression enum, and the
+//! filename / extension conventions live here so any consumer
+//! (tokio-quiche, [`crate::reader::QlogSeqReader::with_file`],
+//! external tooling) shares a single canonical writer story.
+//!
+//! Compression is opt-in via Cargo features:
+//! * `gzip` pulls in [`flate2`].
+//! * `zstd` pulls in the [`zstd`] crate (C dependency via `zstd-sys`).
+//!
+//! The [`QlogCompression`] enum's `Gzip` and `Zstd` variants are
+//! compile-time gated on their respective features, so a build that
+//! disables one of them cannot construct the unsupported variant.
+//!
+//! Bytes flow `producer -> [compressor] -> W` where `W` is any
+//! `Write + Send + Sync + 'static`. No buffering is added here: both
+//! `flate2` and `zstd` emit output in large chunks (DEFLATE blocks /
+//! zstd frames), so an extra `BufWriter` is redundant; callers are
+//! free to add one if they need to.
+
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::Path;
+
+// Extension constants live at the crate root so they can be shared
+// between [`crate::writer`] and [`crate::reader`] without either
+// module depending on the other. Re-exported here for ergonomic
+// access via `qlog::writer::SQLOG_EXT` etc.
+pub use crate::SQLOG_EXT;
+pub use crate::SQLOG_GZ_EXT;
+pub use crate::SQLOG_ZST_EXT;
+
+/// Boxed `Write` returned by [`make_qlog_writer`] /
+/// [`make_qlog_writer_from_path`].
+///
+/// Producers (e.g. `quiche::Connection::set_qlog`) typically require
+/// `Send + Sync`; the boxed form keeps the writer object-safe across
+/// the compression-vs-no-compression branches.
+pub type QlogFileWriter = Box<dyn Write + Send + Sync>;
+
+/// Compression algorithm applied to QLOG output streams.
+///
+/// `None` is always available. `Gzip` and `Zstd` are compile-time
+/// gated on the `gzip` and `zstd` Cargo features respectively; a
+/// build that disables one of those features cannot reference the
+/// corresponding variant.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    serde::Deserialize,
+    serde::Serialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum QlogCompression {
+    /// No compression. Emit raw `.sqlog` files.
+    #[default]
+    None,
+    /// Gzip streaming compression (DEFLATE + gzip framing). Emits
+    /// `.sqlog.gz` files. Requires the `gzip` Cargo feature.
+    #[cfg(feature = "gzip")]
+    Gzip,
+    /// Zstd streaming compression. Emits `.sqlog.zst` files. Requires
+    /// the `zstd` Cargo feature.
+    #[cfg(feature = "zstd")]
+    Zstd,
+}
+
+#[cfg(feature = "foundations")]
+impl foundations::settings::Settings for QlogCompression {}
+
+/// Return the qlog filename (not including the directory) for a
+/// stream whose identifier is `id`, with the suffix matching
+/// `compression`: `<id>.sqlog`, `<id>.sqlog.gz`, or `<id>.sqlog.zst`.
+pub fn qlog_file_name(id: &str, compression: QlogCompression) -> String {
+    match compression {
+        QlogCompression::None => format!("{id}{SQLOG_EXT}"),
+        #[cfg(feature = "gzip")]
+        QlogCompression::Gzip => format!("{id}{SQLOG_GZ_EXT}"),
+        #[cfg(feature = "zstd")]
+        QlogCompression::Zstd => format!("{id}{SQLOG_ZST_EXT}"),
+    }
+}
+
+/// Wrap `inner` in the streaming encoder selected by `compression`
+/// and return a boxed `Write` that a qlog producer (e.g. quiche via
+/// `set_qlog`) writes into.
+///
+/// The generic `W` bound lets production call sites pass a
+/// `std::fs::File` while tests can pass an in-process buffer (e.g.
+/// `Vec<u8>`). For the common case of "open a file at this path and
+/// pick the compressor by extension" use
+/// [`make_qlog_writer_from_path`].
+///
+/// No buffering is added here.
+pub fn make_qlog_writer<W>(
+    inner: W, compression: QlogCompression,
+) -> io::Result<QlogFileWriter>
+where
+    W: Write + Send + Sync + 'static,
+{
+    match compression {
+        QlogCompression::None => Ok(Box::new(inner)),
+        #[cfg(feature = "gzip")]
+        QlogCompression::Gzip => {
+            let encoder = flate2::write::GzEncoder::new(
+                inner,
+                flate2::Compression::default(),
+            );
+            Ok(Box::new(encoder))
+        },
+        #[cfg(feature = "zstd")]
+        QlogCompression::Zstd => {
+            // Level 3 is the zstd default: a balanced point on the
+            // ratio-vs-speed curve.
+            let encoder = zstd::Encoder::new(inner, 3)?;
+            Ok(Box::new(ZstdFinishOnDrop {
+                encoder: Some(encoder),
+            }))
+        },
+    }
+}
+
+/// Convenience function to create a File at `path` with a writer
+/// based on `compression`.
+///
+/// Equivalent to manually creating a File and passing it to
+/// [`make_qlog_writer`].
+pub fn make_qlog_writer_from_path<P: AsRef<Path>>(
+    path: P, compression: QlogCompression,
+) -> io::Result<QlogFileWriter> {
+    let file = File::create(path.as_ref())?;
+    make_qlog_writer(file, compression)
+}
+
+/// `Write` wrapper that calls [`zstd::Encoder::finish`] on drop so
+/// the zstd frame trailer is written to the inner sink.
+///
+/// `zstd::Encoder` does not flush its frame trailer implicitly on
+/// drop, so a qlog stream written through a bare `Encoder` would be
+/// missing the end-of-frame marker and fail to decode.
+/// `AutoFinishEncoder` from the `zstd` crate solves this but is
+/// `!Sync` (it stores a user-supplied `FnMut` closure), while some
+/// producers (e.g. `quiche::Connection::set_qlog`) require
+/// `Send + Sync`. This local wrapper preserves those bounds because
+/// it only holds an `Option<Encoder<_, W>>`, where `Encoder` is
+/// `Send + Sync` whenever `W` is.
+#[cfg(feature = "zstd")]
+struct ZstdFinishOnDrop<W: Write> {
+    encoder: Option<zstd::Encoder<'static, W>>,
+}
+
+#[cfg(feature = "zstd")]
+impl<W: Write> Write for ZstdFinishOnDrop<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.encoder
+            .as_mut()
+            .expect("encoder present until drop")
+            .write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.encoder
+            .as_mut()
+            .expect("encoder present until drop")
+            .flush()
+    }
+}
+
+#[cfg(feature = "zstd")]
+impl<W: Write> Drop for ZstdFinishOnDrop<W> {
+    fn drop(&mut self) {
+        if let Some(encoder) = self.encoder.take() {
+            if let Err(error) = encoder.finish() {
+                // qlog crate has no structured-logging dependency; use
+                // `eprintln!` so trailer-flush failures surface on
+                // stderr rather than silently truncating the stream.
+                eprintln!("qlog: failed to finish zstd encoder: {error}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_name_uses_constants_for_none() {
+        let name = qlog_file_name("abc", QlogCompression::None);
+        assert_eq!(name, "abc.sqlog");
+        assert!(name.ends_with(SQLOG_EXT));
+    }
+
+    #[cfg(feature = "gzip")]
+    #[test]
+    fn file_name_uses_constants_for_gzip() {
+        let name = qlog_file_name("abc", QlogCompression::Gzip);
+        assert_eq!(name, "abc.sqlog.gz");
+        assert!(name.ends_with(SQLOG_GZ_EXT));
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn file_name_uses_constants_for_zstd() {
+        let name = qlog_file_name("abc", QlogCompression::Zstd);
+        assert_eq!(name, "abc.sqlog.zst");
+        assert!(name.ends_with(SQLOG_ZST_EXT));
+    }
+}

--- a/qlog/src/writer.rs
+++ b/qlog/src/writer.rs
@@ -54,9 +54,10 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 
-
 use crate::SQLOG_EXT;
+#[cfg(feature = "gzip")]
 use crate::SQLOG_GZ_EXT;
+#[cfg(feature = "zstd")]
 use crate::SQLOG_ZST_EXT;
 
 /// Boxed `Write` returned by [`make_qlog_writer`] /

--- a/qlog/src/writer.rs
+++ b/qlog/src/writer.rs
@@ -54,13 +54,10 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 
-// Extension constants live at the crate root so they can be shared
-// between [`crate::writer`] and [`crate::reader`] without either
-// module depending on the other. Re-exported here for ergonomic
-// access via `qlog::writer::SQLOG_EXT` etc.
-pub use crate::SQLOG_EXT;
-pub use crate::SQLOG_GZ_EXT;
-pub use crate::SQLOG_ZST_EXT;
+
+use crate::SQLOG_EXT;
+use crate::SQLOG_GZ_EXT;
+use crate::SQLOG_ZST_EXT;
 
 /// Boxed `Write` returned by [`make_qlog_writer`] /
 /// [`make_qlog_writer_from_path`].

--- a/qlog/tests/writer_roundtrip.rs
+++ b/qlog/tests/writer_roundtrip.rs
@@ -1,0 +1,290 @@
+// Copyright (C) 2026, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! Writer-reader round-trip tests for [`qlog::writer`].
+//!
+//! Each test produces a qlog stream via [`qlog::streamer::QlogStreamer`]
+//! written through the selected [`qlog::writer::QlogCompression`]
+//! variant into a file on disk, then reads the file back via
+//! [`qlog::reader::QlogSeqReader::with_file`] and asserts the header
+//! plus at least one event round-tripped.
+//!
+//! These tests do not depend on tokio-quiche or any QUIC connection
+//! machinery: they exercise the writer-reader symmetry directly,
+//! which is the reusable value of owning compression in the qlog
+//! crate.
+
+use std::path::Path;
+use std::time::Instant;
+
+use qlog::events::quic;
+use qlog::events::EventData;
+use qlog::events::EventImportance;
+use qlog::events::RawInfo;
+use qlog::reader::Event;
+use qlog::reader::QlogSeqReader;
+use qlog::streamer::EventTimePrecision;
+use qlog::streamer::QlogStreamer;
+use qlog::testing;
+use qlog::writer::make_qlog_writer_from_path;
+use qlog::writer::qlog_file_name;
+use qlog::writer::QlogCompression;
+
+/// Minimal qlog event used by every round-trip test: a single
+/// `quic:packet_sent`. The specific contents do not matter for this
+/// test -- we just need the reader to parse at least one event.
+fn make_event() -> EventData {
+    EventData::QuicPacketSent(quic::PacketSent {
+        header: testing::make_pkt_hdr(quic::PacketType::Handshake),
+        frames: Some(vec![quic::QuicFrame::Stream {
+            stream_id: 0,
+            offset: Some(0),
+            raw: Some(Box::new(RawInfo {
+                length: None,
+                payload_length: Some(100),
+                data: None,
+            })),
+            fin: Some(true),
+        }]),
+        raw: Some(RawInfo {
+            length: Some(1251),
+            payload_length: Some(1224),
+            data: None,
+        }),
+        ..Default::default()
+    })
+}
+
+/// Drive a `QlogStreamer` from start_log through one event to
+/// finish_log, through `make_qlog_writer_from_path(path,
+/// compression)`, and return the path of the emitted file.
+fn emit_one_event(
+    compression: QlogCompression, dir: &Path,
+) -> std::path::PathBuf {
+    let path = dir.join(qlog_file_name("test", compression));
+    let writer = make_qlog_writer_from_path(&path, compression)
+        .expect("make_qlog_writer_from_path");
+
+    let mut streamer = QlogStreamer::new(
+        Some("round-trip test".to_string()),
+        Some("round-trip description".to_string()),
+        Instant::now(),
+        testing::make_trace_seq(),
+        EventImportance::Base,
+        EventTimePrecision::NanoSeconds,
+        writer,
+    );
+
+    streamer.start_log().expect("start_log");
+    streamer
+        .add_event_data_now(make_event())
+        .expect("add_event_data_now");
+    streamer.finish_log().expect("finish_log");
+
+    // Drop the streamer so the compressor's frame trailer is flushed
+    // (in particular for the zstd variant, which relies on
+    // `ZstdFinishOnDrop::drop` to write the trailer).
+    drop(streamer);
+
+    path
+}
+
+/// Open `path` via `QlogSeqReader::with_file` and assert the header
+/// plus at least one event are produced.
+fn assert_roundtrip(path: &Path) {
+    let mut reader =
+        QlogSeqReader::with_file(path).expect("QlogSeqReader::with_file");
+    let header = reader.qlog.clone();
+    let events: Vec<Event> = (&mut reader).collect();
+
+    assert_eq!(header.serialization_format, "JSON-SEQ");
+    assert!(!events.is_empty(), "expected at least one qlog event");
+}
+
+/// Read the leading bytes of `path` and assert they match the magic
+/// for `compression`. Catches a regression where a future edit to
+/// `make_qlog_writer` silently drops the compressor and emits a raw
+/// JSON-SEQ stream into a `.sqlog.gz` / `.sqlog.zst` file: without
+/// this check the filename suffix would still match and
+/// [`assert_roundtrip`] would only fail later on the decoder side,
+/// far from the writer.
+fn assert_file_magic(path: &Path, compression: QlogCompression) {
+    use std::io::Read;
+    let mut bytes = [0u8; 4];
+    let n = std::fs::File::open(path)
+        .expect("open qlog file")
+        .read(&mut bytes)
+        .expect("read magic bytes");
+    assert!(n >= 4, "qlog file too short to inspect magic: {n} bytes");
+
+    match compression {
+        // 0x1e is the JSON-SEQ record separator (RFC 7464). The
+        // streamer writes a leading null record so an uncompressed
+        // qlog file's first byte is 0x1e.
+        QlogCompression::None => assert_eq!(
+            bytes[0], 0x1e,
+            "expected JSON-SEQ record separator, got {bytes:02x?}"
+        ),
+        #[cfg(feature = "gzip")]
+        QlogCompression::Gzip => assert_eq!(
+            &bytes[..3],
+            &[0x1f, 0x8b, 0x08],
+            "expected gzip magic, got {bytes:02x?}"
+        ),
+        #[cfg(feature = "zstd")]
+        QlogCompression::Zstd => assert_eq!(
+            &bytes[..4],
+            &[0x28, 0xb5, 0x2f, 0xfd],
+            "expected zstd magic, got {bytes:02x?}"
+        ),
+    }
+}
+
+#[test]
+fn roundtrip_none() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = emit_one_event(QlogCompression::None, dir.path());
+    assert!(
+        path.to_str().unwrap().ends_with(".sqlog"),
+        "expected .sqlog extension, got {path:?}"
+    );
+    assert_file_magic(&path, QlogCompression::None);
+    assert_roundtrip(&path);
+}
+
+#[cfg(feature = "gzip")]
+#[test]
+fn roundtrip_gzip() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = emit_one_event(QlogCompression::Gzip, dir.path());
+    assert!(
+        path.to_str().unwrap().ends_with(".sqlog.gz"),
+        "expected .sqlog.gz extension, got {path:?}"
+    );
+    assert_file_magic(&path, QlogCompression::Gzip);
+    assert_roundtrip(&path);
+}
+
+#[cfg(feature = "zstd")]
+#[test]
+fn roundtrip_zstd() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = emit_one_event(QlogCompression::Zstd, dir.path());
+    assert!(
+        path.to_str().unwrap().ends_with(".sqlog.zst"),
+        "expected .sqlog.zst extension, got {path:?}"
+    );
+    assert_file_magic(&path, QlogCompression::Zstd);
+    // If `ZstdFinishOnDrop::drop` failed to write the trailer,
+    // `QlogSeqReader::with_file` would observe a truncated frame and
+    // either fail to parse the header or the iterator would stop
+    // early.
+    assert_roundtrip(&path);
+}
+
+/// Proves that both the `gzip` and `zstd` features can be enabled in
+/// the same binary and that writer + reader pick the correct
+/// decoder by extension for each.
+#[cfg(all(feature = "gzip", feature = "zstd"))]
+#[test]
+fn roundtrip_both_features_coexist() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let gz = emit_one_event(QlogCompression::Gzip, dir.path());
+    // Second file goes into a separate subdir so the two paths don't
+    // collide (both use id = "test").
+    let zst_dir = dir.path().join("zstd-subdir");
+    std::fs::create_dir(&zst_dir).expect("create subdir");
+    let zst = emit_one_event(QlogCompression::Zstd, &zst_dir);
+
+    assert_file_magic(&gz, QlogCompression::Gzip);
+    assert_file_magic(&zst, QlogCompression::Zstd);
+    assert_roundtrip(&gz);
+    assert_roundtrip(&zst);
+}
+
+/// Run `QlogSeqReader::with_file(path)`, expect an error, and assert
+/// the error message contains `expected_substr`. Mirrors
+/// `Result::expect_err` but does not require `T: Debug`
+/// ([`QlogSeqReader`] does not implement [`std::fmt::Debug`]).
+fn assert_with_file_err(path: &Path, expected_substr: &str) {
+    match QlogSeqReader::with_file(path) {
+        Ok(_) => panic!("expected error, got Ok for {path:?}"),
+        Err(err) => {
+            let msg = err.to_string();
+            assert!(
+                msg.contains(expected_substr),
+                "expected error message containing {expected_substr:?}, \
+                 got {msg:?}"
+            );
+        },
+    }
+}
+
+/// Regression test: `QlogSeqReader::with_file` must reject filenames
+/// that have a `.gz` or `.zst` extension but lack the `.sqlog`
+/// segment. The earlier implementation used [`std::path::Path::extension`],
+/// which strips only the last component and would have accepted
+/// `archive.tar.gz` as a gzip-compressed qlog.
+#[cfg(feature = "gzip")]
+#[test]
+fn rejects_non_qlog_gz_extension() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("archive.tar.gz");
+    std::fs::write(&path, b"not a qlog file").expect("write");
+    assert_with_file_err(&path, "does not match a known qlog extension");
+}
+
+/// Regression test: a bare `.gz` extension (without `.sqlog`) is also
+/// rejected. The legacy single-component extension match silently
+/// accepted these.
+#[cfg(feature = "gzip")]
+#[test]
+fn rejects_bare_gz_extension() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("data.gz");
+    std::fs::write(&path, b"not a qlog file").expect("write");
+    assert_with_file_err(&path, "does not match a known qlog extension");
+}
+
+/// Regression test: a bare `.zst` extension (without `.sqlog`) is
+/// rejected. Symmetric to [`rejects_bare_gz_extension`].
+#[cfg(feature = "zstd")]
+#[test]
+fn rejects_bare_zst_extension() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("data.zst");
+    std::fs::write(&path, b"not a qlog file").expect("write");
+    assert_with_file_err(&path, "does not match a known qlog extension");
+}
+
+/// Regression test: unknown extensions surface a clear error message.
+#[test]
+fn rejects_unknown_extension() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("data.txt");
+    std::fs::write(&path, b"not a qlog file").expect("write");
+    assert_with_file_err(&path, "does not match a known qlog extension");
+}

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -11,6 +11,8 @@ readme = "README.md"
 rust-version = "1.85"
 
 [features]
+default = ["qlog-gzip", "qlog-zstd"]
+
 # Forwarded quiche features for re-exports
 fuzzing = ["quiche/fuzzing"]
 quiche_internal = ["quiche/internal"]
@@ -40,6 +42,27 @@ capture_keylogs = []
 # Enable scheduling & poll duration histograms for tokio tasks.
 tokio-task-metrics = []
 
+# Enable gzip compression for QLOG output files. Forwards to the
+# `qlog` crate's `gzip` feature so `QuicSettings::qlog_compression =
+# QlogCompression::Gzip` is available at runtime and emits
+# `.sqlog.gz` files. Pulls in `flate2` with its crate-default backend
+# (consumers can override the backend by depending on `flate2`
+# directly).
+#
+# May be combined with `qlog-zstd`; the algorithm is selected per
+# connection at runtime via `QuicSettings::qlog_compression`.
+qlog-gzip = ["qlog/gzip"]
+
+# Enable zstd compression for QLOG output files. Forwards to the
+# `qlog` crate's `zstd` feature so `QuicSettings::qlog_compression =
+# QlogCompression::Zstd` is available at runtime and emits
+# `.sqlog.zst` files. Pulls in the `zstd` crate, which links against
+# `zstd-sys` (a C dependency).
+#
+# May be combined with `qlog-gzip`; the algorithm is selected per
+# connection at runtime via `QuicSettings::qlog_compression`.
+qlog-zstd = ["qlog/zstd"]
+
 [lints.rust]
 # capture_keylogs: enable SSLKEYLOGFILE capturing for QUIC connections.
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(capture_keylogs)'] }
@@ -59,6 +82,7 @@ ipnetwork = { workspace = true }
 log = { workspace = true }
 octets = { workspace = true }
 pin-project = { workspace = true }
+qlog = { workspace = true, features = ["foundations"] }
 quiche = { workspace = true, features = ["boringssl-boring-crate", "qlog"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_with = { workspace = true }
@@ -88,6 +112,7 @@ http-body = "1"
 http-body-util = "0.1"
 regex = { workspace = true }
 serde_json = { workspace = true }
+tempfile = "3"
 tokio = { workspace = true, features = ["time", "test-util", "rt-multi-thread"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/tokio-quiche/src/lib.rs
+++ b/tokio-quiche/src/lib.rs
@@ -74,8 +74,24 @@
 //! # Feature Flags
 //!
 //! tokio-quiche supports a number of feature flags to enable experimental
-//! features, performance enhancements, and additional telemetry. By default, no
-//! feature flags are enabled.
+//! features, performance enhancements, and additional telemetry.
+//!
+//! Enabled by default:
+//!
+//! - `qlog-gzip`: Forwards to the `qlog` crate's `gzip` feature so QLOG output
+//!   can be emitted as `.sqlog.gz` via `flate2`.
+//! - `qlog-zstd`: Forwards to the `qlog` crate's `zstd` feature so QLOG output
+//!   can be emitted as `.sqlog.zst`. Pulls in the `zstd` crate (C dependency
+//!   via `zstd-sys`).
+//!
+//! Both compression features may be enabled together; the algorithm
+//! is selected per connection at runtime via
+//! [`settings::QuicSettings::qlog_compression`]. Disable both with
+//! `default-features = false` to opt out of the extra dependencies;
+//! the default `QlogCompression::None` keeps writing raw `.sqlog`
+//! files in that configuration.
+//!
+//! Off by default:
 //!
 //! - `rpk`: Support for raw public keys (RPK) in QUIC handshakes (via
 //!   [boring]).

--- a/tokio-quiche/src/quic/mod.rs
+++ b/tokio-quiche/src/quic/mod.rs
@@ -86,6 +86,8 @@ use std::time::Duration;
 use datagram_socket::DatagramSocketRecv;
 use datagram_socket::DatagramSocketSend;
 use foundations::telemetry::log;
+use qlog::writer::make_qlog_writer_from_path;
+use qlog::writer::qlog_file_name;
 
 use crate::http3::settings::Http3Settings;
 use crate::metrics::DefaultMetrics;
@@ -126,17 +128,6 @@ pub use self::hooks::ConnectionHook;
 
 /// Alias of [quiche::Connection] used internally by the crate.
 pub type QuicheConnection = quiche::Connection<crate::buf_factory::BufFactory>;
-
-fn make_qlog_writer(
-    dir: &str, id: &str,
-) -> std::io::Result<std::io::BufWriter<std::fs::File>> {
-    let mut path = std::path::PathBuf::from(dir);
-    let filename = format!("{id}.sqlog");
-    path.push(filename);
-
-    let f = std::fs::File::create(&path)?;
-    Ok(std::io::BufWriter::new(f))
-}
 
 /// Connects to an HTTP/3 server using `socket` and the default client
 /// configuration.
@@ -242,9 +233,13 @@ where
     if let Some(qlog_dir) = &client_config.qlog_dir {
         log::info!("setting up qlogs"; "qlog_dir"=>qlog_dir);
         let id = format!("{:?}", &scid);
-        if let Ok(writer) = make_qlog_writer(qlog_dir, &id) {
+        let path = std::path::Path::new(qlog_dir)
+            .join(qlog_file_name(&id, client_config.qlog_compression));
+        if let Ok(writer) =
+            make_qlog_writer_from_path(&path, client_config.qlog_compression)
+        {
             quiche_conn.set_qlog(
-                std::boxed::Box::new(writer),
+                writer,
                 "tokio-quiche qlog".to_string(),
                 format!("tokio-quiche qlog id={id}"),
             );
@@ -310,6 +305,7 @@ where
         ConnectionAcceptorConfig {
             disable_client_ip_validation: config.disable_client_ip_validation,
             qlog_dir: config.qlog_dir.clone(),
+            qlog_compression: config.qlog_compression,
             keylog_file: config
                 .keylog_file
                 .as_ref()

--- a/tokio-quiche/src/quic/router/acceptor.rs
+++ b/tokio-quiche/src/quic/router/acceptor.rs
@@ -32,6 +32,9 @@ use std::time::Instant;
 use datagram_socket::DatagramSocketSend;
 use datagram_socket::DatagramSocketSendExt;
 use datagram_socket::MAX_DATAGRAM_SIZE;
+use qlog::writer::make_qlog_writer_from_path;
+use qlog::writer::qlog_file_name;
+use qlog::writer::QlogCompression;
 use quiche::ConnectionId;
 use quiche::Header;
 use quiche::RetryConnectionIds;
@@ -42,7 +45,6 @@ use crate::metrics::labels;
 use crate::metrics::Metrics;
 use crate::quic::addr_validation_token::AddrValidationTokenManager;
 use crate::quic::connection::SharedConnectionIdGenerator;
-use crate::quic::make_qlog_writer;
 use crate::quic::router::NewConnection;
 use crate::quic::Incoming;
 use crate::QuicResultExt;
@@ -62,6 +64,7 @@ pub(crate) struct ConnectionAcceptor<S, M> {
 pub(crate) struct ConnectionAcceptorConfig {
     pub(crate) disable_client_ip_validation: bool,
     pub(crate) qlog_dir: Option<String>,
+    pub(crate) qlog_compression: QlogCompression,
     pub(crate) keylog_file: Option<File>,
     #[cfg(target_os = "linux")]
     pub(crate) with_pktinfo: bool,
@@ -114,9 +117,13 @@ where
 
         if let Some(qlog_dir) = &self.config.qlog_dir {
             let id = format!("{:?}", &scid);
-            if let Ok(writer) = make_qlog_writer(qlog_dir, &id) {
+            let path = std::path::Path::new(qlog_dir)
+                .join(qlog_file_name(&id, self.config.qlog_compression));
+            if let Ok(writer) =
+                make_qlog_writer_from_path(&path, self.config.qlog_compression)
+            {
                 conn.set_qlog(
-                    std::boxed::Box::new(writer),
+                    writer,
                     "tokio-quiche qlog".to_string(),
                     format!("tokio-quiche qlog id={id}"),
                 );

--- a/tokio-quiche/src/quic/router/mod.rs
+++ b/tokio-quiche/src/quic/router/mod.rs
@@ -924,6 +924,7 @@ mod tests {
             ConnectionAcceptorConfig {
                 disable_client_ip_validation: config.disable_client_ip_validation,
                 qlog_dir: config.qlog_dir.clone(),
+                qlog_compression: config.qlog_compression,
                 keylog_file: config
                     .keylog_file
                     .as_ref()

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -29,6 +29,8 @@ use std::borrow::Cow;
 use std::fs::File;
 use std::time::Duration;
 
+use qlog::writer::QlogCompression;
+
 use crate::result::QuicResult;
 use crate::settings::CertificateKind;
 use crate::settings::ConnectionParams;
@@ -45,6 +47,7 @@ pub(crate) struct Config {
     pub quiche_config: quiche::Config,
     pub disable_client_ip_validation: bool,
     pub qlog_dir: Option<String>,
+    pub qlog_compression: QlogCompression,
     pub has_gso: bool,
     pub pacing_offload: bool,
     pub enable_expensive_packet_count_metrics: bool,
@@ -95,6 +98,7 @@ impl Config {
             disable_client_ip_validation: quic_settings
                 .disable_client_ip_validation,
             qlog_dir: quic_settings.qlog_dir.clone(),
+            qlog_compression: quic_settings.qlog_compression,
             has_gso,
             pacing_offload,
             enable_expensive_packet_count_metrics: quic_settings

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -29,6 +29,8 @@ use serde_with::serde_as;
 use serde_with::DurationMilliSeconds;
 use std::time::Duration;
 
+pub use qlog::writer::QlogCompression;
+
 /// QUIC configuration parameters.
 #[serde_as]
 #[settings]
@@ -151,6 +153,16 @@ pub struct QuicSettings {
 
     /// Path to a directory where QLOG files will be saved.
     pub qlog_dir: Option<String>,
+
+    /// Compression applied to QLOG output files.
+    ///
+    /// Defaults to [`QlogCompression::None`], preserving the historical
+    /// behavior of emitting raw `.sqlog` files. The `Gzip` and `Zstd`
+    /// variants require the `qlog-gzip` and `qlog-zstd` Cargo features
+    /// (both enabled by default); builds that disable those features
+    /// cannot reference the corresponding variant.
+    #[serde(default)]
+    pub qlog_compression: QlogCompression,
 
     /// Congestion control algorithm to use.
     ///

--- a/tokio-quiche/tests/integration_tests/mod.rs
+++ b/tokio-quiche/tests/integration_tests/mod.rs
@@ -44,6 +44,7 @@ pub mod async_callbacks;
 pub mod connection_close;
 pub mod headers;
 pub mod migration;
+pub mod qlog_compression;
 pub mod stream_limit;
 pub mod timeouts;
 pub mod zero_rtt;

--- a/tokio-quiche/tests/integration_tests/qlog_compression.rs
+++ b/tokio-quiche/tests/integration_tests/qlog_compression.rs
@@ -1,0 +1,115 @@
+// Copyright (C) 2026, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! Thin integration test: drive a real tokio-quiche server+client
+//! handshake with `QuicSettings::qlog_compression` set, and assert
+//! the server produces a qlog file with the expected extension.
+//!
+//! Full writer-reader round-trips (decoding the file, validating the
+//! JSON-SEQ structure, asserting events are present) live in the
+//! `qlog` crate's `compression_roundtrip` integration test. This
+//! file's only job is to confirm the `QuicSettings -> Config ->
+//! ConnectionAcceptorConfig` plumbing threads the compression
+//! selection all the way to the emitted file on disk.
+
+#[cfg(all(feature = "qlog-gzip", feature = "qlog-zstd"))]
+use crate::fixtures::*;
+
+#[cfg(all(feature = "qlog-gzip", feature = "qlog-zstd"))]
+use std::time::Duration;
+
+#[cfg(all(feature = "qlog-gzip", feature = "qlog-zstd"))]
+use tokio::time::sleep;
+#[cfg(all(feature = "qlog-gzip", feature = "qlog-zstd"))]
+use tokio_quiche::settings::QlogCompression;
+
+/// Short sleep used after the request completes but before we read
+/// the qlog file, so the server-side connection's drop path runs
+/// and the compressor's end-of-stream trailer (if any) is flushed.
+/// Connection teardown on localhost typically takes <10 ms; 200 ms
+/// is generous and keeps the test fast.
+#[cfg(all(feature = "qlog-gzip", feature = "qlog-zstd"))]
+const DRAIN_DELAY: Duration = Duration::from_millis(200);
+
+/// Drive one H3 request against a server configured with the given
+/// `compression` + `qlog_dir`, wait for the drop path to flush, and
+/// assert the server produced a file whose name ends with
+/// `expected_suffix`.
+#[cfg(all(feature = "qlog-gzip", feature = "qlog-zstd"))]
+async fn assert_server_emits_suffix(
+    compression: QlogCompression, expected_suffix: &str,
+) {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let mut quic_settings = QuicSettings::default();
+    quic_settings.qlog_dir = Some(dir.path().to_string_lossy().into_owned());
+    quic_settings.qlog_compression = compression;
+
+    let hook = TestConnectionHook::new();
+    let (url, _audit_rx) = start_server_with_settings(
+        quic_settings,
+        Http3Settings::default(),
+        hook,
+        handle_connection,
+    );
+
+    let url = format!("{url}/1");
+    let _ = request(url, 1).await.expect("request failed");
+
+    sleep(DRAIN_DELAY).await;
+
+    let entries: Vec<_> = std::fs::read_dir(dir.path())
+        .expect("qlog dir readable")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_file())
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected 1 qlog file under {:?}, got {entries:?}",
+        dir.path()
+    );
+    let name = entries[0]
+        .file_name()
+        .and_then(|s| s.to_str())
+        .expect("file name");
+    assert!(
+        name.ends_with(expected_suffix),
+        "expected name ending in {expected_suffix}, got {name}"
+    );
+}
+
+/// Proves the full `QuicSettings::qlog_compression` plumbing path by
+/// driving two real handshakes back-to-back with gzip and zstd, and
+/// asserting each produced the correct file extension on disk. The
+/// file *contents* are covered by the qlog crate's round-trip tests;
+/// this test is about TQ-side plumbing.
+#[cfg(all(feature = "qlog-gzip", feature = "qlog-zstd"))]
+#[tokio::test]
+async fn qlog_compression_threads_through_to_disk() {
+    assert_server_emits_suffix(QlogCompression::Gzip, ".sqlog.gz").await;
+    assert_server_emits_suffix(QlogCompression::Zstd, ".sqlog.zst").await;
+}


### PR DESCRIPTION
## Summary

Adds two opt-in Cargo features, `qlog-gzip` and `qlog-zstd`, that wrap `tokio-quiche`'s qlog writer in a streaming gzip or zstd encoder and emit `.sqlog.gz` / `.sqlog.zst` respectively. A new `QuicSettings::qlog_compression` field selects the algorithm (`QlogCompression::{None, Gzip, Zstd}`, default `None`). When `None` is selected — or when a feature is not compiled in — the writer stays on the pre-patch `BufWriter<File>` path and emits byte-identical `.sqlog` output.

Both features may be enabled together: the choice is made per connection at runtime via the config field.

Motivation: QUIC / HTTP/3 benchmarking and observability pipelines produce large qlog traces per run, many of which ship off-host for offline analysis. Using simulation in a controlled environment on ~10 real traces shows zstd-1 reaching ~8.0% of raw at ~34 ms/connection, vs gzip-6 at ~8.1% / ~374 ms/connection — same ratio, ~11× cheaper CPU.

## What's in the change

- **New public enum `tokio_quiche::settings::QlogCompression`** with `None` (always available, default), `Gzip` (requires `qlog-gzip`), and `Zstd` (requires `qlog-zstd`). Uses the foundations `#[settings]` macro so it deserializes from YAML/JSON like the rest of the config surface; derives `Copy + Eq + PartialEq` so it can be passed by value into the internal `Config`.
- **New field** `QuicSettings::qlog_compression: QlogCompression` with `#[serde(default)]`. Existing config files without this field continue to deserialize unchanged.
- **Dedicated internal module `tokio_quiche::qlog`** (`src/qlog.rs`) owns the enum, `make_qlog_writer`, and the zstd drop-wrapper. This keeps the qlog plumbing in one place and leaves room for future additions (configurable compression level, custom filename format, output-buffer tuning) without bloating `quic/mod.rs`. The public path `tokio_quiche::settings::QlogCompression` is preserved as a re-export.
- **`make_qlog_writer` returns `Box<dyn Write + Send + Sync>`** with three arms:
  - `None` → `.sqlog` + `BufWriter<File>` (byte-identical to the pre-patch default).
  - `Gzip` → `.sqlog.gz` + `flate2::write::GzEncoder<BufWriter<File>>`.
  - `Zstd` → `.sqlog.zst` + `zstd::Encoder<BufWriter<File>>` wrapped in a local `ZstdFinishOnDrop<W>` so the zstd frame trailer is flushed when the qlog streamer drops. `zstd`'s own `AutoFinishEncoder` is `!Sync` (holds a user closure), while `quiche::Connection::set_qlog` requires `Send + Sync`; the local wrapper preserves those bounds.
- **Defence-in-depth** path-traversal validator at the top of `make_qlog_writer` rejects `id` values that are empty or contain `/`, `\`, `\0`, or `..`. Today the `id` is the `Debug` form of the source CID (lowercase hex), so the validator only fires on genuinely malformed inputs — a future `Debug` change or a caller passing a differently-formatted identifier cannot escape the configured qlog directory. Rejections return `io::ErrorKind::InvalidInput`; existing `if let Ok(writer)` call sites degrade gracefully by skipping qlog setup for that connection.
- **Memory invariant**: no `Vec<u8>` accumulator anywhere in the qlog path. Every encoder wraps `BufWriter<File>` directly; chunks flush at the 8 KiB buffer boundary regardless of connection lifetime.
- **Dependencies**: `flate2` is optional with `default-features = false, features = ["rust_backend"]`, so `qlog-gzip` adds no C dependency. `zstd` is optional and links against `zstd-sys` (C); opt-in and documented in both `Cargo.toml` and the enum docstring.

## Testing

`tokio-quiche/tests/integration_tests/qlog_compression.rs` drives each `QlogCompression` variant end-to-end through a real QUIC + HTTP/3 handshake and asserts per variant:

- Emitted file has the expected extension (`.sqlog`, `.sqlog.gz`, `.sqlog.zst`).
- File starts with the expected magic bytes (gzip `1f 8b`, zstd `28 b5 2f fd`).
- Decompressed content round-trips through `qlog::reader::QlogSeqReader`, yielding a header whose `serialization_format == "JSON-SEQ"` and at least one event. For zstd this implicitly validates that `ZstdFinishOnDrop::drop` fired — a truncated frame would fail to decode or parse.

An additional test `qlog_compression_both_features_coexist_at_runtime` (gated on `all(feature = "qlog-gzip", feature = "qlog-zstd")`) drives two connections in the same process, one configured for `Gzip` and one for `Zstd`, and round-trips both emitted files through the matching decoders — proving the two features coexist without conflict.

All feature combinations build:

```
cargo check -p tokio-quiche
cargo check -p tokio-quiche --features qlog-gzip
cargo check -p tokio-quiche --features qlog-zstd
cargo check -p tokio-quiche --features qlog-gzip,qlog-zstd
```

Integration suite runs clean under each of the above (`cargo test -p tokio-quiche --test main -- --test-threads=1`) with the new `qlog_compression` tests added per-feature.

## Notes for reviewers

- 10 files changed, +601 / −16. If your diff looks larger, check the target branch.
- `qlog` and `tempfile` are added as `[dev-dependencies]` only (for the `QlogSeqReader` round-trip helper and test tmpdirs).
- The `zstd` level is hardcoded to 3 (the zstd default) in `make_qlog_writer`. Exposing it via a config field is a natural follow-up if benchmarking shows a different default is warranted.
