### PR TITLE
quiche: always use initial_max_data as flow control window

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -253,8 +253,7 @@ void quiche_config_enable_pacing(quiche_config *config, bool v);
 void quiche_config_set_enable_cubic_idle_restart_fix(quiche_config *config,
                                                      bool v);
 
-// Configures whether to use the initial max data value as the initial flow
-// control window for streams and the connection (disabled by default).
+// Deprecated: this is now always enabled and this function is a no-op.
 void quiche_config_set_use_initial_max_data_as_flow_control_win(
     quiche_config *config, bool v);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -372,11 +372,11 @@ pub extern "C" fn quiche_config_set_enable_cubic_idle_restart_fix(
     config.set_enable_cubic_idle_restart_fix(v);
 }
 
+/// Deprecated: this is now always enabled and this function is a no-op.
 #[no_mangle]
 pub extern "C" fn quiche_config_set_use_initial_max_data_as_flow_control_win(
-    config: &mut Config, v: bool,
+    _config: &mut Config, _v: bool,
 ) {
-    config.set_use_initial_max_data_as_flow_control_win(v);
 }
 
 #[no_mangle]

--- a/quiche/src/flowcontrol.rs
+++ b/quiche/src/flowcontrol.rs
@@ -124,13 +124,6 @@ impl FlowControl {
         self.window = std::cmp::min(window, self.max_window);
     }
 
-    /// If the current window has not yet been updated by `autotune_window`
-    pub fn set_window_if_not_tuned_yet(&mut self, window: u64) {
-        if self.last_update.is_none() {
-            self.set_window(window);
-        }
-    }
-
     /// Make sure the lower bound of the window is same to
     /// the current window.
     pub fn ensure_window_lower_bound(&mut self, min_window: u64) {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -481,9 +481,6 @@ const MAX_UNDECRYPTABLE_PACKETS: usize = 10;
 
 const RESERVED_VERSION_MASK: u32 = 0xfafafafa;
 
-// The default size of the receiver connection flow control window.
-const DEFAULT_CONNECTION_WINDOW: u64 = 48 * 1024;
-
 // The maximum size of the receiver connection flow control window.
 const MAX_CONNECTION_WINDOW: u64 = 24 * 1024 * 1024;
 
@@ -608,10 +605,6 @@ pub struct Config {
     track_unknown_transport_params: Option<usize>,
 
     initial_rtt: Duration,
-
-    /// When true, uses the initial max data (for connection
-    /// and stream) as the initial flow control window.
-    use_initial_max_data_as_flow_control_win: bool,
 }
 
 // See https://quicwg.org/base-drafts/rfc9000.html#section-15
@@ -690,8 +683,6 @@ impl Config {
 
             track_unknown_transport_params: None,
             initial_rtt: DEFAULT_INITIAL_RTT,
-
-            use_initial_max_data_as_flow_control_win: false,
         })
     }
 
@@ -1261,16 +1252,10 @@ impl Config {
     /// Sets whether the initial max data value should be used as the initial
     /// flow control window.
     ///
-    /// If set to true, the initial flow control window for streams and the
-    /// connection itself will be set to the initial max data value for streams
-    /// and the connection respectively. If false, the window is set to the
-    /// minimum of initial max data and `DEFAULT_STREAM_WINDOW` or
-    /// `DEFAULT_CONNECTION_WINDOW`
-    ///
-    /// The default is false.
-    pub fn set_use_initial_max_data_as_flow_control_win(&mut self, v: bool) {
-        self.use_initial_max_data_as_flow_control_win = v;
-    }
+    /// This is now always enabled and this method is a no-op. It will be
+    /// removed in a future release.
+    #[deprecated(note = "This is now always enabled. This method is a no-op.")]
+    pub fn set_use_initial_max_data_as_flow_control_win(&mut self, _v: bool) {}
 }
 
 /// Tracks the health of the tx_buffered value.
@@ -2058,12 +2043,7 @@ impl<F: BufFactory> Connection<F> {
             reset_token,
         );
 
-        let initial_flow_control_window =
-            if config.use_initial_max_data_as_flow_control_win {
-                max_rx_data
-            } else {
-                cmp::min(max_rx_data / 2 * 3, DEFAULT_CONNECTION_WINDOW)
-            };
+        let initial_flow_control_window = max_rx_data;
         let mut conn = Connection {
             version: config.version,
 
@@ -2235,10 +2215,6 @@ impl<F: BufFactory> Connection<F> {
 
             max_amplification_factor: config.max_amplification_factor,
         };
-        conn.streams.set_use_initial_max_data_as_flow_control_win(
-            config.use_initial_max_data_as_flow_control_win,
-        );
-
         if let Some(retry_cids) = retry_cids {
             conn.local_transport_params
                 .original_destination_connection_id =
@@ -2788,19 +2764,14 @@ impl<F: BufFactory> Connection<F> {
     /// Sets the `use_initial_max_data_as_flow_control_win` flag during SSL
     /// handshake.
     ///
-    /// This function can only be called inside one of BoringSSL's handshake
-    /// callbacks, before any packet has been sent. Calling this function any
-    /// other time will have no effect.
-    ///
-    /// See [`Connection::enable_use_initial_max_data_as_flow_control_win()`].
+    /// This is now always enabled and this method is a no-op. It will be
+    /// removed in a future release.
     #[cfg(feature = "boringssl-boring-crate")]
     #[cfg_attr(docsrs, doc(cfg(feature = "boringssl-boring-crate")))]
+    #[deprecated(note = "This is now always enabled. This method is a no-op.")]
     pub fn set_use_initial_max_data_as_flow_control_win_in_handshake(
-        ssl: &mut boring::ssl::SslRef,
+        _ssl: &mut boring::ssl::SslRef,
     ) -> Result<()> {
-        let ex_data = tls::ExData::from_ssl_ref(ssl).ok_or(Error::TlsFail)?;
-
-        ex_data.use_initial_max_data_as_flow_control_win = true;
         Ok(())
     }
 
@@ -8034,8 +8005,6 @@ impl<F: BufFactory> Connection<F> {
             pmtud: None,
 
             is_server: self.is_server,
-
-            use_initial_max_data_as_flow_control_win: false,
         };
 
         if self.handshake_completed {
@@ -8085,10 +8054,6 @@ impl<F: BufFactory> Connection<F> {
                         self.local_transport_params =
                             ex_data.local_transport_params;
                     }
-                }
-
-                if ex_data.use_initial_max_data_as_flow_control_win {
-                    self.enable_use_initial_max_data_as_flow_control_win();
                 }
 
                 // Try to parse transport parameters as soon as the first flight
@@ -8156,19 +8121,6 @@ impl<F: BufFactory> Connection<F> {
         }
 
         Ok(())
-    }
-
-    /// Use the value of the intial max_data / initial stream max_data setting
-    /// as the initial flow control window for the connection and streams.
-    /// The connection-level flow control window will only be changed if it
-    /// hasn't been auto tuned yet. For streams: only newly created streams
-    /// receive the new setting.
-    fn enable_use_initial_max_data_as_flow_control_win(&mut self) {
-        self.flow_control.set_window_if_not_tuned_yet(
-            self.local_transport_params.initial_max_data,
-        );
-        self.streams
-            .set_use_initial_max_data_as_flow_control_win(true);
     }
 
     /// Selects the packet type for the next outgoing packet.

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -46,9 +46,6 @@ use crate::Result;
 
 const DEFAULT_URGENCY: u8 = 127;
 
-/// The default size of the receiver stream flow control window.
-pub(crate) const DEFAULT_STREAM_WINDOW: u64 = 32 * 1024;
-
 /// The maximum size of the receiver stream flow control window.
 pub const MAX_STREAM_WINDOW: u64 = 16 * 1024 * 1024;
 
@@ -199,10 +196,6 @@ pub struct StreamMap<F: BufFactory = DefaultBufFactory> {
     /// The maximum size of a stream window.
     max_stream_window: u64,
 
-    /// When `true`, the initial flow control window will be set to the
-    /// `max_rx_data`, if false, it will be set to `DEFAULT_STREAM_WINDOW`
-    use_initial_max_data_as_flow_control_win: bool,
-
     /// Total number of bytes in send buffers across all streams.
     tx_buffered: usize,
 }
@@ -344,12 +337,7 @@ impl<F: BufFactory> StreamMap<F> {
                     },
                 };
 
-                let initial_window =
-                    if self.use_initial_max_data_as_flow_control_win {
-                        max_rx_data
-                    } else {
-                        cmp::min(max_rx_data, DEFAULT_STREAM_WINDOW)
-                    };
+                let initial_window = max_rx_data;
                 let s = Stream::new(
                     id,
                     max_rx_data,
@@ -785,14 +773,6 @@ impl<F: BufFactory> StreamMap<F> {
             );
         }
     }
-
-    /// When `true`, the initial flow control window will be set to the
-    /// `max_rx_data`, if false, it will be set to `DEFAULT_STREAM_WINDOW`
-    pub(crate) fn set_use_initial_max_data_as_flow_control_win(
-        &mut self, v: bool,
-    ) {
-        self.use_initial_max_data_as_flow_control_win = v;
-    }
 }
 
 /// A QUIC stream.
@@ -1044,6 +1024,9 @@ mod tests {
     use crate::range_buf::RangeBuf;
 
     use super::*;
+
+    /// The default size of the receiver stream flow control window.
+    const DEFAULT_STREAM_WINDOW: u64 = 32 * 1024;
 
     #[test]
     fn recv_flow_control() {

--- a/quiche/src/stream/recv_buf.rs
+++ b/quiche/src/stream/recv_buf.rs
@@ -428,7 +428,9 @@ impl RecvBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::stream::DEFAULT_STREAM_WINDOW;
+
+    /// The default size of the receiver stream flow control window.
+    const DEFAULT_STREAM_WINDOW: u64 = 32 * 1024;
     use bytes::BufMut as _;
     use rstest::rstest;
 

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -1557,18 +1557,11 @@ fn flow_control_limit_dup(
 fn flow_control_update(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
     #[values(true, false)] discard: bool,
-    #[values(true, false)] use_initial_max_data_as_flow_control_win: bool,
 ) {
     let mut buf = [0; 65535];
 
     let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
     assert_eq!(pipe.handshake(), Ok(()));
-    if use_initial_max_data_as_flow_control_win {
-        pipe.client
-            .enable_use_initial_max_data_as_flow_control_win();
-        pipe.server
-            .enable_use_initial_max_data_as_flow_control_win();
-    }
 
     // Make sure the pipe is configured as we expect
     assert_eq!(pipe.server.max_rx_data(), 30);
@@ -1616,13 +1609,9 @@ fn flow_control_update(
             max: 30
         })
     );
-    if use_initial_max_data_as_flow_control_win {
-        // Initial max_data/window was 30, we consumed/read 16 bytes, which is
-        // more than 1/2 the window ==> new max data is 30 + 16
-        assert_eq!(iter.next(), Some(&frame::Frame::MaxData { max: 46 }));
-    } else {
-        assert_eq!(iter.next(), Some(&frame::Frame::MaxData { max: 61 }));
-    }
+    // Initial max_data/window was 30, we consumed/read 16 bytes, which is
+    // more than 1/2 the window ==> new max data is 30 + 16
+    assert_eq!(iter.next(), Some(&frame::Frame::MaxData { max: 46 }));
 }
 
 #[rstest]
@@ -3888,10 +3877,6 @@ fn stream_shutdown_read_after_fin(
 
     let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
     assert_eq!(pipe.handshake(), Ok(()));
-    pipe.server
-        .enable_use_initial_max_data_as_flow_control_win();
-    pipe.client
-        .enable_use_initial_max_data_as_flow_control_win();
 
     // Client sends some data and a FIN.
     assert_eq!(pipe.client.stream_send(4, b"hello, world123", true), Ok(15));
@@ -3968,10 +3953,6 @@ fn stream_shutdown_read_update_max_data(
     config.verify_peer(false);
 
     let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
-    pipe.server
-        .enable_use_initial_max_data_as_flow_control_win();
-    pipe.client
-        .enable_use_initial_max_data_as_flow_control_win();
     assert_eq!(pipe.handshake(), Ok(()));
 
     assert_eq!(pipe.client.stream_send(0, b"a", false), Ok(1));
@@ -4060,7 +4041,6 @@ fn stream_shutdown_read_update_max_data(
 fn stream_shutdown_write_update_max_data(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
     #[values(true, false)] discard: bool,
-    #[values(true, false)] use_initial_max_data_as_flow_control_win: bool,
 ) {
     let mut config = Config::new(PROTOCOL_VERSION).unwrap();
     assert_eq!(config.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
@@ -4081,12 +4061,6 @@ fn stream_shutdown_write_update_max_data(
 
     let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
     assert_eq!(pipe.handshake(), Ok(()));
-    if use_initial_max_data_as_flow_control_win {
-        pipe.server
-            .enable_use_initial_max_data_as_flow_control_win();
-        pipe.server
-            .enable_use_initial_max_data_as_flow_control_win();
-    }
 
     assert_eq!(pipe.client.stream_send(0, b"a", false), Ok(1));
     assert_eq!(pipe.advance(), Ok(()));
@@ -4118,16 +4092,9 @@ fn stream_shutdown_write_update_max_data(
     assert_eq!(pipe.server.rx_data, 30);
     assert_eq!(pipe.server.flow_control.consumed(), 30);
     assert_eq!(pipe.client.tx_data, 30);
-    // new max_tx_data is window + consumed
-    if use_initial_max_data_as_flow_control_win {
-        // initial window == initial_max_data == 30; consumed == 30
-        // ==> new max_tx_data is 60
-        assert_eq!(pipe.client.max_tx_data, 60);
-    } else {
-        // initial window == initial_max_data*1.5 == 45; consumed == 30
-        // ==> new max_tx_data is 75
-        assert_eq!(pipe.client.max_tx_data, 75);
-    }
+    // initial window == initial_max_data == 30; consumed == 30
+    // ==> new max_tx_data is 60
+    assert_eq!(pipe.client.max_tx_data, 60);
 
     // client can send again on a different stream
     assert_eq!(pipe.client.stream_send(4, b"a", false), Ok(1));
@@ -9538,8 +9505,10 @@ fn max_streams_threshold_after_handshake_callback_update(
     );
 }
 
+/// Tests that the initial flow control window equals initial_max_data
+/// for both connection and stream level.
 #[test]
-fn enable_use_initial_max_data_as_flow_control_win() {
+fn initial_max_data_is_flow_control_win() {
     let mut config = test_utils::Pipe::default_config("cubic").unwrap();
     config
         .set_application_protos(&[b"proto1", b"proto2"])
@@ -9551,148 +9520,25 @@ fn enable_use_initial_max_data_as_flow_control_win() {
     config.verify_peer(false);
     let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
     assert_eq!(pipe.handshake(), Ok(()));
-    pipe.server
-        .enable_use_initial_max_data_as_flow_control_win();
 
-    // We overrode the server's window and set it to initial_max_data
+    // Both sides use initial_max_data as their connection flow control
+    // window.
     assert_eq!(pipe.server.flow_control.window(), 1_000_000);
-    // the clients window is set to DEFAULT_CONNECTION_WINDOW
-    assert_eq!(pipe.client.flow_control.window(), DEFAULT_CONNECTION_WINDOW);
+    assert_eq!(pipe.client.flow_control.window(), 1_000_000);
 
     // Create a new stream
     pipe.client.stream_send(0, &[1, 2, 3], false).unwrap();
     assert_eq!(pipe.advance(), Ok(()));
+
+    // Stream flow control windows equal initial_max_stream_data.
     assert_eq!(
         pipe.client
             .get_or_create_stream(0, true)
-            .unwrap()
-            .recv
-            .flow_control_for_tests()
-            .window(),
-        stream::DEFAULT_STREAM_WINDOW
-    );
-    assert_eq!(
-        pipe.server
-            .get_or_create_stream(0, false)
             .unwrap()
             .recv
             .flow_control_for_tests()
             .window(),
         500_000
-    );
-}
-
-#[test]
-fn enable_use_initial_max_data_as_flow_control_win_in_config() {
-    let mut client_config = test_utils::Pipe::default_config("cubic").unwrap();
-    let mut server_config = test_utils::Pipe::default_config("cubic").unwrap();
-    for config in [&mut client_config, &mut server_config] {
-        config
-            .set_application_protos(&[b"proto1", b"proto2"])
-            .unwrap();
-        config.set_initial_max_data(1_000_000);
-        config.set_initial_max_stream_data_bidi_remote(500_000);
-        config.set_initial_max_stream_data_bidi_local(500_000);
-        config.set_initial_max_streams_bidi(10);
-        config.verify_peer(false);
-    }
-    server_config.set_use_initial_max_data_as_flow_control_win(true);
-    let mut pipe = test_utils::Pipe::with_client_and_server_config(
-        &mut client_config,
-        &mut server_config,
-    )
-    .unwrap();
-    assert_eq!(pipe.handshake(), Ok(()));
-    pipe.server
-        .enable_use_initial_max_data_as_flow_control_win();
-
-    // We overrode the window and set it to initial_max_data
-    assert_eq!(pipe.server.flow_control.window(), 1_000_000);
-    // the clients window is set to DEFAULT_CONNECTION_WINDOW
-    assert_eq!(pipe.client.flow_control.window(), DEFAULT_CONNECTION_WINDOW);
-
-    // Create a new stream
-    pipe.client.stream_send(0, &[1, 2, 3], false).unwrap();
-    assert_eq!(pipe.advance(), Ok(()));
-    assert_eq!(
-        pipe.client
-            .get_or_create_stream(0, true)
-            .unwrap()
-            .recv
-            .flow_control_for_tests()
-            .window(),
-        stream::DEFAULT_STREAM_WINDOW
-    );
-    assert_eq!(
-        pipe.server
-            .get_or_create_stream(0, false)
-            .unwrap()
-            .recv
-            .flow_control_for_tests()
-            .window(),
-        500_000
-    );
-}
-
-/// Tests that `set_use_initial_max_data_as_flow_control_win_in_handshake()`
-/// correctly updates flow control windows.
-#[cfg(feature = "boringssl-boring-crate")]
-#[test]
-fn set_use_initial_max_data_as_flow_control_win_in_handshake() {
-    // Setup server with handshake callback
-    let mut server_tls_ctx_builder = test_utils::Pipe::default_tls_ctx_builder();
-    server_tls_ctx_builder.set_select_certificate_callback(|mut hello| {
-        // Change initial_max_streams_bidi from 4 to 100 during handshake
-        <Connection>::set_use_initial_max_data_as_flow_control_win_in_handshake(
-            hello.ssl_mut(),
-        )
-        .unwrap();
-
-        Ok(())
-    });
-
-    let mut server_config = Config::with_boring_ssl_ctx_builder(
-        PROTOCOL_VERSION,
-        server_tls_ctx_builder,
-    )
-    .unwrap();
-
-    let mut client_config = test_utils::Pipe::default_config("cubic").unwrap();
-
-    for config in [&mut client_config, &mut server_config] {
-        config
-            .set_application_protos(&[b"proto1", b"proto2"])
-            .unwrap();
-        config.set_initial_max_data(1_000_000);
-        config.set_initial_max_stream_data_bidi_remote(500_000);
-        config.set_initial_max_stream_data_bidi_local(500_000);
-        config.set_initial_max_streams_bidi(10);
-        config.verify_peer(false);
-    }
-
-    let mut pipe = test_utils::Pipe::with_client_and_server_config(
-        &mut client_config,
-        &mut server_config,
-    )
-    .unwrap();
-
-    assert_eq!(pipe.handshake(), Ok(()));
-    // We overrode the server's window and set it to initial_max_data
-    assert_eq!(pipe.server.flow_control.window(), 1_000_000);
-    // the clients window is set to DEFAULT_CONNECTION_WINDOW
-    assert_eq!(pipe.client.flow_control.window(), DEFAULT_CONNECTION_WINDOW);
-
-    // Create a new stream
-    pipe.client.stream_send(0, &[1, 2, 3], false).unwrap();
-    assert_eq!(pipe.advance(), Ok(()));
-    assert_eq!(
-        pipe.client
-            .get_or_create_stream(0, true)
-            .unwrap()
-            .recv
-            .flow_control_for_tests()
-            .window(),
-        stream::DEFAULT_STREAM_WINDOW
     );
     assert_eq!(
         pipe.server

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -711,9 +711,6 @@ pub struct ExData<'a> {
     pub pmtud: Option<(bool, u8)>,
 
     pub is_server: bool,
-
-    /// see [`Connection::use_initial_max_data_as_flow_control_win`]
-    pub use_initial_max_data_as_flow_control_win: bool,
 }
 
 impl<'a> ExData<'a> {

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -190,9 +190,6 @@ fn make_quiche_config(
 
     config.set_max_connection_window(quic_settings.max_connection_window);
     config.set_max_stream_window(quic_settings.max_stream_window);
-    config.set_use_initial_max_data_as_flow_control_win(
-        quic_settings.use_initial_max_data_as_fc_window,
-    );
     config.set_enable_send_streams_blocked(
         quic_settings.enable_send_streams_blocked,
     );

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -270,14 +270,12 @@ pub struct QuicSettings {
     #[serde(default = "QuicSettings::default_max_stream_window")]
     pub max_stream_window: u64,
 
-    /// Whether to use the `initial_max_data` transport parameter as the
-    /// initial connection and stream flow control window.
+    /// Deprecated: this is now always enabled and this setting is
+    /// ignored.
     ///
-    /// See [`set_use_initial_max_data_as_flow_control_win()`] for more.
-    ///
-    /// Defaults to `false`.
-    ///
-    /// [`set_use_initial_max_data_as_flow_control_win()`]: https://docs.rs/quiche/latest/quiche/struct.Config.html#method.set_use_initial_max_data_as_flow_control_win
+    /// Previously controlled whether to use the `initial_max_data`
+    /// transport parameter as the initial connection and stream flow
+    /// control window.
     pub use_initial_max_data_as_fc_window: bool,
 
     /// If true, send an advisory STREAMS_BLOCKED frame when the


### PR DESCRIPTION
The initial flow control window for connections and streams is now
always set to initial_max_data / initial_max_stream_data respectively,
instead of being clamped to small defaults (48 KiB / 32 KiB).

The Config and Connection setter methods are preserved as deprecated
no-ops to avoid a hard API break. The C FFI function is similarly
kept as a no-op. The tokio-quiche QuicSettings field remains but is
ignored. All internal plumbing (Config field, StreamMap field, ExData
field, handshake callback path) is removed.
