### PR TITLE
Fix tx_buffered computation so it matches the sum of bytes in stream buffers

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1425,9 +1425,6 @@ where
     /// The send capacity factor.
     tx_cap_factor: f64,
 
-    /// Number of bytes buffered in the send buffer.
-    tx_buffered: usize,
-
     /// Tracks the health of tx_buffered.
     tx_buffered_state: TxBufferTrackingState,
 
@@ -1457,7 +1454,7 @@ where
     lost_bytes: u64,
 
     /// Streams map, indexed by stream ID.
-    streams: stream::StreamMap<F>,
+    pub(crate) streams: stream::StreamMap<F>,
 
     /// Peer's original destination connection ID. Used by the client to
     /// validate the server's transport parameter.
@@ -2138,7 +2135,6 @@ impl<F: BufFactory> Connection<F> {
             tx_cap: 0,
             tx_cap_factor: config.tx_cap_factor,
 
-            tx_buffered: 0,
             tx_buffered_state: TxBufferTrackingState::Ok,
 
             tx_data: 0,
@@ -3633,12 +3629,9 @@ impl<F: BufFactory> Connection<F> {
                         length,
                         ..
                     } => {
-                        // Update tx_buffered and emit qlog before checking if the
-                        // stream still exists.  The client does need to ACK
-                        // frames that were received after the client sends a
-                        // ResetStream.
-                        self.tx_buffered =
-                            self.tx_buffered.saturating_sub(length);
+                        // Emit qlog before checking if the stream still exists.
+                        // The client does need to ACK frames that were received
+                        // after the client sends a ResetStream.
 
                         qlog_with_type!(QLOG_DATA_MV, self.qlog, q, {
                             let ev_data = EventData::QuicStreamDataMoved(
@@ -3664,8 +3657,7 @@ impl<F: BufFactory> Connection<F> {
                             None => continue,
                         };
 
-                        stream.send.ack_and_drop(offset, length);
-
+                        let dropped = stream.send.ack_and_drop(offset, length);
                         let priority_key = Arc::clone(&stream.priority_key);
 
                         // Only collect the stream if it is complete and not
@@ -3697,6 +3689,13 @@ impl<F: BufFactory> Connection<F> {
                         if is_complete && !is_readable && !is_writable {
                             let local = stream.local;
                             self.streams.collect(stream_id, local);
+                        }
+
+                        // Update cache to reflect any data that was dropped from
+                        // buffers (e.g., data marked for retransmission but then
+                        // acked before it could be resent).
+                        if dropped > 0 {
+                            self.streams.sub_tx_buffered(dropped);
                         }
                     },
 
@@ -4188,12 +4187,9 @@ impl<F: BufFactory> Connection<F> {
                             Some(v) if !v.send.is_stopped() => v,
 
                             // Data on a closed stream will not be retransmitted
-                            // or acked after it is declared lost, so update
-                            // tx_buffered and qlog.
+                            // or acked after it is declared lost, so just drop
+                            // it.
                             _ => {
-                                self.tx_buffered =
-                                    self.tx_buffered.saturating_sub(length);
-
                                 qlog_with_type!(QLOG_DATA_MV, self.qlog, q, {
                                     let ev_data = EventData::QuicStreamDataMoved(
                                         qlog::events::quic::StreamDataMoved {
@@ -4221,7 +4217,8 @@ impl<F: BufFactory> Connection<F> {
 
                         let empty_fin = length == 0 && fin;
 
-                        stream.send.retransmit(offset, length);
+                        let retransmitted =
+                            stream.send.retransmit(offset, length);
 
                         // If the stream is now flushable push it to the
                         // flushable queue, but only if it wasn't already
@@ -4235,6 +4232,13 @@ impl<F: BufFactory> Connection<F> {
                             let priority_key = Arc::clone(&stream.priority_key);
                             self.streams.insert_flushable(&priority_key);
                         }
+
+                        // Update tx_buffered cache when data is marked for
+                        // retransmission (it was decremented when emitted).
+                        // Only increment by the actual amount retransmitted,
+                        // which may be less than `length` if some data was
+                        // already acked.
+                        self.streams.add_tx_buffered(retransmitted);
 
                         self.stream_retrans_bytes += length as u64;
                         p.stream_retrans_bytes += length as u64;
@@ -4396,7 +4400,7 @@ impl<F: BufFactory> Connection<F> {
                 }
             }
         }
-        self.check_tx_buffered_invariant();
+        self.streams.check_tx_buffered_cache();
 
         let is_app_limited = self.delivery_rate_check_if_app_limited();
         let n_paths = self.paths.len();
@@ -5299,6 +5303,9 @@ impl<F: BufFactory> Connection<F> {
                     self.streams.insert_flushable(&priority_key);
                 }
 
+                // Update tx_buffered cache when data is emitted.
+                self.streams.sub_tx_buffered(len);
+
                 #[cfg(feature = "fuzzing")]
                 // Coalesce STREAM frames when fuzzing.
                 if left > frame::MAX_STREAM_OVERHEAD {
@@ -6136,8 +6143,7 @@ impl<F: BufFactory> Connection<F> {
 
         self.tx_data += sent as u64;
 
-        self.tx_buffered += sent;
-        self.check_tx_buffered_invariant();
+        self.streams.add_tx_buffered(sent);
 
         qlog_with_type!(QLOG_DATA_MV, self.qlog, q, {
             let ev_data = EventData::QuicStreamDataMoved(
@@ -6282,14 +6288,19 @@ impl<F: BufFactory> Connection<F> {
             },
 
             Shutdown::Write => {
+                // Save the buffered length before shutdown (shutdown clears the
+                // buffer).
+                let buffered_len = stream.send.len() as usize;
+
                 let (final_size, unsent) = stream.send.shutdown()?;
 
                 // Claw back some flow control allowance from data that was
                 // buffered but not actually sent before the stream was reset.
                 self.tx_data = self.tx_data.saturating_sub(unsent);
 
-                self.tx_buffered =
-                    self.tx_buffered.saturating_sub(unsent as usize);
+                // Update cache: subtract only the buffered data, not inflight
+                // data.
+                self.streams.sub_tx_buffered(buffered_len);
 
                 // These drops in qlog are a bit weird, but the only way to ensure
                 // that all bytes that are moved from App to Transport in
@@ -8459,6 +8470,10 @@ impl<F: BufFactory> Connection<F> {
 
                 let priority_key = Arc::clone(&stream.priority_key);
 
+                // Save the buffered length before stopping (stop clears the
+                // buffer).
+                let buffered_len = stream.send.len() as usize;
+
                 // Try stopping the stream.
                 if let Ok((final_size, unsent)) = stream.send.stop(error_code) {
                     // Claw back some flow control allowance from data that was
@@ -8469,8 +8484,9 @@ impl<F: BufFactory> Connection<F> {
                     // to touch it here.
                     self.tx_data = self.tx_data.saturating_sub(unsent);
 
-                    self.tx_buffered =
-                        self.tx_buffered.saturating_sub(unsent as usize);
+                    // Update cache: subtract only the buffered data, not inflight
+                    // data.
+                    self.streams.sub_tx_buffered(buffered_len);
 
                     // These drops in qlog are a bit weird, but the only way to
                     // ensure that all bytes that are moved from App to Transport
@@ -8958,30 +8974,11 @@ impl<F: BufFactory> Connection<F> {
             .map(|(_, p)| p.recovery.cwnd_available())
             .sum();
 
-        ((self.tx_buffered + self.dgram_send_queue_byte_size()) < cwin_available) &&
+        ((self.streams.tx_buffered() + self.dgram_send_queue_byte_size()) <
+            cwin_available) &&
             (self.tx_data.saturating_sub(self.last_tx_data)) <
                 cwin_available as u64 &&
             cwin_available > 0
-    }
-
-    fn check_tx_buffered_invariant(&mut self) {
-        // tx_buffered should track bytes queued in the stream buffers
-        // and unacked retransmitable bytes in the network.
-        // If tx_buffered > 0 mark the tx_buffered_state if there are no
-        // flushable streams and there no inflight bytes.
-        //
-        // It is normal to have tx_buffered == 0 while there are inflight bytes
-        // since not QUIC frames are retransmittable; inflight tracks all bytes
-        // on the network which are subject to congestion control.
-        if self.tx_buffered > 0 &&
-            !self.streams.has_flushable() &&
-            !self
-                .paths
-                .iter()
-                .any(|(_, p)| p.recovery.bytes_in_flight() > 0)
-        {
-            self.tx_buffered_state = TxBufferTrackingState::Inconsistent;
-        }
     }
 
     fn set_initial_dcid(

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1425,9 +1425,6 @@ where
     /// The send capacity factor.
     tx_cap_factor: f64,
 
-    /// Tracks the health of tx_buffered.
-    tx_buffered_state: TxBufferTrackingState,
-
     /// Total number of bytes sent to the peer.
     tx_data: u64,
 
@@ -2134,8 +2131,6 @@ impl<F: BufFactory> Connection<F> {
 
             tx_cap: 0,
             tx_cap_factor: config.tx_cap_factor,
-
-            tx_buffered_state: TxBufferTrackingState::Ok,
 
             tx_data: 0,
             max_tx_data: 0,
@@ -7857,7 +7852,11 @@ impl<F: BufFactory> Connection<F> {
             path_challenge_rx_count: self.path_challenge_rx_count,
             amplification_limited_count: self.amplification_limited_count,
             bytes_in_flight_duration: self.bytes_in_flight_duration(),
-            tx_buffered_state: self.tx_buffered_state,
+            tx_buffered_state: if self.streams.tx_buffered_is_consistent() {
+                TxBufferTrackingState::Ok
+            } else {
+                TxBufferTrackingState::Inconsistent
+            },
         }
     }
 
@@ -9471,6 +9470,10 @@ pub struct Stats {
     pub bytes_in_flight_duration: Duration,
 
     /// Health state of the connection's tx_buffered.
+    ///
+    /// Indicates whether the cached tx_buffered value is consistent with
+    /// the actual sum of bytes buffered across all stream send buffers.
+    /// Returns `Ok` if consistent, `Inconsistent` if there's a mismatch.
     pub tx_buffered_state: TxBufferTrackingState,
 }
 

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3686,8 +3686,9 @@ impl<F: BufFactory> Connection<F> {
                             self.streams.collect(stream_id, local);
                         }
 
-                        // Update cache to reflect any data that was dropped from
-                        // buffers (e.g., data marked for retransmission but then
+                        // Update tx_bufferd to reflect any data that was dropped
+                        // from stream buffers (e.g., data
+                        // marked for retransmission but then
                         // acked before it could be resent).
                         if dropped > 0 {
                             self.streams.sub_tx_buffered(dropped);
@@ -4228,7 +4229,7 @@ impl<F: BufFactory> Connection<F> {
                             self.streams.insert_flushable(&priority_key);
                         }
 
-                        // Update tx_buffered cache when data is marked for
+                        // Update tx_buffered when data is marked for
                         // retransmission (it was decremented when emitted).
                         // Only increment by the actual amount retransmitted,
                         // which may be less than `length` if some data was
@@ -4395,7 +4396,9 @@ impl<F: BufFactory> Connection<F> {
                 }
             }
         }
-        self.streams.check_tx_buffered_cache();
+
+        #[cfg(debug_assertions)]
+        self.streams.debug_check_tx_buffered_consistency();
 
         let is_app_limited = self.delivery_rate_check_if_app_limited();
         let n_paths = self.paths.len();
@@ -5298,7 +5301,7 @@ impl<F: BufFactory> Connection<F> {
                     self.streams.insert_flushable(&priority_key);
                 }
 
-                // Update tx_buffered cache when data is emitted.
+                // Update tx_buffered when data is emitted.
                 self.streams.sub_tx_buffered(len);
 
                 #[cfg(feature = "fuzzing")]
@@ -6293,8 +6296,8 @@ impl<F: BufFactory> Connection<F> {
                 // buffered but not actually sent before the stream was reset.
                 self.tx_data = self.tx_data.saturating_sub(unsent);
 
-                // Update cache: subtract only the buffered data, not inflight
-                // data.
+                // Update tx_buffered: subtract only the buffered data, not
+                // inflight data.
                 self.streams.sub_tx_buffered(buffered_len);
 
                 // These drops in qlog are a bit weird, but the only way to ensure
@@ -8483,8 +8486,8 @@ impl<F: BufFactory> Connection<F> {
                     // to touch it here.
                     self.tx_data = self.tx_data.saturating_sub(unsent);
 
-                    // Update cache: subtract only the buffered data, not inflight
-                    // data.
+                    // Update tx_buffered: subtract only the buffered data, not
+                    // inflight data.
                     self.streams.sub_tx_buffered(buffered_len);
 
                     // These drops in qlog are a bit weird, but the only way to
@@ -9471,7 +9474,7 @@ pub struct Stats {
 
     /// Health state of the connection's tx_buffered.
     ///
-    /// Indicates whether the cached tx_buffered value is consistent with
+    /// Indicates whether the streams.tx_buffered value is consistent with
     /// the actual sum of bytes buffered across all stream send buffers.
     /// Returns `Ok` if consistent, `Inconsistent` if there's a mismatch.
     pub tx_buffered_state: TxBufferTrackingState,

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6288,7 +6288,7 @@ impl<F: BufFactory> Connection<F> {
             Shutdown::Write => {
                 // Save the buffered length before shutdown (shutdown clears the
                 // buffer).
-                let buffered_len = stream.send.len() as usize;
+                let buffered_len = stream.send.buffered_bytes() as usize;
 
                 let (final_size, unsent) = stream.send.shutdown()?;
 
@@ -8474,7 +8474,7 @@ impl<F: BufFactory> Connection<F> {
 
                 // Save the buffered length before stopping (stop clears the
                 // buffer).
-                let buffered_len = stream.send.len() as usize;
+                let buffered_len = stream.send.buffered_bytes() as usize;
 
                 // Try stopping the stream.
                 if let Ok((final_size, unsent)) = stream.send.stop(error_code) {

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -202,6 +202,9 @@ pub struct StreamMap<F: BufFactory = DefaultBufFactory> {
     /// When `true`, the initial flow control window will be set to the
     /// `max_rx_data`, if false, it will be set to `DEFAULT_STREAM_WINDOW`
     use_initial_max_data_as_flow_control_win: bool,
+
+    /// Cached total number of bytes buffered across all streams.
+    tx_buffered_cache: usize,
 }
 
 impl<F: BufFactory> StreamMap<F> {
@@ -719,6 +722,61 @@ impl<F: BufFactory> StreamMap<F> {
     #[cfg(test)]
     pub fn len(&self) -> usize {
         self.streams.len()
+    }
+
+    /// Returns the total number of bytes buffered across all streams.
+    pub(crate) fn tx_buffered(&self) -> usize {
+        self.tx_buffered_cache
+    }
+
+    /// Computes the actual tx_buffered by summing across all streams.
+    /// This is used for debugging to verify the cache is accurate.
+    #[cfg(debug_assertions)]
+    fn tx_buffered_actual(&self) -> usize {
+        self.streams.values().map(|s| s.send.len() as usize).sum()
+    }
+
+    /// Updates the cached tx_buffered value by adding the delta.
+    pub(crate) fn add_tx_buffered(&mut self, delta: usize) {
+        self.tx_buffered_cache += delta;
+        self.check_tx_buffered_cache();
+    }
+
+    /// Updates the cached tx_buffered value by subtracting the delta.
+    pub(crate) fn sub_tx_buffered(&mut self, delta: usize) {
+        debug_assert!(self.tx_buffered_cache >= delta);
+        self.tx_buffered_cache = self.tx_buffered_cache.saturating_sub(delta);
+        self.check_tx_buffered_cache();
+    }
+
+    /// Verifies that the cached tx_buffered matches the actual value.
+    /// Enabled in debug builds to catch cache inconsistencies early.
+    #[cfg(debug_assertions)]
+    pub(crate) fn check_tx_buffered_cache(&self) {
+        let actual = self.tx_buffered_actual();
+        let cached = self.tx_buffered_cache;
+        if actual != cached {
+            // Print per-stream details to help debug
+            eprintln!("Stream buffer details:");
+            for (id, stream) in &self.streams {
+                let len = stream.send.len();
+                if len > 0 {
+                    eprintln!("  Stream {}: {} bytes", id, len);
+                }
+            }
+            panic!(
+                "tx_buffered cache mismatch: cached={}, actual={}, diff={}",
+                cached,
+                actual,
+                cached as i64 - actual as i64
+            );
+        }
+    }
+
+    /// No-op in release builds for performance.
+    #[cfg(not(debug_assertions))]
+    pub(crate) fn check_tx_buffered_cache(&self) {
+        // No-op in release builds
     }
 
     /// When `true`, the initial flow control window will be set to the
@@ -2203,6 +2261,200 @@ mod tests {
         let walk_2: Vec<u64> =
             prioritized_writable.iter().map(|s| s.id).collect();
         assert_eq!(walk_2, vec![0, 0, 4, 4, 8, 8, 12, 12]);
+    }
+
+    #[test]
+    fn retransmit_returns_zero_when_already_acked() {
+        let mut stream = <Stream>::new(0, 15, 15, true, 0, 15);
+
+        // Write and emit some data.
+        assert_eq!(stream.send.write(b"hello", false), Ok(5));
+        assert_eq!(stream.send.len(), 5);
+
+        let mut buf = [0; 10];
+        let (written, _) = stream.send.emit(&mut buf).unwrap();
+        assert_eq!(written, 5);
+        assert_eq!(stream.send.len(), 0);
+
+        // Mark data for retransmission.
+        let retransmitted = stream.send.retransmit(0, 5);
+        assert_eq!(retransmitted, 5);
+        assert_eq!(stream.send.len(), 5);
+
+        // Ack the data.
+        stream.send.ack_and_drop(0, 5);
+        assert_eq!(stream.send.len(), 0);
+
+        // Try to retransmit again - should return 0 since data is acked.
+        let retransmitted = stream.send.retransmit(0, 5);
+        assert_eq!(retransmitted, 0);
+        assert_eq!(stream.send.len(), 0);
+    }
+
+    #[test]
+    fn retransmit_returns_partial_when_some_acked() {
+        let mut stream = <Stream>::new(0, 15, 15, true, 0, 15);
+
+        // Write and emit 10 bytes.
+        assert_eq!(stream.send.write(b"helloworld", false), Ok(10));
+        assert_eq!(stream.send.len(), 10);
+
+        let mut buf = [0; 10];
+        let (written, _) = stream.send.emit(&mut buf).unwrap();
+        assert_eq!(written, 10);
+        assert_eq!(stream.send.len(), 0);
+
+        // Mark all data for retransmission.
+        let retransmitted = stream.send.retransmit(0, 10);
+        assert_eq!(retransmitted, 10);
+        assert_eq!(stream.send.len(), 10);
+
+        // Ack first 5 bytes and drop them.
+        let dropped = stream.send.ack_and_drop(0, 5);
+        assert_eq!(dropped, 5);
+        assert_eq!(stream.send.len(), 5);
+
+        // Try to retransmit all 10 bytes - should return 5 since first 5 are
+        // acked.
+        let retransmitted = stream.send.retransmit(0, 10);
+        assert_eq!(retransmitted, 0); // Already marked, so no change
+        assert_eq!(stream.send.len(), 5);
+    }
+
+    #[test]
+    fn ack_and_drop_decrements_len_and_returns_dropped() {
+        let mut stream = <Stream>::new(0, 15, 15, true, 0, 15);
+
+        // Write some data.
+        assert_eq!(stream.send.write(b"hello", false), Ok(5));
+        assert_eq!(stream.send.len(), 5);
+
+        // Emit it.
+        let mut buf = [0; 10];
+        let (written, _) = stream.send.emit(&mut buf).unwrap();
+        assert_eq!(written, 5);
+        assert_eq!(stream.send.len(), 0);
+
+        // Mark for retransmission.
+        let retransmitted = stream.send.retransmit(0, 5);
+        assert_eq!(retransmitted, 5);
+        assert_eq!(stream.send.len(), 5);
+
+        // Ack and drop - should decrement len and return dropped amount.
+        let dropped = stream.send.ack_and_drop(0, 5);
+        assert_eq!(dropped, 5);
+        assert_eq!(stream.send.len(), 0);
+    }
+
+    #[test]
+    fn ack_and_drop_partial_buffer() {
+        let mut stream = <Stream>::new(0, 30, 30, true, 0, 30);
+
+        // Write and emit two chunks.
+        assert_eq!(stream.send.write(b"hello", false), Ok(5));
+        assert_eq!(stream.send.write(b"world", false), Ok(5));
+        assert_eq!(stream.send.len(), 10);
+
+        let mut buf = [0; 10];
+        let (written, _) = stream.send.emit(&mut buf).unwrap();
+        assert_eq!(written, 10);
+        assert_eq!(stream.send.len(), 0);
+
+        // Mark both chunks for retransmission.
+        let retransmitted = stream.send.retransmit(0, 10);
+        assert_eq!(retransmitted, 10);
+        assert_eq!(stream.send.len(), 10);
+
+        // Ack and drop only first chunk.
+        let dropped = stream.send.ack_and_drop(0, 5);
+        assert_eq!(dropped, 5);
+        assert_eq!(stream.send.len(), 5);
+
+        // Ack and drop second chunk.
+        let dropped = stream.send.ack_and_drop(5, 5);
+        assert_eq!(dropped, 5);
+        assert_eq!(stream.send.len(), 0);
+    }
+
+    #[test]
+    fn ack_and_drop_returns_zero_when_nothing_dropped() {
+        let mut stream = <Stream>::new(0, 15, 15, true, 0, 15);
+
+        // Write and emit data.
+        assert_eq!(stream.send.write(b"hello", false), Ok(5));
+        let mut buf = [0; 10];
+        let (written, _) = stream.send.emit(&mut buf).unwrap();
+        assert_eq!(written, 5);
+
+        // Ack data that's already been fully emitted and not retransmitted.
+        // Nothing should be dropped since there's no buffered data.
+        let dropped = stream.send.ack_and_drop(0, 5);
+        assert_eq!(dropped, 0);
+        assert_eq!(stream.send.len(), 0);
+    }
+
+    #[test]
+    fn cache_consistency_through_full_lifecycle() {
+        // This test verifies that send.len() stays in sync with manual cache
+        // tracking through a full lifecycle: write → emit → retransmit → ack.
+        let mut stream = <Stream>::new(0, 15, 15, true, 0, 15);
+        let mut cache = 0usize;
+
+        // Write data: both len and cache increase.
+        assert_eq!(stream.send.write(b"hello", false), Ok(5));
+        cache += 5;
+        assert_eq!(stream.send.len(), 5);
+        assert_eq!(cache, 5);
+
+        // Emit data: both len and cache decrease.
+        let mut buf = [0; 10];
+        let (written, _) = stream.send.emit(&mut buf).unwrap();
+        assert_eq!(written, 5);
+        cache -= 5;
+        assert_eq!(stream.send.len(), 0);
+        assert_eq!(cache, 0);
+
+        // Retransmit: both len and cache increase by actual amount retransmitted.
+        let retransmitted = stream.send.retransmit(0, 5);
+        assert_eq!(retransmitted, 5);
+        cache += retransmitted;
+        assert_eq!(stream.send.len(), 5);
+        assert_eq!(cache, 5);
+
+        // Ack and drop: both len and cache decrease by actual amount dropped.
+        let dropped = stream.send.ack_and_drop(0, 5);
+        assert_eq!(dropped, 5);
+        cache -= dropped;
+        assert_eq!(stream.send.len(), 0);
+        assert_eq!(cache, 0);
+    }
+
+    #[test]
+    fn send_buf_len_reflects_buffered_data() {
+        let mut stream = <Stream>::new(0, 15, 15, true, 0, 15);
+
+        // Initially empty.
+        assert_eq!(stream.send.len(), 0);
+
+        // After write.
+        assert_eq!(stream.send.write(b"hello", false), Ok(5));
+        assert_eq!(stream.send.len(), 5);
+
+        // After emit.
+        let mut buf = [0; 10];
+        let (written, _) = stream.send.emit(&mut buf).unwrap();
+        assert_eq!(written, 5);
+        assert_eq!(stream.send.len(), 0);
+
+        // After retransmit.
+        let retransmitted = stream.send.retransmit(0, 5);
+        assert_eq!(retransmitted, 5);
+        assert_eq!(stream.send.len(), 5);
+
+        // After ack_and_drop.
+        let dropped = stream.send.ack_and_drop(0, 5);
+        assert_eq!(dropped, 5);
+        assert_eq!(stream.send.len(), 0);
     }
 }
 

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -733,7 +733,10 @@ impl<F: BufFactory> StreamMap<F> {
     /// all streams. This is used for debugging to verify that tx_buffered
     /// is accurate.
     fn tx_buffered_actual(&self) -> usize {
-        self.streams.values().map(|s| s.send.len() as usize).sum()
+        self.streams
+            .values()
+            .map(|s| s.send.buffered_bytes() as usize)
+            .sum()
     }
 
     /// Checks if the stored tx_buffered matches the actual value.
@@ -768,7 +771,7 @@ impl<F: BufFactory> StreamMap<F> {
             let buffered_per_stream = self
                 .streams
                 .iter()
-                .map(|(id, s)| (*id, s.send.len()))
+                .map(|(id, s)| (*id, s.send.buffered_bytes()))
                 .collect::<Vec<_>>();
 
             let actual = self.tx_buffered_actual();
@@ -2273,26 +2276,26 @@ mod tests {
 
         // Write and emit some data.
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
-        assert_eq!(stream.send.len(), 5);
+        assert_eq!(stream.send.buffered_bytes(), 5);
 
         let mut buf = [0; 10];
         let (written, _) = stream.send.emit(&mut buf).unwrap();
         assert_eq!(written, 5);
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
 
         // Mark data for retransmission.
         let retransmitted = stream.send.retransmit(0, 5);
         assert_eq!(retransmitted, 5);
-        assert_eq!(stream.send.len(), 5);
+        assert_eq!(stream.send.buffered_bytes(), 5);
 
         // Ack the data.
         stream.send.ack_and_drop(0, 5);
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
 
         // Try to retransmit again - should return 0 since data is acked.
         let retransmitted = stream.send.retransmit(0, 5);
         assert_eq!(retransmitted, 0);
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
     }
 
     #[test]
@@ -2301,28 +2304,28 @@ mod tests {
 
         // Write and emit 10 bytes.
         assert_eq!(stream.send.write(b"helloworld", false), Ok(10));
-        assert_eq!(stream.send.len(), 10);
+        assert_eq!(stream.send.buffered_bytes(), 10);
 
         let mut buf = [0; 10];
         let (written, _) = stream.send.emit(&mut buf).unwrap();
         assert_eq!(written, 10);
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
 
         // Mark all data for retransmission.
         let retransmitted = stream.send.retransmit(0, 10);
         assert_eq!(retransmitted, 10);
-        assert_eq!(stream.send.len(), 10);
+        assert_eq!(stream.send.buffered_bytes(), 10);
 
         // Ack first 5 bytes and drop them.
         let dropped = stream.send.ack_and_drop(0, 5);
         assert_eq!(dropped, 5);
-        assert_eq!(stream.send.len(), 5);
+        assert_eq!(stream.send.buffered_bytes(), 5);
 
         // Try to retransmit all 10 bytes - should return 5 since first 5 are
         // acked.
         let retransmitted = stream.send.retransmit(0, 10);
         assert_eq!(retransmitted, 0); // Already marked, so no change
-        assert_eq!(stream.send.len(), 5);
+        assert_eq!(stream.send.buffered_bytes(), 5);
     }
 
     #[test]
@@ -2331,23 +2334,23 @@ mod tests {
 
         // Write some data.
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
-        assert_eq!(stream.send.len(), 5);
+        assert_eq!(stream.send.buffered_bytes(), 5);
 
         // Emit it.
         let mut buf = [0; 10];
         let (written, _) = stream.send.emit(&mut buf).unwrap();
         assert_eq!(written, 5);
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
 
         // Mark for retransmission.
         let retransmitted = stream.send.retransmit(0, 5);
         assert_eq!(retransmitted, 5);
-        assert_eq!(stream.send.len(), 5);
+        assert_eq!(stream.send.buffered_bytes(), 5);
 
         // Ack and drop - should decrement len and return dropped amount.
         let dropped = stream.send.ack_and_drop(0, 5);
         assert_eq!(dropped, 5);
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
     }
 
     #[test]
@@ -2357,27 +2360,27 @@ mod tests {
         // Write and emit two chunks.
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
         assert_eq!(stream.send.write(b"world", false), Ok(5));
-        assert_eq!(stream.send.len(), 10);
+        assert_eq!(stream.send.buffered_bytes(), 10);
 
         let mut buf = [0; 10];
         let (written, _) = stream.send.emit(&mut buf).unwrap();
         assert_eq!(written, 10);
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
 
         // Mark both chunks for retransmission.
         let retransmitted = stream.send.retransmit(0, 10);
         assert_eq!(retransmitted, 10);
-        assert_eq!(stream.send.len(), 10);
+        assert_eq!(stream.send.buffered_bytes(), 10);
 
         // Ack and drop only first chunk.
         let dropped = stream.send.ack_and_drop(0, 5);
         assert_eq!(dropped, 5);
-        assert_eq!(stream.send.len(), 5);
+        assert_eq!(stream.send.buffered_bytes(), 5);
 
         // Ack and drop second chunk.
         let dropped = stream.send.ack_and_drop(5, 5);
         assert_eq!(dropped, 5);
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
     }
 
     #[test]
@@ -2394,7 +2397,7 @@ mod tests {
         // Nothing should be dropped since there's no buffered data.
         let dropped = stream.send.ack_and_drop(0, 5);
         assert_eq!(dropped, 0);
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
     }
 
     #[test]
@@ -2422,7 +2425,7 @@ mod tests {
 
         let stream_id = 0u64;
 
-        // Write data: both stream.send.len() and tx_buffered increase.
+        // Write data: both stream.send.buffered_bytes() and tx_buffered increase.
         {
             let stream = streams
                 .get_or_create(
@@ -2436,11 +2439,11 @@ mod tests {
             assert_eq!(stream.send.write(b"hello", false), Ok(5));
         }
         streams.add_tx_buffered(5);
-        assert_eq!(streams.get(stream_id).unwrap().send.len(), 5);
+        assert_eq!(streams.get(stream_id).unwrap().send.buffered_bytes(), 5);
         assert_eq!(streams.tx_buffered(), 5);
         assert!(streams.tx_buffered_is_consistent());
 
-        // Emit data: both stream.send.len() and tx_buffered decrease.
+        // Emit data: both stream.send.buffered_bytes() and tx_buffered decrease.
         let mut buf = [0; 10];
         let written = {
             let stream = streams.get_mut(stream_id).unwrap();
@@ -2449,31 +2452,31 @@ mod tests {
         };
         assert_eq!(written, 5);
         streams.sub_tx_buffered(5);
-        assert_eq!(streams.get(stream_id).unwrap().send.len(), 0);
+        assert_eq!(streams.get(stream_id).unwrap().send.buffered_bytes(), 0);
         assert_eq!(streams.tx_buffered(), 0);
         assert!(streams.tx_buffered_is_consistent());
 
-        // Retransmit: both stream.send.len() and tx_buffered increase by actual
-        // amount retransmitted.
+        // Retransmit: both stream.send.buffered_bytes() and tx_buffered increase
+        // by actual amount retransmitted.
         let retransmitted = {
             let stream = streams.get_mut(stream_id).unwrap();
             stream.send.retransmit(0, 5)
         };
         assert_eq!(retransmitted, 5);
         streams.add_tx_buffered(retransmitted);
-        assert_eq!(streams.get(stream_id).unwrap().send.len(), 5);
+        assert_eq!(streams.get(stream_id).unwrap().send.buffered_bytes(), 5);
         assert_eq!(streams.tx_buffered(), 5);
         assert!(streams.tx_buffered_is_consistent());
 
-        // Ack and drop: both stream.send.len() and tx_buffered decrease by
-        // actual amount dropped.
+        // Ack and drop: both stream.send.buffered_bytes() and tx_buffered
+        // decrease by actual amount dropped.
         let dropped = {
             let stream = streams.get_mut(stream_id).unwrap();
             stream.send.ack_and_drop(0, 5)
         };
         assert_eq!(dropped, 5);
         streams.sub_tx_buffered(dropped);
-        assert_eq!(streams.get(stream_id).unwrap().send.len(), 0);
+        assert_eq!(streams.get(stream_id).unwrap().send.buffered_bytes(), 0);
         assert_eq!(streams.tx_buffered(), 0);
         assert!(streams.tx_buffered_is_consistent());
     }
@@ -2483,27 +2486,27 @@ mod tests {
         let mut stream = <Stream>::new(0, 15, 15, true, 0, 15);
 
         // Initially empty.
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
 
         // After write.
         assert_eq!(stream.send.write(b"hello", false), Ok(5));
-        assert_eq!(stream.send.len(), 5);
+        assert_eq!(stream.send.buffered_bytes(), 5);
 
         // After emit.
         let mut buf = [0; 10];
         let (written, _) = stream.send.emit(&mut buf).unwrap();
         assert_eq!(written, 5);
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
 
         // After retransmit.
         let retransmitted = stream.send.retransmit(0, 5);
         assert_eq!(retransmitted, 5);
-        assert_eq!(stream.send.len(), 5);
+        assert_eq!(stream.send.buffered_bytes(), 5);
 
         // After ack_and_drop.
         let dropped = stream.send.ack_and_drop(0, 5);
         assert_eq!(dropped, 5);
-        assert_eq!(stream.send.len(), 0);
+        assert_eq!(stream.send.buffered_bytes(), 0);
     }
 }
 

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -203,8 +203,8 @@ pub struct StreamMap<F: BufFactory = DefaultBufFactory> {
     /// `max_rx_data`, if false, it will be set to `DEFAULT_STREAM_WINDOW`
     use_initial_max_data_as_flow_control_win: bool,
 
-    /// Cached total number of bytes buffered across all streams.
-    tx_buffered_cache: usize,
+    /// Total number of bytes in send buffers across all streams.
+    tx_buffered: usize,
 }
 
 impl<F: BufFactory> StreamMap<F> {
@@ -726,65 +726,61 @@ impl<F: BufFactory> StreamMap<F> {
 
     /// Returns the total number of bytes buffered across all streams.
     pub(crate) fn tx_buffered(&self) -> usize {
-        self.tx_buffered_cache
+        self.tx_buffered
     }
 
-    /// Computes the actual tx_buffered by summing across all streams.
-    /// This is used for debugging to verify the cache is accurate.
-    #[cfg(debug_assertions)]
+    /// Computes the actual number of bytes in send buffers by summing across
+    /// all streams. This is used for debugging to verify that tx_buffered
+    /// is accurate.
     fn tx_buffered_actual(&self) -> usize {
         self.streams.values().map(|s| s.send.len() as usize).sum()
     }
 
-    /// Checks if the cached tx_buffered matches the actual value.
+    /// Checks if the stored tx_buffered matches the actual value.
     /// Returns true if they match, false otherwise.
     pub(crate) fn tx_buffered_is_consistent(&self) -> bool {
-        let actual: usize =
-            self.streams.values().map(|s| s.send.len() as usize).sum();
-        self.tx_buffered_cache == actual
+        self.tx_buffered == self.tx_buffered_actual()
     }
 
-    /// Updates the cached tx_buffered value by adding the delta.
+    /// Updates the tx_buffered value by adding the delta.
     pub(crate) fn add_tx_buffered(&mut self, delta: usize) {
-        self.tx_buffered_cache += delta;
-        self.check_tx_buffered_cache();
+        self.tx_buffered += delta;
+
+        #[cfg(debug_assertions)]
+        self.debug_check_tx_buffered_consistency();
     }
 
-    /// Updates the cached tx_buffered value by subtracting the delta.
+    /// Updates the tx_buffered value by subtracting the delta.
     pub(crate) fn sub_tx_buffered(&mut self, delta: usize) {
-        debug_assert!(self.tx_buffered_cache >= delta);
-        self.tx_buffered_cache = self.tx_buffered_cache.saturating_sub(delta);
-        self.check_tx_buffered_cache();
+        debug_assert!(self.tx_buffered >= delta);
+        self.tx_buffered = self.tx_buffered.saturating_sub(delta);
+
+        #[cfg(debug_assertions)]
+        self.debug_check_tx_buffered_consistency();
     }
 
-    /// Verifies that the cached tx_buffered matches the actual value.
-    /// Enabled in debug builds to catch cache inconsistencies early.
+    /// Verifies that the stored tx_buffered value matches the actual bytes in
+    /// send buffers across all streams. Enabled in debug builds to catch
+    /// inconsistencies early.
     #[cfg(debug_assertions)]
-    pub(crate) fn check_tx_buffered_cache(&self) {
-        let actual = self.tx_buffered_actual();
-        let cached = self.tx_buffered_cache;
-        if actual != cached {
-            // Print per-stream details to help debug
-            eprintln!("Stream buffer details:");
-            for (id, stream) in &self.streams {
-                let len = stream.send.len();
-                if len > 0 {
-                    eprintln!("  Stream {}: {} bytes", id, len);
-                }
-            }
+    pub(crate) fn debug_check_tx_buffered_consistency(&self) {
+        if !self.tx_buffered_is_consistent() {
+            let buffered_per_stream = self
+                .streams
+                .iter()
+                .map(|(id, s)| (*id, s.send.len()))
+                .collect::<Vec<_>>();
+
+            let actual = self.tx_buffered_actual();
+            let stored = self.tx_buffered;
             panic!(
-                "tx_buffered cache mismatch: cached={}, actual={}, diff={}",
-                cached,
+                "tx_buffered mismatch: stored={}, actual={}, diff={}, buffered_per_stream={:?}",
+                stored,
                 actual,
-                cached as i64 - actual as i64
+                stored as i64 - actual as i64,
+                buffered_per_stream
             );
         }
-    }
-
-    /// No-op in release builds for performance.
-    #[cfg(not(debug_assertions))]
-    pub(crate) fn check_tx_buffered_cache(&self) {
-        // No-op in release builds
     }
 
     /// When `true`, the initial flow control window will be set to the
@@ -2403,38 +2399,83 @@ mod tests {
 
     #[test]
     fn cache_consistency_through_full_lifecycle() {
-        // This test verifies that send.len() stays in sync with manual cache
-        // tracking through a full lifecycle: write → emit → retransmit → ack.
-        let mut stream = <Stream>::new(0, 15, 15, true, 0, 15);
-        let mut cache = 0usize;
+        // This test verifies that StreamMap.tx_buffered stays in sync with
+        // actual buffered data through a full lifecycle: write → emit →
+        // retransmit → ack.
+        let mut streams = <StreamMap>::new(5, 5, 15);
 
-        // Write data: both len and cache increase.
-        assert_eq!(stream.send.write(b"hello", false), Ok(5));
-        cache += 5;
-        assert_eq!(stream.send.len(), 5);
-        assert_eq!(cache, 5);
+        // Create a stream using low-level StreamMap interface.
+        let local_params = crate::TransportParams {
+            initial_max_data: 30,
+            initial_max_stream_data_bidi_local: 15,
+            initial_max_stream_data_bidi_remote: 15,
+            initial_max_stream_data_uni: 10,
+            initial_max_streams_bidi: 5,
+            initial_max_streams_uni: 5,
+            ..Default::default()
+        };
+        let peer_params = local_params.clone();
 
-        // Emit data: both len and cache decrease.
+        // Update peer stream limits to allow locally-initiated streams.
+        streams.update_peer_max_streams_bidi(5);
+        streams.update_peer_max_streams_uni(5);
+
+        let stream_id = 0u64;
+
+        // Write data: both stream.send.len() and tx_buffered increase.
+        {
+            let stream = streams
+                .get_or_create(
+                    stream_id,
+                    &local_params,
+                    &peer_params,
+                    true,
+                    false,
+                )
+                .unwrap();
+            assert_eq!(stream.send.write(b"hello", false), Ok(5));
+        }
+        streams.add_tx_buffered(5);
+        assert_eq!(streams.get(stream_id).unwrap().send.len(), 5);
+        assert_eq!(streams.tx_buffered(), 5);
+        assert!(streams.tx_buffered_is_consistent());
+
+        // Emit data: both stream.send.len() and tx_buffered decrease.
         let mut buf = [0; 10];
-        let (written, _) = stream.send.emit(&mut buf).unwrap();
+        let written = {
+            let stream = streams.get_mut(stream_id).unwrap();
+            let (written, _) = stream.send.emit(&mut buf).unwrap();
+            written
+        };
         assert_eq!(written, 5);
-        cache -= 5;
-        assert_eq!(stream.send.len(), 0);
-        assert_eq!(cache, 0);
+        streams.sub_tx_buffered(5);
+        assert_eq!(streams.get(stream_id).unwrap().send.len(), 0);
+        assert_eq!(streams.tx_buffered(), 0);
+        assert!(streams.tx_buffered_is_consistent());
 
-        // Retransmit: both len and cache increase by actual amount retransmitted.
-        let retransmitted = stream.send.retransmit(0, 5);
+        // Retransmit: both stream.send.len() and tx_buffered increase by actual
+        // amount retransmitted.
+        let retransmitted = {
+            let stream = streams.get_mut(stream_id).unwrap();
+            stream.send.retransmit(0, 5)
+        };
         assert_eq!(retransmitted, 5);
-        cache += retransmitted;
-        assert_eq!(stream.send.len(), 5);
-        assert_eq!(cache, 5);
+        streams.add_tx_buffered(retransmitted);
+        assert_eq!(streams.get(stream_id).unwrap().send.len(), 5);
+        assert_eq!(streams.tx_buffered(), 5);
+        assert!(streams.tx_buffered_is_consistent());
 
-        // Ack and drop: both len and cache decrease by actual amount dropped.
-        let dropped = stream.send.ack_and_drop(0, 5);
+        // Ack and drop: both stream.send.len() and tx_buffered decrease by
+        // actual amount dropped.
+        let dropped = {
+            let stream = streams.get_mut(stream_id).unwrap();
+            stream.send.ack_and_drop(0, 5)
+        };
         assert_eq!(dropped, 5);
-        cache -= dropped;
-        assert_eq!(stream.send.len(), 0);
-        assert_eq!(cache, 0);
+        streams.sub_tx_buffered(dropped);
+        assert_eq!(streams.get(stream_id).unwrap().send.len(), 0);
+        assert_eq!(streams.tx_buffered(), 0);
+        assert!(streams.tx_buffered_is_consistent());
     }
 
     #[test]

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -736,6 +736,14 @@ impl<F: BufFactory> StreamMap<F> {
         self.streams.values().map(|s| s.send.len() as usize).sum()
     }
 
+    /// Checks if the cached tx_buffered matches the actual value.
+    /// Returns true if they match, false otherwise.
+    pub(crate) fn tx_buffered_is_consistent(&self) -> bool {
+        let actual: usize =
+            self.streams.values().map(|s| s.send.len() as usize).sum();
+        self.tx_buffered_cache == actual
+    }
+
     /// Updates the cached tx_buffered value by adding the delta.
     pub(crate) fn add_tx_buffered(&mut self, delta: usize) {
         self.tx_buffered_cache += delta;

--- a/quiche/src/stream/send_buf.rs
+++ b/quiche/src/stream/send_buf.rs
@@ -320,17 +320,17 @@ impl<F: BufFactory> SendBuf<F> {
         self.acked.insert(off..off + len as u64);
     }
 
-    pub fn ack_and_drop(&mut self, off: u64, len: usize) {
+    pub fn ack_and_drop(&mut self, off: u64, len: usize) -> usize {
         self.ack(off, len);
 
         let ack_off = self.ack_off();
 
         if self.data.is_empty() {
-            return;
+            return 0;
         }
 
         if off > ack_off {
-            return;
+            return 0;
         }
 
         let mut drop_until = None;
@@ -354,26 +354,38 @@ impl<F: BufFactory> SendBuf<F> {
         }
 
         if let Some(drop) = drop_until {
+            // Calculate the total length of buffers being dropped and subtract
+            // from len.
+            let dropped_len: u64 =
+                (0..=drop).map(|i| self.data[i].len() as u64).sum();
+            self.len = self.len.saturating_sub(dropped_len);
+
             self.data.drain(..=drop);
 
             // When a buffer is marked for retransmission, but then acked before
             // it could be retransmitted, we might end up decreasing the SendBuf
             // position too much, so make sure that doesn't happen.
             self.pos = self.pos.saturating_sub(drop + 1);
+
+            dropped_len as usize
+        } else {
+            0
         }
     }
 
-    pub fn retransmit(&mut self, off: u64, len: usize) {
+    pub fn retransmit(&mut self, off: u64, len: usize) -> usize {
         let max_off = off + len as u64;
         let ack_off = self.ack_off();
 
         if self.data.is_empty() {
-            return;
+            return 0;
         }
 
         if max_off <= ack_off {
-            return;
+            return 0;
         }
+
+        let mut total_retransmitted = 0;
 
         for i in 0..self.data.len() {
             let buf = &mut self.data[i];
@@ -406,12 +418,16 @@ impl<F: BufFactory> SendBuf<F> {
 
             self.pos = cmp::min(self.pos, i);
 
-            self.len += (prev_pos - buf.pos) as u64;
+            let retransmitted = (prev_pos - buf.pos) as u64;
+            self.len += retransmitted;
+            total_retransmitted += retransmitted;
 
             if let Some(b) = new_buf {
                 self.data.insert(i + 1, b);
             }
         }
+
+        total_retransmitted as usize
     }
 
     /// Resets the stream at the current offset and clears all buffered data.
@@ -552,6 +568,11 @@ impl<F: BufFactory> SendBuf<F> {
     #[allow(dead_code)]
     pub fn bufs_count(&self) -> usize {
         self.data.len()
+    }
+
+    /// Returns the number of bytes currently buffered.
+    pub fn len(&self) -> u64 {
+        self.len
     }
 }
 

--- a/quiche/src/stream/send_buf.rs
+++ b/quiche/src/stream/send_buf.rs
@@ -66,7 +66,7 @@ impl<F: BufFactory> SendReserve<'_, F> {
         inner.data.push_back(buf);
 
         inner.off += len as u64;
-        inner.len += len as u64;
+        inner.buffered_bytes += len as u64;
         self.reserved -= len;
 
         Ok(())
@@ -106,8 +106,12 @@ where
     /// retransmissions.
     emit_off: u64,
 
-    /// The amount of data currently buffered.
-    len: u64,
+    /// The number of bytes buffered and ready to be emitted to the peer.
+    ///
+    /// This includes fresh data that has not yet been sent, as well as data
+    /// marked for retransmission. It excludes data that has been emitted but
+    /// not yet acknowledged (in-flight data).
+    buffered_bytes: u64,
 
     /// The maximum offset we are allowed to send to the peer.
     max_data: u64,
@@ -269,7 +273,7 @@ impl<F: BufFactory> SendBuf<F> {
             let out_pos = (next_off - out_off) as usize;
             out[out_pos..out_pos + buf_len].copy_from_slice(&buf[..buf_len]);
 
-            self.len -= buf_len as u64;
+            self.buffered_bytes -= buf_len as u64;
 
             out_len -= buf_len;
 
@@ -355,10 +359,10 @@ impl<F: BufFactory> SendBuf<F> {
 
         if let Some(drop) = drop_until {
             // Calculate the total length of buffers being dropped and subtract
-            // from len.
+            // from buffered_bytes.
             let dropped_len: u64 =
                 (0..=drop).map(|i| self.data[i].len() as u64).sum();
-            self.len = self.len.saturating_sub(dropped_len);
+            self.buffered_bytes = self.buffered_bytes.saturating_sub(dropped_len);
 
             self.data.drain(..=drop);
 
@@ -419,7 +423,7 @@ impl<F: BufFactory> SendBuf<F> {
             self.pos = cmp::min(self.pos, i);
 
             let retransmitted = (prev_pos - buf.pos) as u64;
-            self.len += retransmitted;
+            self.buffered_bytes += retransmitted;
             total_retransmitted += retransmitted;
 
             if let Some(b) = new_buf {
@@ -445,7 +449,7 @@ impl<F: BufFactory> SendBuf<F> {
         self.ack(0, self.off as usize);
 
         self.pos = 0;
-        self.len = 0;
+        self.buffered_bytes = 0;
 
         (self.emit_off, unsent_len)
     }
@@ -570,9 +574,13 @@ impl<F: BufFactory> SendBuf<F> {
         self.data.len()
     }
 
-    /// Returns the number of bytes currently buffered.
-    pub fn len(&self) -> u64 {
-        self.len
+    /// Returns the number of bytes ready to be emitted to the peer.
+    ///
+    /// This includes fresh data that has not yet been sent, as well as data
+    /// marked for retransmission. It excludes data that has been emitted but
+    /// not yet acknowledged (in-flight data).
+    pub fn buffered_bytes(&self) -> u64 {
+        self.buffered_bytes
     }
 }
 
@@ -585,7 +593,7 @@ mod tests {
         let mut buf = [0; 5];
 
         let mut send = <SendBuf>::new(u64::MAX);
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
 
         let (written, fin) = send.emit(&mut buf).unwrap();
         assert_eq!(written, 0);
@@ -597,22 +605,22 @@ mod tests {
         let mut buf = [0; 128];
 
         let mut send = <SendBuf>::new(u64::MAX);
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
 
         let first = b"something";
         let second = b"helloworld";
 
         assert!(send.write(first, false).is_ok());
-        assert_eq!(send.len, 9);
+        assert_eq!(send.buffered_bytes, 9);
 
         assert!(send.write(second, true).is_ok());
-        assert_eq!(send.len, 19);
+        assert_eq!(send.buffered_bytes, 19);
 
         let (written, fin) = send.emit(&mut buf[..128]).unwrap();
         assert_eq!(written, 19);
         assert!(fin);
         assert_eq!(&buf[..written], b"somethinghelloworld");
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
     }
 
     #[test]
@@ -620,16 +628,16 @@ mod tests {
         let mut buf = [0; 10];
 
         let mut send = <SendBuf>::new(u64::MAX);
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
 
         let first = b"something";
         let second = b"helloworld";
 
         assert!(send.write(first, false).is_ok());
-        assert_eq!(send.len, 9);
+        assert_eq!(send.buffered_bytes, 9);
 
         assert!(send.write(second, true).is_ok());
-        assert_eq!(send.len, 19);
+        assert_eq!(send.buffered_bytes, 19);
 
         assert_eq!(send.off_front(), 0);
 
@@ -637,7 +645,7 @@ mod tests {
         assert_eq!(written, 10);
         assert!(!fin);
         assert_eq!(&buf[..written], b"somethingh");
-        assert_eq!(send.len, 9);
+        assert_eq!(send.buffered_bytes, 9);
 
         assert_eq!(send.off_front(), 10);
 
@@ -645,7 +653,7 @@ mod tests {
         assert_eq!(written, 5);
         assert!(!fin);
         assert_eq!(&buf[..written], b"ellow");
-        assert_eq!(send.len, 4);
+        assert_eq!(send.buffered_bytes, 4);
 
         assert_eq!(send.off_front(), 15);
 
@@ -653,7 +661,7 @@ mod tests {
         assert_eq!(written, 4);
         assert!(fin);
         assert_eq!(&buf[..written], b"orld");
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
 
         assert_eq!(send.off_front(), 19);
     }
@@ -663,7 +671,7 @@ mod tests {
         let mut buf = [0; 15];
 
         let mut send = <SendBuf>::new(u64::MAX);
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
         assert_eq!(send.off_front(), 0);
 
         let first = b"something";
@@ -675,49 +683,49 @@ mod tests {
         assert!(send.write(second, true).is_ok());
         assert_eq!(send.off_front(), 0);
 
-        assert_eq!(send.len, 19);
+        assert_eq!(send.buffered_bytes, 19);
 
         let (written, fin) = send.emit(&mut buf[..4]).unwrap();
         assert_eq!(written, 4);
         assert!(!fin);
         assert_eq!(&buf[..written], b"some");
-        assert_eq!(send.len, 15);
+        assert_eq!(send.buffered_bytes, 15);
         assert_eq!(send.off_front(), 4);
 
         let (written, fin) = send.emit(&mut buf[..5]).unwrap();
         assert_eq!(written, 5);
         assert!(!fin);
         assert_eq!(&buf[..written], b"thing");
-        assert_eq!(send.len, 10);
+        assert_eq!(send.buffered_bytes, 10);
         assert_eq!(send.off_front(), 9);
 
         let (written, fin) = send.emit(&mut buf[..5]).unwrap();
         assert_eq!(written, 5);
         assert!(!fin);
         assert_eq!(&buf[..written], b"hello");
-        assert_eq!(send.len, 5);
+        assert_eq!(send.buffered_bytes, 5);
         assert_eq!(send.off_front(), 14);
 
         send.retransmit(4, 5);
-        assert_eq!(send.len, 10);
+        assert_eq!(send.buffered_bytes, 10);
         assert_eq!(send.off_front(), 4);
 
         send.retransmit(0, 4);
-        assert_eq!(send.len, 14);
+        assert_eq!(send.buffered_bytes, 14);
         assert_eq!(send.off_front(), 0);
 
         let (written, fin) = send.emit(&mut buf[..11]).unwrap();
         assert_eq!(written, 9);
         assert!(!fin);
         assert_eq!(&buf[..written], b"something");
-        assert_eq!(send.len, 5);
+        assert_eq!(send.buffered_bytes, 5);
         assert_eq!(send.off_front(), 14);
 
         let (written, fin) = send.emit(&mut buf[..11]).unwrap();
         assert_eq!(written, 5);
         assert!(fin);
         assert_eq!(&buf[..written], b"world");
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
         assert_eq!(send.off_front(), 19);
     }
 
@@ -726,24 +734,24 @@ mod tests {
         let mut buf = [0; 10];
 
         let mut send = <SendBuf>::default();
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
 
         let first = b"something";
         let second = b"helloworld";
 
         assert_eq!(send.write(first, false), Ok(0));
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
 
         assert_eq!(send.write(second, true), Ok(0));
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
 
         send.update_max_data(5);
 
         assert_eq!(send.write(first, false), Ok(5));
-        assert_eq!(send.len, 5);
+        assert_eq!(send.buffered_bytes, 5);
 
         assert_eq!(send.write(second, true), Ok(0));
-        assert_eq!(send.len, 5);
+        assert_eq!(send.buffered_bytes, 5);
 
         assert_eq!(send.off_front(), 0);
 
@@ -751,7 +759,7 @@ mod tests {
         assert_eq!(written, 5);
         assert!(!fin);
         assert_eq!(&buf[..written], b"somet");
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
 
         assert_eq!(send.off_front(), 5);
 
@@ -759,15 +767,15 @@ mod tests {
         assert_eq!(written, 0);
         assert!(!fin);
         assert_eq!(&buf[..written], b"");
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
 
         send.update_max_data(15);
 
         assert_eq!(send.write(&first[5..], false), Ok(4));
-        assert_eq!(send.len, 4);
+        assert_eq!(send.buffered_bytes, 4);
 
         assert_eq!(send.write(second, true), Ok(6));
-        assert_eq!(send.len, 10);
+        assert_eq!(send.buffered_bytes, 10);
 
         assert_eq!(send.off_front(), 5);
 
@@ -775,12 +783,12 @@ mod tests {
         assert_eq!(written, 10);
         assert!(!fin);
         assert_eq!(&buf[..10], b"hinghellow");
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
 
         send.update_max_data(25);
 
         assert_eq!(send.write(&second[6..], true), Ok(4));
-        assert_eq!(send.len, 4);
+        assert_eq!(send.buffered_bytes, 4);
 
         assert_eq!(send.off_front(), 15);
 
@@ -788,7 +796,7 @@ mod tests {
         assert_eq!(written, 4);
         assert!(fin);
         assert_eq!(&buf[..written], b"orld");
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
     }
 
     #[test]
@@ -796,15 +804,15 @@ mod tests {
         let mut buf = [0; 10];
 
         let mut send = <SendBuf>::new(u64::MAX);
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
 
         let first = b"something";
 
         assert!(send.write(first, false).is_ok());
-        assert_eq!(send.len, 9);
+        assert_eq!(send.buffered_bytes, 9);
 
         assert!(send.write(&[], true).is_ok());
-        assert_eq!(send.len, 9);
+        assert_eq!(send.buffered_bytes, 9);
 
         assert_eq!(send.off_front(), 0);
 
@@ -812,7 +820,7 @@ mod tests {
         assert_eq!(written, 9);
         assert!(fin);
         assert_eq!(&buf[..written], b"something");
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
     }
 
     /// Check SendBuf::len calculation on a retransmit case
@@ -821,7 +829,7 @@ mod tests {
         let mut buf = [0; 15];
 
         let mut send = <SendBuf>::new(u64::MAX);
-        assert_eq!(send.len, 0);
+        assert_eq!(send.buffered_bytes, 0);
         assert_eq!(send.off_front(), 0);
 
         let first = b"something";
@@ -829,17 +837,17 @@ mod tests {
         assert!(send.write(first, false).is_ok());
         assert_eq!(send.off_front(), 0);
 
-        assert_eq!(send.len, 9);
+        assert_eq!(send.buffered_bytes, 9);
 
         let (written, fin) = send.emit(&mut buf[..4]).unwrap();
         assert_eq!(written, 4);
         assert!(!fin);
         assert_eq!(&buf[..written], b"some");
-        assert_eq!(send.len, 5);
+        assert_eq!(send.buffered_bytes, 5);
         assert_eq!(send.off_front(), 4);
 
         send.retransmit(3, 5);
-        assert_eq!(send.len, 6);
+        assert_eq!(send.buffered_bytes, 6);
         assert_eq!(send.off_front(), 3);
     }
 

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -7830,6 +7830,78 @@ fn early_retransmit(
 }
 
 #[rstest]
+/// Tests that sub_tx_buffered() is called when data marked for retransmission
+/// is acknowledged before being fully re-emitted.
+///
+/// Send 11KB, trigger PTO timeout, call send() which marks data for retransmit
+/// but can't emit it all due to cwnd limits. Then deliver the original packets
+/// and process ACKs. The ack_and_drop() for data still in the retransmit buffer
+/// must call sub_tx_buffered() to maintain correct accounting.
+fn retransmit_data_acked_before_fully_retransmitted(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut buf = [0; 65535];
+
+    let mut config = test_utils::Pipe::default_config(cc_algorithm_name).unwrap();
+    config.set_initial_max_data(100000);
+    config.set_initial_max_stream_data_bidi_local(100000);
+    config.set_initial_max_stream_data_bidi_remote(100000);
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // Establish stream.
+    assert_eq!(pipe.client.stream_send(0, b"init", false), Ok(4));
+    assert_eq!(pipe.advance(), Ok(()));
+
+    // Send 11KB.
+    let data_size = 11000;
+    let large_data = vec![0xAB; data_size];
+    assert_eq!(
+        pipe.client.stream_send(0, &large_data, false),
+        Ok(data_size)
+    );
+
+    // Emit but don't deliver (simulating loss).
+    let flight = test_utils::emit_flight(&mut pipe.client).unwrap();
+    assert_eq!(pipe.client.streams.tx_buffered(), 0);
+
+    // Trigger PTO timeout.
+    let timer = pipe.client.timeout().unwrap();
+    std::thread::sleep(timer + Duration::from_millis(1));
+    pipe.client.on_timeout();
+
+    // Send PTO probe. retransmit() adds data to tx_buffered, but PTO cwnd
+    // limits prevent emitting all of it.
+    pipe.client.send(&mut buf).unwrap();
+
+    assert!(
+        pipe.client.streams.tx_buffered() > 0,
+        "Expected data in tx_buffered after retransmit"
+    );
+
+    // Deliver original packets (delayed arrival).
+    let server_path = &pipe.server.paths.get_active().unwrap();
+    let server_info = RecvInfo {
+        to: server_path.local_addr(),
+        from: server_path.peer_addr(),
+    };
+    for (pkt, _) in &flight {
+        let mut pkt_mut = pkt.clone();
+        pipe.server.recv(&mut pkt_mut, server_info).unwrap();
+    }
+
+    // Process ACKs. ack_and_drop() returns non-zero for data in retransmit
+    // buffer and sub_tx_buffered() must be called.
+    pipe.advance().ok();
+
+    assert_eq!(
+        pipe.client.streams.tx_buffered(),
+        0,
+        "tx_buffered should be 0 after ACK"
+    );
+}
+
+#[rstest]
 /// Tests that MAX_DATA, STREAM_MAX_DATA frames are retransmitted if lost
 fn max_data_frames_retransmit(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -6488,12 +6488,12 @@ fn client_rst_stream_while_bytes_in_flight(
         _ => 24000,
     };
 
-    assert_eq!(pipe.server.tx_buffered, 0);
+    assert_eq!(pipe.server.streams.tx_buffered(), 0);
     assert_eq!(
         pipe.server.stream_send(8, &send_buf, false),
         Ok(expected_cwnd)
     );
-    assert_eq!(pipe.server.tx_buffered, expected_cwnd);
+    assert_eq!(pipe.server.streams.tx_buffered(), expected_cwnd);
     assert_eq!(
         pipe.server
             .paths
@@ -6577,7 +6577,7 @@ fn client_rst_stream_while_bytes_in_flight_with_packet_loss(
         _ => 8400,
     };
 
-    assert_eq!(pipe.server.tx_buffered, 0);
+    assert_eq!(pipe.server.streams.tx_buffered(), 0);
 
     let send_result = pipe.server.stream_send(8, &send_buf, false).unwrap();
     if cc_algorithm_name != "cubic" {
@@ -6587,7 +6587,7 @@ fn client_rst_stream_while_bytes_in_flight_with_packet_loss(
         // lost packet.  The exact send size varies.
         assert!((15000..17000).contains(&send_result));
     }
-    assert_eq!(pipe.server.tx_buffered, send_result);
+    assert_eq!(pipe.server.streams.tx_buffered(), send_result);
     assert_eq!(
         pipe.server
             .paths

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -6504,7 +6504,6 @@ fn client_rst_stream_while_bytes_in_flight(
         expected_cwnd
     );
     assert_eq!(pipe.advance(), Ok(()));
-    assert_eq!(pipe.server.tx_buffered_state, TxBufferTrackingState::Ok);
 }
 
 #[rstest]
@@ -6598,7 +6597,6 @@ fn client_rst_stream_while_bytes_in_flight_with_packet_loss(
         expected_cwnd
     );
     assert_eq!(pipe.advance(), Ok(()));
-    assert_eq!(pipe.server.tx_buffered_state, TxBufferTrackingState::Ok);
 }
 
 #[rstest]


### PR DESCRIPTION
We found that the cached tx_buffered in the connection drifts from the actual sum of stream send buffers when taking retransmissions and stream cancellations into account.  Also, this cached value was not properly updated as bytes were send, so the stored value was closer to the sum(send buffers) plus inflight.

The new tx_buffered holds the cached number of bytes in send buffers so it can be be compared with cwnd_available when determining if Reno and CUBIC congestion controllers are app-limited.