### PR TITLE
lib: introduce MAX_ACK_DELAY_EXPONENT const for ack_delay_exponent bounds

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1049,10 +1049,14 @@ impl Config {
 
     /// Sets the `ack_delay_exponent` transport parameter.
     ///
+    /// Values above the RFC 9000 maximum of
+    /// [`MAX_ACK_DELAY_EXPONENT`] (20) are clamped to that
+    /// maximum.
+    ///
     /// The default value is `3`.
     pub fn set_ack_delay_exponent(&mut self, v: u64) {
         self.local_transport_params.ack_delay_exponent =
-            cmp::min(v, octets::MAX_VAR_INT);
+            cmp::min(v, MAX_ACK_DELAY_EXPONENT);
     }
 
     /// Sets the `max_ack_delay` transport parameter.
@@ -9486,6 +9490,7 @@ pub use crate::transport_params::TransportParams;
 pub use crate::transport_params::UnknownTransportParameter;
 pub use crate::transport_params::UnknownTransportParameterIterator;
 pub use crate::transport_params::UnknownTransportParameters;
+pub use crate::transport_params::MAX_ACK_DELAY_EXPONENT;
 
 pub use crate::buffers::BufFactory;
 pub use crate::buffers::BufSplit;

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -12224,7 +12224,7 @@ fn disable_pmtud_mid_handshake(
 }
 
 #[rstest]
-fn configuration_values_are_limited_to_max_varint() {
+fn configuration_values_clamping() {
     let mut config = Config::new(0x1).unwrap();
     config
         .set_application_protos(&[b"proto1", b"proto2"])
@@ -12285,7 +12285,7 @@ fn configuration_values_are_limited_to_max_varint() {
     );
     assert_eq!(
         pipe.client.local_transport_params.ack_delay_exponent,
-        octets::MAX_VAR_INT
+        MAX_ACK_DELAY_EXPONENT
     );
     assert_eq!(
         pipe.client.local_transport_params.active_conn_id_limit,

--- a/quiche/src/transport_params.rs
+++ b/quiche/src/transport_params.rs
@@ -42,6 +42,10 @@ use qlog::events::quic::TransportInitiator;
 #[cfg(feature = "qlog")]
 use qlog::events::EventData;
 
+/// Maximum permitted value of the `ack_delay_exponent` transport parameter,
+/// as mandated by RFC 9000 Section 18.2.
+pub const MAX_ACK_DELAY_EXPONENT: u64 = 20;
+
 /// QUIC Unknown Transport Parameter.
 ///
 /// A QUIC transport parameter that is not specifically recognized
@@ -315,7 +319,7 @@ impl TransportParams {
                 0x000a => {
                     let ack_delay_exponent = val.get_varint()?;
 
-                    if ack_delay_exponent > 20 {
+                    if ack_delay_exponent > MAX_ACK_DELAY_EXPONENT {
                         return Err(Error::InvalidTransportParam);
                     }
 
@@ -498,7 +502,7 @@ impl TransportParams {
         }
 
         if tp.ack_delay_exponent != 0 {
-            assert!(tp.ack_delay_exponent <= octets::MAX_VAR_INT);
+            assert!(tp.ack_delay_exponent <= MAX_ACK_DELAY_EXPONENT);
             TransportParams::encode_param(
                 &mut b,
                 0x000a,


### PR DESCRIPTION
Replace the magic literal 20 in the transport parameter decode path with a
const MAX_ACK_DELAY_EXPONENT. Tighten Config::set_ack_delay_exponent to
clamp against this const instead of the unrestricted MAX_VAR_INT, so
locally-advertised values are kept within the protocol-mandated range.
