### PR TITLE
Cargo: define additional lints at workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,12 @@ readme = "README.md"
 keywords = ["quic", "http3"]
 categories = ["network-programming"]
 
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(capture_keylogs)',
+  'cfg(test_invalid_len_compilation_fail)',
+] }
+
 [workspace.metadata.release]
 pre-release-commit-message = "{{crate_name}}: release {{version}}"
 consolidate-commits = false

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -9,6 +9,9 @@ keywords = { workspace = true }
 categories = { workspace = true }
 publish = false
 
+[lints]
+workspace = true
+
 [features]
 # Enable quiche's fuzzing mode.
 fuzzing = ["quiche/fuzzing"]

--- a/buffer-pool/Cargo.toml
+++ b/buffer-pool/Cargo.toml
@@ -8,6 +8,9 @@ keywords = { workspace = true }
 categories = { workspace = true }
 description = "Pooled in-memory buffers"
 
+[lints]
+workspace = true
+
 [dependencies]
 crossbeam = { workspace = true, features = ["alloc"] }
 foundations = { workspace = true, default-features = false, features = [

--- a/datagram-socket/Cargo.toml
+++ b/datagram-socket/Cargo.toml
@@ -8,6 +8,9 @@ keywords = { workspace = true }
 categories = { workspace = true }
 description = "Utilities for working with datagram sockets"
 
+[lints]
+workspace = true
+
 [dependencies]
 bytes = { workspace = true }
 futures-util = { workspace = true }

--- a/h3i/Cargo.toml
+++ b/h3i/Cargo.toml
@@ -13,6 +13,9 @@ keywords = { workspace = true }
 categories = { workspace = true }
 readme = "README.md"
 
+[lints]
+workspace = true
+
 [features]
 async = ["dep:tokio", "dep:tokio-quiche"]
 

--- a/netlog/Cargo.toml
+++ b/netlog/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["quic", "http2", "http3"]
 categories = { workspace = true }
 readme = "README.md"
 
+[lints]
+workspace = true
+
 [dependencies]
 log = { workspace = true }
 regex = { workspace = true }

--- a/octets/Cargo.toml
+++ b/octets/Cargo.toml
@@ -13,7 +13,5 @@ categories = { workspace = true }
 # Build the Huffman encoding support as defined by HPACK (RFC7541).
 huffman_hpack = []
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(test_invalid_len_compilation_fail)',
-] }
+[lints]
+workspace = true

--- a/qlog-dancer/Cargo.toml
+++ b/qlog-dancer/Cargo.toml
@@ -10,6 +10,9 @@ keywords = { workspace = true }
 categories = { workspace = true }
 readme = "README.md"
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = "4"
 env_logger = { workspace = true }

--- a/qlog/Cargo.toml
+++ b/qlog/Cargo.toml
@@ -10,6 +10,9 @@ keywords = { workspace = true }
 categories = { workspace = true }
 readme = "README.md"
 
+[lints]
+workspace = true
+
 [features]
 # Enable gzip compression / decompression of qlog streams via
 # [`flate2`]. Used by [`writer::make_qlog_writer`] and

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -21,6 +21,9 @@ include = [
 ]
 rust-version = "1.88"
 
+[lints]
+workspace = true
+
 [features]
 default = ["boringssl-boring-crate"]
 

--- a/task-killswitch/Cargo.toml
+++ b/task-killswitch/Cargo.toml
@@ -8,6 +8,9 @@ keywords = { workspace = true }
 categories = { workspace = true }
 description = "Abort all tokio tasks at once"
 
+[lints]
+workspace = true
+
 [dependencies]
 dashmap = { workspace = true }
 parking_lot = { workspace = true }

--- a/tokio-quiche/Cargo.toml
+++ b/tokio-quiche/Cargo.toml
@@ -63,9 +63,8 @@ qlog-gzip = ["qlog/gzip"]
 # connection at runtime via `QuicSettings::qlog_compression`.
 qlog-zstd = ["qlog/zstd"]
 
-[lints.rust]
-# capture_keylogs: enable SSLKEYLOGFILE capturing for QUIC connections.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(capture_keylogs)'] }
+[lints]
+workspace = true
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
Instead of each crate defining its own list of additional lints, define a common workspace list.