### PR TITLE
tls: avoid mem::forget for borrowed handshakes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ readme = "README.md"
 keywords = ["quic", "http3"]
 categories = ["network-programming"]
 
+[workspace.lints.clippy]
+mem_forget = "deny"
+
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(capture_keylogs)',

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -2776,6 +2776,7 @@ impl<F: BufFactory> Connection<F> {
         params: TransportParams, is_server: bool, ssl: &mut boring::ssl::SslRef,
     ) -> Result<()> {
         use foreign_types_shared::ForeignTypeRef;
+        use std::mem::ManuallyDrop;
 
         // In order to apply the new parameter to the TLS state before TPs are
         // written into a TLS message, we need to re-encode all TPs immediately.
@@ -2783,17 +2784,14 @@ impl<F: BufFactory> Connection<F> {
         // Since we don't have direct access to the main `Connection` object, we
         // need to re-create the `Handshake` state from the `SslRef`.
         //
-        // SAFETY: the `Handshake` object must not be drop()ed, otherwise it
-        // would free the underlying BoringSSL structure.
-        let mut handshake =
-            unsafe { tls::Handshake::from_ptr(ssl.as_ptr() as _) };
-        handshake.set_quic_transport_params(&params, is_server)?;
+        // Wrap the temporary `Handshake` in `ManuallyDrop` because this is only
+        // a borrowed view of `ssl`. The caller retains ownership of the
+        // underlying BoringSSL object.
+        let mut handshake = ManuallyDrop::new(unsafe {
+            tls::Handshake::from_ptr(ssl.as_ptr() as _)
+        });
 
-        // Avoid running `drop(handshake)` as that would free the underlying
-        // handshake state.
-        std::mem::forget(handshake);
-
-        Ok(())
+        handshake.set_quic_transport_params(&params, is_server)
     }
 
     /// Sets the `use_initial_max_data_as_flow_control_win` flag during SSL

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -25,6 +25,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::ffi;
+use std::mem::ManuallyDrop;
 use std::ptr;
 use std::slice;
 
@@ -995,7 +996,9 @@ extern "C" fn new_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int {
         None => return 0,
     };
 
-    let handshake = Handshake::new(ssl);
+    // This callback receives a borrowed `SSL*`, so the temporary `Handshake`
+    // must not free it on any return path.
+    let handshake = ManuallyDrop::new(Handshake::new(ssl));
     let peer_params = handshake.quic_transport_params();
 
     // Serialize session object into buffer.
@@ -1010,31 +1013,24 @@ extern "C" fn new_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int {
     let session_bytes_len = session_bytes.len() as u64;
 
     if buffer.write(&session_bytes_len.to_be_bytes()).is_err() {
-        std::mem::forget(handshake);
         return 0;
     }
 
     if buffer.write(&session_bytes).is_err() {
-        std::mem::forget(handshake);
         return 0;
     }
 
     let peer_params_len = peer_params.len() as u64;
 
     if buffer.write(&peer_params_len.to_be_bytes()).is_err() {
-        std::mem::forget(handshake);
         return 0;
     }
 
     if buffer.write(peer_params).is_err() {
-        std::mem::forget(handshake);
         return 0;
     }
 
     *ex_data.session = Some(buffer);
-
-    // Prevent handshake from being freed, as we still need it.
-    std::mem::forget(handshake);
 
     0
 }

--- a/tokio-quiche/src/lib.rs
+++ b/tokio-quiche/src/lib.rs
@@ -248,9 +248,8 @@ pub(crate) fn capture_quiche_logs() {
 
         // The slog Drain becomes `slog::Discard` when the scope_guard is dropped,
         // and you can't set the global logger again because of a mandate
-        // in the `log` crate. We have to manually `forget` the scope
-        // guard so that the logger remains registered for the duration of the
-        // process.
-        std::mem::forget(scope_guard)
+        // in the `log` crate. We have to retain the scope guard so that the
+        // logger remains registered for the duration of the process.
+        let _scope_guard = std::mem::ManuallyDrop::new(scope_guard);
     });
 }


### PR DESCRIPTION
Represent temporary Handshake views over existing SSL pointers with ManuallyDrop. This keeps the ownership boundary explicit and avoids relying on mem::forget after use.

Also removes one instance from tokio-quiche to allow denying mem::forget at workspace level.