### PR TITLE
recovery: clear loss timer when no PTO timeout is calculated

### DIFF
--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -495,6 +495,8 @@ impl LegacyRecovery {
         if let (Some(timeout), _) = self.pto_time_and_space(handshake_status, now)
         {
             self.loss_timer.update(timeout);
+        } else {
+            self.loss_timer.clear();
         }
     }
 

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -649,6 +649,8 @@ impl GRecovery {
         if let (Some(timeout), _) = self.pto_time_and_space(handshake_status, now)
         {
             self.loss_timer.update(timeout);
+        } else {
+            self.loss_timer.clear();
         }
     }
 }

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -2761,6 +2761,101 @@ mod tests {
             );
         }
     }
+    #[test]
+    fn pto_overflow_reproduction() {
+        let cfg = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        // Use LegacyRecovery (which is part of the default Recovery)
+        let mut r = Recovery::new(&cfg);
+        let now = Instant::now();
+
+        // Scenario: Handshake not completed
+        let handshake_status = HandshakeStatus {
+            has_handshake_keys: true,
+            peer_verified_address: true,
+            completed: false,
+        };
+
+        // 1. Send Initial packet to arm the timer
+        let p_initial = Sent {
+            pkt_num: 0,
+            frames: smallvec::smallvec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: 1000,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
+            has_data: false,
+            is_pmtud_probe: false,
+        };
+        r.on_packet_sent(
+            p_initial,
+            packet::Epoch::Initial,
+            handshake_status,
+            now,
+            "",
+        );
+
+        // The timer should now be set for the Initial packet.
+        assert!(r.loss_detection_timer().is_some());
+
+        // 2. Send Application packet (0-RTT)
+        let p_app = Sent {
+            pkt_num: 0, // Application space has its own packet numbers
+            frames: smallvec::smallvec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: 1000,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            tx_in_flight: 0,
+
+            lost: 0,
+            has_data: true,
+            is_pmtud_probe: false,
+        };
+        r.on_packet_sent(
+            p_app,
+            packet::Epoch::Application,
+            handshake_status,
+            now,
+            "",
+        );
+
+        // 3. Acknowledge the Initial packet.
+        // This empties the Initial space, but Application space still has data in
+        // flight.
+        let mut ranges = RangeSet::default();
+        ranges.insert(0..1);
+        r.on_ack_received(
+            &ranges,
+            0,
+            packet::Epoch::Initial,
+            handshake_status,
+            now,
+            None,
+            "",
+        )
+        .unwrap();
+
+        // The timer should be cleared at this point.
+        // Although there is Application data in flight, the handshake is not
+        // confirmed, so it cannot be used to arm the PTO timer. Since there are
+        // no packets in flight in Initial or Handshake spaces either, no timer
+        // should be set.
+        assert!(r.loss_detection_timer().is_none());
+    }
 }
 
 mod bandwidth;

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -2761,10 +2761,12 @@ mod tests {
             );
         }
     }
-    #[test]
-    fn pto_overflow_reproduction() {
-        let cfg = Config::new(crate::PROTOCOL_VERSION).unwrap();
-        // Use LegacyRecovery (which is part of the default Recovery)
+    #[rstest]
+    fn pto_overflow_reproduction(
+        #[values("reno", "cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+    ) {
+        let mut cfg = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
         let mut r = Recovery::new(&cfg);
         let now = Instant::now();
 


### PR DESCRIPTION
Currently, in `set_loss_detection_timer`, the loss timer is only updated if `pto_time_and_space` returns `Some(timeout)`. If it returns `None`, the timer is left unchanged.

`pto_time_and_space` can return `None` when there are packets in flight in the Application space (e.g., 0-RTT data on the client, or 1-RTT data on the server before handshake confirmation) but no packets in flight in Initial or Handshake spaces, and the handshake is not yet confirmed.

If the timer had already expired when this state is reached, leaving it unchanged causes the connection to repeatedly see an expired timer and immediately trigger `on_loss_detection_timeout`. This creates a tight infinite loop where `pto_count` rapidly increases until it overflows, crashing the process with "attempt to multiply with overflow".

This commit restores the behavior prior to commit bc952e8e09210d5b242640e3e6e56245cd780ded ("recovery: implement the loss detection timer as a struct") by explicitly clearing the loss timer when `pto_time_and_space` returns `None`.

A unit test `pto_overflow_reproduction` is added to reproduce this scenario on a client by simulating 0-RTT data in flight while the Initial space becomes empty before handshake confirmation.