### PR TITLE
qlog: Add RESET_STREAM_AT

### DIFF
--- a/qlog-dancer/src/reports/events.rs
+++ b/qlog-dancer/src/reports/events.rs
@@ -100,6 +100,9 @@ pub fn frames_to_string(frames: &[QuicFrame]) -> String {
             QuicFrame::ResetStream { stream_id, error, error_code, final_size, .. } => {
                 s += &format!(" RESET_STREAM {{id={stream_id}, error={error:?}, error_code={error_code:?}, final_size={final_size}}}");
             },
+            QuicFrame::ResetStreamAt { stream_id, error, error_code, final_size, reliable_size, .. } => {
+                s += &format!(" RESET_STREAM_AT {{id={stream_id}, error={error:?}, error_code={error_code:?}, final_size={final_size}, reliable_size={reliable_size}}}");
+            },
             QuicFrame::StopSending { stream_id, error, error_code, ..} => {
                 s += &format!(" STOP_SENDING {{id={stream_id}, error={error:?}, error_code={error_code:?}}}");
             },

--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -479,6 +479,7 @@ pub enum QuicFrameTypeName {
     Ping,
     Ack,
     ResetStream,
+    ResetStreamAt,
     StopSending,
     Crypto,
     NewToken,
@@ -534,6 +535,16 @@ pub enum QuicFrame {
         error: ApplicationError,
         error_code: Option<u64>,
         final_size: u64,
+
+        raw: Option<Box<RawInfo>>,
+    },
+
+    ResetStreamAt {
+        stream_id: u64,
+        error: ApplicationError,
+        error_code: Option<u64>,
+        final_size: u64,
+        reliable_size: u64,
 
         raw: Option<Box<RawInfo>>,
     },

--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -539,6 +539,7 @@ pub enum QuicFrame {
         raw: Option<Box<RawInfo>>,
     },
 
+    /// See https://datatracker.ietf.org/doc/html/draft-ietf-quic-reliable-stream-reset/#section-4
     ResetStreamAt {
         stream_id: u64,
         error: ApplicationError,


### PR DESCRIPTION
This minimally adds the definition of the frame from https://quicwg.org/reliable-stream-reset/draft-ietf-quic-reliable-stream-reset.html

I couldn't see any tests for this stuff, so I'm assuming that this is all that is needed.