### PR TITLE
quiche: release 0.29.0 and tokio-quiche: release 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ task-killswitch = { version = "0.2.1", path = "./task-killswitch" }
 thiserror = { version = "2" }
 humantime = { version = "2" }
 tokio = { version = "1.44", default-features = false }
-tokio-quiche = { version = "0.18.0", path = "./tokio-quiche" }
+tokio-quiche = { version = "0.19.0", path = "./tokio-quiche" }
 tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7.13" }
 url = { version = "2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ octets = { version = "0.3.5", path = "./octets" }
 parking_lot = { version = "0.12.1", default-features = false }
 pin-project = { version = "1.0.12" }
 qlog = { version = "0.18.0", path = "./qlog" }
-quiche = { version = "0.28.0", path = "./quiche" }
+quiche = { version = "0.29.0", path = "./quiche" }
 regex = { version = "1.4.2" }
 ring = { version = "0.17.8" }
 rstest = { version = "0.26.1" }

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quiche"
-version = "0.28.0"
+version = "0.29.0"
 description = "🥧 Savoury implementation of the QUIC transport protocol and HTTP/3"
 repository = { workspace = true }
 authors = ["Alessandro Ghedini <alessandro@ghedini.me>"]

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-quiche"
-version = "0.18.0"
+version = "0.19.0"
 description = "Asynchronous wrapper around quiche"
 repository = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
quiche changes:
* #2478
* #2464 
* #2465
* #2477
* #2476
* #2475
* #2474
* #2467
* #2469
* #2470
* #2471
* #2466
* #2080 
* #2458
* #2457
* #2441
* #2439
* #2433
* #2428
* #2419
* #2425
* #2432

tokio-quiche changes:
* #2456
* #2455
* #2474
* #2468
* #2459
* #2444
* #2451
* #2442
* #2441
* #2380
* #2438
* #2419