### PR TITLE
h3: harden request stream frame processing in clients

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -6718,6 +6718,127 @@ mod tests {
     }
 
     #[test]
+    /// Tests that a client rejects a SETTINGS frame received on a request
+    /// stream.
+    fn settings_on_request_stream_client() {
+        let mut s = Session::new().unwrap();
+        s.handshake().unwrap();
+
+        let (stream, _req) = s.send_request(true).unwrap();
+
+        let settings = frame::Frame::Settings {
+            max_field_section_size: None,
+            qpack_max_table_capacity: None,
+            qpack_blocked_streams: None,
+            connect_protocol_enabled: None,
+            h3_datagram: None,
+            grease: None,
+            additional_settings: Default::default(),
+            raw: Default::default(),
+        };
+
+        s.send_frame_server(settings, stream, false).unwrap();
+
+        // The client MUST treat this as H3_FRAME_UNEXPECTED.
+        assert_eq!(s.poll_client(), Err(Error::FrameUnexpected));
+        assert_eq!(
+            s.pipe.client.local_error(),
+            Some(&crate::ConnectionError {
+                is_app: true,
+                error_code: WireErrorCode::FrameUnexpected as u64,
+                reason: format!(
+                    "Unexpected frame type {}",
+                    frame::SETTINGS_FRAME_TYPE_ID
+                )
+                .into_bytes(),
+            })
+        );
+    }
+
+    #[test]
+    /// Tests that a client rejects a CANCEL_PUSH frame received on a request
+    /// stream.
+    fn cancel_push_on_request_stream_client() {
+        let mut s = Session::new().unwrap();
+        s.handshake().unwrap();
+
+        let (stream, _req) = s.send_request(true).unwrap();
+        let cancel_push = frame::Frame::CancelPush { push_id: 0 };
+        s.send_frame_server(cancel_push, stream, false).unwrap();
+
+        // The client MUST treat this as H3_FRAME_UNEXPECTED.
+        assert_eq!(s.poll_client(), Err(Error::FrameUnexpected));
+        assert_eq!(
+            s.pipe.client.local_error(),
+            Some(&crate::ConnectionError {
+                is_app: true,
+                error_code: WireErrorCode::FrameUnexpected as u64,
+                reason: format!(
+                    "Unexpected frame type {}",
+                    frame::CANCEL_PUSH_FRAME_TYPE_ID
+                )
+                .into_bytes(),
+            })
+        );
+    }
+
+    #[test]
+    /// Tests that a client rejects a GOAWAY frame received on a request
+    /// stream.
+    fn goaway_on_request_stream_client() {
+        let mut s = Session::new().unwrap();
+        s.handshake().unwrap();
+
+        let (stream, _req) = s.send_request(true).unwrap();
+        let goaway = frame::Frame::GoAway { id: 0 };
+
+        s.send_frame_server(goaway, stream, false).unwrap();
+
+        // The client MUST treat this as H3_FRAME_UNEXPECTED.
+        assert_eq!(s.poll_client(), Err(Error::FrameUnexpected));
+        assert_eq!(
+            s.pipe.client.local_error(),
+            Some(&crate::ConnectionError {
+                is_app: true,
+                error_code: WireErrorCode::FrameUnexpected as u64,
+                reason: format!(
+                    "Unexpected frame type {}",
+                    frame::GOAWAY_FRAME_TYPE_ID
+                )
+                .into_bytes(),
+            })
+        );
+    }
+
+    #[test]
+    /// Tests that a client rejects a MAX_PUSH_ID frame received on a request
+    /// stream.
+    fn max_push_id_on_request_stream_client() {
+        let mut s = Session::new().unwrap();
+        s.handshake().unwrap();
+
+        let (stream, _req) = s.send_request(true).unwrap();
+        let max_push_id = frame::Frame::MaxPushId { push_id: 0 };
+
+        s.send_frame_server(max_push_id, stream, false).unwrap();
+
+        // The client MUST treat this as H3_FRAME_UNEXPECTED.
+        assert_eq!(s.poll_client(), Err(Error::FrameUnexpected));
+        assert_eq!(
+            s.pipe.client.local_error(),
+            Some(&crate::ConnectionError {
+                is_app: true,
+                error_code: WireErrorCode::FrameUnexpected as u64,
+                reason: format!(
+                    "Unexpected frame type {}",
+                    frame::MAX_PUSH_FRAME_TYPE_ID
+                )
+                .into_bytes(),
+            })
+        );
+    }
+
+    #[test]
     /// Tests additional settings are actually exchanged by the peers.
     fn set_additional_settings() {
         let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();

--- a/quiche/src/h3/stream.rs
+++ b/quiche/src/h3/stream.rs
@@ -304,62 +304,7 @@ impl Stream {
             },
 
             Some(Type::Request) => {
-                // Request stream starts uninitialized and only HEADERS is
-                // accepted. After initialization, DATA and HEADERS frames may
-                // be acceptable, depending on the role and HTTP message phase.
-                //
-                // Receiving some other types of known frames on the request
-                // stream is always an error.
-                if !self.is_local {
-                    match (ty, self.remote_initialized) {
-                        (frame::HEADERS_FRAME_TYPE_ID, false) => {
-                            self.remote_initialized = true;
-                        },
-
-                        (frame::DATA_FRAME_TYPE_ID, false) =>
-                            return Err(Error::FrameUnexpected),
-
-                        (frame::HEADERS_FRAME_TYPE_ID, true) => {
-                            if self.trailers_received {
-                                return Err(Error::FrameUnexpected);
-                            }
-
-                            if self.data_received {
-                                self.trailers_received = true;
-                            }
-                        },
-
-                        (frame::DATA_FRAME_TYPE_ID, true) => {
-                            if self.trailers_received {
-                                return Err(Error::FrameUnexpected);
-                            }
-
-                            self.data_received = true;
-                        },
-
-                        (frame::CANCEL_PUSH_FRAME_TYPE_ID, _) =>
-                            return Err(Error::FrameUnexpected),
-
-                        (frame::SETTINGS_FRAME_TYPE_ID, _) =>
-                            return Err(Error::FrameUnexpected),
-
-                        (frame::GOAWAY_FRAME_TYPE_ID, _) =>
-                            return Err(Error::FrameUnexpected),
-
-                        (frame::MAX_PUSH_FRAME_TYPE_ID, _) =>
-                            return Err(Error::FrameUnexpected),
-
-                        (frame::PRIORITY_UPDATE_FRAME_REQUEST_TYPE_ID, _) =>
-                            return Err(Error::FrameUnexpected),
-
-                        (frame::PRIORITY_UPDATE_FRAME_PUSH_TYPE_ID, _) =>
-                            return Err(Error::FrameUnexpected),
-
-                        // All other frames can be ignored regardless of stream
-                        // state.
-                        _ => (),
-                    }
-                }
+                self.validate_request_frame_type(ty)?;
             },
 
             Some(Type::Push) => {
@@ -390,6 +335,72 @@ impl Stream {
         self.frame_type = Some(ty);
 
         self.state_transition(State::FramePayloadLen, 1, true)?;
+
+        Ok(())
+    }
+
+    /// Validates a frame type received on a request stream and advances the
+    /// request-stream HTTP message phase tracking accordingly.
+    ///
+    /// Request streams start uninitialized and only HEADERS is accepted. After
+    /// initialization, DATA and HEADERS frames may be acceptable, depending on
+    /// the HTTP message phase (informational/final headers, body, trailers).
+    /// Receiving any other known frame type on a request stream is always an
+    /// error per RFC 9114, regardless of which endpoint opened the stream.
+    ///
+    /// HTTP message phase bookkeeping (`remote_initialized`, `data_received`,
+    /// `trailers_received`) only applies to peer-initiated streams, since it
+    /// tracks the receive direction.
+    fn validate_request_frame_type(&mut self, ty: u64) -> Result<()> {
+        // Frames that are never valid on a request stream, regardless of which
+        // endpoint opened it.
+        if matches!(
+            ty,
+            frame::CANCEL_PUSH_FRAME_TYPE_ID |
+                frame::SETTINGS_FRAME_TYPE_ID |
+                frame::GOAWAY_FRAME_TYPE_ID |
+                frame::MAX_PUSH_FRAME_TYPE_ID |
+                frame::PRIORITY_UPDATE_FRAME_REQUEST_TYPE_ID |
+                frame::PRIORITY_UPDATE_FRAME_PUSH_TYPE_ID
+        ) {
+            return Err(Error::FrameUnexpected);
+        }
+
+        // HTTP message phase bookkeeping only applies to peer-initiated
+        // streams, since it tracks the receive direction.
+        if self.is_local {
+            return Ok(());
+        }
+
+        match (ty, self.remote_initialized) {
+            (frame::HEADERS_FRAME_TYPE_ID, false) => {
+                self.remote_initialized = true;
+            },
+
+            (frame::DATA_FRAME_TYPE_ID, false) =>
+                return Err(Error::FrameUnexpected),
+
+            (frame::HEADERS_FRAME_TYPE_ID, true) => {
+                if self.trailers_received {
+                    return Err(Error::FrameUnexpected);
+                }
+
+                if self.data_received {
+                    self.trailers_received = true;
+                }
+            },
+
+            (frame::DATA_FRAME_TYPE_ID, true) => {
+                if self.trailers_received {
+                    return Err(Error::FrameUnexpected);
+                }
+
+                self.data_received = true;
+            },
+
+            // All other frames can be ignored regardless of stream state.
+            _ => (),
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Previously, the request-stream frame-type validation in
`set_frame_type` was gated on `!self.is_local`, which meant that
on a client (where request streams are locally initiated) the entire
match block was skipped. As a result, a server could send CANCEL_PUSH,
SETTINGS, GOAWAY, MAX_PUSH_ID or PRIORITY_UPDATE frames on a request
stream and the client would silently accept them, in some cases
mutating connection state (peer_settings, peer_goaway_id) or surfacing
spurious events to the application.

RFC 9114 requires these frames to be rejected with H3_FRAME_UNEXPECTED
regardless of which endpoint opened the stream.

This change is focused on hardening illegal-frame-type check gaps that
existed for the client; new tests have been added to exercise them. Other
types of exchanges already have coverage, or are due for a significant
refactor in planned work.
