### PR TITLE
Only poll ApplicationOverQuic wait_for_data after handshake is ready or we're in early data

### DIFF
--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -259,7 +259,8 @@ pub enum H3Event {
     /// [`H3Event::ResetStream`] variant.
     StreamClosed { stream_id: u64 },
     /// A GOAWAY frame was received from the peer containing `id`,
-    /// as described in https://datatracker.ietf.org/doc/html/rfc9114#section-5.2.
+    /// as described in
+    /// <https://datatracker.ietf.org/doc/html/rfc9114#section-5.2.>
     GoAway { id: u64 },
 }
 

--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -445,7 +445,7 @@ where
             match handshake_fut.await {
                 Ok(running) => Self::resume(running),
                 Err(e) => {
-                    log::error!("QUIC handshake failed in IQC::start"; "error" => e)
+                    log::error!("QUIC handshake failed in IQC::start"; "error" => e);
                 },
             }
         };

--- a/tokio-quiche/src/quic/io/worker.rs
+++ b/tokio-quiche/src/quic/io/worker.rs
@@ -704,7 +704,9 @@ where
     async fn wait_for_data_or_handshake<A: ApplicationOverQuic>(
         &mut self, qconn: &mut QuicheConnection, quic_application: &mut A,
     ) -> QuicResult<WaitForDataOrHandshakeDirective> {
-        if quic_application.should_act() {
+        let connection_ready = qconn.is_established() || qconn.is_in_early_data();
+
+        if connection_ready && quic_application.should_act() {
             // Poll the application to make progress.
             //
             // Once the connection has been established (i.e. the handshake is

--- a/tokio-quiche/src/quic/mod.rs
+++ b/tokio-quiche/src/quic/mod.rs
@@ -269,9 +269,11 @@ where
     // drive the packet router:
     tokio::spawn(async move {
         match router.await {
-            Ok(()) => log::debug!("incoming packet router finished"),
+            Ok(()) => {
+                log::debug!("incoming packet router finished");
+            },
             Err(error) => {
-                log::error!("incoming packet router failed"; "error"=>error)
+                log::error!("incoming packet router failed"; "error"=>error);
             },
         }
     });
@@ -334,9 +336,11 @@ where
 
     crate::metrics::tokio_task::spawn("quic_udp_listener", metrics, async move {
         match socket_driver.await {
-            Ok(()) => log::trace!("incoming packet router finished"),
+            Ok(()) => {
+                log::trace!("incoming packet router finished");
+            },
             Err(error) => {
-                log::error!("incoming packet router failed"; "error"=>error)
+                log::error!("incoming packet router failed"; "error"=>error);
             },
         }
     });

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -74,13 +74,15 @@ impl Config {
             None => std::env::var_os("SSLKEYLOGFILE").map(Cow::from),
         };
         let keylog_file = keylog_path.and_then(|path| if KEYLOGFILE_ENABLED {
-                File::options().create(true).append(true).open(path)
-                    .inspect_err(|e| log::warn!("failed to open SSLKEYLOGFILE"; "error" => e))
-                    .ok()
-            } else {
-                log::warn!("SSLKEYLOGFILE is set, but `--cfg capture_keylogs` was not enabled. No keys will be logged.");
-                None
-            });
+            File::options().create(true).append(true).open(path)
+                .inspect_err(|e| {
+                    log::warn!("failed to open SSLKEYLOGFILE"; "error" => e);
+                })
+                .ok()
+        } else {
+            log::warn!("SSLKEYLOGFILE is set, but `--cfg capture_keylogs` was not enabled. No keys will be logged.");
+            None
+        });
 
         let SocketCapabilities {
             has_gso,

--- a/tokio-quiche/tests/integration_tests/async_callbacks.rs
+++ b/tokio-quiche/tests/integration_tests/async_callbacks.rs
@@ -32,12 +32,27 @@ use boring::ssl::ClientHello;
 use boring::ssl::SslContextBuilder;
 use boring::ssl::SslFiletype;
 use boring::ssl::SslMethod;
+use futures::StreamExt;
+use std::future::poll_fn;
+use std::future::Future;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::task::Poll;
+use std::time::Duration;
 use tokio::task::yield_now;
+use tokio::time::timeout;
+use tokio_quiche::listen;
+use tokio_quiche::metrics::DefaultMetrics;
+use tokio_quiche::quic::connect_with_config;
 use tokio_quiche::quic::ConnectionHook;
+use tokio_quiche::quic::QuicheConnection;
+use tokio_quiche::settings::Hooks;
 use tokio_quiche::settings::TlsCertificatePaths;
+use tokio_quiche::socket::Socket;
+use tokio_quiche::ApplicationOverQuic;
+use tokio_quiche::ConnectionParams;
+use tokio_quiche::QuicResult;
 
 #[tokio::test]
 async fn test_hello_world_async_callbacks() {
@@ -149,4 +164,166 @@ async fn test_async_callbacks_fail_after_initial_send() {
     let url = format!("{url}/1");
     let client_res = h3i_fixtures::request(&url, 1).await;
     assert!(matches!(client_res, Err(ClientError::HandshakeFail)));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_eager_wait_for_data_does_not_starve_handshake() {
+    struct TestApplication {
+        buffer: [u8; 1500],
+        eager_pre_handshake: bool,
+        should_act: bool,
+        established_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    }
+
+    impl ApplicationOverQuic for TestApplication {
+        fn on_conn_established(
+            &mut self, _qconn: &mut QuicheConnection,
+            _handshake_info: &tokio_quiche::quic::HandshakeInfo,
+        ) -> QuicResult<()> {
+            if let Some(established_tx) = self.established_tx.take() {
+                let _ = established_tx.send(());
+            }
+
+            Ok(())
+        }
+
+        fn should_act(&self) -> bool {
+            self.should_act
+        }
+
+        fn buffer(&mut self) -> &mut [u8] {
+            &mut self.buffer
+        }
+
+        fn wait_for_data(
+            &mut self, qconn: &mut QuicheConnection,
+        ) -> impl Future<Output = QuicResult<()>> + Send {
+            let should_resolve = self.eager_pre_handshake &&
+                !qconn.is_established() &&
+                !qconn.is_in_early_data();
+
+            poll_fn(move |_| {
+                if should_resolve {
+                    Poll::Ready(Ok(()))
+                } else {
+                    Poll::Pending
+                }
+            })
+        }
+
+        fn process_reads(
+            &mut self, _qconn: &mut QuicheConnection,
+        ) -> QuicResult<()> {
+            Ok(())
+        }
+
+        fn process_writes(
+            &mut self, _qconn: &mut QuicheConnection,
+        ) -> QuicResult<()> {
+            Ok(())
+        }
+    }
+
+    struct TestAsyncCallbackConnectionHook {
+        callback_completed: Arc<AtomicBool>,
+    }
+
+    impl ConnectionHook for TestAsyncCallbackConnectionHook {
+        fn create_custom_ssl_context_builder(
+            &self, _settings: TlsCertificatePaths<'_>,
+        ) -> Option<SslContextBuilder> {
+            let callback_completed = Arc::clone(&self.callback_completed);
+            let mut ssl_ctx_builder =
+                SslContextBuilder::new(SslMethod::tls()).ok()?;
+            ssl_ctx_builder.set_async_select_certificate_callback(move |_| {
+                let callback_completed = Arc::clone(&callback_completed);
+
+                Ok(Box::pin(async move {
+                    yield_now().await;
+                    callback_completed.store(true, Ordering::SeqCst);
+
+                    Ok(Box::new(|_: ClientHello<'_>| Ok(()))
+                        as BoxSelectCertFinish)
+                }))
+            });
+
+            ssl_ctx_builder
+                .set_private_key_file(TEST_KEY_FILE, SslFiletype::PEM)
+                .unwrap();
+
+            ssl_ctx_builder
+                .set_certificate_chain_file(TEST_CERT_FILE)
+                .unwrap();
+
+            Some(ssl_ctx_builder)
+        }
+    }
+
+    let server_socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let server_addr = server_socket.local_addr().unwrap();
+
+    let tls_cert_settings = TlsCertificatePaths {
+        cert: TEST_CERT_FILE,
+        private_key: TEST_KEY_FILE,
+        kind: tokio_quiche::settings::CertificateKind::X509,
+    };
+
+    let hook = Arc::new(TestAsyncCallbackConnectionHook {
+        callback_completed: Arc::new(AtomicBool::new(false)),
+    });
+    let hooks = Hooks {
+        connection_hook: Some(hook.clone()),
+    };
+    let mut quic_settings = QuicSettings::default();
+    quic_settings.handshake_timeout = Some(Duration::from_secs(2));
+    let params =
+        ConnectionParams::new_server(quic_settings, tls_cert_settings, hooks);
+    let mut stream = listen(vec![server_socket], params, DefaultMetrics)
+        .unwrap()
+        .remove(0);
+
+    let (established_tx, established_rx) = tokio::sync::oneshot::channel();
+    let server_task = tokio::spawn(async move {
+        let conn = stream.next().await.unwrap().unwrap();
+        let app = TestApplication {
+            buffer: [0; 1500],
+            eager_pre_handshake: true,
+            should_act: true,
+            established_tx: Some(established_tx),
+        };
+
+        let _ = conn.handshake(app).await.expect("handshake failed");
+    });
+
+    let client_socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    client_socket.connect(server_addr).await.unwrap();
+    let client_socket = Socket::try_from(client_socket).unwrap();
+    let client_app = TestApplication {
+        buffer: [0; 1500],
+        eager_pre_handshake: false,
+        should_act: false,
+        established_tx: None,
+    };
+
+    timeout(
+        Duration::from_secs(5),
+        connect_with_config(
+            client_socket,
+            Some("127.0.0.1"),
+            &ConnectionParams::default(),
+            client_app,
+        ),
+    )
+    .await
+    .expect("client handshake timed out")
+    .expect("client handshake failed");
+
+    timeout(Duration::from_secs(5), established_rx)
+        .await
+        .expect("server handshake timed out")
+        .expect("server app was dropped before establishment");
+
+    server_task.await.unwrap();
+
+    assert!(hook.callback_completed.load(Ordering::SeqCst));
 }


### PR DESCRIPTION
tokio-quiche can poll wait_for_data() too early during connection setup. For apps that always report should_act()==true an overly eager wait_for_data() could preempt the handshake which might stall the handshake itself. Now wait_for_data() can only be polled if the 1-RTT handshake is either completed or we are in early-data