### PR TITLE
tokio-quiche: box quiche::Connection to shrink async state

### DIFF
--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -42,7 +42,6 @@ use datagram_socket::QuicAuditStats;
 use datagram_socket::ShutdownConnection;
 use datagram_socket::SocketStats;
 use foundations::telemetry::log;
-use futures::future::BoxFuture;
 use futures::Future;
 use quiche::ConnectionId;
 use std::fmt;
@@ -277,7 +276,8 @@ where
     /// [boring]'s SSL object for this connection.
     #[doc(hidden)]
     pub fn ssl_mut(&mut self) -> &mut SslRef {
-        self.params.quiche_conn.as_mut()
+        // Deref to pick `Connection::as_mut` over `Box::as_mut`.
+        (*self.params.quiche_conn).as_mut()
     }
 
     /// A handle to the [`QuicAuditStats`] for this connection.
@@ -307,12 +307,11 @@ where
     /// This is a lower-level alternative to the `handshake` function which
     /// gives the caller more control over execution of the future. See
     /// `handshake` for details on the return values.
-    #[allow(clippy::type_complexity)]
     pub fn handshake_fut<A: ApplicationOverQuic>(
         self, app: A,
     ) -> (
         QuicConnection,
-        BoxFuture<'static, io::Result<Running<Arc<Tx>, M, A>>>,
+        impl Future<Output = io::Result<Running<Arc<Tx>, M, A>>> + Send + 'static,
     ) {
         self.params.metrics.connections_in_memory().inc();
 
@@ -367,7 +366,7 @@ where
             }
         };
 
-        (conn, Box::pin(handshake_fut))
+        (conn, handshake_fut)
     }
 
     /// Performs the QUIC handshake in a separate tokio task and awaits its
@@ -438,6 +437,9 @@ where
     pub fn start<A: ApplicationOverQuic>(self, app: A) -> QuicConnection {
         let task_metrics = self.params.metrics.clone();
         let (conn, handshake_fut) = Self::handshake_fut(self, app);
+        // Pin to the heap so the spawned task only carries a pointer to it
+        // instead of inlining the full future state across the await.
+        let handshake_fut = Box::pin(handshake_fut);
 
         let fut = async move {
             match handshake_fut.await {
@@ -473,7 +475,11 @@ where
     #[cfg(feature = "perf-quic-listener-metrics")]
     pub init_rx_time: Option<SystemTime>,
     pub handshake_info: HandshakeInfo,
-    pub quiche_conn: QuicheConnection,
+    /// Boxed because this value is moved by-value through several nested
+    /// async state machines. Inlining a [`QuicheConnection`] here would
+    /// duplicate its payload across the future state slots that hold it
+    /// across an `.await`.
+    pub quiche_conn: Box<QuicheConnection>,
     pub socket: Arc<Tx>,
     pub local_addr: SocketAddr,
     pub peer_addr: SocketAddr,

--- a/tokio-quiche/src/quic/io/worker.rs
+++ b/tokio-quiche/src/quic/io/worker.rs
@@ -773,12 +773,14 @@ enum WaitForDataOrHandshakeDirective {
 pub struct Running<Tx, M, A> {
     pub(crate) params: IoWorkerParams<Tx, M>,
     pub(crate) context: ConnectionStageContext<A>,
-    pub(crate) qconn: QuicheConnection,
+    /// See [`QuicConnectionParams::quiche_conn`].
+    pub(crate) qconn: Box<QuicheConnection>,
 }
 
 impl<Tx, M, A> Running<Tx, M, A> {
     pub fn ssl(&mut self) -> &mut SslRef {
-        self.qconn.as_mut()
+        // Deref to pick `Connection::as_mut` over `Box::as_mut`.
+        (*self.qconn).as_mut()
     }
 }
 
@@ -786,7 +788,8 @@ pub(crate) struct Closing<Tx, M, A> {
     pub(crate) params: IoWorkerParams<Tx, M>,
     pub(crate) context: ConnectionStageContext<A>,
     pub(crate) work_loop_result: QuicResult<()>,
-    pub(crate) qconn: QuicheConnection,
+    /// See [`QuicConnectionParams::quiche_conn`].
+    pub(crate) qconn: Box<QuicheConnection>,
 }
 
 pub enum RunningOrClosing<Tx, M, A> {
@@ -800,7 +803,8 @@ where
     M: Metrics,
 {
     pub(crate) async fn run<A>(
-        mut self, mut qconn: QuicheConnection, mut ctx: ConnectionStageContext<A>,
+        mut self, mut qconn: Box<QuicheConnection>,
+        mut ctx: ConnectionStageContext<A>,
     ) -> RunningOrClosing<Tx, M, A>
     where
         A: ApplicationOverQuic,
@@ -811,7 +815,8 @@ where
         // cause issues as this waker will then be stale and attempt to
         // wake the wrong task.
         std::future::poll_fn(|cx| {
-            let ssl = qconn.as_mut();
+            // Deref to pick `Connection::as_mut` over `Box::as_mut`.
+            let ssl = (*qconn).as_mut();
             ssl.set_task_waker(Some(cx.waker().clone()));
 
             Poll::Ready(())
@@ -908,7 +913,8 @@ where
     M: Metrics,
 {
     pub(crate) async fn run<A: ApplicationOverQuic>(
-        mut self, mut qconn: QuicheConnection, mut ctx: ConnectionStageContext<A>,
+        mut self, mut qconn: Box<QuicheConnection>,
+        mut ctx: ConnectionStageContext<A>,
     ) -> Closing<Tx, M, A> {
         // Perform a single call to process_reads()/process_writes(),
         // unconditionally, to ensure that any application data (e.g.

--- a/tokio-quiche/src/quic/mod.rs
+++ b/tokio-quiche/src/quic/mod.rs
@@ -262,7 +262,7 @@ where
         Arc::clone(&socket_tx),
         socket_rx,
         socket.local_addr,
-        ClientConnector::new(socket_tx, quiche_conn),
+        ClientConnector::new(socket_tx, Box::new(quiche_conn)),
         DefaultMetrics,
     );
 

--- a/tokio-quiche/src/quic/raw.rs
+++ b/tokio-quiche/src/quic/raw.rs
@@ -126,7 +126,7 @@ where
         #[cfg(feature = "perf-quic-listener-metrics")]
         init_rx_time: None,
         handshake_info: HandshakeInfo::new(Instant::now(), None),
-        quiche_conn,
+        quiche_conn: Box::new(quiche_conn),
         socket,
         local_addr,
         peer_addr,

--- a/tokio-quiche/src/quic/router/acceptor.rs
+++ b/tokio-quiche/src/quic/router/acceptor.rs
@@ -137,7 +137,7 @@ where
         }
 
         Ok(Some(NewConnection {
-            conn,
+            conn: Box::new(conn),
             handshake_start_time,
             pending_cid: Some(pending_cid),
             cid_generator: Some(Arc::clone(&self.cid_generator)),

--- a/tokio-quiche/src/quic/router/connector.rs
+++ b/tokio-quiche/src/quic/router/connector.rs
@@ -58,7 +58,7 @@ pub(crate) struct ClientConnector<Tx> {
 /// State the connecting connection is in.
 enum ConnectionState {
     /// Connection hasn't had any initials sent for it
-    Queued(QuicheConnection),
+    Queued(Box<QuicheConnection>),
     /// It's currently in a QUIC handshake
     Pending(PendingConnection),
     /// It's been returned to the
@@ -67,7 +67,7 @@ enum ConnectionState {
 }
 
 impl ConnectionState {
-    fn take_if_queued(&mut self) -> Option<QuicheConnection> {
+    fn take_if_queued(&mut self) -> Option<Box<QuicheConnection>> {
         match mem::replace(self, Self::Returned) {
             Self::Queued(conn) => Some(conn),
             state => {
@@ -94,7 +94,7 @@ impl ConnectionState {
 /// A [`PendingConnection`] holds an internal [`quiche::Connection`] and an
 /// optional timeout [`Key`].
 struct PendingConnection {
-    conn: QuicheConnection,
+    conn: Box<QuicheConnection>,
     timeout_key: Option<Key>,
     handshake_start_time: Instant,
 }
@@ -103,7 +103,9 @@ impl<Tx> ClientConnector<Tx>
 where
     Tx: DatagramSocketSend + Send + 'static,
 {
-    pub(crate) fn new(socket_tx: Arc<Tx>, connection: QuicheConnection) -> Self {
+    pub(crate) fn new(
+        socket_tx: Arc<Tx>, connection: Box<QuicheConnection>,
+    ) -> Self {
         Self {
             socket_tx: MaybeConnectedSocket::new(socket_tx),
             connection: ConnectionState::Queued(connection),
@@ -115,7 +117,7 @@ where
     ///
     /// This sends any pending packets and arms the connection's timeout timer.
     fn set_connection_to_pending(
-        &mut self, mut conn: QuicheConnection,
+        &mut self, mut conn: Box<QuicheConnection>,
     ) -> io::Result<()> {
         simple_conn_send(&self.socket_tx, &mut conn)?;
 

--- a/tokio-quiche/src/quic/router/mod.rs
+++ b/tokio-quiche/src/quic/router/mod.rs
@@ -825,7 +825,8 @@ pub trait InitialPacketHandler {
 /// A [`NewConnection`] describes a new [`quiche::Connection`] that can be
 /// driven by an io worker.
 pub struct NewConnection {
-    conn: QuicheConnection,
+    /// See [`QuicConnectionParams::quiche_conn`].
+    conn: Box<QuicheConnection>,
     pending_cid: Option<ConnectionId<'static>>,
     initial_pkt: Option<Incoming>,
     cid_generator: Option<SharedConnectionIdGenerator>,


### PR DESCRIPTION
Store quiche::Connection as Box<QuicheConnection> in QuicConnectionParams, Running, Closing, NewConnection, the connector states, and IoWorker::run parameters. The connection is moved by value through several nested async state machines, and rustc does not deduplicate that storage across nested awaits, so the ~15 KB payload was reserved in multiple state slots.

Also drops BoxFuture from handshake_fut's return type now that the inner future is small; start() pins it locally to avoid inlining it twice.

Per server-side H3 connection (-Zprint-type-sizes):
  resume future:    53664 -> 7024  (+15552 heap)  31088 saved
  handshake future: 71360 -> 9168  (+15552 heap)  46640 saved
  start task:          40 ->   24