### PR TITLE
qlog-dancer: add support for compressed sqlog inputs

### DIFF
--- a/qlog-dancer/Cargo.toml
+++ b/qlog-dancer/Cargo.toml
@@ -18,7 +18,7 @@ js-sys = "0.3"
 log = { workspace = true }
 netlog = { workspace = true }
 plotters = "0.3.4"
-qlog = { workspace = true }
+qlog = { workspace = true, features = ["gzip", "zstd"] }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/qlog-dancer/src/config.rs
+++ b/qlog-dancer/src/config.rs
@@ -364,12 +364,7 @@ impl AppConfig {
 
         let ignore_acks = false;
 
-        let qlog_ext = std::path::Path::new(&file)
-            .extension()
-            .unwrap()
-            .to_str()
-            .unwrap();
-        let log_format = SerializationFormat::from_file_extension(qlog_ext);
+        let log_format = SerializationFormat::from_filename(&file);
 
         let config = Self {
             file: file.to_string(),

--- a/qlog-dancer/src/lib.rs
+++ b/qlog-dancer/src/lib.rs
@@ -121,10 +121,28 @@ impl SerializationFormat {
     pub fn from_file_extension(extension: &str) -> Self {
         match extension {
             "qlog" => SerializationFormat::QlogJson,
-            "sqlog" => SerializationFormat::QlogJsonSeq,
+            "sqlog" | "gz" | "zst" => SerializationFormat::QlogJsonSeq,
             "json" => Self::NetlogJson,
             _ => SerializationFormat::Unknown,
         }
+    }
+
+    pub fn from_filename(filename: &str) -> Self {
+        // Check for compound extensions first (order matters!)
+        if filename.ends_with(".sqlog.gz") || filename.ends_with(".sqlog.zst") {
+            return SerializationFormat::QlogJsonSeq;
+        }
+        if filename.ends_with(".sqlog") {
+            return SerializationFormat::QlogJsonSeq;
+        }
+        if filename.ends_with(".qlog") {
+            return SerializationFormat::QlogJson;
+        }
+        // Fall back to extension-based detection
+        if let Some(ext) = filename.rsplit('.').next() {
+            return Self::from_file_extension(ext);
+        }
+        SerializationFormat::Unknown
     }
 }
 
@@ -295,13 +313,11 @@ pub fn read_qlog_from_file<P: AsRef<Path>>(
 
 pub fn qlog_seq_reader(
     config: &AppConfig,
-) -> Result<(QlogSeqReader<'_>, LogFileDetails), Box<dyn Error>> {
-    let file = std::fs::File::open(config.file.clone())?;
-    let reader = BufReader::new(file);
-
-    let qlog_reader = QlogSeqReader::new(Box::new(reader)).map_err(|e| {
-        std::io::Error::other(format!("problem reading file! {}", e))
-    })?;
+) -> Result<(QlogSeqReader<'static>, LogFileDetails), Box<dyn Error>> {
+    let qlog_reader =
+        QlogSeqReader::with_file(config.file.clone()).map_err(|e| {
+            std::io::Error::other(format!("problem reading file! {}", e))
+        })?;
 
     let vp = qlog_reader
         .qlog

--- a/qlog-dancer/src/main.rs
+++ b/qlog-dancer/src/main.rs
@@ -75,17 +75,17 @@ fn run() -> i32 {
     let mut log_file = match parse_log_file(&config) {
         Ok(v) => v,
 
-        Err(_) => {
+        Err(e) => {
             // Failed, so try a fallback once
             match config.log_format {
                 SerializationFormat::QlogJson => {
-                    warn!("Failed to parse as qlog, trying sqlog");
+                    warn!("Failed to parse as qlog: {}, trying sqlog", e);
                     config.log_format = SerializationFormat::QlogJsonSeq;
                     parse_log_file(&config).unwrap()
                 },
 
                 SerializationFormat::QlogJsonSeq => {
-                    warn!("Failed to parse as sqlog, trying qlog");
+                    warn!("Failed to parse as sqlog: {}, trying qlog", e);
                     config.log_format = SerializationFormat::QlogJson;
                     parse_log_file(&config).unwrap()
                 },


### PR DESCRIPTION
Adds support for `.sqlog.gz` and `.sqlog.zst` formats