### PR TITLE
ci(deploy): per-job permissions for docs + docker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ env:
 
 jobs:
   docs:
+    permissions:
+      contents: write  # crazy-max/ghaction-github-pages pushes to gh-pages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -36,6 +38,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docker:
+    permissions:
+      contents: read  # DockerHub push uses DOCKER_USERNAME/DOCKER_TOKEN, not GITHUB_TOKEN
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Declares per-job `permissions` blocks on the two jobs in `deploy.yml`:

- **docs** uses `crazy-max/ghaction-github-pages@v3` to push the generated rustdoc to the `gh-pages` branch, so it needs `contents: write` for the default `GITHUB_TOKEN`.
- **docker** logs in to DockerHub with `DOCKER_USERNAME` + `DOCKER_TOKEN` and runs `make docker-publish` — the GitHub token isn't used after checkout, so `contents: read` is sufficient.

Other workflows here (`stable.yml`, `nightly.yml`, `semgrep.yml`) already declare their own permissions blocks. YAML validated with `yaml.safe_load`.