### PR TITLE
ffi: fix undefined behavior in _free functions with null checks

### DIFF
--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -448,7 +448,9 @@ pub extern "C" fn quiche_config_set_ticket_key(
 
 #[no_mangle]
 pub extern "C" fn quiche_config_free(config: *mut Config) {
-    drop(unsafe { Box::from_raw(config) });
+    if !config.is_null() {
+        drop(unsafe { Box::from_raw(config) });
+    }
 }
 
 #[no_mangle]
@@ -1157,7 +1159,9 @@ pub extern "C" fn quiche_connection_id_iter_next(
 
 #[no_mangle]
 pub extern "C" fn quiche_connection_id_iter_free(iter: *mut ConnectionIdIter) {
-    drop(unsafe { Box::from_raw(iter) });
+    if !iter.is_null() {
+        drop(unsafe { Box::from_raw(iter) });
+    }
 }
 
 #[no_mangle]
@@ -1315,7 +1319,9 @@ pub extern "C" fn quiche_stream_iter_next(
 
 #[no_mangle]
 pub extern "C" fn quiche_stream_iter_free(iter: *mut StreamIter) {
-    drop(unsafe { Box::from_raw(iter) });
+    if !iter.is_null() {
+        drop(unsafe { Box::from_raw(iter) });
+    }
 }
 
 #[repr(C)]
@@ -1633,7 +1639,9 @@ pub extern "C" fn quiche_conn_send_ack_eliciting_on_path(
 
 #[no_mangle]
 pub extern "C" fn quiche_conn_free(conn: *mut Connection) {
-    drop(unsafe { Box::from_raw(conn) });
+    if !conn.is_null() {
+        drop(unsafe { Box::from_raw(conn) });
+    }
 }
 
 #[no_mangle]
@@ -1756,7 +1764,9 @@ pub extern "C" fn quiche_socket_addr_iter_next(
 
 #[no_mangle]
 pub extern "C" fn quiche_socket_addr_iter_free(iter: *mut SocketAddrIter) {
-    drop(unsafe { Box::from_raw(iter) });
+    if !iter.is_null() {
+        drop(unsafe { Box::from_raw(iter) });
+    }
 }
 
 #[no_mangle]
@@ -1949,7 +1959,9 @@ pub extern "C" fn quiche_path_event_peer_migrated(
 
 #[no_mangle]
 pub extern "C" fn quiche_path_event_free(ev: *mut PathEvent) {
-    drop(unsafe { Box::from_raw(ev) });
+    if !ev.is_null() {
+        drop(unsafe { Box::from_raw(ev) });
+    }
 }
 
 #[no_mangle]

--- a/quiche/src/h3/ffi.rs
+++ b/quiche/src/h3/ffi.rs
@@ -79,7 +79,9 @@ pub extern "C" fn quiche_h3_config_enable_extended_connect(
 
 #[no_mangle]
 pub extern "C" fn quiche_h3_config_free(config: *mut h3::Config) {
-    drop(unsafe { Box::from_raw(config) });
+    if !config.is_null() {
+        drop(unsafe { Box::from_raw(config) });
+    }
 }
 
 #[no_mangle]
@@ -207,7 +209,9 @@ pub extern "C" fn quiche_h3_extended_connect_enabled_by_peer(
 
 #[no_mangle]
 pub extern "C" fn quiche_h3_event_free(ev: *mut h3::Event) {
-    drop(unsafe { Box::from_raw(ev) });
+    if !ev.is_null() {
+        drop(unsafe { Box::from_raw(ev) });
+    }
 }
 
 #[repr(C)]
@@ -399,7 +403,9 @@ pub extern "C" fn quiche_h3_dgram_enabled_by_peer(
 
 #[no_mangle]
 pub extern "C" fn quiche_h3_conn_free(conn: *mut h3::Connection) {
-    drop(unsafe { Box::from_raw(conn) });
+    if !conn.is_null() {
+        drop(unsafe { Box::from_raw(conn) });
+    }
 }
 
 fn headers_from_ptr<'a>(


### PR DESCRIPTION
Add null pointer guards before Box::from_raw() calls to prevent UB
and align with C API conventions where free(NULL) is safe.
