### PR TITLE
qlog: release 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ netlog = { version = "0.1", path="./netlog" }
 octets = { version = "0.3.5", path = "./octets" }
 parking_lot = { version = "0.12.1", default-features = false }
 pin-project = { version = "1.0.12" }
-qlog = { version = "0.17.0", path = "./qlog" }
+qlog = { version = "0.18.0", path = "./qlog" }
 quiche = { version = "0.28.0", path = "./quiche" }
 regex = { version = "1.4.2" }
 ring = { version = "0.17.8" }

--- a/qlog/Cargo.toml
+++ b/qlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qlog"
-version = "0.17.0"
+version = "0.18.0"
 description = "qlog data model for QUIC and HTTP/3"
 repository = { workspace = true }
 authors = ["Lucas Pardue <lucas@lucaspardue.com>"]


### PR DESCRIPTION
## qlog 0.18.0

Minor (breaking) release. Bumps `qlog/Cargo.toml` from `0.17.0` to `0.18.0`
and updates the workspace dependency declaration.

### Breaking changes

- `QlogStreamer::new` gained a 7th parameter for the new compression argument
  (introduced in #2444). Callers must pass a compression value:

  ```rust
  // Before
  QlogStreamer::new(qlog_version, title, description, summary, time_ref, vp, writer);
  // After
  QlogStreamer::new(qlog_version, title, description, summary, time_ref, vp, compression, writer);