### PR TITLE
Only add to lost_frames on PTO if there is indication that previous added frames were sent.

### DIFF
--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -89,7 +89,12 @@ struct RecoveryEpoch {
     in_flight_count: usize,
 
     acked_frames: Vec<frame::Frame>,
-    lost_frames: Vec<frame::Frame>,
+
+    // Frames scheduled for retransmission due to PTO are tracked
+    // separately so we can check that frames were drained before
+    // generating more PTO probes.
+    lost_frames_ack: Vec<frame::Frame>,
+    lost_frames_pto: Vec<frame::Frame>,
 
     /// The largest packet number sent in the packet number space so far.
     #[cfg(test)]
@@ -247,7 +252,7 @@ impl RecoveryEpoch {
             if unacked.time_sent <= lost_send_time ||
                 largest_acked >= unacked.pkt_num + pkt_thresh
             {
-                self.lost_frames.extend(unacked.frames.drain(..));
+                self.lost_frames_ack.extend(unacked.frames.drain(..));
 
                 unacked.time_lost = Some(now);
 
@@ -320,6 +325,31 @@ impl RecoveryEpoch {
 
             self.sent_packets.pop_front();
         }
+    }
+
+    /// Returns the next lost frame, trying ACK-based lost frames first,
+    /// then PTO-based lost frames.
+    fn next_lost_frame(&mut self) -> Option<frame::Frame> {
+        self.lost_frames_ack
+            .pop()
+            .or_else(|| self.lost_frames_pto.pop())
+    }
+
+    /// Returns true if there are any lost frames (ACK or PTO).
+    fn has_lost_frames(&self) -> bool {
+        !self.lost_frames_ack.is_empty() || !self.lost_frames_pto.is_empty()
+    }
+
+    /// Returns the total count of lost frames (ACK + PTO).
+    #[cfg(test)]
+    fn lost_frames_count(&self) -> usize {
+        self.lost_frames_ack.len() + self.lost_frames_pto.len()
+    }
+
+    /// Clears all lost frames (both ACK and PTO).
+    fn clear_lost_frames(&mut self) {
+        self.lost_frames_ack.clear();
+        self.lost_frames_pto.clear();
     }
 }
 
@@ -557,7 +587,7 @@ impl RecoveryOps for LegacyRecovery {
     }
 
     fn next_lost_frame(&mut self, epoch: Epoch) -> Option<frame::Frame> {
-        self.epochs[epoch].lost_frames.pop()
+        self.epochs[epoch].next_lost_frame()
     }
 
     fn get_largest_acked_on_epoch(&self, epoch: Epoch) -> Option<u64> {
@@ -565,7 +595,7 @@ impl RecoveryOps for LegacyRecovery {
     }
 
     fn has_lost_frames(&self, epoch: Epoch) -> bool {
-        !self.epochs[epoch].lost_frames.is_empty()
+        self.epochs[epoch].has_lost_frames()
     }
 
     fn loss_probes(&self, epoch: Epoch) -> usize {
@@ -575,6 +605,11 @@ impl RecoveryOps for LegacyRecovery {
     #[cfg(test)]
     fn inc_loss_probes(&mut self, epoch: Epoch) {
         self.epochs[epoch].loss_probes += 1;
+    }
+
+    #[cfg(test)]
+    fn lost_frames_count(&self, epoch: Epoch) -> usize {
+        self.epochs[epoch].lost_frames_count()
     }
 
     fn ping_sent(&mut self, epoch: Epoch) {
@@ -768,8 +803,17 @@ impl RecoveryOps for LegacyRecovery {
         epoch.loss_probes =
             cmp::min(self.pto_count as usize, MAX_PTO_PROBES_COUNT);
 
+        let sent_packets_iter_limit = if !epoch.lost_frames_pto.is_empty() {
+            // Skip the search for frames to add to PTO probes if frames
+            // added in a prior PTO haven't been processed yet.
+            0
+        } else {
+            usize::MAX
+        };
+
         let unacked_iter = epoch.sent_packets
-            .iter_mut()
+            .iter()
+            .take(sent_packets_iter_limit)
             // Skip packets that have already been acked or lost, and packets
             // that don't contain either CRYPTO or STREAM frames.
             .filter(|p| p.has_data && p.time_acked.is_none() && p.time_lost.is_none())
@@ -785,7 +829,7 @@ impl RecoveryOps for LegacyRecovery {
         // HANDSHAKE_DONE and MAX_DATA / MAX_STREAM_DATA as well, in addition
         // to CRYPTO and STREAM, if the original packet carried them.
         for unacked in unacked_iter {
-            epoch.lost_frames.extend_from_slice(&unacked.frames);
+            epoch.lost_frames_pto.extend_from_slice(&unacked.frames);
         }
 
         self.set_loss_detection_timer(handshake_status, now);
@@ -814,7 +858,7 @@ impl RecoveryOps for LegacyRecovery {
         self.bytes_in_flight.saturating_subtract(unacked_bytes, now);
 
         epoch.sent_packets.clear();
-        epoch.lost_frames.clear();
+        epoch.clear_lost_frames();
         epoch.acked_frames.clear();
 
         epoch.time_of_last_ack_eliciting_packet = None;

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -106,7 +106,12 @@ struct RecoveryEpoch {
     pkts_in_flight: usize,
 
     acked_frames: VecDeque<frame::Frame>,
-    lost_frames: VecDeque<frame::Frame>,
+
+    // Frames scheduled for retransmission due to PTO are tracked
+    // separately so we can check that frames were drained before
+    // generating more PTO probes.
+    lost_frames_ack: VecDeque<frame::Frame>,
+    lost_frames_pto: VecDeque<frame::Frame>,
 
     /// The largest packet number sent in the packet number space so far.
     #[allow(dead_code)]
@@ -156,6 +161,8 @@ impl RecoveryEpoch {
             .sum();
 
         std::mem::take(&mut self.sent_packets);
+        self.clear_lost_frames();
+        std::mem::take(&mut self.acked_frames);
         self.time_of_last_ack_eliciting_packet = None;
         self.loss_time = None;
         self.loss_probes = 0;
@@ -294,7 +301,7 @@ impl RecoveryEpoch {
                         ..
                     } = status.lose()
                     {
-                        self.lost_frames.extend(frames);
+                        self.lost_frames_ack.extend(frames);
 
                         if in_flight {
                             self.pkts_in_flight -= 1;
@@ -355,6 +362,31 @@ impl RecoveryEpoch {
         }
 
         self.largest_acked_packet.unwrap_or(0) + 1
+    }
+
+    /// Returns the next lost frame, trying ACK-based lost frames first,
+    /// then PTO-based lost frames.
+    fn next_lost_frame(&mut self) -> Option<frame::Frame> {
+        self.lost_frames_ack
+            .pop_front()
+            .or_else(|| self.lost_frames_pto.pop_front())
+    }
+
+    /// Returns true if there are any lost frames (ACK or PTO).
+    fn has_lost_frames(&self) -> bool {
+        !self.lost_frames_ack.is_empty() || !self.lost_frames_pto.is_empty()
+    }
+
+    /// Returns the total count of lost frames (ACK + PTO).
+    #[cfg(test)]
+    fn lost_frames_count(&self) -> usize {
+        self.lost_frames_ack.len() + self.lost_frames_pto.len()
+    }
+
+    /// Clears all lost frames (both ACK and PTO).
+    fn clear_lost_frames(&mut self) {
+        self.lost_frames_ack.clear();
+        self.lost_frames_pto.clear();
     }
 }
 
@@ -675,7 +707,7 @@ impl RecoveryOps for GRecovery {
     }
 
     fn next_lost_frame(&mut self, epoch: packet::Epoch) -> Option<frame::Frame> {
-        self.epochs[epoch].lost_frames.pop_front()
+        self.epochs[epoch].next_lost_frame()
     }
 
     fn get_largest_acked_on_epoch(&self, epoch: packet::Epoch) -> Option<u64> {
@@ -683,7 +715,7 @@ impl RecoveryOps for GRecovery {
     }
 
     fn has_lost_frames(&self, epoch: packet::Epoch) -> bool {
-        !self.epochs[epoch].lost_frames.is_empty()
+        self.epochs[epoch].has_lost_frames()
     }
 
     fn loss_probes(&self, epoch: packet::Epoch) -> usize {
@@ -693,6 +725,11 @@ impl RecoveryOps for GRecovery {
     #[cfg(test)]
     fn inc_loss_probes(&mut self, epoch: packet::Epoch) {
         self.epochs[epoch].loss_probes += 1;
+    }
+
+    #[cfg(test)]
+    fn lost_frames_count(&self, epoch: packet::Epoch) -> usize {
+        self.epochs[epoch].lost_frames_count()
     }
 
     fn ping_sent(&mut self, epoch: packet::Epoch) {
@@ -918,12 +955,21 @@ impl RecoveryOps for GRecovery {
 
         epoch.loss_probes = MAX_PTO_PROBES_COUNT.min(self.pto_count as usize);
 
+        let sent_packets_iter_limit = if !epoch.lost_frames_pto.is_empty() {
+            // Skip the search for frames to add to PTO probes if frames
+            // added in a prior PTO haven't been processed yet.
+            0
+        } else {
+            usize::MAX
+        };
+
         // Skip packets that have already been acked or lost, and packets
         // that don't contain either CRYPTO or STREAM frames and only return as
         // many packets as the number of probe packets that will be sent.
         let unacked_frames = epoch
             .sent_packets
-            .iter_mut()
+            .iter()
+            .take(sent_packets_iter_limit)
             .filter_map(|p| {
                 if let SentStatus::Sent {
                     has_data: true,
@@ -947,10 +993,10 @@ impl RecoveryOps for GRecovery {
         // This will also trigger sending an ACK and retransmitting frames like
         // HANDSHAKE_DONE and MAX_DATA / MAX_STREAM_DATA as well, in addition
         // to CRYPTO and STREAM, if the original packet carried them.
-        epoch.lost_frames.extend(unacked_frames.cloned());
+        epoch.lost_frames_pto.extend(unacked_frames.cloned());
 
         self.pacer
-            .on_retransmission_timeout(!epoch.lost_frames.is_empty());
+            .on_retransmission_timeout(epoch.has_lost_frames());
 
         self.set_loss_detection_timer(handshake_status, now);
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -206,6 +206,8 @@ pub trait RecoveryOps {
     fn loss_probes(&self, epoch: packet::Epoch) -> usize;
     #[cfg(test)]
     fn inc_loss_probes(&mut self, epoch: packet::Epoch);
+    #[cfg(test)]
+    fn lost_frames_count(&self, epoch: packet::Epoch) -> usize;
 
     fn ping_sent(&mut self, epoch: packet::Epoch);
 
@@ -830,6 +832,7 @@ pub enum StartupExitReason {
 mod tests {
     use super::*;
     use crate::packet;
+    use crate::range_buf::RangeBuf;
     use crate::test_utils;
     use crate::CongestionControlAlgorithm;
     use crate::DEFAULT_INITIAL_RTT;
@@ -2857,6 +2860,222 @@ mod tests {
         // no packets in flight in Initial or Handshake spaces either, no timer
         // should be set.
         assert!(r.loss_detection_timer().is_none());
+    }
+
+    // Test that consecutive PTOs don't add duplicate frames to lost_frames.
+    // This validates the fix: `if epoch.lost_frames.is_empty()` guard.
+    #[rstest]
+    fn pto_does_not_duplicate_frames_on_consecutive_timeouts(
+        #[values("reno", "cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+    ) {
+        let mut cfg = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
+
+        let mut r = Recovery::new(&cfg);
+        let mut now = Instant::now();
+
+        // Send a packet with a STREAM frame.
+        let frames = smallvec![frame::Frame::Stream {
+            stream_id: 4,
+            data: RangeBuf::from(b"test", 0, false),
+        },];
+
+        let p = Sent {
+            pkt_num: 0,
+            frames: frames.clone(),
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: 1000,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
+            has_data: true,
+            is_pmtud_probe: false,
+        };
+
+        r.on_packet_sent(
+            p,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+            now,
+            "",
+        );
+
+        // Verify initial state
+        assert_eq!(r.lost_frames_count(packet::Epoch::Application), 0);
+        assert_eq!(r.lost_count(), 0);
+
+        // First PTO - should add frames when lost_frames is empty.
+        now = r.loss_detection_timer().unwrap();
+        r.on_loss_detection_timeout(HandshakeStatus::default(), now, "");
+
+        assert_eq!(r.pto_count(), 1);
+        let frames_after_first_pto =
+            r.lost_frames_count(packet::Epoch::Application);
+        assert_eq!(
+            frames_after_first_pto, 1,
+            "First PTO should add exactly 1 frame"
+        );
+        assert_eq!(
+            r.lost_count(),
+            0,
+            "PTO doesn't declare packets lost (no CC impact)"
+        );
+
+        // Second PTO while lost_frames is still populated.
+        // WITHOUT the fix: would add duplicate frame (count becomes 2).
+        // WITH the fix: skips adding (count stays 1).
+        now = r.loss_detection_timer().unwrap();
+        r.on_loss_detection_timeout(HandshakeStatus::default(), now, "");
+
+        assert_eq!(r.pto_count(), 2);
+        let frames_after_second_pto =
+            r.lost_frames_count(packet::Epoch::Application);
+        assert_eq!(
+            frames_after_second_pto, frames_after_first_pto,
+            "Second PTO must NOT add duplicate frames (fix: `if \
+             lost_frames.is_empty()`)"
+        );
+
+        // Third PTO for extra validation
+        now = r.loss_detection_timer().unwrap();
+        r.on_loss_detection_timeout(HandshakeStatus::default(), now, "");
+
+        assert_eq!(r.pto_count(), 3);
+        let frames_after_third_pto =
+            r.lost_frames_count(packet::Epoch::Application);
+        assert_eq!(
+            frames_after_third_pto, frames_after_first_pto,
+            "Third PTO must NOT add duplicate frames"
+        );
+
+        // Verify packets are still tracked (not removed)
+        assert_eq!(r.sent_packets_len(packet::Epoch::Application), 1);
+        // Verify lost_count never increased (PTO doesn't trigger CC)
+        assert_eq!(r.lost_count(), 0);
+    }
+
+    // Test that send_on_path after PTO timeout properly sends retransmissions
+    // and doesn't mark packets as lost (lost_count should remain 0).
+    #[rstest]
+    fn pto_send_on_path_retransmits_without_loss(
+        #[values("reno", "cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+    ) {
+        use crate::test_utils;
+
+        let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+
+        // Complete handshake
+        assert_eq!(pipe.handshake(), Ok(()));
+
+        // Client sends stream data
+        assert_eq!(pipe.client.stream_send(4, b"hello", false), Ok(5));
+
+        let mut buf = [0; 65535];
+
+        // Send the packet but drop it (don't deliver to server)
+        let (len1, _) = pipe.client.send(&mut buf).unwrap();
+        assert!(len1 > 0);
+
+        // Verify lost_count is 0 (no losses yet)
+        let initial_lost_count = pipe
+            .client
+            .paths
+            .get_active()
+            .unwrap()
+            .recovery
+            .lost_count();
+        assert_eq!(initial_lost_count, 0, "No packets should be lost initially");
+
+        // Verify frames are not yet in lost_frames
+        let initial_lost_frames = pipe
+            .client
+            .paths
+            .get_active()
+            .unwrap()
+            .recovery
+            .lost_frames_count(packet::Epoch::Application);
+        assert_eq!(
+            initial_lost_frames, 0,
+            "No frames should be in lost_frames initially"
+        );
+
+        // Wait for PTO timeout
+        let timer = pipe.client.timeout().unwrap();
+        std::thread::sleep(timer + Duration::from_millis(1));
+
+        // Trigger PTO via on_timeout()
+        pipe.client.on_timeout();
+
+        // After PTO, frames should be in lost_frames for retransmission
+        let lost_frames_after_pto = pipe
+            .client
+            .paths
+            .get_active()
+            .unwrap()
+            .recovery
+            .lost_frames_count(packet::Epoch::Application);
+        assert!(
+            lost_frames_after_pto > 0,
+            "PTO should add frames to lost_frames for retransmission"
+        );
+
+        // But lost_count should still be 0 (PTO doesn't declare packets lost)
+        let lost_count_after_pto = pipe
+            .client
+            .paths
+            .get_active()
+            .unwrap()
+            .recovery
+            .lost_count();
+        assert_eq!(
+            lost_count_after_pto, 0,
+            "PTO should not increment lost_count"
+        );
+
+        // Now send the retransmission via send_on_path
+        let (len2, _) = pipe.client.send(&mut buf).unwrap();
+        assert!(len2 > 0, "Should send PTO probe packet");
+
+        // After sending, lost_count should still be 0
+        let lost_count_after_send = pipe
+            .client
+            .paths
+            .get_active()
+            .unwrap()
+            .recovery
+            .lost_count();
+        assert_eq!(
+            lost_count_after_send, 0,
+            "Sending PTO probe should not increment lost_count"
+        );
+
+        // Deliver the retransmission to server
+        assert_eq!(pipe.server_recv(&mut buf[..len2]), Ok(len2));
+
+        // Server should receive the stream data
+        let mut recv_buf = [0; 100];
+        assert_eq!(pipe.server.stream_recv(4, &mut recv_buf), Ok((5, false)));
+        assert_eq!(&recv_buf[..5], b"hello");
+
+        // Final verification: lost_count on client should still be 0
+        let final_lost_count = pipe
+            .client
+            .paths
+            .get_active()
+            .unwrap()
+            .recovery
+            .lost_count();
+        assert_eq!(
+            final_lost_count, 0,
+            "No packets should be marked as lost - PTO only retransmits"
+        );
     }
 }
 


### PR DESCRIPTION
This avoids scheduling the same frames for retransmission multiple times.