### PR TITLE
ffi: don't unecessarily use a slice when constructing SockAddr

### DIFF
--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -2007,10 +2007,7 @@ fn optional_std_addr_from_c(
         return None;
     }
 
-    Some({
-        let addr = unsafe { slice::from_raw_parts(addr, addr_len as usize) };
-        std_addr_from_c(addr.first().unwrap(), addr_len)
-    })
+    Some(std_addr_from_c(unsafe { &*addr }, addr_len))
 }
 
 fn std_addr_from_c(addr: &sockaddr, addr_len: socklen_t) -> SocketAddr {


### PR DESCRIPTION
The optional_std_addr_from_c function only accepts a single sockaddr.
We can avoid potential UB caused by using a slice (as in the prior version)
by constructing directly.
