### PR TITLE
ffi: fix dangling pointer in quiche_connection_id_iter_next

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -495,7 +495,8 @@ typedef struct quiche_connection_id_iter quiche_connection_id_iter;
 quiche_connection_id_iter *quiche_conn_source_ids(quiche_conn *conn);
 
 // Fetches the next id from the given iterator. Returns false if there are
-// no more elements in the iterator.
+// no more elements in the iterator. `out` stays valid until the iterator
+// is freed.
 bool quiche_connection_id_iter_next(quiche_connection_id_iter *iter,  const uint8_t **out, size_t *out_len);
 
 // Frees the given path iterator object.

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1154,7 +1154,10 @@ pub extern "C" fn quiche_conn_source_ids(
 pub extern "C" fn quiche_connection_id_iter_next(
     iter: &mut ConnectionIdIter, out: &mut *const u8, out_len: &mut size_t,
 ) -> bool {
-    if let Some(conn_id) = iter.next() {
+    // Don't use `Iterator::next()` here: it returns a clone that is dropped
+    // before this function returns, leaving `out` dangling.
+    if let Some(conn_id) = iter.cids.get(iter.index) {
+        iter.index += 1;
         let id = conn_id.as_ref();
         *out = id.as_ptr();
         *out_len = id.len();


### PR DESCRIPTION
`quiche_connection_id_iter_next()` sets `*out` to a pointer into the `ConnectionId` clone returned by `Iterator::next()`, which is dropped before the function returns — so C callers read freed memory.

Borrow from the iterator's own storage instead; the pointer then stays valid until `quiche_connection_id_iter_free()`, and the header documents that lifetime.

Part of #2509. `quiche_conn_retired_scid_next` has the same problem, but the popped id has no owner to borrow from, so fixing it needs an API decision — left out of this PR.