### PR TITLE
qlog,quiche,tokio-quiche: add QlogSink abstraction for custom qlogs

### DIFF
--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -381,8 +381,10 @@ fn main() {
                         let id = format!("{:?}", scid);
                         let writer = make_qlog_writer(&dir, "server", &id);
 
-                        conn.set_qlog(
-                            std::boxed::Box::new(writer),
+                        conn.set_qlog_sink(
+                            std::boxed::Box::new(quiche::QlogWriterSink::new(
+                                writer,
+                            )),
                             "quiche-server qlog".to_string(),
                             format!("{} id={}", "quiche-server qlog", id),
                         );

--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -205,8 +205,8 @@ pub fn connect(
             let id = format!("{scid:?}");
             let writer = make_qlog_writer(&dir, "client", &id);
 
-            conn.set_qlog(
-                std::boxed::Box::new(writer),
+            conn.set_qlog_sink(
+                std::boxed::Box::new(quiche::QlogWriterSink::new(writer)),
                 "quiche-client qlog".to_string(),
                 format!("{} id={}", "quiche-client qlog", id),
             );

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -671,7 +671,11 @@ impl std::fmt::Display for HexSlice<'_> {
 
 pub mod events;
 pub mod reader;
+pub mod sink;
 pub mod streamer;
+pub use sink::QlogEvent;
+pub use sink::QlogSink;
+pub use sink::QlogWriterSink;
 #[doc(hidden)]
 pub mod testing;
 pub mod writer;

--- a/qlog/src/sink.rs
+++ b/qlog/src/sink.rs
@@ -1,0 +1,265 @@
+// Copyright (C) 2026, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::io::Write;
+
+use crate::events;
+use crate::Error;
+use crate::QlogSeq;
+use crate::Result;
+
+/// An event that can be delivered to a [`QlogSink`].
+pub enum QlogEvent {
+    /// A native qlog event.
+    Event(events::Event),
+
+    /// An extended JSON event.
+    JsonEvent(events::JsonEvent),
+}
+
+impl From<events::Event> for QlogEvent {
+    fn from(event: events::Event) -> Self {
+        Self::Event(event)
+    }
+}
+
+impl From<events::JsonEvent> for QlogEvent {
+    fn from(event: events::JsonEvent) -> Self {
+        Self::JsonEvent(event)
+    }
+}
+
+/// A destination for sequential qlog events.
+pub trait QlogSink: Send + Sync {
+    /// Start a qlog stream by writing or otherwise recording the stream header.
+    fn start_log(&mut self, qlog: &QlogSeq) -> Result<()>;
+
+    /// Add a native qlog event to the stream.
+    fn add_event(&mut self, event: events::Event) -> Result<()>;
+
+    /// Add a pretty-printed native qlog event to the stream.
+    fn add_event_pretty(&mut self, event: events::Event) -> Result<()> {
+        self.add_event(event)
+    }
+
+    /// Add an extended JSON qlog event to the stream.
+    fn add_json_event(&mut self, event: events::JsonEvent) -> Result<()>;
+
+    /// Add a pretty-printed extended JSON qlog event to the stream.
+    fn add_json_event_pretty(&mut self, event: events::JsonEvent) -> Result<()> {
+        self.add_json_event(event)
+    }
+
+    /// Finish the stream.
+    fn finish_log(&mut self) -> Result<()>;
+
+    /// Returns whether this sink wants events of `event_type`.
+    fn should_log(&self, _event_type: events::EventType) -> bool {
+        true
+    }
+}
+
+/// A [`QlogSink`] that writes JSON-SEQ qlog records to a [`Write`].
+pub struct QlogWriterSink<W: Write + Send + Sync> {
+    writer: W,
+}
+
+impl<W: Write + Send + Sync> QlogWriterSink<W> {
+    /// Creates a new writer-backed sink.
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+}
+
+impl<W: Write + Send + Sync> QlogSink for QlogWriterSink<W> {
+    fn start_log(&mut self, qlog: &QlogSeq) -> Result<()> {
+        self.writer.write_all(b"\x1e")?;
+        serde_json::to_writer(&mut self.writer, qlog).map_err(|_| Error::Done)?;
+        self.writer.write_all(b"\n")?;
+
+        Ok(())
+    }
+
+    fn add_event(&mut self, event: events::Event) -> Result<()> {
+        self.writer.write_all(b"\x1e")?;
+        serde_json::to_writer(&mut self.writer, &event)
+            .map_err(|_| Error::Done)?;
+        self.writer.write_all(b"\n")?;
+
+        Ok(())
+    }
+
+    fn add_event_pretty(&mut self, event: events::Event) -> Result<()> {
+        self.writer.write_all(b"\x1e")?;
+        serde_json::to_writer_pretty(&mut self.writer, &event)
+            .map_err(|_| Error::Done)?;
+        self.writer.write_all(b"\n")?;
+
+        Ok(())
+    }
+
+    fn add_json_event(&mut self, event: events::JsonEvent) -> Result<()> {
+        self.writer.write_all(b"\x1e")?;
+        serde_json::to_writer(&mut self.writer, &event)
+            .map_err(|_| Error::Done)?;
+        self.writer.write_all(b"\n")?;
+
+        Ok(())
+    }
+
+    fn add_json_event_pretty(&mut self, event: events::JsonEvent) -> Result<()> {
+        self.writer.write_all(b"\x1e")?;
+        serde_json::to_writer_pretty(&mut self.writer, &event)
+            .map_err(|_| Error::Done)?;
+        self.writer.write_all(b"\n")?;
+
+        Ok(())
+    }
+
+    fn finish_log(&mut self) -> Result<()> {
+        self.writer.flush()?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::io::Write;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use crate::events::quic;
+    use crate::events::quic::QuicEventType;
+    use crate::events::Event;
+    use crate::events::EventData;
+    use crate::events::EventImportance;
+    use crate::events::EventType;
+    use crate::events::JsonEvent;
+    use crate::events::RawInfo;
+    use crate::sink::QlogSink;
+    use crate::sink::QlogWriterSink;
+    use crate::testing;
+    use crate::QlogSeq;
+    use crate::QLOGFILESEQ_URI;
+
+    #[derive(Clone, Default)]
+    struct SharedWriter {
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl SharedWriter {
+        fn bytes(&self) -> Vec<u8> {
+            self.bytes.lock().unwrap().clone()
+        }
+    }
+
+    impl Write for SharedWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.bytes.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_qlog() -> QlogSeq {
+        QlogSeq {
+            file_schema: QLOGFILESEQ_URI.to_string(),
+            serialization_format: "JSON-SEQ".to_string(),
+            title: Some("title".to_string()),
+            description: Some("description".to_string()),
+            trace: testing::make_trace_seq(),
+        }
+    }
+
+    fn make_event() -> Event {
+        let event_data = EventData::QuicPacketSent(quic::PacketSent {
+            header: testing::make_pkt_hdr(quic::PacketType::Handshake),
+            raw: Some(RawInfo {
+                length: Some(1251),
+                payload_length: Some(1224),
+                data: None,
+            }),
+            ..Default::default()
+        });
+
+        Event::with_time(0.0, event_data)
+    }
+
+    #[test]
+    fn writer_sink_writes_json_seq_header_and_native_event() {
+        let writer = SharedWriter::default();
+        let bytes = writer.clone();
+        let mut sink = QlogWriterSink::new(writer);
+
+        sink.start_log(&make_qlog()).unwrap();
+        sink.add_event(make_event()).unwrap();
+        sink.finish_log().unwrap();
+
+        let written = String::from_utf8(bytes.bytes()).unwrap();
+        let expected = r#"{"file_schema":"urn:ietf:params:qlog:file:sequential","serialization_format":"JSON-SEQ","title":"title","description":"description","trace":{"title":"Quiche qlog trace","description":"Quiche qlog trace description","vantage_point":{"type":"server"},"event_schemas":[]}}
+{"time":0.0,"name":"quic:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"1","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw":{"length":1251,"payload_length":1224}}}
+"#;
+
+        pretty_assertions::assert_eq!(expected, written);
+    }
+
+    #[test]
+    fn writer_sink_writes_json_event() {
+        let writer = SharedWriter::default();
+        let bytes = writer.clone();
+        let mut sink = QlogWriterSink::new(writer);
+
+        let event = JsonEvent {
+            time: 0.0,
+            importance: EventImportance::Core,
+            name: "jsonevent:sample".to_string(),
+            data: serde_json::json!({"foo":"bar"}),
+        };
+
+        sink.start_log(&make_qlog()).unwrap();
+        sink.add_json_event(event).unwrap();
+        sink.finish_log().unwrap();
+
+        let written = String::from_utf8(bytes.bytes()).unwrap();
+        assert!(written.contains(r#""name":"jsonevent:sample""#));
+        assert!(written.contains(r#""foo":"bar""#));
+    }
+
+    #[test]
+    fn writer_sink_defaults_to_logging_all_event_types() {
+        let writer = SharedWriter::default();
+        let sink = QlogWriterSink::new(writer);
+
+        assert!(
+            sink.should_log(EventType::QuicEventType(QuicEventType::PacketSent))
+        );
+    }
+}

--- a/qlog/src/streamer.rs
+++ b/qlog/src/streamer.rs
@@ -92,7 +92,7 @@ pub enum StreamerState {
 
 pub struct QlogStreamer {
     start_time: std::time::Instant,
-    writer: Box<dyn std::io::Write + Send + Sync>,
+    sink: Box<dyn crate::QlogSink>,
     qlog: QlogSeq,
     state: StreamerState,
     log_level: EventImportance,
@@ -116,6 +116,27 @@ impl QlogStreamer {
         log_level: EventImportance, time_precision: EventTimePrecision,
         writer: Box<dyn std::io::Write + Send + Sync>,
     ) -> Self {
+        Self::new_with_sink(
+            title,
+            description,
+            start_time,
+            trace,
+            log_level,
+            time_precision,
+            Box::new(crate::QlogWriterSink::new(writer)),
+        )
+    }
+
+    /// Creates a [QlogStreamer] object with a custom [QlogSink].
+    ///
+    /// [QlogSink]: crate::QlogSink
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_sink(
+        title: Option<String>, description: Option<String>,
+        start_time: std::time::Instant, trace: TraceSeq,
+        log_level: EventImportance, time_precision: EventTimePrecision,
+        sink: Box<dyn crate::QlogSink>,
+    ) -> Self {
         let qlog = QlogSeq {
             file_schema: QLOGFILESEQ_URI.to_string(),
             serialization_format: "JSON-SEQ".to_string(),
@@ -126,7 +147,7 @@ impl QlogStreamer {
 
         QlogStreamer {
             start_time,
-            writer,
+            sink,
             qlog,
             state: StreamerState::Initial,
             log_level,
@@ -151,10 +172,7 @@ impl QlogStreamer {
             return Err(Error::Done);
         }
 
-        self.writer.as_mut().write_all(b"")?;
-        serde_json::to_writer(self.writer.as_mut(), &self.qlog)
-            .map_err(|_| Error::Done)?;
-        self.writer.as_mut().write_all(b"\n")?;
+        self.sink.start_log(&self.qlog)?;
 
         self.state = StreamerState::Ready;
 
@@ -164,6 +182,19 @@ impl QlogStreamer {
     /// Finishes qlog streaming serialization.
     ///
     /// After this is called, no more serialization will occur.
+    ///
+    /// Calling `finish_log` explicitly is optional. [`QlogStreamer`]'s
+    /// [`Drop`] impl also invokes `finish_log` and discards the result,
+    /// so callers that do not need to observe a finalization error can
+    /// simply drop the streamer. Call `finish_log` directly only when
+    /// you want to surface an [`Error`] (for example, if the underlying
+    /// [`QlogSink`] performs I/O during finalization that you want to
+    /// react to).
+    ///
+    /// Returns [`Error::InvalidState`] if the streamer has not yet been
+    /// started or has already been finished.
+    ///
+    /// [`QlogSink`]: crate::QlogSink
     pub fn finish_log(&mut self) -> Result<()> {
         if self.state == StreamerState::Initial ||
             self.state == StreamerState::Finished
@@ -173,14 +204,14 @@ impl QlogStreamer {
 
         self.state = StreamerState::Finished;
 
-        self.writer.as_mut().flush()?;
+        self.sink.finish_log()?;
 
         Ok(())
     }
 
     /// Writes a serializable to a JSON-SEQ record using
     /// [std::time::Instant::now()].
-    pub fn add_event_now<E: Serialize + Eventable>(
+    pub fn add_event_now<E: Into<crate::QlogEvent> + Eventable>(
         &mut self, event: E,
     ) -> Result<()> {
         let now = std::time::Instant::now();
@@ -190,7 +221,7 @@ impl QlogStreamer {
 
     /// Writes a serializable to a pretty-printed JSON-SEQ record using
     /// [std::time::Instant::now()].
-    pub fn add_event_now_pretty<E: Serialize + Eventable>(
+    pub fn add_event_now_pretty<E: Into<crate::QlogEvent> + Eventable>(
         &mut self, event: E,
     ) -> Result<()> {
         let now = std::time::Instant::now();
@@ -200,7 +231,7 @@ impl QlogStreamer {
 
     /// Writes a serializable to a JSON-SEQ record using the provided
     /// [std::time::Instant].
-    pub fn add_event_with_instant<E: Serialize + Eventable>(
+    pub fn add_event_with_instant<E: Into<crate::QlogEvent> + Eventable>(
         &mut self, event: E, now: std::time::Instant,
     ) -> Result<()> {
         self.event_with_instant(event, now, false)
@@ -208,13 +239,15 @@ impl QlogStreamer {
 
     /// Writes a serializable to a pretty-printed JSON-SEQ record using the
     /// provided [std::time::Instant].
-    pub fn add_event_with_instant_pretty<E: Serialize + Eventable>(
+    pub fn add_event_with_instant_pretty<
+        E: Into<crate::QlogEvent> + Eventable,
+    >(
         &mut self, event: E, now: std::time::Instant,
     ) -> Result<()> {
         self.event_with_instant(event, now, true)
     }
 
-    fn event_with_instant<E: Serialize + Eventable>(
+    fn event_with_instant<E: Into<crate::QlogEvent> + Eventable>(
         &mut self, mut event: E, now: std::time::Instant, pretty: bool,
     ) -> Result<()> {
         if self.state != StreamerState::Ready {
@@ -322,6 +355,9 @@ impl QlogStreamer {
         if !EventImportance::from(ty).is_contained_in(&self.log_level) {
             return Err(Error::Done);
         }
+        if !self.sink.should_log(ty) {
+            return Err(Error::Done);
+        }
 
         let event = Event::with_time_ex(
             elapsed_millis(self.start_time, now, &self.time_precision),
@@ -337,7 +373,7 @@ impl QlogStreamer {
     }
 
     /// Writes a JSON-SEQ-serialized [Event] using the provided [Event].
-    pub fn add_event<E: Serialize + Eventable>(
+    pub fn add_event<E: Into<crate::QlogEvent> + Eventable>(
         &mut self, event: E,
     ) -> Result<()> {
         self.write_event(event, false)
@@ -345,14 +381,20 @@ impl QlogStreamer {
 
     /// Writes a pretty-printed JSON-SEQ-serialized [Event] using the provided
     /// [Event].
-    pub fn add_event_pretty<E: Serialize + Eventable>(
+    pub fn add_event_pretty<E: Into<crate::QlogEvent> + Eventable>(
         &mut self, event: E,
     ) -> Result<()> {
         self.write_event(event, true)
     }
 
     /// Writes a JSON-SEQ-serialized [Event] using the provided [Event].
-    fn write_event<E: Serialize + Eventable>(
+    ///
+    /// For native [`crate::events::Event`] payloads, both the
+    /// `EventImportance` filter and [`crate::QlogSink::should_log`] are
+    /// honored. [`crate::events::JsonEvent`] payloads only respect the
+    /// `EventImportance` filter because they do not carry an
+    /// [`EventType`].
+    fn write_event<E: Into<crate::QlogEvent> + Eventable>(
         &mut self, event: E, pretty: bool,
     ) -> Result<()> {
         if self.state != StreamerState::Ready {
@@ -363,27 +405,41 @@ impl QlogStreamer {
             return Err(Error::Done);
         }
 
-        self.writer.as_mut().write_all(b"")?;
-        if pretty {
-            serde_json::to_writer_pretty(self.writer.as_mut(), &event)
-                .map_err(|_| Error::Done)?;
-        } else {
-            serde_json::to_writer(self.writer.as_mut(), &event)
-                .map_err(|_| Error::Done)?;
+        match event.into() {
+            crate::QlogEvent::Event(event) => {
+                let ty = EventType::from(&event.data);
+                if !self.sink.should_log(ty) {
+                    return Err(Error::Done);
+                }
+                if pretty {
+                    self.sink.add_event_pretty(event)?;
+                } else {
+                    self.sink.add_event(event)?;
+                }
+            },
+
+            crate::QlogEvent::JsonEvent(event) if pretty =>
+                self.sink.add_json_event_pretty(event)?,
+            crate::QlogEvent::JsonEvent(event) =>
+                self.sink.add_json_event(event)?,
         }
-        self.writer.as_mut().write_all(b"\n")?;
 
         Ok(())
     }
 
-    /// Returns the writer.
-    #[allow(clippy::borrowed_box)]
-    pub fn writer(&self) -> &Box<dyn std::io::Write + Send + Sync> {
-        &self.writer
+    /// Returns a reference to the underlying [`QlogSink`].
+    pub fn sink(&self) -> &dyn crate::QlogSink {
+        self.sink.as_ref()
     }
 
     pub fn start_time(&self) -> std::time::Instant {
         self.start_time
+    }
+
+    /// Returns whether an event type should be logged.
+    pub fn should_log(&self, event_type: EventType) -> bool {
+        EventImportance::from(event_type).is_contained_in(&self.log_level) &&
+            self.sink.should_log(event_type)
     }
 }
 
@@ -407,9 +463,7 @@ mod tests {
 
     #[test]
     fn serialization_states() {
-        let v: Vec<u8> = Vec::new();
-        let buff = std::io::Cursor::new(v);
-        let writer = Box::new(buff);
+        let writer = crate::testing::SharedWriter::new();
 
         let trace = make_trace_seq();
         let pkt_hdr = make_pkt_hdr(quic::PacketType::Handshake);
@@ -487,7 +541,7 @@ mod tests {
             trace,
             EventImportance::Base,
             EventTimePrecision::NanoSeconds,
-            writer,
+            Box::new(writer.clone()),
         );
 
         // Before the log is started all other operations should fail.
@@ -511,10 +565,6 @@ mod tests {
 
         assert!(matches!(s.finish_log(), Ok(())));
 
-        let r = s.writer();
-        #[allow(clippy::borrowed_box)]
-        let w: &Box<std::io::Cursor<Vec<u8>>> = unsafe { std::mem::transmute(r) };
-
         let log_string = r#"{"file_schema":"urn:ietf:params:qlog:file:sequential","serialization_format":"JSON-SEQ","title":"title","description":"description","trace":{"title":"Quiche qlog trace","description":"Quiche qlog trace description","vantage_point":{"type":"server"},"event_schemas":[]}}
 {"time":0.0,"name":"quic:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"1","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":40,"offset":40,"fin":true,"raw":{"payload_length":400}}]}}
 {"time":0.0,"name":"quic:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"1","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":0,"offset":0,"fin":true,"raw":{"payload_length":100}}]}}
@@ -522,9 +572,7 @@ mod tests {
 {"time":0.0,"name":"quic:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"1","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"stateless_reset_token":"reset_token","raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":0,"offset":0,"fin":true,"raw":{"payload_length":100}}]}}
 "#;
 
-        let written_string = std::str::from_utf8(w.as_ref().get_ref()).unwrap();
-
-        pretty_assertions::assert_eq!(log_string, written_string);
+        pretty_assertions::assert_eq!(log_string, writer.as_string());
     }
 
     #[test]
@@ -537,9 +585,7 @@ mod tests {
             data,
         };
 
-        let v: Vec<u8> = Vec::new();
-        let buff = std::io::Cursor::new(v);
-        let writer = Box::new(buff);
+        let writer = crate::testing::SharedWriter::new();
 
         let trace = make_trace_seq();
 
@@ -550,31 +596,23 @@ mod tests {
             trace,
             EventImportance::Base,
             EventTimePrecision::NanoSeconds,
-            writer,
+            Box::new(writer.clone()),
         );
 
         assert!(matches!(s.start_log(), Ok(())));
         assert!(matches!(s.add_event(ev), Ok(())));
         assert!(matches!(s.finish_log(), Ok(())));
 
-        let r = s.writer();
-        #[allow(clippy::borrowed_box)]
-        let w: &Box<std::io::Cursor<Vec<u8>>> = unsafe { std::mem::transmute(r) };
-
         let log_string = r#"{"file_schema":"urn:ietf:params:qlog:file:sequential","serialization_format":"JSON-SEQ","title":"title","description":"description","trace":{"title":"Quiche qlog trace","description":"Quiche qlog trace description","vantage_point":{"type":"server"},"event_schemas":[]}}
 {"time":0.0,"name":"jsonevent:sample","data":{"foo":"Bar","hello":123}}
 "#;
 
-        let written_string = std::str::from_utf8(w.as_ref().get_ref()).unwrap();
-
-        pretty_assertions::assert_eq!(log_string, written_string);
+        pretty_assertions::assert_eq!(log_string, writer.as_string());
     }
 
     #[test]
     fn stream_data_ex() {
-        let v: Vec<u8> = Vec::new();
-        let buff = std::io::Cursor::new(v);
-        let writer = Box::new(buff);
+        let writer = crate::testing::SharedWriter::new();
 
         let trace = make_trace_seq();
         let pkt_hdr = make_pkt_hdr(quic::PacketType::Handshake);
@@ -636,7 +674,7 @@ mod tests {
             trace,
             EventImportance::Base,
             EventTimePrecision::NanoSeconds,
-            writer,
+            Box::new(writer.clone()),
         );
 
         assert!(matches!(s.start_log(), Ok(())));
@@ -644,18 +682,153 @@ mod tests {
         assert!(matches!(s.add_event(ev2), Ok(())));
         assert!(matches!(s.finish_log(), Ok(())));
 
-        let r = s.writer();
-        #[allow(clippy::borrowed_box)]
-        let w: &Box<std::io::Cursor<Vec<u8>>> = unsafe { std::mem::transmute(r) };
-
         let log_string = r#"{"file_schema":"urn:ietf:params:qlog:file:sequential","serialization_format":"JSON-SEQ","title":"title","description":"description","trace":{"title":"Quiche qlog trace","description":"Quiche qlog trace description","vantage_point":{"type":"server"},"event_schemas":[]}}
 {"time":0.0,"name":"quic:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"1","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":40,"offset":40,"fin":true,"raw":{"payload_length":400}}]},"first":{"foo":"Bar","hello":123},"second":{"baz":[1,2,3,4]}}
 {"time":0.0,"name":"quic:packet_sent","data":{"header":{"packet_type":"handshake","packet_number":0,"version":"1","scil":8,"dcil":8,"scid":"7e37e4dcc6682da8","dcid":"36ce104eee50101c"},"raw":{"length":1251,"payload_length":1224},"frames":[{"frame_type":"stream","stream_id":1,"offset":0,"fin":true,"raw":{"payload_length":100}}]}}
 "#;
 
-        let written_string = std::str::from_utf8(w.as_ref().get_ref()).unwrap();
+        pretty_assertions::assert_eq!(log_string, writer.as_string());
+    }
 
-        pretty_assertions::assert_eq!(log_string, written_string);
+    struct FilteringSink;
+
+    impl crate::QlogSink for FilteringSink {
+        fn start_log(&mut self, _qlog: &QlogSeq) -> Result<()> {
+            Ok(())
+        }
+
+        fn add_event(&mut self, _event: Event) -> Result<()> {
+            Ok(())
+        }
+
+        fn add_json_event(&mut self, _event: events::JsonEvent) -> Result<()> {
+            Ok(())
+        }
+
+        fn finish_log(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn should_log(&self, event_type: EventType) -> bool {
+            event_type !=
+                EventType::QuicEventType(quic::QuicEventType::PacketSent)
+        }
+    }
+
+    #[test]
+    fn streamer_should_log_combines_importance_and_sink_filter() {
+        let streamer = streamer::QlogStreamer::new_with_sink(
+            Some("title".to_string()),
+            Some("description".to_string()),
+            std::time::Instant::now(),
+            make_trace_seq(),
+            EventImportance::Base,
+            EventTimePrecision::NanoSeconds,
+            Box::new(FilteringSink),
+        );
+
+        assert!(!streamer.should_log(EventType::QuicEventType(
+            quic::QuicEventType::PacketSent,
+        )));
+        assert!(streamer.should_log(EventType::QuicEventType(
+            quic::QuicEventType::ConnectionClosed,
+        )));
+        assert!(!streamer.should_log(EventType::QuicEventType(
+            quic::QuicEventType::ServerListening,
+        )));
+    }
+
+    /// Sink that rejects [`PacketSent`] events and counts every event
+    /// actually delivered to its `add_event` method. Used to prove
+    /// that [`QlogStreamer`]'s public event-writing methods honor
+    /// [`QlogSink::should_log`].
+    struct CountingFilterSink {
+        delivered: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl crate::QlogSink for CountingFilterSink {
+        fn start_log(&mut self, _qlog: &QlogSeq) -> Result<()> {
+            Ok(())
+        }
+
+        fn add_event(&mut self, _event: Event) -> Result<()> {
+            self.delivered
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn add_json_event(&mut self, _event: events::JsonEvent) -> Result<()> {
+            Ok(())
+        }
+
+        fn finish_log(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn should_log(&self, event_type: EventType) -> bool {
+            event_type !=
+                EventType::QuicEventType(quic::QuicEventType::PacketSent)
+        }
+    }
+
+    #[test]
+    fn add_event_paths_honor_sink_should_log() {
+        let delivered =
+            std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let sink = CountingFilterSink {
+            delivered: delivered.clone(),
+        };
+
+        let mut s = streamer::QlogStreamer::new_with_sink(
+            Some("title".to_string()),
+            Some("description".to_string()),
+            std::time::Instant::now(),
+            make_trace_seq(),
+            EventImportance::Base,
+            EventTimePrecision::NanoSeconds,
+            Box::new(sink),
+        );
+        s.start_log().unwrap();
+
+        let pkt_hdr = make_pkt_hdr(quic::PacketType::Handshake);
+
+        // Rejected: PacketSent event delivered via add_event_data_now.
+        let rejected = EventData::QuicPacketSent(quic::PacketSent {
+            header: pkt_hdr.clone(),
+            ..Default::default()
+        });
+        let res = s.add_event_data_now(rejected);
+        assert!(matches!(res, Err(Error::Done)));
+
+        // Rejected: PacketSent event delivered via add_event.
+        let rejected_event = Event::with_time(
+            0.0,
+            EventData::QuicPacketSent(quic::PacketSent {
+                header: pkt_hdr.clone(),
+                ..Default::default()
+            }),
+        );
+        let res = s.add_event(rejected_event);
+        assert!(matches!(res, Err(Error::Done)));
+
+        // Accepted: ConnectionClosed event delivered via add_event_data_now.
+        let accepted = EventData::QuicConnectionClosed(quic::ConnectionClosed {
+            initiator: None,
+            connection_error: None,
+            application_error: None,
+            error_code: None,
+            internal_code: None,
+            reason: None,
+            trigger: None,
+        });
+        let res = s.add_event_data_now(accepted);
+        assert!(matches!(res, Ok(())));
+
+        assert_eq!(
+            delivered.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "only ConnectionClosed should have reached the sink"
+        );
     }
 
     #[test]

--- a/qlog/src/testing/mod.rs
+++ b/qlog/src/testing/mod.rs
@@ -79,6 +79,46 @@ pub fn make_trace_seq() -> TraceSeq {
     )
 }
 
+/// Shared in-memory writer for test sinks.
+///
+/// Cloned references see the same underlying buffer. Tests typically
+/// hold one handle and hand a clone to a writer-based qlog sink, then
+/// read bytes through the original handle after the streamer has
+/// flushed.
+#[derive(Clone, Default)]
+pub struct SharedWriter {
+    bytes: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+}
+
+impl SharedWriter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a snapshot of the bytes written so far.
+    pub fn bytes(&self) -> Vec<u8> {
+        self.bytes.lock().unwrap().clone()
+    }
+
+    /// Returns the bytes as a UTF-8 string.
+    ///
+    /// Panics if the buffer contains non-UTF-8 bytes.
+    pub fn as_string(&self) -> String {
+        String::from_utf8(self.bytes()).expect("non-UTF-8 bytes in SharedWriter")
+    }
+}
+
+impl std::io::Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.bytes.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod event_tests;
 #[cfg(test)]

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -770,8 +770,8 @@ pub extern "C" fn quiche_conn_set_qlog_path(
     let title = unsafe { ffi::CStr::from_ptr(log_title).to_str().unwrap() };
     let description = unsafe { ffi::CStr::from_ptr(log_desc).to_str().unwrap() };
 
-    conn.set_qlog(
-        Box::new(writer),
+    conn.set_qlog_sink(
+        Box::new(qlog::QlogWriterSink::new(writer)),
         title.to_string(),
         format!("{} id={}", description, conn.trace_id),
     );
@@ -791,8 +791,8 @@ pub extern "C" fn quiche_conn_set_qlog_fd(
     let title = unsafe { ffi::CStr::from_ptr(log_title).to_str().unwrap() };
     let description = unsafe { ffi::CStr::from_ptr(log_desc).to_str().unwrap() };
 
-    conn.set_qlog(
-        Box::new(writer),
+    conn.set_qlog_sink(
+        Box::new(qlog::QlogWriterSink::new(writer)),
         title.to_string(),
         format!("{} id={}", description, conn.trace_id),
     );

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -308,8 +308,6 @@ use qlog::events::http3::StreamTypeSet;
 #[cfg(feature = "qlog")]
 use qlog::events::EventData;
 #[cfg(feature = "qlog")]
-use qlog::events::EventImportance;
-#[cfg(feature = "qlog")]
 use qlog::events::EventType;
 
 use crate::buffers::BufFactory;

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1906,8 +1906,8 @@ macro_rules! qlog_with_type {
     ($ty:expr, $qlog:expr, $qlog_streamer_ref:ident, $body:block) => {{
         #[cfg(feature = "qlog")]
         {
-            if EventImportance::from($ty).is_contained_in(&$qlog.level) {
-                if let Some($qlog_streamer_ref) = &mut $qlog.streamer {
+            if let Some($qlog_streamer_ref) = &mut $qlog.streamer {
+                if $qlog_streamer_ref.should_log($ty) {
                     $body
                 }
             }
@@ -2291,13 +2291,21 @@ impl<F: BufFactory> Connection<F> {
     /// This needs to be called as soon as the connection is created, to avoid
     /// missing some early logs.
     ///
+    /// **Deprecated:** prefer [`Connection::set_qlog_sink`], which accepts a
+    /// [`qlog::QlogSink`] for more flexibility. This function is now a thin
+    /// wrapper that constructs a [`qlog::QlogWriterSink`] from `writer` and
+    /// forwards to [`Connection::set_qlog_sink`].
+    ///
     /// [`Writer`]: https://doc.rust-lang.org/std/io/trait.Write.html
+    /// [`Connection::set_qlog_sink`]: Self::set_qlog_sink
     #[cfg(feature = "qlog")]
     #[cfg_attr(docsrs, doc(cfg(feature = "qlog")))]
+    #[deprecated(note = "use Connection::set_qlog_sink")]
     pub fn set_qlog(
         &mut self, writer: Box<dyn std::io::Write + Send + Sync>, title: String,
         description: String,
     ) {
+        #[allow(deprecated)]
         self.set_qlog_with_level(writer, title, description, QlogLevel::Base)
     }
 
@@ -2309,12 +2317,57 @@ impl<F: BufFactory> Connection<F> {
     /// This needs to be called as soon as the connection is created, to avoid
     /// missing some early logs.
     ///
+    /// **Deprecated:** prefer [`Connection::set_qlog_sink_with_level`], which
+    /// accepts a [`qlog::QlogSink`] for more flexibility. This function is now
+    /// a thin wrapper that constructs a [`qlog::QlogWriterSink`] from `writer`
+    /// and forwards to [`Connection::set_qlog_sink_with_level`].
+    ///
     /// [`Writer`]: https://doc.rust-lang.org/std/io/trait.Write.html
+    /// [`Connection::set_qlog_sink_with_level`]: Self::set_qlog_sink_with_level
     #[cfg(feature = "qlog")]
     #[cfg_attr(docsrs, doc(cfg(feature = "qlog")))]
+    #[deprecated(note = "use Connection::set_qlog_sink_with_level")]
     pub fn set_qlog_with_level(
         &mut self, writer: Box<dyn std::io::Write + Send + Sync>, title: String,
         description: String, qlog_level: QlogLevel,
+    ) {
+        self.set_qlog_sink_with_level(
+            Box::new(QlogWriterSink::new(writer)),
+            title,
+            description,
+            qlog_level,
+        )
+    }
+
+    /// Sets qlog output to the designated [`QlogSink`].
+    ///
+    /// Only events included in `QlogLevel::Base` are written.
+    ///
+    /// This needs to be called as soon as the connection is created, to avoid
+    /// missing some early logs.
+    ///
+    /// [`QlogSink`]: qlog::QlogSink
+    #[cfg(feature = "qlog")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "qlog")))]
+    pub fn set_qlog_sink(
+        &mut self, sink: Box<dyn QlogSink>, title: String, description: String,
+    ) {
+        self.set_qlog_sink_with_level(sink, title, description, QlogLevel::Base)
+    }
+
+    /// Sets qlog output to the designated [`QlogSink`].
+    ///
+    /// Only qlog events included in the specified `QlogLevel` are written.
+    ///
+    /// This needs to be called as soon as the connection is created, to avoid
+    /// missing some early logs.
+    ///
+    /// [`QlogSink`]: qlog::QlogSink
+    #[cfg(feature = "qlog")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "qlog")))]
+    pub fn set_qlog_sink_with_level(
+        &mut self, sink: Box<dyn QlogSink>, title: String, description: String,
+        qlog_level: QlogLevel,
     ) {
         use qlog::events::quic::TransportInitiator;
         use qlog::events::HTTP3_URI;
@@ -2358,14 +2411,14 @@ impl<F: BufFactory> Connection<F> {
             vec![QUIC_URI.to_string(), HTTP3_URI.to_string()],
         );
 
-        let mut streamer = qlog::streamer::QlogStreamer::new(
+        let mut streamer = qlog::streamer::QlogStreamer::new_with_sink(
             Some(title),
             Some(description),
             now,
             trace,
             self.qlog.level,
             qlog::streamer::EventTimePrecision::MicroSeconds,
-            writer,
+            sink,
         );
 
         streamer.start_log().ok();
@@ -2385,6 +2438,20 @@ impl<F: BufFactory> Connection<F> {
     #[cfg_attr(docsrs, doc(cfg(feature = "qlog")))]
     pub fn qlog_streamer(&mut self) -> Option<&mut qlog::streamer::QlogStreamer> {
         self.qlog.streamer.as_mut()
+    }
+
+    /// Removes any qlog streamer previously installed via
+    /// [`set_qlog_sink`], [`set_qlog_sink_with_level`], or the
+    /// deprecated [`set_qlog`] / [`set_qlog_with_level`] entry points.
+    ///
+    /// [`set_qlog`]: Self::set_qlog
+    /// [`set_qlog_with_level`]: Self::set_qlog_with_level
+    /// [`set_qlog_sink`]: Self::set_qlog_sink
+    /// [`set_qlog_sink_with_level`]: Self::set_qlog_sink_with_level
+    #[cfg(feature = "qlog")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "qlog")))]
+    pub fn unset_qlog_sink(&mut self) {
+        self.qlog.streamer = None;
     }
 
     /// Configures the given session for resumption.
@@ -3269,7 +3336,12 @@ impl<F: BufFactory> Connection<F> {
         );
 
         #[cfg(feature = "qlog")]
-        let mut qlog_frames = vec![];
+        let mut qlog_frames = self
+            .qlog
+            .streamer
+            .as_ref()
+            .is_some_and(|q| q.should_log(QLOG_PACKET_RX))
+            .then(Vec::new);
 
         // Check for key update.
         let mut aead_next = None;
@@ -3445,7 +3517,9 @@ impl<F: BufFactory> Connection<F> {
             let frame = frame::Frame::from_bytes(&mut payload, hdr.ty)?;
 
             qlog_with_type!(QLOG_PACKET_RX, self.qlog, _q, {
-                qlog_frames.push(frame.to_qlog());
+                if let Some(qlog_frames) = qlog_frames.as_mut() {
+                    qlog_frames.push(frame.to_qlog());
+                }
             });
 
             if frame.ack_eliciting() {
@@ -3483,7 +3557,7 @@ impl<F: BufFactory> Connection<F> {
             let ev_data = EventData::QuicPacketReceived(
                 qlog::events::quic::PacketReceived {
                     header: qlog_pkt_hdr,
-                    frames: Some(qlog_frames),
+                    frames: Some(qlog_frames.unwrap_or_default()),
                     raw: Some(qlog_raw_info),
                     ..Default::default()
                 },
@@ -4447,15 +4521,20 @@ impl<F: BufFactory> Connection<F> {
         let hdr_ty = hdr.ty;
 
         #[cfg(feature = "qlog")]
-        let qlog_pkt_hdr = self.qlog.streamer.as_ref().map(|_q| {
-            qlog::events::quic::PacketHeader::with_type(
-                hdr.ty.to_qlog(),
-                Some(pn),
-                Some(hdr.version),
-                Some(&hdr.scid),
-                Some(&hdr.dcid),
-            )
-        });
+        let qlog_pkt_hdr = self
+            .qlog
+            .streamer
+            .as_ref()
+            .filter(|q| q.should_log(QLOG_PACKET_TX))
+            .map(|_q| {
+                qlog::events::quic::PacketHeader::with_type(
+                    hdr.ty.to_qlog(),
+                    Some(pn),
+                    Some(hdr.version),
+                    Some(&hdr.scid),
+                    Some(&hdr.dcid),
+                )
+            });
 
         // Calculate the space required for the packet, including the header
         // the payload length, the packet number and the AEAD overhead.
@@ -5379,14 +5458,20 @@ impl<F: BufFactory> Connection<F> {
         );
 
         #[cfg(feature = "qlog")]
-        let mut qlog_frames: Vec<qlog::events::quic::QuicFrame> =
-            Vec::with_capacity(frames.len());
+        let mut qlog_frames = self
+            .qlog
+            .streamer
+            .as_ref()
+            .is_some_and(|q| q.should_log(QLOG_PACKET_TX))
+            .then(|| Vec::with_capacity(frames.len()));
 
         for frame in &mut frames {
             trace!("{} tx frm {:?}", self.trace_id, frame);
 
             qlog_with_type!(QLOG_PACKET_TX, self.qlog, _q, {
-                qlog_frames.push(frame.to_qlog());
+                if let Some(qlog_frames) = qlog_frames.as_mut() {
+                    qlog_frames.push(frame.to_qlog());
+                }
             });
         }
 
@@ -5409,7 +5494,7 @@ impl<F: BufFactory> Connection<F> {
                 let ev_data =
                     EventData::QuicPacketSent(qlog::events::quic::PacketSent {
                         header,
-                        frames: Some(qlog_frames),
+                        frames: Some(qlog_frames.unwrap_or_default()),
                         raw: Some(qlog_raw_info),
                         send_at_time: Some(send_at_time),
                         ..Default::default()
@@ -9487,6 +9572,13 @@ pub use crate::error::ConnectionError;
 pub use crate::error::Error;
 pub use crate::error::Result;
 pub use crate::error::WireErrorCode;
+
+#[cfg(feature = "qlog")]
+#[cfg_attr(docsrs, doc(cfg(feature = "qlog")))]
+pub use qlog::QlogSink;
+#[cfg(feature = "qlog")]
+#[cfg_attr(docsrs, doc(cfg(feature = "qlog")))]
+pub use qlog::QlogWriterSink;
 
 mod buffers;
 mod cid;

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -32,6 +32,11 @@ use crate::Header;
 
 use rstest::rstest;
 
+#[cfg(feature = "qlog")]
+use std::sync::Arc;
+#[cfg(feature = "qlog")]
+use std::sync::Mutex;
+
 #[test]
 fn transport_params() {
     // Server encodes, client decodes.
@@ -12791,8 +12796,13 @@ fn server_qlog() {
 
     let mut pipe = test_utils::Pipe::new("cubic").unwrap();
 
+    let writer = qlog::testing::SharedWriter::new();
+
+    // Intentional: cover the deprecated writer-based path to ensure
+    // backward compatibility.
+    #[allow(deprecated)]
     pipe.server.set_qlog(
-        Box::new(std::io::Cursor::new(Vec::<u8>::new())),
+        Box::new(writer.clone()),
         "test qlog".to_string(),
         "test qlog description".to_string(),
     );
@@ -12801,10 +12811,7 @@ fn server_qlog() {
 
     pipe.server.qlog_streamer().unwrap().finish_log().unwrap();
 
-    let raw = pipe.server.qlog_streamer().unwrap().writer();
-    #[allow(clippy::borrowed_box)]
-    let w: &Box<std::io::Cursor<Vec<u8>>> = unsafe { std::mem::transmute(raw) };
-    let bytes = w.get_ref().clone();
+    let bytes = writer.bytes();
 
     let mut reader = QlogSeqReader::new(Box::new(std::io::BufReader::new(
         std::io::Cursor::new(bytes),
@@ -12835,4 +12842,153 @@ fn server_qlog() {
     } else {
         panic!("expected Qlog event");
     }
+}
+
+#[cfg(feature = "qlog")]
+#[derive(Clone, Default)]
+struct RecordingQlogSink {
+    inner: Arc<Mutex<RecordingQlogSinkInner>>,
+    rejected_event_type: Option<EventType>,
+}
+
+#[cfg(feature = "qlog")]
+#[derive(Default)]
+struct RecordingQlogSinkInner {
+    header_title: Option<String>,
+    event_types: Vec<EventType>,
+    finish_log_calls: u32,
+}
+
+#[cfg(feature = "qlog")]
+impl QlogSink for RecordingQlogSink {
+    fn start_log(&mut self, qlog: &qlog::QlogSeq) -> qlog::Result<()> {
+        self.inner.lock().unwrap().header_title = qlog.title.clone();
+
+        Ok(())
+    }
+
+    fn add_event(&mut self, event: Event) -> qlog::Result<()> {
+        self.inner
+            .lock()
+            .unwrap()
+            .event_types
+            .push(EventType::from(&event.data));
+
+        Ok(())
+    }
+
+    fn add_json_event(
+        &mut self, _event: qlog::events::JsonEvent,
+    ) -> qlog::Result<()> {
+        Ok(())
+    }
+
+    fn finish_log(&mut self) -> qlog::Result<()> {
+        self.inner.lock().unwrap().finish_log_calls += 1;
+        Ok(())
+    }
+
+    fn should_log(&self, event_type: EventType) -> bool {
+        Some(event_type) != self.rejected_event_type
+    }
+}
+
+#[cfg(feature = "qlog")]
+#[test]
+fn server_qlog_sink_receives_header_and_initial_event() {
+    let mut pipe = test_utils::Pipe::new("cubic").unwrap();
+    let sink = RecordingQlogSink::default();
+    let recorded = sink.inner.clone();
+
+    pipe.server.set_qlog_sink(
+        Box::new(sink),
+        "test qlog sink".to_string(),
+        "test qlog sink description".to_string(),
+    );
+
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    let recorded = recorded.lock().unwrap();
+    assert_eq!(recorded.header_title.as_deref(), Some("test qlog sink"));
+    assert!(recorded
+        .event_types
+        .contains(&EventType::QuicEventType(QuicEventType::ParametersSet,)));
+}
+
+#[cfg(feature = "qlog")]
+#[test]
+fn server_qlog_sink_filters_packet_sent() {
+    let mut pipe = test_utils::Pipe::new("cubic").unwrap();
+    let sink = RecordingQlogSink {
+        rejected_event_type: Some(EventType::QuicEventType(
+            QuicEventType::PacketSent,
+        )),
+        ..Default::default()
+    };
+    let recorded = sink.inner.clone();
+
+    pipe.server.set_qlog_sink(
+        Box::new(sink),
+        "test qlog sink".to_string(),
+        "test qlog sink description".to_string(),
+    );
+
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    let recorded = recorded.lock().unwrap();
+    assert!(recorded
+        .event_types
+        .contains(&EventType::QuicEventType(QuicEventType::ParametersSet,)));
+    assert!(!recorded
+        .event_types
+        .contains(&EventType::QuicEventType(QuicEventType::PacketSent,)));
+}
+
+#[cfg(feature = "qlog")]
+#[test]
+fn server_qlog_sink_unset_detaches_streamer() {
+    let mut pipe = test_utils::Pipe::new("cubic").unwrap();
+    let sink = RecordingQlogSink::default();
+    let recorded = sink.inner.clone();
+
+    pipe.server.set_qlog_sink(
+        Box::new(sink),
+        "test qlog sink".to_string(),
+        "test qlog sink description".to_string(),
+    );
+
+    // Drive enough of the handshake for at least one event to land in
+    // the sink, then detach.
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    {
+        let recorded = recorded.lock().unwrap();
+        assert!(recorded.header_title.is_some());
+        assert!(!recorded.event_types.is_empty());
+        assert_eq!(recorded.finish_log_calls, 0);
+    }
+
+    pipe.server.unset_qlog_sink();
+
+    // Streamer is gone, so qlog_streamer() returns None and Drop has
+    // already flushed via finish_log.
+    assert!(pipe.server.qlog_streamer().is_none());
+    {
+        let recorded = recorded.lock().unwrap();
+        assert_eq!(recorded.finish_log_calls, 1);
+    }
+
+    let events_before = recorded.lock().unwrap().event_types.len();
+
+    // Exchange application data so the server would normally emit
+    // additional qlog events. With the streamer detached, the sink
+    // must not see anything new.
+    assert_eq!(pipe.client.stream_send(4, b"hello", true), Ok(5));
+    pipe.advance().unwrap();
+    let mut recv_buf = [0; 16];
+    let _ = pipe.server.stream_recv(4, &mut recv_buf);
+
+    let recorded = recorded.lock().unwrap();
+    assert_eq!(recorded.event_types.len(), events_before);
+    assert_eq!(recorded.finish_log_calls, 1);
 }

--- a/tokio-quiche/src/lib.rs
+++ b/tokio-quiche/src/lib.rs
@@ -110,6 +110,19 @@
 //!
 //! - `--cfg capture_keylogs`: Optional `SSLKEYLOGFILE` capturing for QUIC
 //!   connections.
+//!
+//! # Custom qlog sinks
+//!
+//! In addition to the writer-backed [`QuicSettings::qlog_dir`] path, apps
+//! can install a custom [`qlog::QlogSink`] per connection by implementing
+//! [`ConnectionHook::create_qlog_sink`](crate::quic::ConnectionHook::create_qlog_sink).
+//! The hook takes precedence over `qlog_dir`. Apps can also switch
+//! the active sink on a live connection by sending a
+//! [`QuicCommand::Custom`](crate::quic::QuicCommand::Custom) closure that
+//! calls `quiche::Connection::set_qlog_sink_with_level` on the live
+//! [`QuicheConnection`](crate::quic::QuicheConnection).
+//!
+//! [`QuicSettings::qlog_dir`]: crate::settings::QuicSettings::qlog_dir
 
 pub extern crate quiche;
 

--- a/tokio-quiche/src/quic/hooks.rs
+++ b/tokio-quiche/src/quic/hooks.rs
@@ -24,8 +24,28 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::settings::TlsCertificatePaths;
+use std::net::SocketAddr;
+
 use boring::ssl::SslContextBuilder;
+
+use crate::settings::TlsCertificatePaths;
+
+/// Context passed to [`ConnectionHook::create_qlog_sink`] when tokio-quiche
+/// needs an initial qlog sink for a new connection.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct QlogSinkContext<'a> {
+    /// Trace id for this connection. Formatted from the local source
+    /// connection id (`scid`) — i.e. the server's SCID on the server
+    /// path and the client's SCID on the client path.
+    pub id: &'a str,
+    /// True if this connection was accepted as a server.
+    pub is_server: bool,
+    /// Local socket address of the connection.
+    pub local_addr: SocketAddr,
+    /// Peer socket address of the connection.
+    pub peer_addr: SocketAddr,
+}
 
 /// A set of hooks executed at the level of a [quiche::Connection].
 pub trait ConnectionHook {
@@ -41,4 +61,16 @@ pub trait ConnectionHook {
     fn create_custom_ssl_context_builder(
         &self, settings: TlsCertificatePaths<'_>,
     ) -> Option<SslContextBuilder>;
+
+    /// Returns an optional [`qlog::QlogSink`] for a new connection.
+    ///
+    /// Called once per accepted/connected `quiche::Connection`. If `Some` is
+    /// returned, tokio-quiche installs it via
+    /// `quiche::Connection::set_qlog_sink`. If `None` is returned,
+    /// tokio-quiche falls back to the existing `qlog_dir` writer-backed path.
+    fn create_qlog_sink(
+        &self, _ctx: QlogSinkContext<'_>,
+    ) -> Option<Box<dyn qlog::QlogSink>> {
+        None
+    }
 }

--- a/tokio-quiche/src/quic/mod.rs
+++ b/tokio-quiche/src/quic/mod.rs
@@ -125,6 +125,7 @@ pub use self::connection::QuicCommand;
 pub use self::connection::QuicConnectionStats;
 pub use self::connection::SimpleConnectionIdGenerator;
 pub use self::hooks::ConnectionHook;
+pub use self::hooks::QlogSinkContext;
 
 /// Alias of [quiche::Connection] used internally by the crate.
 pub type QuicheConnection = quiche::Connection<crate::buf_factory::BufFactory>;
@@ -228,18 +229,33 @@ where
         })?;
     }
 
-    // Set the qlog writer here instead of in the `ClientConnector` to avoid
-    // missing logs from early in the connection
-    if let Some(qlog_dir) = &client_config.qlog_dir {
+    // Set the qlog sink/writer here instead of in the `ClientConnector` to
+    // avoid missing logs from early in the connection.
+    let id = format!("{:?}", scid);
+    let hook_sink = client_config.connection_hook.as_ref().and_then(|hook| {
+        hook.create_qlog_sink(QlogSinkContext {
+            id: &id,
+            is_server: false,
+            local_addr: socket.local_addr,
+            peer_addr: socket.peer_addr,
+        })
+    });
+
+    if let Some(sink) = hook_sink {
+        quiche_conn.set_qlog_sink(
+            sink,
+            "tokio-quiche qlog".to_string(),
+            format!("tokio-quiche qlog id={id}"),
+        );
+    } else if let Some(qlog_dir) = &client_config.qlog_dir {
         log::info!("setting up qlogs"; "qlog_dir"=>qlog_dir);
-        let id = format!("{:?}", scid);
         let path = std::path::Path::new(qlog_dir)
             .join(qlog_file_name(&id, client_config.qlog_compression));
         if let Ok(writer) =
             make_qlog_writer_from_path(&path, client_config.qlog_compression)
         {
-            quiche_conn.set_qlog(
-                writer,
+            quiche_conn.set_qlog_sink(
+                Box::new(qlog::QlogWriterSink::new(writer)),
                 "tokio-quiche qlog".to_string(),
                 format!("tokio-quiche qlog id={id}"),
             );
@@ -306,6 +322,7 @@ where
             disable_client_ip_validation: config.disable_client_ip_validation,
             qlog_dir: config.qlog_dir.clone(),
             qlog_compression: config.qlog_compression,
+            connection_hook: config.connection_hook.clone(),
             keylog_file: config
                 .keylog_file
                 .as_ref()

--- a/tokio-quiche/src/quic/router/acceptor.rs
+++ b/tokio-quiche/src/quic/router/acceptor.rs
@@ -46,7 +46,9 @@ use crate::metrics::Metrics;
 use crate::quic::addr_validation_token::AddrValidationTokenManager;
 use crate::quic::connection::SharedConnectionIdGenerator;
 use crate::quic::router::NewConnection;
+use crate::quic::ConnectionHook;
 use crate::quic::Incoming;
+use crate::quic::QlogSinkContext;
 use crate::QuicResultExt;
 
 use super::InitialPacketHandler;
@@ -65,6 +67,8 @@ pub(crate) struct ConnectionAcceptorConfig {
     pub(crate) disable_client_ip_validation: bool,
     pub(crate) qlog_dir: Option<String>,
     pub(crate) qlog_compression: QlogCompression,
+    pub(crate) connection_hook:
+        Option<Arc<dyn ConnectionHook + Send + Sync + 'static>>,
     pub(crate) keylog_file: Option<File>,
     #[cfg(target_os = "linux")]
     pub(crate) with_pktinfo: bool,
@@ -115,15 +119,30 @@ where
         }
         .into_io()?;
 
-        if let Some(qlog_dir) = &self.config.qlog_dir {
-            let id = format!("{:?}", scid);
+        let id = format!("{:?}", scid);
+        let hook_sink = self.config.connection_hook.as_ref().and_then(|hook| {
+            hook.create_qlog_sink(QlogSinkContext {
+                id: &id,
+                is_server: true,
+                local_addr: incoming.local_addr,
+                peer_addr: incoming.peer_addr,
+            })
+        });
+
+        if let Some(sink) = hook_sink {
+            conn.set_qlog_sink(
+                sink,
+                "tokio-quiche qlog".to_string(),
+                format!("tokio-quiche qlog id={id}"),
+            );
+        } else if let Some(qlog_dir) = &self.config.qlog_dir {
             let path = std::path::Path::new(qlog_dir)
                 .join(qlog_file_name(&id, self.config.qlog_compression));
             if let Ok(writer) =
                 make_qlog_writer_from_path(&path, self.config.qlog_compression)
             {
-                conn.set_qlog(
-                    writer,
+                conn.set_qlog_sink(
+                    Box::new(qlog::QlogWriterSink::new(writer)),
                     "tokio-quiche qlog".to_string(),
                     format!("tokio-quiche qlog id={id}"),
                 );

--- a/tokio-quiche/src/quic/router/mod.rs
+++ b/tokio-quiche/src/quic/router/mod.rs
@@ -965,6 +965,7 @@ mod tests {
                 disable_client_ip_validation: config.disable_client_ip_validation,
                 qlog_dir: config.qlog_dir.clone(),
                 qlog_compression: config.qlog_compression,
+                connection_hook: config.connection_hook.clone(),
                 keylog_file: config
                     .keylog_file
                     .as_ref()

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -27,10 +27,12 @@
 use foundations::telemetry::log;
 use std::borrow::Cow;
 use std::fs::File;
+use std::sync::Arc;
 use std::time::Duration;
 
 use qlog::writer::QlogCompression;
 
+use crate::quic::ConnectionHook;
 use crate::result::QuicResult;
 use crate::settings::CertificateKind;
 use crate::settings::ConnectionParams;
@@ -56,6 +58,7 @@ pub(crate) struct Config {
     pub handshake_timeout: Option<Duration>,
     pub has_ippktinfo: bool,
     pub has_ipv6pktinfo: bool,
+    pub connection_hook: Option<Arc<dyn ConnectionHook + Send + Sync + 'static>>,
 }
 
 impl AsMut<quiche::Config> for Config {
@@ -108,6 +111,7 @@ impl Config {
             handshake_timeout: quic_settings.handshake_timeout,
             has_ippktinfo,
             has_ipv6pktinfo,
+            connection_hook: params.hooks.connection_hook.clone(),
         })
     }
 }

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -152,6 +152,11 @@ pub struct QuicSettings {
     pub keylog_file: Option<String>,
 
     /// Path to a directory where QLOG files will be saved.
+    ///
+    /// Ignored for a given connection if
+    /// [`ConnectionHook::create_qlog_sink`](crate::quic::ConnectionHook::create_qlog_sink)
+    /// returns `Some` for it. The hook takes precedence over this writer-backed
+    /// path.
     pub qlog_dir: Option<String>,
 
     /// Compression applied to QLOG output files.

--- a/tokio-quiche/tests/integration_tests/mod.rs
+++ b/tokio-quiche/tests/integration_tests/mod.rs
@@ -45,6 +45,7 @@ pub mod connection_close;
 pub mod headers;
 pub mod migration;
 pub mod qlog_compression;
+pub mod qlog_sink;
 pub mod stream_limit;
 pub mod timeouts;
 pub mod zero_rtt;

--- a/tokio-quiche/tests/integration_tests/qlog_sink.rs
+++ b/tokio-quiche/tests/integration_tests/qlog_sink.rs
@@ -1,0 +1,318 @@
+// Copyright (C) 2026, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! Integration tests for the tokio-quiche
+//! [`ConnectionHook::create_qlog_sink`] path. Drives a real
+//! handshake against a server whose `ConnectionHook` installs a
+//! recording sink, then asserts the sink received the qlog header
+//! and the initial local transport-parameters event.
+
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use boring::ssl::SslContextBuilder;
+use futures::stream::StreamExt;
+use qlog::events::quic::QuicEventType;
+use qlog::events::Event;
+use qlog::events::EventType;
+use qlog::events::JsonEvent;
+use qlog::QlogSeq;
+use qlog::QlogSink;
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+use tokio_quiche::listen;
+use tokio_quiche::metrics::DefaultMetrics;
+use tokio_quiche::quic::ConnectionHook;
+use tokio_quiche::quic::QlogSinkContext;
+use tokio_quiche::quic::QuicCommand;
+use tokio_quiche::settings::CertificateKind;
+use tokio_quiche::settings::Hooks;
+use tokio_quiche::settings::TlsCertificatePaths;
+use tokio_quiche::ConnectionParams;
+
+use crate::fixtures::*;
+
+/// Sink that records the qlog header title and the
+/// `EventType` of every native event it receives. JSON events are
+/// accepted but not recorded — this test only inspects native
+/// quic-domain events.
+#[derive(Clone, Default)]
+struct RecordingSink {
+    inner: Arc<Mutex<RecordingSinkInner>>,
+}
+
+#[derive(Default)]
+struct RecordingSinkInner {
+    header_title: Option<String>,
+    event_types: Vec<EventType>,
+}
+
+impl QlogSink for RecordingSink {
+    fn start_log(&mut self, qlog: &QlogSeq) -> qlog::Result<()> {
+        self.inner.lock().unwrap().header_title = qlog.title.clone();
+        Ok(())
+    }
+
+    fn add_event(&mut self, event: Event) -> qlog::Result<()> {
+        self.inner
+            .lock()
+            .unwrap()
+            .event_types
+            .push(EventType::from(&event.data));
+        Ok(())
+    }
+
+    fn add_json_event(&mut self, _event: JsonEvent) -> qlog::Result<()> {
+        Ok(())
+    }
+
+    fn finish_log(&mut self) -> qlog::Result<()> {
+        Ok(())
+    }
+}
+
+/// `ConnectionHook` that returns a clone of the wrapped
+/// `RecordingSink` for every connection. Does not customize TLS.
+struct QlogHook {
+    sink: RecordingSink,
+}
+
+impl ConnectionHook for QlogHook {
+    fn create_custom_ssl_context_builder(
+        &self, _settings: TlsCertificatePaths<'_>,
+    ) -> Option<SslContextBuilder> {
+        None
+    }
+
+    fn create_qlog_sink(
+        &self, _ctx: QlogSinkContext<'_>,
+    ) -> Option<Box<dyn QlogSink>> {
+        Some(Box::new(self.sink.clone()))
+    }
+}
+
+/// Short sleep used after the request completes but before we
+/// inspect the recorded events, so the server-side connection's
+/// drop path runs and the streamer's `finish_log` lands. Connection
+/// teardown on localhost typically takes <10 ms; 200 ms is generous
+/// and keeps the test fast. (Mirrors the convention in
+/// `qlog_compression.rs`.)
+const DRAIN_DELAY: Duration = Duration::from_millis(200);
+
+#[tokio::test]
+async fn hook_installed_sink_receives_initial_event() {
+    let sink = RecordingSink::default();
+    let hook = Arc::new(QlogHook { sink: sink.clone() });
+
+    let (url, _audit_rx) = start_server_with_settings(
+        QuicSettings::default(),
+        Http3Settings::default(),
+        hook,
+        handle_connection,
+    );
+
+    let url = format!("{url}/1");
+    let _ = request(url, 1).await.expect("request failed");
+
+    sleep(DRAIN_DELAY).await;
+
+    let recorded = sink.inner.lock().unwrap();
+    assert_eq!(recorded.header_title.as_deref(), Some("tokio-quiche qlog"));
+    assert!(
+        recorded
+            .event_types
+            .contains(&EventType::QuicEventType(QuicEventType::ParametersSet)),
+        "expected ParametersSet event, got {:?}",
+        recorded.event_types
+    );
+}
+
+#[tokio::test]
+async fn custom_command_switches_sinks_mid_connection() {
+    /// `ConnectionHook` that records whether `create_qlog_sink` was called.
+    ///
+    /// Returns `None` so the connection starts with no qlog sink at all,
+    /// then the test installs a `RecordingSink` via a
+    /// `QuicCommand::Custom` closure.
+    struct NoSinkHook {
+        consulted: Arc<AtomicBool>,
+    }
+
+    impl ConnectionHook for NoSinkHook {
+        fn create_custom_ssl_context_builder(
+            &self, _settings: TlsCertificatePaths<'_>,
+        ) -> Option<SslContextBuilder> {
+            None
+        }
+
+        fn create_qlog_sink(
+            &self, _ctx: QlogSinkContext<'_>,
+        ) -> Option<Box<dyn QlogSink>> {
+            self.consulted.store(true, Ordering::SeqCst);
+            None
+        }
+    }
+
+    let socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let server_addr: SocketAddr = socket.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", server_addr.port());
+
+    let quic_settings = QuicSettings::default();
+
+    let consulted = Arc::new(AtomicBool::new(false));
+    let hook = Arc::new(NoSinkHook {
+        consulted: consulted.clone(),
+    });
+
+    let tls_cert_settings = TlsCertificatePaths {
+        cert: TEST_CERT_FILE,
+        private_key: TEST_KEY_FILE,
+        kind: CertificateKind::X509,
+    };
+
+    let hooks = Hooks {
+        connection_hook: Some(hook),
+    };
+
+    let params =
+        ConnectionParams::new_server(quic_settings, tls_cert_settings, hooks);
+
+    let mut stream = listen(vec![socket], params, DefaultMetrics)
+        .unwrap()
+        .remove(0);
+
+    // Channel used to pass the per-connection `cmd_sender` from the
+    // server-accept task to the test thread.
+    type ServerCmdSender = tokio_quiche::http3::driver::RequestSender<
+        tokio_quiche::http3::driver::ServerH3Command,
+        QuicCommand,
+    >;
+    let (sender_tx, mut sender_rx) = mpsc::unbounded_channel::<ServerCmdSender>();
+
+    tokio::spawn(async move {
+        let (h3_driver, h3_controller) =
+            ServerH3Driver::new(Http3Settings::default());
+        let conn = stream
+            .next()
+            .await
+            .expect("listener stream closed")
+            .expect("listener error")
+            .start(h3_driver);
+        let h3_over_quic = ServerH3Connection::new(conn, h3_controller);
+        // Hand the cmd_sender back to the test before we hand the
+        // controller to `handle_connection`.
+        let _ = sender_tx.send(h3_over_quic.h3_controller.cmd_sender());
+        handle_connection(h3_over_quic).await;
+    });
+
+    // Build the sink we want to install on the live connection. Keep a
+    // shared handle so the test thread can inspect what it recorded.
+    let recording = RecordingSink::default();
+    let recording_state = recording.inner.clone();
+
+    // Drive the client in the background. We send the `Custom` command
+    // as soon as the per-connection `cmd_sender` becomes available,
+    // then await the request.
+    let url_for_request = format!("{url}/1");
+    let req_handle =
+        tokio::spawn(async move { request(url_for_request, 1).await });
+
+    // Wait for the accept loop to publish the per-connection cmd_sender.
+    let cmd_sender =
+        tokio::time::timeout(Duration::from_secs(2), sender_rx.recv())
+            .await
+            .expect("timed out waiting for connection")
+            .expect("connection accept loop exited");
+
+    let sink_for_cmd: Box<dyn QlogSink> = Box::new(recording.clone());
+    cmd_sender
+        .send(QuicCommand::Custom(Box::new(move |qconn| {
+            qconn.set_qlog_sink_with_level(
+                sink_for_cmd,
+                "switched".to_string(),
+                "switched mid-connection".to_string(),
+                tokio_quiche::quiche::QlogLevel::Base,
+            );
+        })))
+        .expect("send Custom command");
+
+    let _ = req_handle.await.expect("request task panicked");
+
+    sleep(DRAIN_DELAY).await;
+
+    assert!(
+        consulted.load(Ordering::SeqCst),
+        "ConnectionHook::create_qlog_sink should have been consulted on accept"
+    );
+
+    let recorded = recording_state.lock().unwrap();
+    assert_eq!(
+        recorded.header_title.as_deref(),
+        Some("switched"),
+        "qlog header should reflect the title set via QuicCommand::Custom"
+    );
+    assert!(
+        !recorded.event_types.is_empty(),
+        "expected at least one event after sink swap"
+    );
+}
+
+#[tokio::test]
+async fn qlog_dir_still_writes_file_without_hook_sink() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let mut quic_settings = QuicSettings::default();
+    quic_settings.qlog_dir = Some(dir.path().to_string_lossy().into_owned());
+
+    let hook = TestConnectionHook::new();
+    let (url, _audit_rx) = start_server_with_settings(
+        quic_settings,
+        Http3Settings::default(),
+        hook,
+        handle_connection,
+    );
+
+    let url = format!("{url}/1");
+    let _ = request(url, 1).await.expect("request failed");
+
+    sleep(DRAIN_DELAY).await;
+
+    let entries: Vec<_> = std::fs::read_dir(dir.path())
+        .expect("qlog dir readable")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_file())
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected qlog file under {:?}, got {entries:?}",
+        dir.path()
+    );
+}


### PR DESCRIPTION
Add a QlogSink trait that allows overriding qlog behavior. Previously QlogStreamer was instantiated with a writer object. Instead, it is instantiated with a QlogSink object which allows more flexibility. A QlogWriterSink implementation provides backwards compatibility.

Implementations have new methods for overriding qlog behavior:
  - Connection::set_qlog_sink and set_qlog_sink_with_level allow setting a custom qlog sink. The existing set_qlog and set_qlog_with_level exist for backwards compatibility and call these new functions with a QlogWriterSink object.
  - A new ConnectionHook::create_qlog_sink hook can be implemented to install a sink at connection accept/connect time. If a sink is returned it overrides any qlog_dir behavior.

Add QlogStreamer::should_log(EventType) that allows high volume events to be skipped without construction. Modified both the recv and write path to make use of this.