### PR TITLE
Send first-flight transport closes after post-auth errors

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1371,6 +1371,9 @@ where
     /// Total number of received packets.
     recv_count: usize,
 
+    /// Whether at least one packet from the peer was authenticated.
+    received_authenticated_packet: bool,
+
     /// Total number of sent packets.
     sent_count: usize,
 
@@ -2088,6 +2091,7 @@ impl<F: BufFactory> Connection<F> {
             application_protos: config.application_protos.clone(),
 
             recv_count: 0,
+            received_authenticated_packet: false,
             sent_count: 0,
             lost_count: 0,
             spurious_lost_count: 0,
@@ -3324,6 +3328,8 @@ impl<F: BufFactory> Connection<F> {
             trace!("{} ignored duplicate packet {}", self.trace_id, pn);
             return Err(Error::Done);
         }
+
+        self.received_authenticated_packet = true;
 
         // Packets with no frames are invalid.
         if payload.cap() == 0 {
@@ -7550,8 +7556,8 @@ impl<F: BufFactory> Connection<F> {
             });
         }
 
-        // When no packet was successfully processed close connection immediately.
-        if self.recv_count == 0 {
+        // When no peer packet was authenticated, close connection immediately.
+        if self.recv_count == 0 && !self.received_authenticated_packet {
             self.mark_closed();
         }
 
@@ -8141,6 +8147,15 @@ impl<F: BufFactory> Connection<F> {
 
             if !self.handshake_confirmed {
                 match epoch {
+                    // When a first-flight error happens after packet
+                    // authentication, prefer an Initial close that the peer
+                    // can decrypt.
+                    packet::Epoch::Application
+                        if self.recv_count == 0 &&
+                            self.received_authenticated_packet &&
+                            self.crypto_ctx[packet::Epoch::Initial].has_keys() =>
+                        return Ok(Type::Initial),
+
                     // Downgrade the epoch to Handshake as the handshake is not
                     // completed yet.
                     packet::Epoch::Application => return Ok(Type::Handshake),

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -385,6 +385,37 @@ fn missing_initial_source_connection_id(
         pipe.server_recv(&mut buf[..len]),
         Err(Error::InvalidTransportParam)
     );
+
+    assert_eq!(
+        pipe.server.local_error(),
+        Some(&ConnectionError {
+            is_app: false,
+            error_code: WireErrorCode::TransportParameterError as u64,
+            reason: vec![],
+        })
+    );
+
+    assert!(!pipe.server.is_closed());
+
+    let (len, _) = pipe.server.send(&mut buf).unwrap();
+
+    let hdr = Header::from_slice(&mut buf[..len], pipe.client.source_id().len())
+        .unwrap();
+    assert_eq!(hdr.ty, Type::Initial);
+
+    assert_eq!(
+        pipe.client_recv(&mut buf[..len]),
+        Ok(len),
+    );
+
+    assert_eq!(
+        pipe.client.peer_error(),
+        Some(&ConnectionError {
+            is_app: false,
+            error_code: WireErrorCode::TransportParameterError as u64,
+            reason: vec![],
+        })
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

- keep first-flight post-auth transport errors sendable instead of immediately marking the connection closed when `recv_count` is still zero
- prefer an Initial `CONNECTION_CLOSE` only for authenticated first-flight errors while Initial keys are still available
- extend `missing_initial_source_connection_id` to verify the server emits an Initial close that the client processes as `TRANSPORT_PARAMETER_ERROR`

Fixes #2515.

## Validation

- `git diff --check`
- `cargo test -p quiche missing_initial_source_connection_id -- --nocapture`
- `cargo test -p quiche invalid_initial -- --nocapture`
- `cargo test -p quiche local_error -- --nocapture`
- `cargo test -p quiche close -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo test -p quiche --all-targets`
- `RUSTFLAGS="-D warnings" cargo clippy -p quiche --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --all-targets --features=async,ffi,qlog --workspace`
- `RUSTFLAGS="-D warnings" cargo clippy --features=async,ffi,qlog --workspace -- -D warnings`
