### PR TITLE
mark Stats and PathStats as non_exhaustive

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -925,6 +925,7 @@ struct QpackStreams {
 ///
 /// [`stats()`]: struct.Connection.html#method.stats
 #[derive(Clone, Default)]
+#[non_exhaustive]
 pub struct Stats {
     /// The number of bytes received on the QPACK encoder stream.
     pub qpack_encoder_stream_recv_bytes: u64,

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -9357,6 +9357,7 @@ impl std::fmt::Display for AddrTupleFmt {
 ///
 /// [`stats()`]: struct.Connection.html#method.stats
 #[derive(Clone, Default)]
+#[non_exhaustive]
 pub struct Stats {
     /// The number of QUIC packets received.
     pub recv: usize,

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -930,6 +930,7 @@ impl PathMap {
 ///
 /// [`path_stats()`]: struct.Connection.html#method.path_stats
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct PathStats {
     /// The local address of the path.
     pub local_addr: SocketAddr,


### PR DESCRIPTION
Adding new fields to these public structs is currently a breaking change for downstream crates, because they can be matched or constructed exhaustively. New transport or path level counters are added relatively often (for example new packet or frame type counters), and each addition forces a major version bump or has to wait for the next breaking release window.

Mark quiche::Stats, quiche::PathStats and quiche::h3::Stats as compatible way. Downstream code can still read existing fields as before, but is prevented from constructing or exhaustively matching these structs, which is the desired behaviour for opaque statistics containers.

The FFI Stats and PathStats in ffi.rs are intentionally left alone since they are #[repr(C)] mirrors used only at the C ABI boundary.