### PR TITLE
Fix panic in exponential backoff logic

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -504,6 +504,11 @@ const MAX_CRYPTO_STREAM_OFFSET: u64 = 1 << 16;
 // The send capacity factor.
 const TX_CAP_FACTOR: f64 = 1.0;
 
+// The upper cap on the exponent when using exponential backoff for probes. With a
+// value of 5, the maximum possible value is 2^5 = 32 times the minimum PTO. This
+// prevents arithmetic overflow.
+const MAX_PTO_EXPONENT: u32 = 5;
+
 /// Ancillary information about incoming packets.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RecvInfo {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -504,11 +504,6 @@ const MAX_CRYPTO_STREAM_OFFSET: u64 = 1 << 16;
 // The send capacity factor.
 const TX_CAP_FACTOR: f64 = 1.0;
 
-// The upper cap on the exponent when using exponential backoff for probes. With a
-// value of 5, the maximum possible value is 2^5 = 32 times the minimum PTO. This
-// prevents arithmetic overflow.
-const MAX_PTO_EXPONENT: u32 = 5;
-
 /// Ancillary information about incoming packets.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RecvInfo {

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -426,7 +426,7 @@ impl LegacyRecovery {
     fn pto_time_and_space(
         &self, handshake_status: HandshakeStatus, now: Instant,
     ) -> (Option<Instant>, Epoch) {
-        let mut duration = self.pto() * 2_u32.pow(self.pto_count);
+        let mut duration = self.pto() * 2_u32.pow(self.pto_count.min(20));
 
         // Arm PTO from now when there are no inflight packets.
         if self.bytes_in_flight.is_zero() {
@@ -454,8 +454,8 @@ impl LegacyRecovery {
                 }
 
                 // Include max_ack_delay and backoff for Application Data.
-                duration +=
-                    self.rtt_stats.max_ack_delay * 2_u32.pow(self.pto_count);
+                duration += self.rtt_stats.max_ack_delay
+                    * 2_u32.pow(self.pto_count.min(20));
             }
 
             let new_time = epoch
@@ -1093,4 +1093,30 @@ pub struct Acked {
     pub first_sent_time: Instant,
 
     pub is_app_limited: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recovery::HandshakeStatus;
+    use crate::recovery::RecoveryConfig;
+    use std::time::Instant;
+
+    #[test]
+    fn test_high_pto_count_no_panic() {
+        let config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        let recovery_config = RecoveryConfig::from_config(&config);
+        let mut r = LegacyRecovery::new_with_config(&recovery_config);
+
+        r.pto_count = 99999;
+
+        let handshake_status = HandshakeStatus {
+            completed: true,
+            has_handshake_keys: true,
+            peer_verified_address: true,
+        };
+        let now = Instant::now();
+
+        let _ = r.pto_time_and_space(handshake_status, now);
+    }
 }

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -64,6 +64,7 @@ use crate::recovery::INITIAL_PACKET_THRESHOLD;
 use crate::recovery::INITIAL_TIME_THRESHOLD;
 use crate::recovery::MAX_OUTSTANDING_NON_ACK_ELICITING;
 use crate::recovery::MAX_PACKET_THRESHOLD;
+use crate::recovery::MAX_PTO_EXPONENT;
 use crate::recovery::MAX_PTO_PROBES_COUNT;
 use crate::recovery::PACKET_REORDER_TIME_THRESHOLD;
 
@@ -427,7 +428,7 @@ impl LegacyRecovery {
         &self, handshake_status: HandshakeStatus, now: Instant,
     ) -> (Option<Instant>, Epoch) {
         let mut duration =
-            self.pto() * 2_u32.pow(self.pto_count.min(crate::MAX_PTO_EXPONENT));
+            self.pto() * 2_u32.pow(self.pto_count.min(MAX_PTO_EXPONENT));
 
         // Arm PTO from now when there are no inflight packets.
         if self.bytes_in_flight.is_zero() {
@@ -456,7 +457,7 @@ impl LegacyRecovery {
 
                 // Include max_ack_delay and backoff for Application Data.
                 duration += self.rtt_stats.max_ack_delay *
-                    2_u32.pow(self.pto_count.min(crate::MAX_PTO_EXPONENT));
+                    2_u32.pow(self.pto_count.min(MAX_PTO_EXPONENT));
             }
 
             let new_time = epoch

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -426,7 +426,8 @@ impl LegacyRecovery {
     fn pto_time_and_space(
         &self, handshake_status: HandshakeStatus, now: Instant,
     ) -> (Option<Instant>, Epoch) {
-        let mut duration = self.pto() * 2_u32.pow(self.pto_count.min(20));
+        let mut duration =
+            self.pto() * 2_u32.pow(self.pto_count.min(crate::MAX_PTO_EXPONENT));
 
         // Arm PTO from now when there are no inflight packets.
         if self.bytes_in_flight.is_zero() {
@@ -454,8 +455,8 @@ impl LegacyRecovery {
                 }
 
                 // Include max_ack_delay and backoff for Application Data.
-                duration += self.rtt_stats.max_ack_delay
-                    * 2_u32.pow(self.pto_count.min(20));
+                duration += self.rtt_stats.max_ack_delay *
+                    2_u32.pow(self.pto_count.min(crate::MAX_PTO_EXPONENT));
             }
 
             let new_time = epoch

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -38,6 +38,7 @@ use crate::recovery::INITIAL_PACKET_THRESHOLD;
 use crate::recovery::INITIAL_TIME_THRESHOLD;
 use crate::recovery::MAX_OUTSTANDING_NON_ACK_ELICITING;
 use crate::recovery::MAX_PACKET_THRESHOLD;
+use crate::recovery::MAX_PTO_EXPONENT;
 use crate::recovery::MAX_PTO_PROBES_COUNT;
 use crate::recovery::PACKET_REORDER_TIME_THRESHOLD;
 
@@ -582,7 +583,7 @@ impl GRecovery {
         &self, handshake_status: HandshakeStatus, now: Instant,
     ) -> (Option<Instant>, packet::Epoch) {
         let mut duration =
-            self.pto() * 2_u32.pow(self.pto_count.min(crate::MAX_PTO_EXPONENT));
+            self.pto() * 2_u32.pow(self.pto_count.min(MAX_PTO_EXPONENT));
 
         // Arm PTO from now when there are no inflight packets.
         if self.bytes_in_flight.is_zero() {
@@ -612,7 +613,7 @@ impl GRecovery {
 
                 // Include max_ack_delay and backoff for Application Data.
                 duration += self.rtt_stats.max_ack_delay *
-                    2_u32.pow(self.pto_count.min(crate::MAX_PTO_EXPONENT));
+                    2_u32.pow(self.pto_count.min(MAX_PTO_EXPONENT));
             }
 
             let new_time = self.epochs[e]

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -581,7 +581,8 @@ impl GRecovery {
     fn pto_time_and_space(
         &self, handshake_status: HandshakeStatus, now: Instant,
     ) -> (Option<Instant>, packet::Epoch) {
-        let mut duration = self.pto() * 2_u32.pow(self.pto_count.min(20));
+        let mut duration =
+            self.pto() * 2_u32.pow(self.pto_count.min(crate::MAX_PTO_EXPONENT));
 
         // Arm PTO from now when there are no inflight packets.
         if self.bytes_in_flight.is_zero() {
@@ -610,8 +611,8 @@ impl GRecovery {
                 }
 
                 // Include max_ack_delay and backoff for Application Data.
-                duration += self.rtt_stats.max_ack_delay
-                    * 2_u32.pow(self.pto_count.min(20));
+                duration += self.rtt_stats.max_ack_delay *
+                    2_u32.pow(self.pto_count.min(crate::MAX_PTO_EXPONENT));
             }
 
             let new_time = self.epochs[e]

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -581,7 +581,7 @@ impl GRecovery {
     fn pto_time_and_space(
         &self, handshake_status: HandshakeStatus, now: Instant,
     ) -> (Option<Instant>, packet::Epoch) {
-        let mut duration = self.pto() * (1 << self.pto_count);
+        let mut duration = self.pto() * 2_u32.pow(self.pto_count.min(20));
 
         // Arm PTO from now when there are no inflight packets.
         if self.bytes_in_flight.is_zero() {
@@ -610,8 +610,8 @@ impl GRecovery {
                 }
 
                 // Include max_ack_delay and backoff for Application Data.
-                duration +=
-                    self.rtt_stats.max_ack_delay * 2_u32.pow(self.pto_count);
+                duration += self.rtt_stats.max_ack_delay
+                    * 2_u32.pow(self.pto_count.min(20));
             }
 
             let new_time = self.epochs[e]
@@ -1311,5 +1311,24 @@ mod tests {
         // Time threshold is capped at 2.0.
         assert_eq!(loss_thresh.pkt_thresh(), None);
         assert_eq!(loss_thresh.time_thresh(), MAX_TIME_THRESHOLD);
+    }
+
+    #[test]
+    fn test_high_pto_count_no_panic() {
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config.set_cc_algorithm(CongestionControlAlgorithm::Bbr2Gcongestion);
+        let recovery_config = RecoveryConfig::from_config(&config);
+        let mut r = GRecovery::new(&recovery_config).unwrap();
+
+        r.pto_count = 99999;
+
+        let handshake_status = HandshakeStatus {
+            completed: true,
+            has_handshake_keys: true,
+            peer_verified_address: true,
+        };
+        let now = Instant::now();
+
+        let _ = r.pto_time_and_space(handshake_status, now);
     }
 }

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -94,6 +94,11 @@ const LOSS_REDUCTION_FACTOR: f64 = 0.5;
 // an ACK.
 pub(super) const MAX_OUTSTANDING_NON_ACK_ELICITING: usize = 24;
 
+// The upper cap on the exponent when using exponential backoff for probes. With
+// a value of 5, the maximum possible value is 2^5 = 32 times the minimum PTO.
+// This prevents arithmetic overflow.
+const MAX_PTO_EXPONENT: u32 = 5;
+
 #[derive(Default)]
 struct LossDetectionTimer {
     time: Option<Instant>,


### PR DESCRIPTION
Previously, exponential backoff was uncapped and would increase exponentially until reaching an arithmetic overflow. This change caps the exponent at 20.

Tested with `cargo test -p quiche`