### PR TITLE
Accept `impl AsRef<ffi::OsStr>` instead of `&str` in methods that expect a path

### DIFF
--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -166,8 +166,11 @@ impl Context {
         }
     }
 
-    pub fn load_verify_locations_from_file(&mut self, file: &str) -> Result<()> {
-        let file = ffi::CString::new(file).map_err(|_| Error::TlsFail)?;
+    pub fn load_verify_locations_from_file(
+        &mut self, file: impl AsRef<ffi::OsStr>,
+    ) -> Result<()> {
+        let file = ffi::CString::new(file.as_ref().as_encoded_bytes())
+            .map_err(|_| Error::TlsFail)?;
         map_result(unsafe {
             SSL_CTX_load_verify_locations(
                 self.as_mut_ptr(),
@@ -178,9 +181,10 @@ impl Context {
     }
 
     pub fn load_verify_locations_from_directory(
-        &mut self, path: &str,
+        &mut self, path: impl AsRef<ffi::OsStr>,
     ) -> Result<()> {
-        let path = ffi::CString::new(path).map_err(|_| Error::TlsFail)?;
+        let path = ffi::CString::new(path.as_ref().as_encoded_bytes())
+            .map_err(|_| Error::TlsFail)?;
         map_result(unsafe {
             SSL_CTX_load_verify_locations(
                 self.as_mut_ptr(),
@@ -190,15 +194,21 @@ impl Context {
         })
     }
 
-    pub fn use_certificate_chain_file(&mut self, file: &str) -> Result<()> {
-        let cstr = ffi::CString::new(file).map_err(|_| Error::TlsFail)?;
+    pub fn use_certificate_chain_file(
+        &mut self, file: impl AsRef<ffi::OsStr>,
+    ) -> Result<()> {
+        let cstr = ffi::CString::new(file.as_ref().as_encoded_bytes())
+            .map_err(|_| Error::TlsFail)?;
         map_result(unsafe {
             SSL_CTX_use_certificate_chain_file(self.as_mut_ptr(), cstr.as_ptr())
         })
     }
 
-    pub fn use_privkey_file(&mut self, file: &str) -> Result<()> {
-        let cstr = ffi::CString::new(file).map_err(|_| Error::TlsFail)?;
+    pub fn use_privkey_file(
+        &mut self, file: impl AsRef<ffi::OsStr>,
+    ) -> Result<()> {
+        let cstr = ffi::CString::new(file.as_ref().as_encoded_bytes())
+            .map_err(|_| Error::TlsFail)?;
         map_result(unsafe {
             SSL_CTX_use_PrivateKey_file(self.as_mut_ptr(), cstr.as_ptr(), 1)
         })


### PR DESCRIPTION
The goal is to let clients call these functions with a `&Path` (among others) instead of forcing a conversion to `&str` where they would have to deal with the error.