### PR TITLE
Implement PKTS_BETWEEN_PROBES for PMTUD

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -177,6 +177,10 @@ void quiche_config_grease(quiche_config *config, bool v);
 // Configures whether to do path MTU discovery.
 void quiche_config_discover_pmtu(quiche_config *config, bool v);
 
+// Configures the number of non-probe packets between PMTUD probes.
+void quiche_config_set_pmtud_pkts_between_probes(quiche_config *config,
+                                                 size_t pkts);
+
 // Enables logging of secrets.
 void quiche_config_log_keys(quiche_config *config);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -223,6 +223,13 @@ pub extern "C" fn quiche_config_set_pmtud_max_probes(
 }
 
 #[no_mangle]
+pub extern "C" fn quiche_config_set_pmtud_pkts_between_probes(
+    config: &mut Config, pkts: usize,
+) {
+    config.set_pmtud_pkts_between_probes(pkts);
+}
+
+#[no_mangle]
 pub extern "C" fn quiche_config_log_keys(config: &mut Config) {
     config.log_keys();
 }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4004,7 +4004,7 @@ impl<F: BufFactory> Connection<F> {
 
         let send_path = self.paths.get_mut(send_pid)?;
 
-        // Update max datagram size to allow path MTU discovery probe to be sent.
+        // Increase output size to allow path MTU discovery probe to be sent.
         if let Some(pmtud) = send_path.pmtud.as_mut() {
             if pmtud.should_probe() {
                 let size = if self.handshake_confirmed || self.handshake_completed
@@ -4014,10 +4014,7 @@ impl<F: BufFactory> Connection<F> {
                     pmtud.get_current_mtu()
                 };
 
-                send_path.recovery.pmtud_update_max_datagram_size(size);
-
-                left =
-                    cmp::min(out.len(), send_path.recovery.max_datagram_size());
+                left = cmp::min(out.len(), size);
             }
         }
 
@@ -4296,6 +4293,9 @@ impl<F: BufFactory> Connection<F> {
                             if let Some(pmtud) = p.pmtud.as_mut() {
                                 trace!("pmtud probe dropped: {failed_probe}");
                                 pmtud.failed_probe(failed_probe);
+                                p.recovery.pmtud_update_max_datagram_size(
+                                    pmtud.get_current_mtu(),
+                                );
                             }
                         }
                     },
@@ -7988,7 +7988,7 @@ impl<F: BufFactory> Connection<F> {
                     .pmtud
                     .as_mut()
                     .expect("PMTUD existence verified above")
-                    .get_probe_size()
+                    .get_current_mtu()
                     .min(peer_params.max_udp_payload_size as usize),
             );
         } else {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -579,6 +579,7 @@ pub struct Config {
 
     pmtud: bool,
     pmtud_max_probes: u8,
+    pmtud_pkts_between_probes: usize,
 
     hystart: bool,
 
@@ -660,6 +661,7 @@ impl Config {
             enable_send_streams_blocked: false,
             pmtud: false,
             pmtud_max_probes: pmtud::MAX_PROBES_DEFAULT,
+            pmtud_pkts_between_probes: pmtud::PKTS_BETWEEN_PROBES,
             hystart: true,
             pacing: true,
             max_pacing_rate: None,
@@ -784,6 +786,14 @@ impl Config {
     /// If 0 is passed, the default value is used.
     pub fn set_pmtud_max_probes(&mut self, max_probes: u8) {
         self.pmtud_max_probes = max_probes;
+    }
+
+    /// Configures the number of non-probe packets that must be sent between
+    /// PMTUD probes.
+    ///
+    /// The default value is `0`.
+    pub fn set_pmtud_pkts_between_probes(&mut self, pkts: usize) {
+        self.pmtud_pkts_between_probes = pkts;
     }
 
     /// Configures whether to send GREASE values.
@@ -2683,7 +2693,11 @@ impl<F: BufFactory> Connection<F> {
     ) -> Result<()> {
         let ex_data = tls::ExData::from_ssl_ref(ssl).ok_or(Error::TlsFail)?;
 
-        ex_data.pmtud = Some((discover, max_probes));
+        ex_data.pmtud = Some(pmtud::PmtudConfig {
+            enable: discover,
+            max_probes,
+            pkts_between_probes: pmtud::PKTS_BETWEEN_PROBES,
+        });
 
         Ok(())
     }
@@ -5489,6 +5503,12 @@ impl<F: BufFactory> Connection<F> {
         path.sent_count += 1;
         path.sent_bytes += written as u64;
 
+        if !is_pmtud_probe {
+            if let Some(pmtud) = path.pmtud.as_mut() {
+                pmtud.on_non_probe_sent();
+            }
+        }
+
         if self.dgram_send_queue.byte_size() > path.recovery.cwnd_available() {
             path.recovery.update_app_limited(false);
         }
@@ -8061,11 +8081,10 @@ impl<F: BufFactory> Connection<F> {
                         self.tx_cap_factor = ex_data.tx_cap_factor;
                     }
 
-                    if let Some((discover, max_probes)) = ex_data.pmtud {
+                    if let Some(params) = ex_data.pmtud {
                         self.paths.set_discover_pmtu_on_existing_paths(
-                            discover,
+                            params,
                             self.recovery_config.max_send_udp_payload_size,
-                            max_probes,
                         );
                     }
 

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -251,7 +251,14 @@ impl Path {
                         .unwrap_or(c.max_send_udp_payload_size),
                     c.max_send_udp_payload_size,
                 );
-                Some(pmtud::Pmtud::new(maximum_supported_mtu, c.pmtud_max_probes))
+                Some(pmtud::Pmtud::new(
+                    maximum_supported_mtu,
+                    pmtud::PmtudConfig {
+                        enable: c.pmtud,
+                        max_probes: c.pmtud_max_probes,
+                        pkts_between_probes: c.pmtud_pkts_between_probes,
+                    },
+                ))
             } else {
                 None
             }
@@ -908,15 +915,11 @@ impl PathMap {
 
     /// Configures path MTU discovery on all existing paths.
     pub fn set_discover_pmtu_on_existing_paths(
-        &mut self, discover: bool, max_send_udp_payload_size: usize,
-        pmtud_max_probes: u8,
+        &mut self, params: pmtud::PmtudConfig, max_send_udp_payload_size: usize,
     ) {
         for (_, path) in self.paths.iter_mut() {
-            path.pmtud = if discover {
-                Some(pmtud::Pmtud::new(
-                    max_send_udp_payload_size,
-                    pmtud_max_probes,
-                ))
+            path.pmtud = if params.enable {
+                Some(pmtud::Pmtud::new(max_send_udp_payload_size, params))
             } else {
                 None
             };

--- a/quiche/src/pmtud.rs
+++ b/quiche/src/pmtud.rs
@@ -21,10 +21,26 @@
 /// https://datatracker.ietf.org/doc/html/rfc8899#section-5.1.2
 pub(crate) const MAX_PROBES_DEFAULT: u8 = 3;
 
+/// Number of non-probe packets between PMTUD probes.
+pub(crate) const PKTS_BETWEEN_PROBES: usize = 0;
+
 /// Min Packetization Layer Path MTU (PLPMTU).
 /// https://datatracker.ietf.org/doc/html/rfc8899#section-5.1.2
 /// For QUIC, this is 1200 bytes per https://datatracker.ietf.org/doc/html/rfc9000#section-14.1
 const MIN_PLPMTU: usize = crate::MIN_CLIENT_INITIAL_LEN;
+
+/// PMTUD configuration carried across the handshake and applied to paths.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PmtudConfig {
+    /// Whether path MTU discovery is enabled.
+    pub enable: bool,
+
+    /// Consecutive probe failures tolerated before a size is treated as failed.
+    pub max_probes: u8,
+
+    /// Minimum number of non-probe packets required between PMTUD probes.
+    pub pkts_between_probes: usize,
+}
 
 #[derive(Default)]
 pub struct Pmtud {
@@ -54,27 +70,36 @@ pub struct Pmtud {
     /// The maximum number of failed probe attempts before treating a size as
     /// failed.
     max_probes: u8,
+
+    /// Non-probe packets sent since the last PMTUD probe.
+    pkts_since_last_probe: usize,
+
+    /// Minimum non-probe packets required between PMTUD probes.
+    pkts_between_probes: usize,
 }
 
 impl Pmtud {
     /// Creates new PMTUD instance.
     ///
-    /// If `max_probes` is 0, uses the default value of [`MAX_PROBES_DEFAULT`].
-    pub fn new(maximum_supported_mtu: usize, max_probes: u8) -> Self {
-        let max_probes = if max_probes == 0 {
+    /// If `params.max_probes` is 0, uses the default value of
+    /// [`MAX_PROBES_DEFAULT`].
+    pub fn new(maximum_supported_mtu: usize, params: PmtudConfig) -> Self {
+        let max_probes = if params.max_probes == 0 {
             warn!(
                 "max_probes is 0, using default value {}",
                 MAX_PROBES_DEFAULT
             );
             MAX_PROBES_DEFAULT
         } else {
-            max_probes
+            params.max_probes
         };
 
         Self {
             maximum_supported_mtu,
             probe_size: maximum_supported_mtu,
             max_probes,
+            pkts_since_last_probe: params.pkts_between_probes,
+            pkts_between_probes: params.pkts_between_probes,
             ..Default::default()
         }
     }
@@ -82,11 +107,18 @@ impl Pmtud {
     /// Indicates whether probing should continue on the connection.
     ///
     /// Checks there are no probes in flight, that a PMTU has not been
-    /// found, and that the minimum supported MTU has not been reached.
+    /// found, that the minimum supported MTU has not been reached, and that
+    /// enough non-probe packets have been sent since the last probe.
     pub fn should_probe(&self) -> bool {
         !self.in_flight &&
             self.pmtu.is_none() &&
-            self.smallest_failed_probe_size != Some(MIN_PLPMTU)
+            self.smallest_failed_probe_size != Some(MIN_PLPMTU) &&
+            self.pkts_since_last_probe >= self.pkts_between_probes
+    }
+
+    /// Records that a non-probe packet was sent.
+    pub fn on_non_probe_sent(&mut self) {
+        self.pkts_since_last_probe = self.pkts_since_last_probe.saturating_add(1);
     }
 
     /// Sets the PMTUD probe size.
@@ -163,6 +195,9 @@ impl Pmtud {
     /// Sets whether a probe is currently in flight for this connection.
     pub fn set_in_flight(&mut self, in_flight: bool) {
         self.in_flight = in_flight;
+        if in_flight {
+            self.pkts_since_last_probe = 0;
+        }
     }
 
     /// Records a successful probe and returns the largest successful probe size
@@ -222,6 +257,7 @@ impl Pmtud {
         self.largest_successful_probe_size = None;
         self.pmtu = None;
         self.probe_failure_count = 0;
+        self.pkts_since_last_probe = self.pkts_between_probes;
     }
 
     // Checks that a probe of PMTU size can be ack'd by enabling
@@ -233,6 +269,7 @@ impl Pmtud {
             self.pmtu = None;
             self.probe_failure_count = 0;
             self.largest_successful_probe_size = None;
+            self.pkts_since_last_probe = self.pkts_between_probes;
         }
     }
 
@@ -261,9 +298,18 @@ impl std::fmt::Debug for Pmtud {
 mod tests {
     use super::*;
 
+    /// Builds enabled [`PmtudConfig`] for tests.
+    fn params(max_probes: u8, pkts_between_probes: usize) -> PmtudConfig {
+        PmtudConfig {
+            enable: true,
+            max_probes,
+            pkts_between_probes,
+        }
+    }
+
     #[test]
     fn pmtud_initial_state() {
-        let pmtud = Pmtud::new(1350, 1);
+        let pmtud = Pmtud::new(1350, params(1, PKTS_BETWEEN_PROBES));
         assert_eq!(pmtud.get_current_mtu(), 1200);
         assert_eq!(pmtud.get_probe_size(), 1350);
         assert!(pmtud.should_probe());
@@ -271,20 +317,104 @@ mod tests {
 
     #[test]
     fn pmtud_max_probes_zero_uses_default() {
-        let pmtud = Pmtud::new(1500, 0);
+        let pmtud = Pmtud::new(1500, params(0, PKTS_BETWEEN_PROBES));
         assert_eq!(pmtud.max_probes, MAX_PROBES_DEFAULT);
     }
 
     #[test]
     fn pmtud_max_probes_set_to_provided_value() {
-        let pmtud = Pmtud::new(1500, 5);
+        let pmtud = Pmtud::new(1500, params(5, PKTS_BETWEEN_PROBES));
         assert_eq!(pmtud.max_probes, 5);
         assert_ne!(pmtud.max_probes, MAX_PROBES_DEFAULT);
     }
 
     #[test]
+    fn pmtud_first_probe_allowed_without_non_probe_packets() {
+        let mut pmtud = Pmtud::new(1500, params(1, 4));
+
+        assert_eq!(pmtud.pkts_since_last_probe, 4);
+        assert!(pmtud.should_probe());
+
+        // Non-probe packets sent before the first PMTUD probe do not delay it.
+        for _ in 0..4 {
+            pmtud.on_non_probe_sent();
+        }
+
+        assert_eq!(pmtud.pkts_since_last_probe, 8);
+        assert!(pmtud.should_probe());
+    }
+
+    #[test]
+    fn pmtud_blocks_next_probe_until_enough_non_probe_packets() {
+        const PKTS_BETWEEN_PROBES: usize = 4;
+
+        let mut pmtud = Pmtud::new(1500, params(1, PKTS_BETWEEN_PROBES));
+
+        assert!(pmtud.should_probe());
+
+        pmtud.set_in_flight(true);
+        assert_eq!(pmtud.pkts_since_last_probe, 0);
+        assert!(!pmtud.should_probe());
+
+        pmtud.failed_probe(1500);
+
+        assert!(!pmtud.in_flight);
+        assert_eq!(pmtud.pkts_since_last_probe, 0);
+        assert!(!pmtud.should_probe());
+
+        for i in 0..PKTS_BETWEEN_PROBES {
+            assert_eq!(pmtud.pkts_since_last_probe, i);
+            assert!(!pmtud.should_probe());
+
+            pmtud.on_non_probe_sent();
+        }
+
+        assert_eq!(pmtud.pkts_since_last_probe, PKTS_BETWEEN_PROBES);
+        assert!(pmtud.should_probe());
+    }
+
+    #[test]
+    fn pmtud_probe_spacing_resets_when_probe_is_sent() {
+        const PKTS_BETWEEN_PROBES: usize = 4;
+
+        let mut pmtud = Pmtud::new(1500, params(1, PKTS_BETWEEN_PROBES));
+
+        pmtud.set_in_flight(true);
+        pmtud.failed_probe(1500);
+
+        for _ in 0..PKTS_BETWEEN_PROBES {
+            pmtud.on_non_probe_sent();
+        }
+
+        assert!(pmtud.should_probe());
+
+        pmtud.set_in_flight(true);
+
+        assert_eq!(pmtud.pkts_since_last_probe, 0);
+        assert!(!pmtud.should_probe());
+    }
+
+    #[test]
+    fn pmtud_revalidation_probe_bypasses_spacing() {
+        const PKTS_BETWEEN_PROBES: usize = 4;
+
+        let mut pmtud = Pmtud::new(1500, params(1, PKTS_BETWEEN_PROBES));
+
+        pmtud.set_in_flight(true);
+        pmtud.successful_probe(1500);
+
+        assert_eq!(pmtud.get_pmtu(), Some(1500));
+
+        pmtud.revalidate_pmtu();
+
+        assert_eq!(pmtud.get_pmtu(), None);
+        assert_eq!(pmtud.pkts_since_last_probe, PKTS_BETWEEN_PROBES);
+        assert!(pmtud.should_probe());
+    }
+
+    #[test]
     fn pmtud_binary_search_algorithm() {
-        let mut pmtud = Pmtud::new(1500, 1);
+        let mut pmtud = Pmtud::new(1500, params(1, PKTS_BETWEEN_PROBES));
 
         // Set initial probe size to 1500
         assert_eq!(pmtud.get_probe_size(), 1500);
@@ -330,7 +460,7 @@ mod tests {
 
     #[test]
     fn pmtud_successful_probe() {
-        let mut pmtud = Pmtud::new(1400, 1);
+        let mut pmtud = Pmtud::new(1400, params(1, PKTS_BETWEEN_PROBES));
 
         // Simulate successful probe
         pmtud.successful_probe(1400);
@@ -345,7 +475,7 @@ mod tests {
     /// to verify the PMTU discovery process.
     #[test]
     fn test_pmtud_reset() {
-        let mut pmtud = Pmtud::new(1350, 1);
+        let mut pmtud = Pmtud::new(1350, params(1, PKTS_BETWEEN_PROBES));
         pmtud.successful_probe(1350);
         assert_eq!(pmtud.pmtu, Some(1350));
         assert!(!pmtud.should_probe());
@@ -360,7 +490,7 @@ mod tests {
     /// Test case for receiving a probe outside the defined supported MTU range.
     #[test]
     fn test_pmtud_errant_probe() {
-        let mut pmtud = Pmtud::new(1350, 1);
+        let mut pmtud = Pmtud::new(1350, params(1, PKTS_BETWEEN_PROBES));
         pmtud.successful_probe(1500);
         // Even though we've received a probe larger than supported
         // maximum MTU, the PMTU should still respect the configured maximum
@@ -383,7 +513,7 @@ mod tests {
     /// when the PMTU is equal to the minimum supported MTU.
     #[test]
     fn test_pmtu_equal_to_min_supported_mtu() {
-        let mut pmtud = Pmtud::new(1350, 1);
+        let mut pmtud = Pmtud::new(1350, params(1, PKTS_BETWEEN_PROBES));
         pmtud_test_runner(&mut pmtud, 1200);
     }
 
@@ -393,7 +523,7 @@ mod tests {
     /// when the PMTU is greater than the minimum supported MTU.
     #[test]
     fn test_pmtu_greater_than_min_supported_mtu() {
-        let mut pmtud = Pmtud::new(1350, 1);
+        let mut pmtud = Pmtud::new(1350, params(1, PKTS_BETWEEN_PROBES));
         pmtud_test_runner(&mut pmtud, 1500);
     }
 
@@ -403,7 +533,7 @@ mod tests {
     /// the case when the PMTU is less than the minimum supported MTU.
     #[test]
     fn test_pmtu_less_than_min_supported_mtu() {
-        let mut pmtud = Pmtud::new(1350, 1);
+        let mut pmtud = Pmtud::new(1350, params(1, PKTS_BETWEEN_PROBES));
         pmtud_test_runner(&mut pmtud, 1100);
     }
 
@@ -414,7 +544,7 @@ mod tests {
     /// validation probe.
     #[test]
     fn test_pmtu_revalidation() {
-        let mut pmtud = Pmtud::new(1350, 1);
+        let mut pmtud = Pmtud::new(1350, params(1, PKTS_BETWEEN_PROBES));
         pmtud.set_probe_size(1350);
         pmtud.successful_probe(1350);
 
@@ -428,7 +558,8 @@ mod tests {
 
     #[test]
     fn pmtud_revalidation_tolerates_random_packet_loss() {
-        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT);
+        let mut pmtud =
+            Pmtud::new(1500, params(MAX_PROBES_DEFAULT, PKTS_BETWEEN_PROBES));
 
         pmtud.successful_probe(1500);
         assert_eq!(pmtud.get_pmtu(), Some(1500));
@@ -453,7 +584,7 @@ mod tests {
     /// PMTUD should binary search down, not restart.
     #[test]
     fn pmtud_revalidation_failure_binary_searches_not_restarts() {
-        let mut pmtud = Pmtud::new(1500, 1);
+        let mut pmtud = Pmtud::new(1500, params(1, PKTS_BETWEEN_PROBES));
 
         pmtud.successful_probe(1500);
         assert_eq!(pmtud.get_pmtu(), Some(1500));
@@ -472,7 +603,8 @@ mod tests {
 
     #[test]
     fn pmtud_tolerates_initial_packet_loss() {
-        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT);
+        let mut pmtud =
+            Pmtud::new(1500, params(MAX_PROBES_DEFAULT, PKTS_BETWEEN_PROBES));
 
         pmtud.failed_probe(1500);
         assert_eq!(pmtud.probe_failure_count, 1);
@@ -489,7 +621,7 @@ mod tests {
 
     #[test]
     fn pmtud_confirms_failure_after_max_probes() {
-        let mut pmtud = Pmtud::new(1500, 1);
+        let mut pmtud = Pmtud::new(1500, params(1, PKTS_BETWEEN_PROBES));
 
         pmtud.failed_probe(1500);
 
@@ -501,7 +633,7 @@ mod tests {
 
     #[test]
     fn pmtud_binary_search_no_slowdown() {
-        let mut pmtud = Pmtud::new(1500, 2);
+        let mut pmtud = Pmtud::new(1500, params(2, PKTS_BETWEEN_PROBES));
 
         fail_probe_max_times(&mut pmtud, 1500);
         assert!(pmtud.pmtu.is_none());
@@ -528,7 +660,7 @@ mod tests {
     /// 3. Algorithm converges to the correct MTU of 1337
     #[test]
     fn pmtud_convergence_with_intermittent_loss() {
-        let mut pmtud = Pmtud::new(1500, 3);
+        let mut pmtud = Pmtud::new(1500, params(3, PKTS_BETWEEN_PROBES));
         let target_mtu = 1337;
 
         while pmtud.get_pmtu().is_none() {
@@ -560,7 +692,8 @@ mod tests {
 
     #[test]
     fn pmtud_failure_at_min_plpmtu() {
-        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT);
+        let mut pmtud =
+            Pmtud::new(1500, params(MAX_PROBES_DEFAULT, PKTS_BETWEEN_PROBES));
 
         pmtud.failed_probe(100);
         pmtud.failed_probe(100);
@@ -571,7 +704,7 @@ mod tests {
 
     #[test]
     fn pmtud_in_flight_cleared_on_all_outcomes() {
-        let mut pmtud = Pmtud::new(1500, 1);
+        let mut pmtud = Pmtud::new(1500, params(1, PKTS_BETWEEN_PROBES));
 
         pmtud.set_in_flight(true);
         assert!(pmtud.in_flight);
@@ -587,7 +720,7 @@ mod tests {
 
     #[test]
     fn pmtud_update_probe_size_initial_state() {
-        let mut pmtud = Pmtud::new(1500, 1);
+        let mut pmtud = Pmtud::new(1500, params(1, PKTS_BETWEEN_PROBES));
 
         // Manually set probe_size to something else to verify update_probe_size
         // resets it

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -11952,7 +11952,19 @@ fn pmtud_probe_success(
     let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
     assert_eq!(pipe.handshake(), Ok(()));
 
-    // Send probe and let it be acknowledged
+    // Send the probe, but don't deliver it yet.
+    let flight = test_utils::emit_flight(&mut pipe.client).unwrap();
+    assert_eq!(
+        pipe.client
+            .paths
+            .get_active()
+            .unwrap()
+            .recovery
+            .max_datagram_size(),
+        1200,
+    );
+
+    test_utils::process_flight(&mut pipe.server, flight).unwrap();
     assert_eq!(pipe.advance(), Ok(()));
 
     // Verify probing is disabled after successful probe
@@ -11969,9 +11981,56 @@ fn pmtud_probe_success(
     // Verify MTU was updated
     let current_mtu = pmtud.get_current_mtu();
     assert_eq!(current_mtu, 1400);
+    assert_eq!(
+        pipe.client
+            .paths
+            .get_active()
+            .unwrap()
+            .recovery
+            .max_datagram_size(),
+        current_mtu,
+    );
 
     let path_stats = pipe.client.path_stats().next().unwrap();
     assert_eq!(path_stats.pmtu, current_mtu);
+}
+
+#[rstest]
+fn pmtud_probe_loss_restores_recovery_mss(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut config = test_utils::Pipe::default_config(cc_algorithm_name).unwrap();
+    config.set_max_send_udp_payload_size(1400);
+    config.discover_pmtu(true);
+    config.set_pmtud_max_probes(1);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    let mut out = [0; 4096];
+    let _ = pipe.client.send(&mut out).unwrap();
+    let (probe_size, _) = pipe.client.send(&mut out).unwrap();
+    assert_eq!(probe_size, 1400);
+
+    let active_path = pipe.client.paths.get_active_mut().unwrap();
+    let current_mtu = active_path.pmtud.as_ref().unwrap().get_current_mtu();
+    active_path
+        .recovery
+        .pmtud_update_max_datagram_size(probe_size);
+
+    test_utils::trigger_ack_based_loss(&mut pipe.client, &mut pipe.server);
+
+    let _ = pipe.client.send(&mut out);
+
+    assert_eq!(
+        pipe.client
+            .paths
+            .get_active()
+            .unwrap()
+            .recovery
+            .max_datagram_size(),
+        current_mtu,
+    );
 }
 
 #[rstest]

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -12003,6 +12003,7 @@ fn pmtud_probe_loss_restores_recovery_mss(
     config.set_max_send_udp_payload_size(1400);
     config.discover_pmtu(true);
     config.set_pmtud_max_probes(1);
+    config.set_pmtud_pkts_between_probes(100);
 
     let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
     assert_eq!(pipe.handshake(), Ok(()));
@@ -12022,15 +12023,9 @@ fn pmtud_probe_loss_restores_recovery_mss(
 
     let _ = pipe.client.send(&mut out);
 
-    assert_eq!(
-        pipe.client
-            .paths
-            .get_active()
-            .unwrap()
-            .recovery
-            .max_datagram_size(),
-        current_mtu,
-    );
+    let active_path = pipe.client.paths.get_active().unwrap();
+    assert!(!active_path.pmtud.as_ref().unwrap().should_probe());
+    assert_eq!(active_path.recovery.max_datagram_size(), current_mtu);
 }
 
 #[rstest]

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -711,8 +711,8 @@ pub struct ExData<'a> {
 
     pub tx_cap_factor: f64,
 
-    /// PMTUD configuration: (enable, max_probes)
-    pub pmtud: Option<(bool, u8)>,
+    /// PMTUD configuration to apply to the connection's paths.
+    pub pmtud: Option<crate::pmtud::PmtudConfig>,
 
     pub is_server: bool,
 }


### PR DESCRIPTION
Add configurable spacing between PMTUD probes. When configured, PMTUD waits until the given number of non-probe packets has been sent before allowing the next probe.

This prevents lost probes on idle connections from inflating the in-flight byte count, triggering PTO, and causing further probes. Without spacing, this can create a self-reinforcing loop that escalates the PTO exponent and generates unnecessary traffic.