### PR TITLE
quiche: reject zero-length integer transport parameters (RFC 9000 §18.2)

### DIFF
--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -133,6 +133,81 @@ fn transport_params_forbid_duplicates() {
 }
 
 #[test]
+fn transport_params_reject_zero_length_integer() {
+    // RFC 9000 Section 16: a varint must be at least 1 byte.
+    // A transport parameter with an integer value encoded as zero-length
+    // is invalid and must be rejected with TRANSPORT_PARAMETER_ERROR.
+
+    // max_idle_timeout (0x01) with length 0: invalid.
+    let raw_params: &[u8] = &[0x01, 0x00];
+    assert_eq!(
+        TransportParams::decode(raw_params, true, None),
+        Err(Error::InvalidTransportParam)
+    );
+
+    // max_ack_delay (0x0b) with length 0: invalid.
+    let raw_params: &[u8] = &[0x0b, 0x00];
+    assert_eq!(
+        TransportParams::decode(raw_params, true, None),
+        Err(Error::InvalidTransportParam)
+    );
+
+    // initial_max_data (0x04) with length 0: invalid.
+    let raw_params: &[u8] = &[0x04, 0x00];
+    assert_eq!(
+        TransportParams::decode(raw_params, true, None),
+        Err(Error::InvalidTransportParam)
+    );
+
+    // initial_max_streams_bidi (0x08) with length 0: invalid.
+    let raw_params: &[u8] = &[0x08, 0x00];
+    assert_eq!(
+        TransportParams::decode(raw_params, true, None),
+        Err(Error::InvalidTransportParam)
+    );
+
+    // ack_delay_exponent (0x0a) with length 0: invalid.
+    let raw_params: &[u8] = &[0x0a, 0x00];
+    assert_eq!(
+        TransportParams::decode(raw_params, true, None),
+        Err(Error::InvalidTransportParam)
+    );
+
+    // max_datagram_frame_size (0x20) with length 0: invalid.
+    let raw_params: &[u8] = &[0x20, 0x00];
+    assert_eq!(
+        TransportParams::decode(raw_params, true, None),
+        Err(Error::InvalidTransportParam)
+    );
+}
+
+#[test]
+fn transport_params_accept_legal_zero_integer() {
+    // A varint value of 0 encoded as a single byte (0x00) is valid.
+    // max_idle_timeout (0x01) with length 1, value 0x00 = varint 0.
+    let raw_params: &[u8] = &[0x01, 0x01, 0x00];
+    let tp = TransportParams::decode(raw_params, true, None).unwrap();
+    assert_eq!(tp.max_idle_timeout, 0);
+
+    // max_ack_delay (0x0b) with length 1, value 0x00 = varint 0.
+    let raw_params: &[u8] = &[0x0b, 0x01, 0x00];
+    let tp = TransportParams::decode(raw_params, true, None).unwrap();
+    assert_eq!(tp.max_ack_delay, 0);
+}
+
+#[test]
+fn transport_params_reject_trailing_bytes_in_integer() {
+    // A varint that does not exactly consume the value length is invalid.
+    // max_idle_timeout (0x01) with length 2, value 0x00 (1-byte varint)
+    // + trailing 0x00 byte.
+    let raw_params: &[u8] = &[0x01, 0x02, 0x00, 0x00];
+    assert_eq!(
+        TransportParams::decode(raw_params, true, None),
+        Err(Error::InvalidTransportParam)
+    );
+}
+
+#[test]
 fn transport_params_unknown_zero_space() {
     let mut unknown_params: UnknownTransportParameters =
         UnknownTransportParameters {

--- a/quiche/src/transport_params.rs
+++ b/quiche/src/transport_params.rs
@@ -220,6 +220,24 @@ impl Default for TransportParams {
 }
 
 impl TransportParams {
+    /// Reads an integer transport parameter value as a varint, rejecting an
+    /// empty value or any trailing bytes after the varint (RFC 9000 §16, §18.2).
+    fn decode_tp_varint(val: &mut octets::Octets) -> Result<u64> {
+        if val.cap() == 0 {
+            return Err(Error::InvalidTransportParam);
+        }
+
+        let v = val
+            .get_varint()
+            .map_err(|_| Error::InvalidTransportParam)?;
+
+        if val.cap() != 0 {
+            return Err(Error::InvalidTransportParam);
+        }
+
+        Ok(v)
+    }
+
     pub(crate) fn decode(
         buf: &[u8], is_server: bool, unknown_size: Option<usize>,
     ) -> Result<TransportParams> {
@@ -256,7 +274,7 @@ impl TransportParams {
                 },
 
                 0x0001 => {
-                    tp.max_idle_timeout = val.get_varint()?;
+                    tp.max_idle_timeout = Self::decode_tp_varint(&mut val)?;
                 },
 
                 0x0002 => {
@@ -273,7 +291,8 @@ impl TransportParams {
                 },
 
                 0x0003 => {
-                    tp.max_udp_payload_size = val.get_varint()?;
+                    tp.max_udp_payload_size =
+                        Self::decode_tp_varint(&mut val)?;
 
                     if tp.max_udp_payload_size < 1200 {
                         return Err(Error::InvalidTransportParam);
@@ -281,23 +300,26 @@ impl TransportParams {
                 },
 
                 0x0004 => {
-                    tp.initial_max_data = val.get_varint()?;
+                    tp.initial_max_data = Self::decode_tp_varint(&mut val)?;
                 },
 
                 0x0005 => {
-                    tp.initial_max_stream_data_bidi_local = val.get_varint()?;
+                    tp.initial_max_stream_data_bidi_local =
+                        Self::decode_tp_varint(&mut val)?;
                 },
 
                 0x0006 => {
-                    tp.initial_max_stream_data_bidi_remote = val.get_varint()?;
+                    tp.initial_max_stream_data_bidi_remote =
+                        Self::decode_tp_varint(&mut val)?;
                 },
 
                 0x0007 => {
-                    tp.initial_max_stream_data_uni = val.get_varint()?;
+                    tp.initial_max_stream_data_uni =
+                        Self::decode_tp_varint(&mut val)?;
                 },
 
                 0x0008 => {
-                    let max = val.get_varint()?;
+                    let max = Self::decode_tp_varint(&mut val)?;
 
                     if max > MAX_STREAM_ID {
                         return Err(Error::InvalidTransportParam);
@@ -307,7 +329,7 @@ impl TransportParams {
                 },
 
                 0x0009 => {
-                    let max = val.get_varint()?;
+                    let max = Self::decode_tp_varint(&mut val)?;
 
                     if max > MAX_STREAM_ID {
                         return Err(Error::InvalidTransportParam);
@@ -317,7 +339,8 @@ impl TransportParams {
                 },
 
                 0x000a => {
-                    let ack_delay_exponent = val.get_varint()?;
+                    let ack_delay_exponent =
+                        Self::decode_tp_varint(&mut val)?;
 
                     if ack_delay_exponent > MAX_ACK_DELAY_EXPONENT {
                         return Err(Error::InvalidTransportParam);
@@ -327,7 +350,7 @@ impl TransportParams {
                 },
 
                 0x000b => {
-                    let max_ack_delay = val.get_varint()?;
+                    let max_ack_delay = Self::decode_tp_varint(&mut val)?;
 
                     if max_ack_delay >= 2_u64.pow(14) {
                         return Err(Error::InvalidTransportParam);
@@ -349,7 +372,7 @@ impl TransportParams {
                 },
 
                 0x000e => {
-                    let limit = val.get_varint()?;
+                    let limit = Self::decode_tp_varint(&mut val)?;
 
                     if limit < 2 {
                         return Err(Error::InvalidTransportParam);
@@ -371,7 +394,8 @@ impl TransportParams {
                 },
 
                 0x0020 => {
-                    tp.max_datagram_frame_size = Some(val.get_varint()?);
+                    tp.max_datagram_frame_size =
+                        Some(Self::decode_tp_varint(&mut val)?);
                 },
 
                 // Track unknown transport parameters specially.


### PR DESCRIPTION
Fixes #2508.

An integer transport parameter with a zero-length value is currently accepted and decoded as `0`. A zero-length encoding is not a valid varint (RFC 9000 §16), so per §18.2 such a transport parameter should be rejected with a `TRANSPORT_PARAMETER_ERROR`. Other implementations (ngtcp2, lsquic) already reject these.

This adds a small helper that validates the value buffer is non-empty and that the decoded varint consumes the whole value (no trailing bytes), and uses it when decoding the integer transport parameters. Malformed parameters now surface `Error::InvalidTransportParam` instead of being silently interpreted as `0`.

Includes tests covering the zero-length case and the trailing-bytes case.