### PR TITLE
ffi: expose set_use_initial_max_data_as_flow_control_win

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -253,6 +253,11 @@ void quiche_config_enable_pacing(quiche_config *config, bool v);
 void quiche_config_set_enable_cubic_idle_restart_fix(quiche_config *config,
                                                      bool v);
 
+// Configures whether to use the initial max data value as the initial flow
+// control window for streams and the connection (disabled by default).
+void quiche_config_set_use_initial_max_data_as_flow_control_win(
+    quiche_config *config, bool v);
+
 // Configures max pacing rate to be used.
 void quiche_config_set_max_pacing_rate(quiche_config *config, uint64_t v);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -373,6 +373,13 @@ pub extern "C" fn quiche_config_set_enable_cubic_idle_restart_fix(
 }
 
 #[no_mangle]
+pub extern "C" fn quiche_config_set_use_initial_max_data_as_flow_control_win(
+    config: &mut Config, v: bool,
+) {
+    config.set_use_initial_max_data_as_flow_control_win(v);
+}
+
+#[no_mangle]
 pub extern "C" fn quiche_config_set_max_pacing_rate(config: &mut Config, v: u64) {
     config.set_max_pacing_rate(v);
 }


### PR DESCRIPTION
Adds a `quiche_config_set_use_initial_max_data_as_flow_control_win` C
FFI export so C consumers can enable the flow-control fix added in
#2356 from a config flag. Mirrors the FFI shape used by
`quiche_config_set_enable_cubic_idle_restart_fix`.

The Rust setter (`Config::set_use_initial_max_data_as_flow_control_win`)
and the corresponding tokio-quiche `QuicSettings` field (#2451) already
exist; this PR completes the parity on the C side.