### PR TITLE
Fix BBRv2: CWND plateaus at low value due to misinterpreted idleness 

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -578,6 +578,7 @@ pub struct Config {
     initial_congestion_window_packets: usize,
     enable_relaxed_loss_threshold: bool,
     enable_cubic_idle_restart_fix: bool,
+    enable_bbr_fix: bool,
     enable_send_streams_blocked: bool,
 
     pmtud: bool,
@@ -692,6 +693,7 @@ impl Config {
             initial_rtt: DEFAULT_INITIAL_RTT,
 
             use_initial_max_data_as_flow_control_win: false,
+            enable_bbr_fix: true,
         })
     }
 
@@ -1146,6 +1148,11 @@ impl Config {
     /// The default value is `true`.
     pub fn set_enable_cubic_idle_restart_fix(&mut self, enable: bool) {
         self.enable_cubic_idle_restart_fix = enable;
+    }
+
+    /// Configure whether or not the BBR fix should be enabled
+    pub fn set_enable_bbr_fix(&mut self, enable: bool) {
+        self.enable_bbr_fix = enable;
     }
 
     /// Configure whether to enable sending STREAMS_BLOCKED frames.

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -208,6 +208,8 @@ struct Params {
     /// 1/8th of an RTT into the future, so the error introduced by
     /// setting `time_sent` to `now` is bounded.
     time_sent_set_to_now: bool,
+
+    enable_bbr_fix: bool,
 }
 
 impl Params {
@@ -252,6 +254,7 @@ impl Params {
         apply_override!(scale_pacing_rate_by_mss);
         apply_override!(disable_probe_down_early_exit);
         apply_override!(time_sent_set_to_now);
+        apply_override!(enable_bbr_fix);
         apply_optional_override!(initial_pacing_rate_bytes_per_second);
 
         if let Some(custom_value) = custom_bbr_settings.bw_lo_reduction_strategy {
@@ -348,6 +351,8 @@ const DEFAULT_PARAMS: Params = Params {
     disable_probe_down_early_exit: false,
 
     time_sent_set_to_now: true,
+
+    enable_bbr_fix: true,
 };
 
 #[derive(Debug, PartialEq)]
@@ -508,16 +513,17 @@ impl BBRv2CongestionEvent {
 impl BBRv2 {
     pub fn new(
         initial_congestion_window: usize, max_congestion_window: usize,
-        max_segment_size: usize, smoothed_rtt: Duration,
+        max_segment_size: usize, smoothed_rtt: Duration, enable_bbr_fix: bool,
         custom_bbr_params: Option<&BbrParams>,
     ) -> Self {
         let cwnd = initial_congestion_window * max_segment_size;
 
-        let params = if let Some(custom_bbr_settings) = custom_bbr_params {
+        let mut params = if let Some(custom_bbr_settings) = custom_bbr_params {
             DEFAULT_PARAMS.with_overrides(custom_bbr_settings)
         } else {
             DEFAULT_PARAMS
         };
+        params.enable_bbr_fix=enable_bbr_fix;
 
         BBRv2 {
             mode: Mode::startup(BBRv2NetworkModel::new(&params, smoothed_rtt)),
@@ -746,13 +752,18 @@ impl CongestionControl for BBRv2 {
         if !self.last_sample_is_app_limited {
             self.has_non_app_limited_sample = true;
         }
+
         if congestion_event.bytes_in_flight == 0 &&
             self.params.avoid_unnecessary_probe_rtt
         {
-            let delta = event_time -
-                self.idle_start.unwrap_or(event_time) -
-                rtt_stats.latest_rtt;
-            if delta.as_nanos() > 0 {
+            if network_model.enable_bbr_fix() {
+                let delta = event_time -
+                    self.idle_start.unwrap_or(event_time) -
+                    rtt_stats.latest_rtt;
+                if delta.as_nanos() > 0 {
+                    self.on_enter_quiescence(event_time);
+                }
+            } else {
                 self.on_enter_quiescence(event_time);
             }
         }
@@ -836,17 +847,65 @@ mod tests {
     const MAX_DATAGRAM_SIZE: usize = 1350;
     use super::*;
 
-    fn test_sender() -> TestSender {
-        TestSender::new(CongestionControlAlgorithm::Bbr2Gcongestion, false)
+    fn test_sender(enabled: bool) -> TestSender {
+        TestSender::new(CongestionControlAlgorithm::Bbr2Gcongestion, enabled)
+    }
+
+    #[rstest]
+    fn bbr_wrong_plateau() {
+        let mut sender = test_sender(false);
+        let size = MAX_DATAGRAM_SIZE;
+        let rtt = Duration::from_millis(1000);
+
+        // Fill the pipe.
+        for _ in 0..DEFAULT_INITIAL_CONGESTION_WINDOW_PACKETS {
+            sender.send_packet(
+                size,
+                packet::Epoch::Handshake,
+                HandshakeStatus::default(),
+            );
+        }
+        sender.advance_time(rtt);
+
+        // ack all inflight data
+        sender.ack_n_packets(
+            DEFAULT_INITIAL_CONGESTION_WINDOW_PACKETS,
+            size,
+            300,
+            packet::Epoch::Handshake,
+            HandshakeStatus::default(),
+            None,
+        );
+        assert_eq!(sender.cc.bytes_in_flight(), 0);
+        // Now simulate the problematic pattern: send a small burst at
+        // minimum cwnd, ACK it (bif drops to 0), advance one RTT, repeat. --> bif
+        // at 0
+
+        sender.send_packet(
+            size,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+        );
+
+        sender.advance_time(rtt);
+
+        sender.ack_n_packets(
+            1,
+            size,
+            300,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+            None,
+        );
+        // eventhough bytes in flight is 0, the connection is clearly not
+        // idle, thus no quiescence has been detected
+        assert_eq!(sender.cc.bytes_in_flight(), 0);
+        assert_eq!(sender.cc.pacer.sender.last_quiescence_start, None);
     }
 
     #[rstest]
     fn bbr_plateau_no_quiescence() {
-        // Reproduces the bug where cwnd stays pinned at minimum after a
-        // loss event because the idle-time epoch shift pushes
-        // congestion_recovery_start_time into the future on every
-        // send -> ACK -> send cycle when bif transiently hits 0.
-        let mut sender = test_sender();
+        let mut sender = test_sender(true);
         let size = MAX_DATAGRAM_SIZE;
         let rtt = Duration::from_millis(1000);
 
@@ -902,7 +961,7 @@ mod tests {
         // loss event because the idle-time epoch shift pushes
         // congestion_recovery_start_time into the future on every
         // send -> ACK -> send cycle when bif transiently hits 0.
-        let mut sender = test_sender();
+        let mut sender = test_sender(true);
         let size = MAX_DATAGRAM_SIZE;
         let rtt = Duration::from_millis(1000);
 
@@ -976,6 +1035,7 @@ mod tests {
             MAX_WINDOW_PACKETS,
             INIT_PACKET_SIZE,
             initial_rtt,
+            true,
             Some(bbr_params),
         );
 

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -35,6 +35,7 @@ mod probe_bw;
 mod probe_rtt;
 mod startup;
 
+use std::cmp;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -438,6 +439,14 @@ pub(crate) struct BBRv2 {
     has_non_app_limited_sample: bool,
     last_quiescence_start: Option<Instant>,
     params: Params,
+
+    idle_start: Option<Instant>,
+
+    /// Track last processed ack time
+    last_ack_time: Option<Instant>,
+
+    /// Track time of last sent packet
+    last_sent_time: Option<Instant>,
 }
 
 struct BBRv2CongestionEvent {
@@ -524,6 +533,9 @@ impl BBRv2 {
             last_quiescence_start: None,
             mss: max_segment_size,
             params,
+            idle_start: None,
+            last_ack_time: None,
+            last_sent_time: None,
         }
     }
 
@@ -663,6 +675,11 @@ impl CongestionControl for BBRv2 {
         &mut self, sent_time: Instant, bytes_in_flight: usize,
         packet_number: u64, bytes: usize, is_retransmissible: bool,
     ) {
+        self.idle_start = Some(cmp::max(
+            self.last_ack_time.unwrap_or(sent_time),
+            self.last_sent_time.unwrap_or(sent_time),
+        ));
+        self.last_sent_time = Some(sent_time);
         if bytes_in_flight == 0 && self.params.avoid_unnecessary_probe_rtt {
             self.on_exit_quiescence(sent_time);
         }
@@ -680,9 +697,10 @@ impl CongestionControl for BBRv2 {
     fn on_congestion_event(
         &mut self, _rtt_updated: bool, prior_in_flight: usize,
         _bytes_in_flight: usize, event_time: Instant, acked_packets: &[Acked],
-        lost_packets: &[Lost], least_unacked: u64, _rtt_stats: &RttStats,
-        recovery_stats: &mut RecoveryStats,
+        lost_packets: &[Lost], least_unacked: u64, rtt_stats: &RttStats,
+        recovery_stats: &mut RecoveryStats, last_ack_time: Option<Instant>,
     ) {
+        self.last_ack_time = last_ack_time;
         let mut congestion_event = BBRv2CongestionEvent::new(
             event_time,
             self.cwnd,
@@ -731,7 +749,12 @@ impl CongestionControl for BBRv2 {
         if congestion_event.bytes_in_flight == 0 &&
             self.params.avoid_unnecessary_probe_rtt
         {
-            self.on_enter_quiescence(event_time);
+            let delta = event_time -
+                self.idle_start.unwrap_or(event_time) -
+                rtt_stats.latest_rtt;
+            if delta.as_nanos() > 0 {
+                self.on_enter_quiescence(event_time);
+            }
         }
     }
 
@@ -800,9 +823,136 @@ impl CongestionControl for BBRv2 {
 
 #[cfg(test)]
 mod tests {
+    use crate::packet;
+    use crate::recovery::gcongestion::test_sender::TestSender;
+    use crate::recovery::HandshakeStatus;
+    use crate::recovery::RecoveryOps;
+    use crate::CongestionControlAlgorithm;
     use rstest::rstest;
 
+    // The default initial congestion window size in terms of packet count.
+    const DEFAULT_INITIAL_CONGESTION_WINDOW_PACKETS: usize = 10;
+
+    const MAX_DATAGRAM_SIZE: usize = 1350;
     use super::*;
+
+    fn test_sender() -> TestSender {
+        TestSender::new(CongestionControlAlgorithm::Bbr2Gcongestion, false)
+    }
+
+    #[rstest]
+    fn bbr_plateau_no_quiescence() {
+        // Reproduces the bug where cwnd stays pinned at minimum after a
+        // loss event because the idle-time epoch shift pushes
+        // congestion_recovery_start_time into the future on every
+        // send -> ACK -> send cycle when bif transiently hits 0.
+        let mut sender = test_sender();
+        let size = MAX_DATAGRAM_SIZE;
+        let rtt = Duration::from_millis(1000);
+
+        // Fill the pipe.
+        for _ in 0..DEFAULT_INITIAL_CONGESTION_WINDOW_PACKETS {
+            sender.send_packet(
+                size,
+                packet::Epoch::Handshake,
+                HandshakeStatus::default(),
+            );
+        }
+        sender.advance_time(rtt);
+
+        // ack all inflight data
+        sender.ack_n_packets(
+            DEFAULT_INITIAL_CONGESTION_WINDOW_PACKETS,
+            size,
+            300,
+            packet::Epoch::Handshake,
+            HandshakeStatus::default(),
+            None,
+        );
+        assert_eq!(sender.cc.bytes_in_flight(), 0);
+        // Now simulate the problematic pattern: send a small burst at
+        // minimum cwnd, ACK it (bif drops to 0), advance one RTT, repeat. --> bif
+        // at 0
+
+        sender.send_packet(
+            size,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+        );
+
+        sender.advance_time(rtt);
+
+        sender.ack_n_packets(
+            1,
+            size,
+            300,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+            None,
+        );
+        // eventhough bytes in flight is 0, the connection is clearly not
+        // idle, thus no quiescence has been detected
+        assert_eq!(sender.cc.bytes_in_flight(), 0);
+        assert_eq!(sender.cc.pacer.sender.last_quiescence_start, None);
+    }
+
+    #[rstest]
+    fn bbr_plateau_quiescence() {
+        // Reproduces the bug where cwnd stays pinned at minimum after a
+        // loss event because the idle-time epoch shift pushes
+        // congestion_recovery_start_time into the future on every
+        // send -> ACK -> send cycle when bif transiently hits 0.
+        let mut sender = test_sender();
+        let size = MAX_DATAGRAM_SIZE;
+        let rtt = Duration::from_millis(1000);
+
+        // Fill the pipe.
+        for _ in 0..DEFAULT_INITIAL_CONGESTION_WINDOW_PACKETS {
+            sender.send_packet(
+                size,
+                packet::Epoch::Handshake,
+                HandshakeStatus::default(),
+            );
+        }
+
+        sender.advance_time(rtt);
+
+        // ack all inflight data
+        sender.ack_n_packets(
+            DEFAULT_INITIAL_CONGESTION_WINDOW_PACKETS,
+            size,
+            300,
+            packet::Epoch::Handshake,
+            HandshakeStatus::default(),
+            None,
+        );
+        assert_eq!(sender.cc.bytes_in_flight(), 0);
+        // Let the connection be idle for some seconds, the resume sending and
+        // ensure that bbr correctly recognized the idleness
+        let idle_duration = Duration::from_secs(5);
+        sender.advance_time(idle_duration);
+
+        sender.send_packet(
+            size,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+        );
+
+        sender.advance_time(rtt);
+        sender.ack_n_packets(
+            1,
+            size,
+            300,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+            None,
+        );
+        // due to the idle duration, the connection is indeed idle, thus the
+        // last_quiescence_start has a value; since we again acked everything
+        // there is nothing in flight
+        assert_eq!(sender.cc.bytes_in_flight(), 0);
+        assert_ne!(sender.cc.pacer.sender.last_quiescence_start, None);
+    }
 
     #[rstest]
     fn update_mss(#[values(false, true)] scale_pacing_rate_by_mss: bool) {

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -523,7 +523,7 @@ impl BBRv2 {
         } else {
             DEFAULT_PARAMS
         };
-        params.enable_bbr_fix=enable_bbr_fix;
+        params.enable_bbr_fix = enable_bbr_fix;
 
         BBRv2 {
             mode: Mode::startup(BBRv2NetworkModel::new(&params, smoothed_rtt)),
@@ -853,7 +853,7 @@ mod tests {
 
     #[rstest]
     fn bbr_wrong_plateau() {
-        let mut sender = test_sender(false);
+        let mut sender = test_sender(false); // force the sender to use the old code without the bbr fix enabled
         let size = MAX_DATAGRAM_SIZE;
         let rtt = Duration::from_millis(1000);
 
@@ -877,10 +877,6 @@ mod tests {
             None,
         );
         assert_eq!(sender.cc.bytes_in_flight(), 0);
-        // Now simulate the problematic pattern: send a small burst at
-        // minimum cwnd, ACK it (bif drops to 0), advance one RTT, repeat. --> bif
-        // at 0
-
         sender.send_packet(
             size,
             packet::Epoch::Application,
@@ -897,10 +893,10 @@ mod tests {
             HandshakeStatus::default(),
             None,
         );
-        // eventhough bytes in flight is 0, the connection is clearly not
-        // idle, thus no quiescence has been detected
+        // bytes in flight is 0, which was previously understood as quiescence,
+        // thus the connection is understood to be idle
         assert_eq!(sender.cc.bytes_in_flight(), 0);
-        assert_eq!(sender.cc.pacer.sender.last_quiescence_start, None);
+        assert_ne!(sender.cc.pacer.sender.last_quiescence_start, None);
     }
 
     #[rstest]
@@ -929,10 +925,6 @@ mod tests {
             None,
         );
         assert_eq!(sender.cc.bytes_in_flight(), 0);
-        // Now simulate the problematic pattern: send a small burst at
-        // minimum cwnd, ACK it (bif drops to 0), advance one RTT, repeat. --> bif
-        // at 0
-
         sender.send_packet(
             size,
             packet::Epoch::Application,

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -877,26 +877,30 @@ mod tests {
             None,
         );
         assert_eq!(sender.cc.bytes_in_flight(), 0);
-        sender.send_packet(
-            size,
-            packet::Epoch::Application,
-            HandshakeStatus::default(),
-        );
+        for _ in 0..100 {
+            sender.send_packet(
+                size,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+            );
 
-        sender.advance_time(rtt);
+            sender.advance_time(rtt);
 
-        sender.ack_n_packets(
-            1,
-            size,
-            300,
-            packet::Epoch::Application,
-            HandshakeStatus::default(),
-            None,
-        );
-        // bytes in flight is 0, which was previously understood as quiescence,
-        // thus the connection is understood to be idle
-        assert_eq!(sender.cc.bytes_in_flight(), 0);
-        assert_ne!(sender.cc.pacer.sender.last_quiescence_start, None);
+            sender.ack_n_packets(
+                1,
+                size,
+                300,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                None,
+            );
+            // bytes in flight is 0, which was previously understood as
+            // quiescence, thus the connection is understood to be
+            // idle
+            assert_eq!(sender.cc.bytes_in_flight(), 0);
+            assert_ne!(sender.cc.pacer.sender.last_quiescence_start, None);
+            assert_ne!(sender.cc.pacer.sender.mode.name(),"ProbeRTT");
+        }
     }
 
     #[rstest]

--- a/quiche/src/recovery/gcongestion/bbr2/mode.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/mode.rs
@@ -185,6 +185,17 @@ impl Mode {
         Mode::ProbeRTT(ProbeRTT::new(model, cycle))
     }
 
+    #[cfg(test)]
+    pub(super) fn name(&self) -> &str {
+        match self {
+            Mode::Startup(_) => "Startup",
+            Mode::Drain(_) => "Drain",
+            Mode::ProbeBW(_) => "ProbeBw",
+            Mode::ProbeRTT(_) => "ProbeRTT",
+            Mode::Placheolder(_) => unreachable!(),
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn do_on_congestion_event(
         &mut self, prior_in_flight: usize, event_time: Instant,

--- a/quiche/src/recovery/gcongestion/bbr2/network_model.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/network_model.rs
@@ -197,7 +197,6 @@ pub(super) struct BBRv2NetworkModel {
 
 impl BBRv2NetworkModel {
     pub(super) fn new(params: &Params, initial_rtt: Duration) -> Self {
-        println!("enable fix: {:?}", params.enable_bbr_fix);
         BBRv2NetworkModel {
             min_bytes_in_flight_in_round: usize::MAX,
             inflight_hi_limited_in_round: false,

--- a/quiche/src/recovery/gcongestion/bbr2/network_model.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/network_model.rs
@@ -191,10 +191,13 @@ pub(super) struct BBRv2NetworkModel {
     latest_send_rate: Option<Bandwidth>,
     /// The most recent ack rate from the BandwidthSampler.
     latest_ack_rate: Option<Bandwidth>,
+
+    enable_bbr_fix:bool,
 }
 
 impl BBRv2NetworkModel {
     pub(super) fn new(params: &Params, initial_rtt: Duration) -> Self {
+        println!("enable fix: {:?}", params.enable_bbr_fix);
         BBRv2NetworkModel {
             min_bytes_in_flight_in_round: usize::MAX,
             inflight_hi_limited_in_round: false,
@@ -238,6 +241,7 @@ impl BBRv2NetworkModel {
 
             latest_send_rate: None,
             latest_ack_rate: None,
+            enable_bbr_fix:params.enable_bbr_fix
         }
     }
 
@@ -249,6 +253,10 @@ impl BBRv2NetworkModel {
     #[cfg(feature = "qlog")]
     pub(super) fn ack_rate(&self) -> Option<Bandwidth> {
         self.latest_ack_rate
+    }
+
+    pub(super) fn enable_bbr_fix(&self)->bool{
+        self.enable_bbr_fix
     }
 
     pub(super) fn max_ack_height(&self) -> usize {

--- a/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
@@ -123,6 +123,14 @@ impl ModeImpl for ProbeBW {
                     congestion_event,
                     params,
                 );
+                if !self.model.enable_bbr_fix() {
+                    if self.cycle.phase != CyclePhase::Down &&
+                        self.model
+                            .maybe_expire_min_rtt(congestion_event, params)
+                    {
+                        switch_to_probe_rtt = true;
+                    }
+                }
             },
             CyclePhase::Cruise => self.update_probe_cruise(
                 target_bytes_inflight,
@@ -135,10 +143,12 @@ impl ModeImpl for ProbeBW {
                 params,
             ),
         }
-        if self.cycle.phase != CyclePhase::Down &&
-            self.model.maybe_expire_min_rtt(congestion_event, params)
-        {
-            switch_to_probe_rtt = true;
+        if self.model.enable_bbr_fix() {
+            if self.cycle.phase != CyclePhase::Down &&
+                self.model.maybe_expire_min_rtt(congestion_event, params)
+            {
+                switch_to_probe_rtt = true;
+            }
         }
 
         // Do not need to set the gains if switching to PROBE_RTT, they will be

--- a/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
@@ -123,11 +123,6 @@ impl ModeImpl for ProbeBW {
                     congestion_event,
                     params,
                 );
-                if self.cycle.phase != CyclePhase::Down &&
-                    self.model.maybe_expire_min_rtt(congestion_event, params)
-                {
-                    switch_to_probe_rtt = true;
-                }
             },
             CyclePhase::Cruise => self.update_probe_cruise(
                 target_bytes_inflight,
@@ -139,6 +134,11 @@ impl ModeImpl for ProbeBW {
                 congestion_event,
                 params,
             ),
+        }
+        if self.cycle.phase != CyclePhase::Down &&
+            self.model.maybe_expire_min_rtt(congestion_event, params)
+        {
+            switch_to_probe_rtt = true;
         }
 
         // Do not need to set the gains if switching to PROBE_RTT, they will be

--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -28,6 +28,8 @@ mod bbr;
 mod bbr2;
 pub mod pacer;
 mod recovery;
+#[cfg(test)]
+mod test_sender;
 
 use std::fmt::Debug;
 use std::str::FromStr;
@@ -45,10 +47,11 @@ pub struct Lost {
     pub(super) bytes_lost: usize,
 }
 
-#[derive(Debug)]
+#[derive(Clone)]
 pub struct Acked {
-    pub(super) pkt_num: u64,
-    pub(super) time_sent: Instant,
+    pub pkt_num: u64,
+
+    pub time_sent: Instant,
 }
 
 pub(super) trait CongestionControl: Debug {
@@ -94,7 +97,7 @@ pub(super) trait CongestionControl: Debug {
         &mut self, rtt_updated: bool, prior_in_flight: usize,
         bytes_in_flight: usize, event_time: Instant, acked_packets: &[Acked],
         lost_packets: &[Lost], least_unacked: u64, rtt_stats: &RttStats,
-        recovery_stats: &mut RecoveryStats,
+        recovery_stats: &mut RecoveryStats, last_ack_time: Option<Instant>,
     );
 
     /// Called when an RTO fires.  Resets the retransmission alarm if there are

--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -236,6 +236,8 @@ pub struct BbrParams {
     /// on `get_next_release_time()` can result in artificially low
     /// minRTT measurements which will make BBR misbehave.
     pub time_sent_set_to_now: Option<bool>,
+
+    pub enable_bbr_fix: Option<bool>,
 }
 
 /// Controls BBR's bandwidth reduction strategy on congestion event.

--- a/quiche/src/recovery/gcongestion/pacer.rs
+++ b/quiche/src/recovery/gcongestion/pacer.rs
@@ -63,7 +63,7 @@ pub struct Pacer {
     /// Should this [`Pacer`] be making any release decisions?
     enabled: bool,
     /// Underlying sender
-    sender: BBRv2,
+    pub sender: BBRv2,
     /// The maximum rate the [`Pacer`] will use.
     max_pacing_rate: Option<Bandwidth>,
     /// Number of unpaced packets to be sent before packets are delayed.
@@ -199,7 +199,7 @@ impl Pacer {
         &mut self, rtt_updated: bool, prior_in_flight: usize,
         bytes_in_flight: usize, event_time: Instant, acked_packets: &[Acked],
         lost_packets: &[Lost], least_unacked: u64, rtt_stats: &RttStats,
-        recovery_stats: &mut RecoveryStats,
+        recovery_stats: &mut RecoveryStats,last_ack_time:Option<Instant>,
     ) {
         self.sender.on_congestion_event(
             rtt_updated,
@@ -211,6 +211,7 @@ impl Pacer {
             least_unacked,
             rtt_stats,
             recovery_stats,
+            last_ack_time
         );
 
         if !self.enabled {

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -19,6 +19,7 @@ use crate::recovery::QlogMetrics;
 
 use crate::frame;
 
+use super::Acked;
 use crate::recovery::bytes_in_flight::BytesInFlight;
 use crate::recovery::gcongestion::Bandwidth;
 use crate::recovery::rtt::RttStats;
@@ -44,7 +45,6 @@ use crate::recovery::PACKET_REORDER_TIME_THRESHOLD;
 
 use super::bbr2::BBRv2;
 use super::pacer::Pacer;
-use super::Acked;
 use super::Lost;
 
 // Congestion Control
@@ -466,7 +466,8 @@ pub struct GRecovery {
     /// [`Self::detect_and_remove_lost_packets`] to avoid allocations
     lost_reuse: Vec<Lost>,
 
-    pacer: Pacer,
+    pub pacer: Pacer,
+    last_ack_time: Option<Instant>,
 }
 
 impl GRecovery {
@@ -531,6 +532,8 @@ impl GRecovery {
 
             newly_acked: Vec::new(),
             lost_reuse: Vec::new(),
+
+            last_ack_time: None,
         })
     }
 
@@ -820,6 +823,9 @@ impl RecoveryOps for GRecovery {
         // Check if largest packet is newly acked.
         let update_rtt = largest_newly_acked.pkt_num == largest_acked_pkt_num &&
             has_ack_eliciting;
+
+        self.last_ack_time = Some(now);
+
         if update_rtt {
             let latest_rtt = now - largest_newly_acked.time_sent;
             self.rtt_stats.update_rtt(
@@ -843,6 +849,7 @@ impl RecoveryOps for GRecovery {
             self.epochs[epoch].least_unacked(),
             &self.rtt_stats,
             &mut self.recovery_stats,
+            self.last_ack_time,
         );
 
         self.pto_count = 0;
@@ -882,6 +889,7 @@ impl RecoveryOps for GRecovery {
                 self.epochs[epoch].least_unacked(),
                 &self.rtt_stats,
                 &mut self.recovery_stats,
+                self.last_ack_time,
             );
 
             self.lost_count += lost_packets;

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -488,6 +488,7 @@ impl GRecovery {
                 MAX_WINDOW_PACKETS,
                 recovery_config.max_send_udp_payload_size,
                 recovery_config.initial_rtt,
+                recovery_config.enable_bbr_fix,
                 recovery_config.custom_bbr_params.as_ref(),
             ),
             _ => return None,

--- a/quiche/src/recovery/gcongestion/test_sender.rs
+++ b/quiche/src/recovery/gcongestion/test_sender.rs
@@ -39,7 +39,6 @@ use crate::recovery::RecoveryConfig;
 use crate::recovery::RecoveryOps;
 use crate::recovery::Sent;
 use crate::CongestionControlAlgorithm;
-use std::fs;
 
 pub(crate) struct TestSender {
     pub(crate) cc: GRecovery,
@@ -59,8 +58,6 @@ impl TestSender {
         cfg.enable_hystart(false);
 
         cfg.set_enable_bbr_fix(enable_bbr_fix);
-        println!("config, set enabled: {:?}", cfg.enable_bbr_fix);
-        let _ = fs::remove_file("saved_params.csv");
         TestSender {
             next_pkt: 0,
             next_ack: 0,

--- a/quiche/src/recovery/gcongestion/test_sender.rs
+++ b/quiche/src/recovery/gcongestion/test_sender.rs
@@ -51,10 +51,15 @@ pub(crate) struct TestSender {
 }
 
 impl TestSender {
-    pub(crate) fn new(algo: CongestionControlAlgorithm, hystart: bool) -> Self {
+    pub(crate) fn new(
+        algo: CongestionControlAlgorithm, enable_bbr_fix: bool,
+    ) -> Self {
         let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
         cfg.set_cc_algorithm(algo);
-        cfg.enable_hystart(hystart);
+        cfg.enable_hystart(false);
+
+        cfg.set_enable_bbr_fix(enable_bbr_fix);
+        println!("config, set enabled: {:?}", cfg.enable_bbr_fix);
         let _ = fs::remove_file("saved_params.csv");
         TestSender {
             next_pkt: 0,

--- a/quiche/src/recovery/gcongestion/test_sender.rs
+++ b/quiche/src/recovery/gcongestion/test_sender.rs
@@ -1,0 +1,150 @@
+// Copyright (C) 2024, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::collections::VecDeque;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::time::Duration;
+use std::time::Instant;
+
+use super::Acked;
+use crate::packet;
+use crate::ranges::RangeSet;
+use crate::recovery::gcongestion::GRecovery;
+use crate::recovery::HandshakeStatus;
+use crate::recovery::RecoveryConfig;
+use crate::recovery::RecoveryOps;
+use crate::recovery::Sent;
+use crate::CongestionControlAlgorithm;
+use std::fs;
+
+pub(crate) struct TestSender {
+    pub(crate) cc: GRecovery,
+    pub(crate) next_pkt: u64,
+    pub(crate) next_ack: u64,
+    pub(crate) bytes_in_flight: usize,
+    pub(crate) time: Instant,
+    sent_packets: VecDeque<Sent>,
+}
+
+impl TestSender {
+    pub(crate) fn new(algo: CongestionControlAlgorithm, hystart: bool) -> Self {
+        let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        cfg.set_cc_algorithm(algo);
+        cfg.enable_hystart(hystart);
+        let _ = fs::remove_file("saved_params.csv");
+        TestSender {
+            next_pkt: 0,
+            next_ack: 0,
+            bytes_in_flight: 0,
+            time: Instant::now(),
+            cc: GRecovery::new(&RecoveryConfig::from_config(&cfg)).unwrap(),
+            sent_packets: VecDeque::new(),
+        }
+    }
+
+    pub(crate) fn send_packet(
+        &mut self, bytes: usize, epoch: packet::Epoch,
+        handshake_status: HandshakeStatus,
+    ) {
+        let sent = Sent {
+            pkt_num: self.next_pkt,
+            frames: Default::default(),
+            time_sent: self.time,
+            time_acked: None,
+            time_lost: None,
+            size: bytes,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: self.time,
+            first_sent_time: self.time,
+            is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
+            has_data: true,
+            is_pmtud_probe: false,
+        };
+
+        self.cc.on_packet_sent(
+            sent.clone(),
+            epoch,
+            handshake_status,
+            self.time,
+            &"".to_owned(),
+        );
+
+        self.sent_packets.push_back(sent.clone());
+
+        self.bytes_in_flight += bytes;
+        self.next_pkt += 1;
+    }
+
+    pub(crate) fn ack_n_packets(
+        &mut self, n: usize, bytes: usize, ack_delay: u64, epoch: packet::Epoch,
+        handshake_status: HandshakeStatus, skip_pn: Option<u64>,
+    ) {
+        let mut acked = Vec::new();
+        let mut range = RangeSet::new(n);
+        for _ in 0..n {
+            let unacked = self.sent_packets.pop_front().unwrap();
+            acked.push(Acked {
+                pkt_num: unacked.pkt_num,
+                time_sent: unacked.time_sent,
+            });
+            range.push_item(unacked.pkt_num as u64);
+            self.next_ack += 1;
+        }
+        let _ = self.cc.on_ack_received(
+            &range,
+            ack_delay,
+            epoch,
+            handshake_status,
+            self.time,
+            skip_pn,
+            &"".to_ascii_lowercase(),
+        );
+        self.bytes_in_flight -= n * bytes;
+    }
+
+    pub(crate) fn advance_time(&mut self, period: Duration) {
+        self.time += period;
+    }
+}
+
+impl Deref for TestSender {
+    type Target = GRecovery;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cc
+    }
+}
+
+impl DerefMut for TestSender {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cc
+    }
+}

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -144,6 +144,7 @@ pub struct RecoveryConfig {
     pub initial_congestion_window_packets: usize,
     pub enable_relaxed_loss_threshold: bool,
     pub enable_cubic_idle_restart_fix: bool,
+    pub enable_bbr_fix: bool,
 }
 
 impl RecoveryConfig {
@@ -161,6 +162,7 @@ impl RecoveryConfig {
                 .initial_congestion_window_packets,
             enable_relaxed_loss_threshold: config.enable_relaxed_loss_threshold,
             enable_cubic_idle_restart_fix: config.enable_cubic_idle_restart_fix,
+            enable_bbr_fix: config.enable_bbr_fix,
         }
     }
 }


### PR DESCRIPTION
Fixes issue described in https://github.com/cloudflare/quiche/issues/2496
