### PR TITLE
FFI fix - fix missing set for max_rtt in PathStats

### DIFF
--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1493,6 +1493,7 @@ pub extern "C" fn quiche_conn_path_stats(
     out.dgram_sent = stats.dgram_sent;
     out.rtt = stats.rtt.as_nanos() as u64;
     out.min_rtt = stats.min_rtt.unwrap_or_default().as_nanos() as u64;
+    out.max_rtt = stats.max_rtt.unwrap_or_default().as_nanos() as u64;
     out.rttvar = stats.rttvar.as_nanos() as u64;
     out.cwnd = stats.cwnd;
     out.sent_bytes = stats.sent_bytes;


### PR DESCRIPTION
While trying to acquire statistics for the state of the connection I have noticed that `max_rtt` was always 0, and larger than `min_rtt`. After digging through, I have noticed that the FFI function `quiche_conn_path_stats` was missing a setter for the `max_rtt` field resulting in max_rtt always being 0 when used via FFI.

This commit fixes the aforementioned issue