### PR TITLE
lib: use saturating_sub in scids_left() to prevent underflow during SCID rotation

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -7304,12 +7304,16 @@ impl<F: BufFactory> Connection<F> {
         self.ids.active_source_cids()
     }
 
-    /// Returns the number of source Connection IDs that should be provided
-    /// to the peer without exceeding the limit it advertised.
+    /// Returns the number of additional source Connection IDs that can be
+    /// provided to the peer without exceeding the limit it advertised.
     ///
-    /// This will automatically limit the number of Connection IDs to the
-    /// minimum between the locally configured active connection ID limit,
-    /// and the one sent by the peer.
+    /// The limit is the minimum of the locally configured active connection
+    /// ID limit and the one sent by the peer.
+    ///
+    /// Returns `0` when the peer's limit is already reached or temporarily
+    /// exceeded (e.g. during a SCID rotation where a retirement is in
+    /// flight and `active_scids()` transiently exceeds the advertised
+    /// limit).
     ///
     /// To obtain the maximum possible value allowed by the peer an application
     /// can instead inspect the [`peer_active_conn_id_limit`] value.
@@ -7322,7 +7326,7 @@ impl<F: BufFactory> Connection<F> {
             self.local_transport_params.active_conn_id_limit,
         ) as usize;
 
-        max_active_source_cids - self.active_scids()
+        max_active_source_cids.saturating_sub(self.active_scids())
     }
 
     /// Requests the retirement of the destination Connection ID used by the

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -10198,6 +10198,42 @@ fn connection_id_retire_limit(
 }
 
 #[rstest]
+fn avoid_scids_left_underflow_during_rotation(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    // Default active_conn_id_limit is 2, sufficient to trigger the rotation.
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // Fill up to the advertised limit.
+    let (scid_1, token_1) = test_utils::create_cid_and_reset_token(16);
+    assert_eq!(pipe.client.new_scid(&scid_1, token_1, false), Ok(1));
+    assert_eq!(pipe.advance(), Ok(()));
+    assert_eq!(pipe.client.scids_left(), 0);
+
+    // Issue a new SCID with retire_prior_to=true. This forces a rotation:
+    // the client now holds 3 SCIDs internally (seq 0 retiring, seq 1, seq 2)
+    // while the advertised limit is still 2. active_scids() = 3,
+    // max_active_source_cids = 2 => underflow.
+    let (scid_2, token_2) = test_utils::create_cid_and_reset_token(16);
+    assert_eq!(pipe.client.new_scid(&scid_2, token_2, true), Ok(2));
+
+    // Before advancing (retirement not yet acknowledged), active_scids()
+    // exceeds the advertised limit. scids_left() should return 0.
+    let active = pipe.client.active_scids();
+    let left = pipe.client.scids_left();
+
+    assert!(
+        active > 2,
+        "expected active_scids ({active}) > limit (2) during rotation"
+    );
+    assert_eq!(
+        left, 0,
+        "scids_left() should be 0 during rotation but returned {left}"
+    );
+}
+
+#[rstest]
 fn connection_id_retire_exotic_sequence(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
     #[values(true, false)] discard: bool,


### PR DESCRIPTION
During rotation, active_scids() can transiently exceed the advertised
limit. The prior unchecked subtraction panicked in debug and wrapped to
usize::MAX in release. Also adds a regression test and documents the
transient-zero behaviour.
