### PR TITLE
fix: do not send zero-length non-FIN stream frames

### DIFF
--- a/quiche/src/frame.rs
+++ b/quiche/src/frame.rs
@@ -42,9 +42,12 @@ use qlog::events::quic::QuicFrame;
 #[cfg(feature = "qlog")]
 use qlog::events::quic::StreamType;
 
-pub const MAX_CRYPTO_OVERHEAD: usize = 8;
+/// Maximum CRYPTO frame overhead:
+/// 1-byte type + varint-encoded offset (bounded by `MAX_CRYPTO_STREAM_OFFSET`)
+/// + 2-byte length (we always encode as 2 bytes)
+pub const MAX_CRYPTO_OVERHEAD: usize =
+    1 + octets::varint_len(crate::MAX_CRYPTO_STREAM_OFFSET) + 2;
 pub const MAX_DGRAM_OVERHEAD: usize = 2;
-pub const MAX_STREAM_OVERHEAD: usize = 12;
 pub const MAX_STREAM_SIZE: u64 = 1 << 62;
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -499,7 +499,13 @@ const MAX_PROBING_TIMEOUTS: usize = 3;
 const DEFAULT_INITIAL_CONGESTION_WINDOW_PACKETS: usize = 10;
 
 // The maximum data offset that can be stored in a crypto stream.
-const MAX_CRYPTO_STREAM_OFFSET: u64 = 1 << 16;
+pub(crate) const MAX_CRYPTO_STREAM_OFFSET: u64 = 1 << 16;
+
+// TODO: Removed once https://github.com/cloudflare/quiche/pull/2453 is done.
+// This used to be the value of MAX_STREAM_OVERHEAD (but it's incorrect for
+// that purpose) and is now only used for gcongestion recovery for
+// app-limited tracking. Cf. https://github.com/cloudflare/quiche/pull/2492
+const LEGACY_APP_LIMITED_BYTE_THRESHOLD: usize = 12;
 
 // The send capacity factor.
 const TX_CAP_FACTOR: f64 = 1.0;
@@ -5199,7 +5205,6 @@ impl<F: BufFactory> Connection<F> {
 
         // Create a single STREAM frame for the first stream that is flushable.
         if (pkt_type == Type::Short || pkt_type == Type::ZeroRTT) &&
-            left > frame::MAX_STREAM_OVERHEAD &&
             !is_closing &&
             path.active() &&
             !dgram_emitted
@@ -5239,13 +5244,24 @@ impl<F: BufFactory> Connection<F> {
                     octets::varint_len(stream_off) + // offset
                     2; // length, always encode as 2-byte varint
 
+                // Require at least 1 byte of payload beyond the header
+                // or an empty FIN
+                //
+                // If even the minimum payload (hdr_len + 1 byte (or empty fin)
+                // doesn't fit, stop trying.  We could continue to the next
+                // stream (a lower stream_id or offset might encode in fewer
+                // varint bytes), but we'd need to keep track of  which streams
+                // we've tried to avoid looping forever.
                 let max_len = match left.checked_sub(hdr_len) {
-                    Some(v) => v,
-                    None => {
-                        let priority_key = Arc::clone(&stream.priority_key);
-                        self.streams.remove_flushable(&priority_key);
-
-                        continue;
+                    Some(v) if v > 0 || stream.send.empty_fin_next() => v,
+                    _ => {
+                        if stream.incremental {
+                            // Shuffle the incremental stream to the back of the
+                            // queue (of streams with the same priority).
+                            self.streams.remove_flushable(&priority_key);
+                            self.streams.insert_flushable(&priority_key);
+                        }
+                        break;
                     },
                 };
 
@@ -5255,6 +5271,14 @@ impl<F: BufFactory> Connection<F> {
                 // Write stream data into the packet buffer.
                 let (len, fin) =
                     stream.send.emit(&mut stream_payload.as_mut()[..max_len])?;
+
+                // The stream was flushable and max_len ≥ 1, so emit() must
+                // have produced at least one byte, or set FIN. While a zero
+                // length non-fin STREAM frame is legal, it's silly.
+                debug_assert!(
+                    len > 0 || fin,
+                    "emit() from flushable stream produced 0 bytes without FIN"
+                );
 
                 // Encode the frame's header.
                 //
@@ -5301,10 +5325,9 @@ impl<F: BufFactory> Connection<F> {
 
                 #[cfg(feature = "fuzzing")]
                 // Coalesce STREAM frames when fuzzing.
-                if left > frame::MAX_STREAM_OVERHEAD {
-                    continue;
-                }
+                continue;
 
+                #[cfg(not(feature = "fuzzing"))]
                 break;
             }
         }
@@ -5337,12 +5360,13 @@ impl<F: BufFactory> Connection<F> {
 
         if !has_data &&
             !dgram_emitted &&
-            cwnd_available > frame::MAX_STREAM_OVERHEAD
+            cwnd_available > LEGACY_APP_LIMITED_BYTE_THRESHOLD
         {
             path.recovery.on_app_limited();
         }
 
         if frames.is_empty() {
+            // Used by legacy recovery.
             // When we reach this point we are not able to write more, so set
             // app_limited to false.
             path.recovery.update_app_limited(false);

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -1684,6 +1684,78 @@ mod tests {
     }
 
     #[test]
+    /// Tests that `is_flushable()` returns false when `off_front` reaches the
+    /// stream-level flow control limit (`max_off`).
+    /// This prevents zero-length stream frames when a stream is at the stream
+    /// level flow control limit.
+    fn is_flushable_at_flow_control_limit() {
+        let max_tx_data = 5;
+        let mut stream =
+            <Stream>::new(0, 0, max_tx_data, true, 0, DEFAULT_STREAM_WINDOW);
+
+        // Nothing written yet: not flushable.
+        assert!(!stream.is_flushable());
+
+        // Write up to the flow control limit.
+        assert_eq!(stream.send.write(b"hello", false), Ok(5));
+        assert!(stream.is_flushable());
+
+        // Emit all 5 bytes.
+        let mut buf = [0u8; 5];
+        assert_eq!(stream.send.emit(&mut buf), Ok((5, false)));
+        assert_eq!(stream.send.off_front(), 5);
+
+        // off_front (5) == max_off (5): NOT flushable.
+        assert!(!stream.is_flushable());
+
+        // Raise the flow control limit to allow 5 more bytes.
+        stream.send.update_max_data(10);
+
+        // But the send buffer is empty, so still not flushable.
+        assert!(!stream.is_flushable());
+
+        // Write more data; now flushable.
+        assert_eq!(stream.send.write(b"world", false), Ok(5));
+        assert!(stream.is_flushable());
+    }
+
+    #[test]
+    /// Tests the state transitions of [`SendBuf::empty_fin_next`].
+    fn send_buf_empty_fin_next() {
+        let mut stream = <Stream>::new(0, 0, 20, true, 0, DEFAULT_STREAM_WINDOW);
+
+        // No data, no FIN: empty_fin_next is false.
+        assert!(!stream.send.empty_fin_next());
+
+        // Write data without FIN: still false.
+        assert_eq!(stream.send.write(b"hello", false), Ok(5));
+        assert!(!stream.send.empty_fin_next());
+
+        // Emit all data: FIN not set yet, so still false.
+        let mut buf = [0u8; 5];
+        assert_eq!(stream.send.emit(&mut buf), Ok((5, false)));
+        assert!(!stream.send.empty_fin_next());
+
+        // Now set the FIN with an empty write: empty_fin_next becomes true.
+        assert_eq!(stream.send.write(b"", true), Ok(0));
+        assert!(stream.send.empty_fin_next());
+
+        // Emit with a zero-length buffer: returns (0, true) — the empty FIN.
+        let mut empty: [u8; 0] = [];
+        assert_eq!(stream.send.emit(&mut empty), Ok((0, true)));
+
+        // The predicate is still true — it only resets once the stream is
+        // removed from the flushable queue by the caller (lib.rs), not by
+        // emit() itself.
+        assert!(stream.send.empty_fin_next());
+
+        // After retransmit the data is re-queued ahead of the FIN offset,
+        // so the next emit will produce data bytes rather than an empty FIN.
+        stream.send.retransmit(0, 5);
+        assert!(!stream.send.empty_fin_next());
+    }
+
+    #[test]
     fn rangebuf_split_off() {
         let mut buf = <RangeBuf>::from(b"helloworld", 5, true);
         assert_eq!(buf.start, 0);

--- a/quiche/src/stream/send_buf.rs
+++ b/quiche/src/stream/send_buf.rs
@@ -498,6 +498,12 @@ impl<F: BufFactory> SendBuf<F> {
         false
     }
 
+    /// Returns true if the next call to [`Self::emit`] will emit an empty
+    /// FIN.
+    pub fn empty_fin_next(&self) -> bool {
+        self.fin_off == Some(self.off_front())
+    }
+
     /// Returns true if the send-side of the stream is complete.
     ///
     /// This happens when the stream's send final size is known, and the peer

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -5497,6 +5497,183 @@ fn stream_zero_length_non_fin(
     assert!(r.next().is_none());
 }
 
+/// Helper for parameterizing tests over different QUIC stream ID varint
+/// sizes.  Each variant yields a client-initiated bidirectional stream ID
+/// whose varint encoding is 1, 2, or 4 bytes respectively.
+#[derive(Clone, Copy, Debug)]
+enum StreamIdSize {
+    /// stream_id 0: 1-byte varint.
+    OneByteVarint,
+    /// stream_id 64: 2-byte varint.
+    TwoByteVarint,
+    /// stream_id 16384: 4-byte varint.
+    FourByteVarint,
+}
+
+impl StreamIdSize {
+    fn stream_id(self) -> u64 {
+        match self {
+            StreamIdSize::OneByteVarint => 0,
+            StreamIdSize::TwoByteVarint => 64,
+            StreamIdSize::FourByteVarint => 16384,
+        }
+    }
+}
+
+#[rstest]
+/// Tests STREAM frame emission with tight packet buffers.
+///
+/// Two scenarios are covered via the `empty_fin` parameter:
+///
+/// - `false`: the stream has pending data but no FIN.  We assert that no
+///   zero-length non-FIN STREAM frame is ever emitted, and that the stream
+///   remains flushable when the buffer is too small even for the header. The
+///   first buffer size that fits the header should produce a STREAM frame with
+///   exactly 1 byte of payload.
+///
+/// - `true`: the stream has only an empty FIN (no data at all).  We assert that
+///   a zero-length STREAM frame *with* FIN is eventually emitted, and that the
+///   stream remains flushable until that moment.
+///
+/// The test is parameterized over stream IDs with 1-, 2-, and 4-byte
+/// varint encodings to exercise different STREAM frame header sizes.
+///
+/// We sweep buffer sizes from 35 to 50.  A Short packet header for a
+/// 16-byte DCID is approximately 35 bytes
+///   (1 flags + 16 dcid + 2 pkt_num + 16 AEAD tag).
+fn stream_frame_tight_buffer(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+    #[values(
+        StreamIdSize::OneByteVarint,
+        StreamIdSize::TwoByteVarint,
+        StreamIdSize::FourByteVarint
+    )]
+    stream_id_size: StreamIdSize,
+    #[values(false, true)] empty_fin: bool,
+) {
+    // We need to set initial_max_streams high enough to "fit" the stream_id.
+    // Since the two low-bits of the id encode the type, we can use
+    // `(id >> 2) + 1`.
+    let stream_id = stream_id_size.stream_id();
+    let max_streams_bidi = (stream_id >> 2) + 1;
+
+    let mut config = test_utils::Pipe::default_config(cc_algorithm_name).unwrap();
+    config.set_initial_max_streams_bidi(max_streams_bidi);
+    // Just use some large flow control values so they don't get in the way of
+    // the test.
+    config.set_initial_max_data(10_000);
+    config.set_initial_max_stream_data_bidi_local(10_000);
+    config.set_initial_max_stream_data_bidi_remote(10_000);
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+    // Drain any additional ACKs.
+    assert_eq!(pipe.advance(), Ok(()));
+
+    if empty_fin {
+        // Write only an empty FIN — no data payload at all.
+        assert_eq!(pipe.client.stream_send(stream_id, b"", true), Ok(0));
+    } else {
+        assert_eq!(pipe.client.stream_send(stream_id, b"data", false), Ok(4));
+    }
+    assert!(pipe.client.streams.has_flushable());
+
+    let active_pid = pipe
+        .client
+        .paths
+        .get_active_path_id()
+        .expect("no active path");
+
+    for buf_sz in 35..=50_usize {
+        let mut small_buf = vec![0u8; buf_sz];
+        let result = pipe.client.send_single(
+            &mut small_buf,
+            active_pid,
+            false,
+            Instant::now(),
+        );
+
+        match result {
+            Err(Error::Done) => {
+                // Header didn't fit: stream must remain flushable.
+                assert!(
+                    pipe.client.streams.has_flushable(),
+                    "stream removed from flushable at buf_sz={buf_sz}"
+                );
+            },
+
+            Ok((_, len)) => {
+                // A packet was emitted.  Decrypt and inspect its frames.
+                let frames = test_utils::decode_pkt(
+                    &mut pipe.server,
+                    &mut small_buf[..len],
+                )
+                .unwrap();
+
+                let stream_frames: Vec<_> = frames
+                    .iter()
+                    .filter(|f| matches!(f, frame::Frame::Stream { .. }))
+                    .collect();
+
+                if stream_frames.is_empty() {
+                    // Some other frame; this shouldn't really happen, since
+                    // we don't expect any frames. The Pipe::handshake() call
+                    // above should have drained all such frames.
+                    panic!(
+                        "unexpected non-STREAM frames at buf_sz={buf_sz}: \
+                        {frames:?}"
+                    );
+                }
+
+                assert_eq!(
+                    stream_frames.len(),
+                    1,
+                    "expected exactly one STREAM frame at buf_sz={buf_sz}"
+                );
+
+                match &stream_frames[0] {
+                    frame::Frame::Stream { data, .. } => {
+                        if empty_fin {
+                            // The empty-FIN frame must have zero payload and
+                            // the FIN bit set.
+                            assert_eq!(
+                                data.len(),
+                                0,
+                                "empty-FIN STREAM frame had non-zero payload \
+                                at buf_sz={buf_sz}"
+                            );
+                            assert!(
+                                data.fin(),
+                                "empty-FIN STREAM frame missing FIN bit \
+                                at buf_sz={buf_sz}"
+                            );
+                        } else {
+                            // Non-FIN frame: must carry at least 1 byte and
+                            // must NOT have the FIN bit set.
+                            assert_eq!(
+                                data.len(),
+                                1,
+                                "STREAM frame payload at buf_sz={buf_sz}"
+                            );
+                            assert!(
+                                !data.fin(),
+                                "non-FIN STREAM frame had FIN bit \
+                                at buf_sz={buf_sz}"
+                            );
+                        }
+                    },
+                    _ => unreachable!(),
+                }
+
+                return;
+            },
+
+            Err(e) => panic!("unexpected error at buf_sz={buf_sz}: {e:?}"),
+        }
+    }
+
+    panic!("no buffer size in the range we swept produced a packet with a STREAM frame");
+}
+
 #[rstest]
 /// Tests that completed streams are garbage collected.
 fn collect_streams(


### PR DESCRIPTION
While these frames are valid per RFC 9000, it is pointless to send them (and they triggered another bug on the receive side).

The MAX_STREAM_OVERHEAD constant we used to guard the path that writes STREAM frames was too low; STREAM frame headers can be up to 19 bytes. However, using the maximum overhead is a bit iffy as well, since it would prevent us from writing the more common, smaller frames. So instead, we guard on MIN_STREAM_OVERHEAD and add a secondary check to ensure the remaining capacity is enough to fit at least one byte of stream payload.

While doing this, I also noticed that we were removing the stream from the flushable queue when there was not enough space for its header. That could strand the stream permanently and may also account for connections running out of flow-control send credit. Fixed that as well.

The MAX_STREAM_OVERHEAD constant was also used in the recovery on_app_limited() check, so I had to tweak that logic too.