### PR TITLE
opencode: add draft release skill

### DIFF
--- a/.opencode/skills/quiche-draft-release/SKILL.md
+++ b/.opencode/skills/quiche-draft-release/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: quiche-draft-release
+description: quiche draft GitHub release automation from a release commit hash or existing tag. Use when creating draft releases for the quiche crate from a quiche/Cargo.toml version bump.
+---
+
+# quiche Draft Release
+
+Use this skill when the user asks to create a GitHub draft release for the
+`quiche` crate and provides, or should provide, either the commit hash that
+bumped `quiche/Cargo.toml` or an existing release tag pointing at that commit.
+
+Do not require a pre-existing tag. quiche release tags are created after the
+release PR is merged, because GitHub does not support fast-forward PR merges.
+Use the release commit hash as the source of truth when the tag does not exist
+yet, and let `gh release create` target that commit. If the release tag already
+exists, the user may provide either the tag or the commit hash.
+
+## Inputs
+
+- Required: a release ref. This is either a commit hash for the commit that
+  changed `quiche/Cargo.toml` to the released version, or an existing quiche
+  release tag such as `0.29.1` that points at that commit.
+- Optional: a release title emoji. If none is requested, choose one consistent
+  with existing quiche releases.
+
+If the release ref is missing or ambiguous, ask one short clarification question.
+
+## Workflow
+
+1. Run a dry run with the helper script:
+
+   ```bash
+   ./.opencode/skills/quiche-draft-release/scripts/create-draft-release.sh --dry-run <release-ref>
+   ```
+
+2. Use the dry-run output to identify the version, previous quiche release tag,
+   compare range, and whether the tag already exists.
+
+3. Prepare release notes for `quiche/` only, following `RELEASING.md`:
+
+   - Do not use a raw commit list.
+   - Include only important user-visible changes.
+   - Clearly mark breaking changes and security fixes.
+   - Explain what applications need to change for breaking changes.
+   - Use versioned `docs.rs` links for new public APIs where useful.
+   - Ignore unrelated workspace crates, release commits, formatting, clippy,
+     test-only changes, and internal refactors unless user-visible.
+
+4. Write the release notes to a temporary file, for example:
+
+   ```bash
+   /tmp/opencode/quiche-release-<version>.md
+   ```
+
+5. Before creating the release, unless the user has explicitly asked to proceed
+   without confirmation, show the exact `gh release create` command and ask for
+   confirmation.
+
+6. Create the GitHub draft release with the helper script:
+
+   ```bash
+   ./.opencode/skills/quiche-draft-release/scripts/create-draft-release.sh \
+     --title "<emoji> <version>" \
+     --notes-file /tmp/opencode/quiche-release-<version>.md \
+     <release-ref>
+   ```
+
+7. Verify the draft after creation:
+
+   ```bash
+   gh release view <version> --repo cloudflare/quiche \
+     --json tagName,name,isDraft,isPrerelease,url
+   ```
+
+GitHub draft release URLs often use `untagged-*`. Trust `tagName` from
+`gh release view` to verify the draft is associated with the expected version.
+
+## Helper Script Behavior
+
+The helper script:
+
+- Resolves the supplied release ref to a commit. The ref may be a commit hash or
+  an existing quiche release tag.
+- Reads the release version from `quiche/Cargo.toml` at the resolved commit.
+- Verifies the resolved commit changed the quiche crate version relative to its
+  first parent.
+- Infers the previous quiche release tag from semver-like quiche tags merged
+  into the release commit.
+- Refuses to create a release if a GitHub release for that version already
+  exists.
+- Uses the existing release tag if it exists and points at the resolved commit.
+- Adds `--target <commit>` when the tag does not exist yet.
+- Creates the GitHub release as a draft only.
+
+## Examples
+
+Dry run:
+
+```bash
+./.opencode/skills/quiche-draft-release/scripts/create-draft-release.sh \
+  --dry-run f0c7193c3
+```
+
+Dry run with an existing tag:
+
+```bash
+./.opencode/skills/quiche-draft-release/scripts/create-draft-release.sh \
+  --dry-run 0.29.1
+```
+
+Create a draft release:
+
+```bash
+./.opencode/skills/quiche-draft-release/scripts/create-draft-release.sh \
+  --title "🩹 0.29.1" \
+  --notes-file /tmp/opencode/quiche-release-0.29.1.md \
+  f0c7193c3
+```
+
+Create a draft release from an existing tag:
+
+```bash
+./.opencode/skills/quiche-draft-release/scripts/create-draft-release.sh \
+  --title "🩹 0.29.1" \
+  --notes-file /tmp/opencode/quiche-release-0.29.1.md \
+  0.29.1
+```
+
+## Do Not
+
+- Do not create or move git tags manually as part of this skill.
+- Do not publish the release; keep it as a draft.
+- Do not create releases for non-`quiche` workspace crates with this skill.
+- Do not overwrite or edit an existing GitHub release unless the user explicitly
+  asks for that.

--- a/.opencode/skills/quiche-draft-release/scripts/create-draft-release.sh
+++ b/.opencode/skills/quiche-draft-release/scripts/create-draft-release.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  create-draft-release.sh [options] <release-ref>
+
+Creates a GitHub draft release for the quiche crate using either the commit
+that bumped quiche/Cargo.toml, or an existing release tag pointing at that
+commit. The tag does not need to exist yet; when it is missing, the release is
+created with --target <release-commit>.
+
+Options:
+  --dry-run            Print inferred release metadata and the gh command.
+  --notes-file PATH    Markdown notes file to use for the draft release.
+  --repo OWNER/REPO    GitHub repository. Defaults to cloudflare/quiche.
+  --title TITLE        Release title. Defaults to the inferred version.
+  -h, --help           Show this help.
+USAGE
+}
+
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+quote_cmd() {
+    local first=1
+
+    for arg in "$@"; do
+        if [ "$first" -eq 0 ]; then
+            printf ' '
+        fi
+
+        first=0
+        printf '%q' "$arg"
+    done
+
+    printf '\n'
+}
+
+version_from_commit() {
+    local commit=$1
+
+    git show "$commit:quiche/Cargo.toml" |
+        awk -F '"' '/^version = / { print $2; exit }'
+}
+
+repo=cloudflare/quiche
+dry_run=0
+notes_file=
+title=
+release_ref=
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+
+        --notes-file)
+            [ "$#" -ge 2 ] || die '--notes-file requires a path'
+            notes_file=$2
+            shift 2
+            ;;
+
+        --repo)
+            [ "$#" -ge 2 ] || die '--repo requires OWNER/REPO'
+            repo=$2
+            shift 2
+            ;;
+
+        --title)
+            [ "$#" -ge 2 ] || die '--title requires a value'
+            title=$2
+            shift 2
+            ;;
+
+        -h|--help)
+            usage
+            exit 0
+            ;;
+
+        --)
+            shift
+            break
+            ;;
+
+        -*)
+            die "unknown option: $1"
+            ;;
+
+        *)
+            [ -z "$release_ref" ] || die 'only one release ref is supported'
+            release_ref=$1
+            shift
+            ;;
+    esac
+done
+
+[ -n "$release_ref" ] || {
+    usage >&2
+    exit 2
+}
+
+command -v git >/dev/null 2>&1 || die 'git is required'
+command -v gh >/dev/null 2>&1 || die 'GitHub CLI (gh) is required'
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) ||
+    die 'must be run from inside the quiche git repository'
+cd "$repo_root"
+
+input_tag=
+if git rev-parse -q --verify "refs/tags/$release_ref" >/dev/null; then
+    input_tag=$release_ref
+elif [[ "$release_ref" == refs/tags/* ]] &&
+    git rev-parse -q --verify "$release_ref" >/dev/null
+then
+    input_tag=${release_ref#refs/tags/}
+fi
+
+commit=$(git rev-parse --verify "$release_ref^{commit}" 2>/dev/null) ||
+    die "not a commit or tag: $release_ref"
+
+version=$(version_from_commit "$commit")
+[ -n "$version" ] ||
+    die "could not read version from quiche/Cargo.toml at $commit"
+
+if [ -n "$input_tag" ] && [ "$input_tag" != "$version" ]; then
+    die "input tag $input_tag does not match quiche version $version"
+fi
+
+parent=$(git rev-parse --verify "$commit^" 2>/dev/null || true)
+if [ -n "$parent" ]; then
+    previous_version=$(version_from_commit "$parent" || true)
+
+    if [ "$previous_version" = "$version" ]; then
+        die "commit $commit does not bump quiche/Cargo.toml version"
+    fi
+fi
+
+previous_tag=
+while IFS= read -r tag; do
+    [ "$tag" != "$version" ] || continue
+
+    previous_tag=$tag
+    break
+done < <(
+    git tag --merged "$commit" \
+        --sort=-version:refname \
+        --list '[0-9]*.[0-9]*.[0-9]*'
+)
+
+[ -n "$previous_tag" ] ||
+    die "could not infer previous quiche release tag before $version"
+
+compare_url="https://github.com/$repo/compare/$previous_tag...$version"
+title=${title:-$version}
+
+tag_exists=0
+target_args=()
+if git rev-parse -q --verify "refs/tags/$version" >/dev/null; then
+    tag_exists=1
+    tag_commit=$(git rev-list -n 1 "$version")
+
+    if [ "$tag_commit" != "$commit" ]; then
+        die "tag $version points to $tag_commit, not $commit"
+    fi
+else
+    target_args=(--target "$commit")
+fi
+
+cmd=(
+    gh release create "$version"
+    --repo "$repo"
+    --draft
+    --title "$title"
+)
+
+if [ -n "$notes_file" ]; then
+    cmd+=(--notes-file "$notes_file")
+fi
+
+cmd+=("${target_args[@]}")
+
+if [ "$dry_run" -eq 1 ]; then
+    cat <<EOF
+release_ref=$release_ref
+input_tag=$input_tag
+release_commit=$commit
+version=$version
+previous_version=${previous_version:-}
+previous_tag=$previous_tag
+compare_url=$compare_url
+tag_exists=$tag_exists
+title=$title
+notes_file=${notes_file:-}
+EOF
+
+    printf 'command='
+    quote_cmd "${cmd[@]}"
+    exit 0
+fi
+
+[ -n "$notes_file" ] || die '--notes-file is required when creating a release'
+[ -f "$notes_file" ] || die "notes file not found: $notes_file"
+
+if gh release view "$version" --repo "$repo" >/dev/null 2>&1; then
+    die "GitHub release already exists for $version"
+fi
+
+"${cmd[@]}"
+
+gh release view "$version" --repo "$repo" \
+    --json tagName,name,isDraft,isPrerelease,url


### PR DESCRIPTION
Add a project-local opencode skill for preparing quiche GitHub draft releases from either a release commit hash or an existing release tag.

The helper script validates the quiche version bump, infers the previous quiche release tag, and creates draft releases with --target when the tag has not been created yet.