### PR TITLE
fix: args.rs P1/P2 bugs in CLI parser

### DIFF
--- a/apps/src/args.rs
+++ b/apps/src/args.rs
@@ -369,21 +369,21 @@ impl Args for ClientArgs {
             None
         };
 
-        let body = if args.get_bool("--body") {
-            std::fs::read(args.get_str("--body")).ok()
+        let body = if !args.get_str("--body").is_empty() {
+            Some(std::fs::read(args.get_str("--body")).unwrap_or_else(|e| { eprintln!("error reading --body: {e}"); std::process::exit(1); }))
         } else {
             None
         };
 
         let method = args.get_str("--method").to_string();
 
-        let connect_to = if args.get_bool("--connect-to") {
+        let connect_to = if !args.get_str("--connect-to").is_empty() {
             Some(args.get_str("--connect-to").to_string())
         } else {
             None
         };
 
-        let session_file = if args.get_bool("--session-file") {
+        let session_file = if !args.get_str("--session-file").is_empty() {
             Some(args.get_str("--session-file").to_string())
         } else {
             None
@@ -473,6 +473,7 @@ Options:
   --qpack-blocked-streams STREAMS   Limit of streams that can be blocked while decoding. Any value other that 0 is currently unsupported.
   --disable-gso               Disable GSO (linux only).
   --disable-pacing            Disable pacing (linux only).
+  --enable-pmtud              Enable Path MTU Discovery.
   --initial-rtt MILLIS     The initial RTT in milliseconds [default: 333].
   --initial-cwnd-packets PACKETS      The initial congestion window size in terms of packet count [default: 10].
   -h --help                   Show this screen.


### PR DESCRIPTION
Fix critical reliability bugs in the CLI argument parser (apps/src/args.rs). Added missing --enable-pmtud option to SERVER_USAGE, which previously caused a deterministic startup panic due to docopt accessing an unknown key. Replaced incorrect get_bool() API usage on value-bearing options --body, --connect-to, and --session-file with proper get_str() checks. File read errors on --body are now surfaced explicitly instead of being silently swallowed via .ok(), preventing request-body omission without any diagnostic output