### PR TITLE
Bump version of `serde_with` and raise msrv.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ make docker-build                                     # quiche-base + quiche-qns
 ## NOTES
 
 - **No git submodules**: BoringSSL is built by `boring-sys`; `cmake` must be available.
-- **MSRV 1.85**: `rust-version` field in Cargo.toml.
+- **MSRV 1.88**: `rust-version` field in Cargo.toml.
 - **Doc tests are separate**: `cargo test --all-targets` does NOT run doc tests (cargo#6669).
 - **`BORING_BSSL_PATH`**: env var to point `boring-sys` at a custom BoringSSL source tree.
 - **`RUSTFLAGS="-D warnings"`**: CI enforces; all warnings are errors.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ ring = { version = "0.17.8" }
 rstest = { version = "0.26.1" }
 serde = { version = "1" }
 serde_json = { version = "1" }
-serde_with = { version = "~3.17", default-features = false }
+serde_with = { version = "3.20.0", default-features = false }
 slog-scope = { version = "4.0" }
 slog-stdlog = { version = "4.1.1" }
 smallvec = { version = "1.10", default-features = false }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86 AS build
+FROM rust:1.88 AS build
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ is disabled by default), by passing ``--features ffi`` to ``cargo``.
 Building
 --------
 
-quiche requires Rust 1.85 or later to build. The latest stable Rust release can
+quiche requires Rust 1.88 or later to build. The latest stable Rust release can
 be installed using [rustup](https://rustup.rs/).
 
 Once the Rust build environment is setup, the quiche source code can be fetched

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -19,7 +19,7 @@ include = [
   "/quiche.svg",
   "/src",
 ]
-rust-version = "1.85"
+rust-version = "1.88"
 
 [features]
 default = ["boringssl-boring-crate"]

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -1639,7 +1639,7 @@ impl Connection {
         let len = body.as_ref().len();
 
         // Validate that it is sane to send data on the stream.
-        if stream_id % 4 != 0 {
+        if !stream_id.is_multiple_of(4) {
             return Err(Error::FrameUnexpected);
         }
 
@@ -1917,7 +1917,7 @@ impl Connection {
             return Err(Error::FrameUnexpected);
         }
 
-        if stream_id % 4 != 0 {
+        if !stream_id.is_multiple_of(4) {
             return Err(Error::FrameUnexpected);
         }
 
@@ -2170,7 +2170,7 @@ impl Connection {
             id = 0;
         }
 
-        if self.is_server && id % 4 != 0 {
+        if self.is_server && !id.is_multiple_of(4) {
             return Err(Error::IdError);
         }
 
@@ -3101,7 +3101,7 @@ impl Connection {
                     return Err(Error::FrameUnexpected);
                 }
 
-                if stream_id % 4 != 0 {
+                if !stream_id.is_multiple_of(4) {
                     conn.close(
                         true,
                         Error::FrameUnexpected.to_wire(),

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 keywords = ["quic", "http3", "tokio"]
 categories = { workspace = true }
 readme = "README.md"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [features]
 default = ["qlog-gzip", "qlog-zstd"]

--- a/tokio-quiche/src/metrics/labels.rs
+++ b/tokio-quiche/src/metrics/labels.rs
@@ -158,7 +158,7 @@ impl Serialize for H3Error {
         let code = self.0;
 
         // https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml
-        let v = if code > 0x21 && (code - 0x21) % 0x1f == 0 {
+        let v = if code > 0x21 && (code - 0x21).is_multiple_of(0x1f) {
             "H3_GREASE"
         } else {
             match code {


### PR DESCRIPTION
The version requirement on `serde_with` was `~3.17` which made it impossible to use quiche on crates that had a (direct or indirect) requirement of a `serde_with` >= 3.18.