### PR TITLE
tokio-quiche: expose use_initial_max_data_as_fc_window on QuicSettings

### DIFF
--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -186,6 +186,9 @@ fn make_quiche_config(
 
     config.set_max_connection_window(quic_settings.max_connection_window);
     config.set_max_stream_window(quic_settings.max_stream_window);
+    config.set_use_initial_max_data_as_flow_control_win(
+        quic_settings.use_initial_max_data_as_fc_window,
+    );
     config.set_enable_send_streams_blocked(
         quic_settings.enable_send_streams_blocked,
     );

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -258,6 +258,16 @@ pub struct QuicSettings {
     #[serde(default = "QuicSettings::default_max_stream_window")]
     pub max_stream_window: u64,
 
+    /// Whether to use the `initial_max_data` transport parameter as the
+    /// initial connection and stream flow control window.
+    ///
+    /// See [`set_use_initial_max_data_as_flow_control_win()`] for more.
+    ///
+    /// Defaults to `false`.
+    ///
+    /// [`set_use_initial_max_data_as_flow_control_win()`]: https://docs.rs/quiche/latest/quiche/struct.Config.html#method.set_use_initial_max_data_as_flow_control_win
+    pub use_initial_max_data_as_fc_window: bool,
+
     /// If true, send an advisory STREAMS_BLOCKED frame when the
     /// application's local stream creation attempts fail due to the
     /// peer advertised MAX_STREAMS limit.


### PR DESCRIPTION
Adds a `use_initial_max_data_as_fc_window` field to `QuicSettings` that wires through `make_quiche_config` to the existing `quiche::Config::set_use_initial_max_data_as_flow_control_win` setter. Defaults to `false`, preserving current behavior.