### PR TITLE
Implement PMTU_RAISE_TIMER for PMTUD re-probing

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -177,6 +177,14 @@ void quiche_config_grease(quiche_config *config, bool v);
 // Configures whether to do path MTU discovery.
 void quiche_config_discover_pmtu(quiche_config *config, bool v);
 
+// Configures the maximum number of PMTUD probe attempts before treating a size
+// as failed.
+void quiche_config_set_pmtud_max_probes(quiche_config *config, uint8_t max_probes);
+
+// Configures how long PMTUD stays on a discovered PMTU before re-entering the
+// Search Phase, in milliseconds. Zero disables periodic re-probing.
+void quiche_config_set_pmtud_raise_timer(quiche_config *config, uint64_t millis);
+
 // Enables logging of secrets.
 void quiche_config_log_keys(quiche_config *config);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -223,6 +223,13 @@ pub extern "C" fn quiche_config_set_pmtud_max_probes(
 }
 
 #[no_mangle]
+pub extern "C" fn quiche_config_set_pmtud_raise_timer(
+    config: &mut Config, millis: u64,
+) {
+    config.set_pmtud_raise_timer(Duration::from_millis(millis));
+}
+
+#[no_mangle]
 pub extern "C" fn quiche_config_log_keys(config: &mut Config) {
     config.log_keys();
 }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -579,6 +579,7 @@ pub struct Config {
 
     pmtud: bool,
     pmtud_max_probes: u8,
+    pmtud_raise_timer: Option<Duration>,
 
     hystart: bool,
 
@@ -660,6 +661,7 @@ impl Config {
             enable_send_streams_blocked: false,
             pmtud: false,
             pmtud_max_probes: pmtud::MAX_PROBES_DEFAULT,
+            pmtud_raise_timer: None,
             hystart: true,
             pacing: true,
             max_pacing_rate: None,
@@ -784,6 +786,14 @@ impl Config {
     /// If 0 is passed, the default value is used.
     pub fn set_pmtud_max_probes(&mut self, max_probes: u8) {
         self.pmtud_max_probes = max_probes;
+    }
+
+    /// Configures how long PMTUD stays on a discovered PMTU before re-entering
+    /// the Search Phase to probe for a larger path MTU.
+    ///
+    /// Defaults to disabled. A duration of zero disables periodic re-probing.
+    pub fn set_pmtud_raise_timer(&mut self, raise_timer: Duration) {
+        self.pmtud_raise_timer = (!raise_timer.is_zero()).then_some(raise_timer);
     }
 
     /// Configures whether to send GREASE values.
@@ -1355,6 +1365,11 @@ where
 
     /// The configuration for recovery.
     recovery_config: recovery::RecoveryConfig,
+
+    /// Period on the discovered PMTU before re-entering the Search Phase,
+    /// applied to paths that enable PMTUD during the handshake. [`None`]
+    /// disables periodic re-probing.
+    pmtud_raise_timer: Option<Duration>,
 
     /// The path manager.
     paths: path::PathMap,
@@ -2080,6 +2095,8 @@ impl<F: BufFactory> Connection<F> {
 
             recovery_config,
 
+            pmtud_raise_timer: config.pmtud_raise_timer,
+
             paths,
             path_challenge_recv_max_queue_len: config
                 .path_challenge_recv_max_queue_len,
@@ -2683,7 +2700,10 @@ impl<F: BufFactory> Connection<F> {
     ) -> Result<()> {
         let ex_data = tls::ExData::from_ssl_ref(ssl).ok_or(Error::TlsFail)?;
 
-        ex_data.pmtud = Some((discover, max_probes));
+        ex_data.pmtud = Some(pmtud::PmtudParams {
+            enable: discover,
+            max_probes,
+        });
 
         Ok(())
     }
@@ -3538,7 +3558,7 @@ impl<F: BufFactory> Connection<F> {
                             // Ensure the probe is within the supported MTU range
                             // before updating the max datagram size
                             if let Some(current_mtu) =
-                                pmtud.successful_probe(mtu_probe)
+                                pmtud.successful_probe(mtu_probe, now)
                             {
                                 qlog_with_type!(
                                     EventType::QuicEventType(
@@ -4295,7 +4315,7 @@ impl<F: BufFactory> Connection<F> {
                         if let Some(failed_probe) = mtu_probe {
                             if let Some(pmtud) = p.pmtud.as_mut() {
                                 trace!("pmtud probe dropped: {failed_probe}");
-                                pmtud.failed_probe(failed_probe);
+                                pmtud.failed_probe(failed_probe, now);
                             }
                         }
                     },
@@ -7009,12 +7029,23 @@ impl<F: BufFactory> Connection<F> {
                 .filter_map(|(_, p)| p.recovery.loss_detection_timer())
                 .min();
 
+            let pmtud_raise_timer = self
+                .paths
+                .iter()
+                .filter_map(|(_, p)| p.pmtud.as_ref()?.raise_timer())
+                .min();
+
             let key_update_timer = self.crypto_ctx[packet::Epoch::Application]
                 .key_update
                 .as_ref()
                 .map(|key_update| key_update.timer);
 
-            let timers = [self.idle_timer, path_timer, key_update_timer];
+            let timers = [
+                self.idle_timer,
+                path_timer,
+                pmtud_raise_timer,
+                key_update_timer,
+            ];
 
             timers.iter().filter_map(|&x| x).min()
         }
@@ -7042,8 +7073,10 @@ impl<F: BufFactory> Connection<F> {
     ///
     /// If no timeout has occurred it does nothing.
     pub fn on_timeout(&mut self) {
-        let now = Instant::now();
+        self.on_timeout_at(Instant::now());
+    }
 
+    fn on_timeout_at(&mut self, now: Instant) {
         if let Some(draining_timer) = self.draining_timer {
             if draining_timer <= now {
                 trace!("{} draining timeout expired", self.trace_id);
@@ -7104,6 +7137,10 @@ impl<F: BufFactory> Connection<F> {
                         p.recovery.maybe_qlog(q, now);
                     });
                 }
+            }
+
+            if let Some(pmtud) = p.pmtud.as_mut() {
+                pmtud.on_raise_timeout(now);
             }
         }
 
@@ -8034,11 +8071,11 @@ impl<F: BufFactory> Connection<F> {
                         self.tx_cap_factor = ex_data.tx_cap_factor;
                     }
 
-                    if let Some((discover, max_probes)) = ex_data.pmtud {
+                    if let Some(params) = ex_data.pmtud {
                         self.paths.set_discover_pmtu_on_existing_paths(
-                            discover,
+                            params,
+                            self.pmtud_raise_timer,
                             self.recovery_config.max_send_udp_payload_size,
-                            max_probes,
                         );
                     }
 

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -251,7 +251,11 @@ impl Path {
                         .unwrap_or(c.max_send_udp_payload_size),
                     c.max_send_udp_payload_size,
                 );
-                Some(pmtud::Pmtud::new(maximum_supported_mtu, c.pmtud_max_probes))
+                Some(pmtud::Pmtud::new(
+                    maximum_supported_mtu,
+                    c.pmtud_max_probes,
+                    c.pmtud_raise_timer,
+                ))
             } else {
                 None
             }
@@ -907,14 +911,15 @@ impl PathMap {
 
     /// Configures path MTU discovery on all existing paths.
     pub fn set_discover_pmtu_on_existing_paths(
-        &mut self, discover: bool, max_send_udp_payload_size: usize,
-        pmtud_max_probes: u8,
+        &mut self, params: pmtud::PmtudParams, raise_interval: Option<Duration>,
+        max_send_udp_payload_size: usize,
     ) {
         for (_, path) in self.paths.iter_mut() {
-            path.pmtud = if discover {
+            path.pmtud = if params.enable {
                 Some(pmtud::Pmtud::new(
                     max_send_udp_payload_size,
-                    pmtud_max_probes,
+                    params.max_probes,
+                    raise_interval,
                 ))
             } else {
                 None

--- a/quiche/src/pmtud.rs
+++ b/quiche/src/pmtud.rs
@@ -17,9 +17,21 @@
 //!
 //! [RFC 8899]: https://datatracker.ietf.org/doc/html/rfc8899
 
+use std::time::Duration;
+use std::time::Instant;
+
 /// Maximum number of probe attempts before treating a size as failed.
 /// https://datatracker.ietf.org/doc/html/rfc8899#section-5.1.2
 pub(crate) const MAX_PROBES_DEFAULT: u8 = 3;
+
+/// PMTUD configuration carried across the handshake and applied to paths.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PmtudParams {
+    pub enable: bool,
+
+    /// Consecutive probe failures tolerated before a size is treated as failed.
+    pub max_probes: u8,
+}
 
 /// Min Packetization Layer Path MTU (PLPMTU).
 /// https://datatracker.ietf.org/doc/html/rfc8899#section-5.1.2
@@ -54,13 +66,26 @@ pub struct Pmtud {
     /// The maximum number of failed probe attempts before treating a size as
     /// failed.
     max_probes: u8,
+
+    /// How long to stay on the discovered PMTU before re-entering the Search
+    /// Phase. [`None`] disables periodic re-probing.
+    raise_interval: Option<Duration>,
+
+    /// When set, the instant at which the Search Phase should be re-entered.
+    /// Armed once a PMTU is found; cleared while searching.
+    raise_deadline: Option<Instant>,
 }
 
 impl Pmtud {
     /// Creates new PMTUD instance.
     ///
     /// If `max_probes` is 0, uses the default value of [`MAX_PROBES_DEFAULT`].
-    pub fn new(maximum_supported_mtu: usize, max_probes: u8) -> Self {
+    /// `raise_interval` of [`None`] disables periodic re-probing once a PMTU is
+    /// found.
+    pub fn new(
+        maximum_supported_mtu: usize, max_probes: u8,
+        raise_interval: Option<Duration>,
+    ) -> Self {
         let max_probes = if max_probes == 0 {
             warn!(
                 "max_probes is 0, using default value {}",
@@ -75,6 +100,7 @@ impl Pmtud {
             maximum_supported_mtu,
             probe_size: maximum_supported_mtu,
             max_probes,
+            raise_interval,
             ..Default::default()
         }
     }
@@ -114,7 +140,7 @@ impl Pmtud {
     ///
     /// Based on the Optimistic Binary algorithm defined in:
     /// Ref: <https://www.hb.fh-muenster.de/opus4/frontdoor/deliver/index/docId/14965/file/dplpmtudQuicPaper.pdf>
-    fn update_probe_size(&mut self) {
+    fn update_probe_size(&mut self, now: Instant) {
         match (
             self.smallest_failed_probe_size,
             self.largest_successful_probe_size,
@@ -136,7 +162,7 @@ impl Pmtud {
                 // Found the PMTU
                 if failed_probe_size - successful_probe_size <= 1 {
                     debug!("Found PMTU: {successful_probe_size}");
-                    self.set_pmtu(successful_probe_size);
+                    self.set_pmtu(successful_probe_size, now);
                 } else {
                     self.probe_size =
                         (successful_probe_size + failed_probe_size) / 2
@@ -152,7 +178,7 @@ impl Pmtud {
             // is the maximum supported MTU, then having only a successful probe
             // means the maximum supported MTU is <= PMTU
             (None, Some(successful_probe_size)) => {
-                self.set_pmtu(successful_probe_size);
+                self.set_pmtu(successful_probe_size, now);
             },
 
             // Use the initial probe size if no record of success/failures
@@ -166,7 +192,9 @@ impl Pmtud {
     }
 
     /// Records a successful probe and returns the largest successful probe size
-    pub fn successful_probe(&mut self, probe_size: usize) -> Option<usize> {
+    pub fn successful_probe(
+        &mut self, probe_size: usize, now: Instant,
+    ) -> Option<usize> {
         self.probe_failure_count = 0;
 
         self.largest_successful_probe_size = std::cmp::max(
@@ -175,14 +203,29 @@ impl Pmtud {
             self.largest_successful_probe_size,
         );
 
-        self.update_probe_size();
+        self.update_probe_size(now);
         self.in_flight = false;
 
         self.largest_successful_probe_size
     }
 
+    /// Returns the instant at which the Search Phase should be re-entered, if a
+    /// raise timer is currently armed.
+    pub fn raise_timer(&self) -> Option<Instant> {
+        self.raise_deadline
+    }
+
+    /// Re-enters the Search Phase if the raise timer has expired.
+    ///
+    /// A no-op if the timer is unarmed or has not yet elapsed.
+    pub fn on_raise_timeout(&mut self, now: Instant) {
+        if self.raise_deadline.is_some_and(|deadline| now >= deadline) {
+            self.enter_search_phase();
+        }
+    }
+
     /// Records a failed probe
-    pub fn failed_probe(&mut self, probe_size: usize) {
+    pub fn failed_probe(&mut self, probe_size: usize, now: Instant) {
         // Treat errant probes as if they failed at the minimum supported MTU
         let probe_size = std::cmp::max(probe_size, MIN_PLPMTU);
         self.probe_failure_count += 1;
@@ -210,18 +253,26 @@ impl Pmtud {
         );
 
         self.probe_failure_count = 0;
-        self.update_probe_size();
+        self.update_probe_size(now);
         self.in_flight = false;
     }
 
     // Resets PMTUD internals such that PMTUD will be recalculated
     // on the next opportunity
     fn restart_pmtud(&mut self) {
+        self.largest_successful_probe_size = None;
+        self.enter_search_phase();
+    }
+
+    // Re-enters the Search Phase, retaining the largest confirmed probe size so
+    // ordinary traffic keeps flowing at the current PLPMTU while a larger size
+    // is probed.
+    fn enter_search_phase(&mut self) {
         self.set_probe_size(self.maximum_supported_mtu);
         self.smallest_failed_probe_size = None;
-        self.largest_successful_probe_size = None;
         self.pmtu = None;
         self.probe_failure_count = 0;
+        self.raise_deadline = None;
     }
 
     // Checks that a probe of PMTU size can be ack'd by enabling
@@ -233,13 +284,21 @@ impl Pmtud {
             self.pmtu = None;
             self.probe_failure_count = 0;
             self.largest_successful_probe_size = None;
+            self.raise_deadline = None;
         }
     }
 
-    fn set_pmtu(&mut self, successful_probe_size: usize) {
+    fn set_pmtu(&mut self, successful_probe_size: usize, now: Instant) {
         self.pmtu = Some(successful_probe_size);
         self.probe_size = successful_probe_size;
         self.probe_failure_count = 0;
+
+        // Entering the Search Complete state arms the raise timer so the path
+        // is periodically re-probed for a larger MTU, regardless of whether a
+        // successful or failed probe completed the search.
+        self.raise_deadline = self
+            .raise_interval
+            .and_then(|interval| now.checked_add(interval));
     }
 }
 
@@ -263,7 +322,7 @@ mod tests {
 
     #[test]
     fn pmtud_initial_state() {
-        let pmtud = Pmtud::new(1350, 1);
+        let pmtud = Pmtud::new(1350, 1, None);
         assert_eq!(pmtud.get_current_mtu(), 1200);
         assert_eq!(pmtud.get_probe_size(), 1350);
         assert!(pmtud.should_probe());
@@ -271,69 +330,69 @@ mod tests {
 
     #[test]
     fn pmtud_max_probes_zero_uses_default() {
-        let pmtud = Pmtud::new(1500, 0);
+        let pmtud = Pmtud::new(1500, 0, None);
         assert_eq!(pmtud.max_probes, MAX_PROBES_DEFAULT);
     }
 
     #[test]
     fn pmtud_max_probes_set_to_provided_value() {
-        let pmtud = Pmtud::new(1500, 5);
+        let pmtud = Pmtud::new(1500, 5, None);
         assert_eq!(pmtud.max_probes, 5);
         assert_ne!(pmtud.max_probes, MAX_PROBES_DEFAULT);
     }
 
     #[test]
     fn pmtud_binary_search_algorithm() {
-        let mut pmtud = Pmtud::new(1500, 1);
+        let mut pmtud = Pmtud::new(1500, 1, None);
 
         // Set initial probe size to 1500
         assert_eq!(pmtud.get_probe_size(), 1500);
 
         // Simulate probe loss - should update to midpoint
-        pmtud.failed_probe(1500);
+        pmtud.failed_probe(1500, Instant::now());
         // Expected: 1200 + ((1500 - 1200) / 2) = 1200 + 150 = 1350
         assert_eq!(pmtud.get_probe_size(), 1350);
 
         // Another probe loss
-        pmtud.failed_probe(1350);
+        pmtud.failed_probe(1350, Instant::now());
         // Expected: 1200 + ((1350 - 1200) / 2) = 1200 + 75 = 1275
         assert_eq!(pmtud.get_probe_size(), 1275);
 
-        pmtud.failed_probe(1275);
+        pmtud.failed_probe(1275, Instant::now());
         // Expected: 1200 + ((1275 - 1200) / 2) = 1200 + 37 = 1237
         assert_eq!(pmtud.get_probe_size(), 1237);
 
-        pmtud.failed_probe(1237);
+        pmtud.failed_probe(1237, Instant::now());
         // Expected: 1200 + ((1237 - 1200) / 2) = 1200 + 18 = 1218
         assert_eq!(pmtud.get_probe_size(), 1218);
 
-        pmtud.failed_probe(1218);
+        pmtud.failed_probe(1218, Instant::now());
         // Expected: 1200 + ((1218 - 1200) / 2) = 1200 + 9 = 1209
         assert_eq!(pmtud.get_probe_size(), 1209);
 
-        pmtud.failed_probe(1209);
+        pmtud.failed_probe(1209, Instant::now());
         // Expected: 1200 + ((1209 - 1200) / 2) = 1200 + 4 = 1204
         assert_eq!(pmtud.get_probe_size(), 1204);
 
-        pmtud.failed_probe(1204);
+        pmtud.failed_probe(1204, Instant::now());
         // Expected: 1200 + ((1204 - 1200) / 2) = 1200 + 2 = 1202
         assert_eq!(pmtud.get_probe_size(), 1202);
 
-        pmtud.failed_probe(1202);
+        pmtud.failed_probe(1202, Instant::now());
         // Expected: 1200 + ((1202 - 1200) / 2) = 1200 + 1 = 1201
         assert_eq!(pmtud.get_probe_size(), 1201);
 
-        pmtud.failed_probe(1201);
+        pmtud.failed_probe(1201, Instant::now());
         // Expected: 1200 + ((1201 - 1200) / 2) = 1200 + 0 = 1200
         assert_eq!(pmtud.get_probe_size(), 1200);
     }
 
     #[test]
     fn pmtud_successful_probe() {
-        let mut pmtud = Pmtud::new(1400, 1);
+        let mut pmtud = Pmtud::new(1400, 1, None);
 
         // Simulate successful probe
-        pmtud.successful_probe(1400);
+        pmtud.successful_probe(1400, Instant::now());
 
         assert_eq!(pmtud.get_current_mtu(), 1400);
     }
@@ -345,8 +404,8 @@ mod tests {
     /// to verify the PMTU discovery process.
     #[test]
     fn test_pmtud_reset() {
-        let mut pmtud = Pmtud::new(1350, 1);
-        pmtud.successful_probe(1350);
+        let mut pmtud = Pmtud::new(1350, 1, None);
+        pmtud.successful_probe(1350, Instant::now());
         assert_eq!(pmtud.pmtu, Some(1350));
         assert!(!pmtud.should_probe());
 
@@ -360,8 +419,8 @@ mod tests {
     /// Test case for receiving a probe outside the defined supported MTU range.
     #[test]
     fn test_pmtud_errant_probe() {
-        let mut pmtud = Pmtud::new(1350, 1);
-        pmtud.successful_probe(1500);
+        let mut pmtud = Pmtud::new(1350, 1, None);
+        pmtud.successful_probe(1500, Instant::now());
         // Even though we've received a probe larger than supported
         // maximum MTU, the PMTU should still respect the configured maximum
         assert_eq!(pmtud.pmtu, Some(1350));
@@ -371,7 +430,7 @@ mod tests {
 
         // A failed probe of a value less than the minimum supported MTU
         // should stop probing
-        pmtud.failed_probe(1100);
+        pmtud.failed_probe(1100, Instant::now());
         assert_eq!(pmtud.pmtu, None);
         assert_eq!(pmtud.get_probe_size(), 1200);
         assert!(!pmtud.should_probe());
@@ -383,7 +442,7 @@ mod tests {
     /// when the PMTU is equal to the minimum supported MTU.
     #[test]
     fn test_pmtu_equal_to_min_supported_mtu() {
-        let mut pmtud = Pmtud::new(1350, 1);
+        let mut pmtud = Pmtud::new(1350, 1, None);
         pmtud_test_runner(&mut pmtud, 1200);
     }
 
@@ -393,7 +452,7 @@ mod tests {
     /// when the PMTU is greater than the minimum supported MTU.
     #[test]
     fn test_pmtu_greater_than_min_supported_mtu() {
-        let mut pmtud = Pmtud::new(1350, 1);
+        let mut pmtud = Pmtud::new(1350, 1, None);
         pmtud_test_runner(&mut pmtud, 1500);
     }
 
@@ -403,7 +462,7 @@ mod tests {
     /// the case when the PMTU is less than the minimum supported MTU.
     #[test]
     fn test_pmtu_less_than_min_supported_mtu() {
-        let mut pmtud = Pmtud::new(1350, 1);
+        let mut pmtud = Pmtud::new(1350, 1, None);
         pmtud_test_runner(&mut pmtud, 1100);
     }
 
@@ -414,9 +473,9 @@ mod tests {
     /// validation probe.
     #[test]
     fn test_pmtu_revalidation() {
-        let mut pmtud = Pmtud::new(1350, 1);
+        let mut pmtud = Pmtud::new(1350, 1, None);
         pmtud.set_probe_size(1350);
-        pmtud.successful_probe(1350);
+        pmtud.successful_probe(1350, Instant::now());
 
         // Simulate a case where an established PMTU probe is dropped repeatedly
         pmtud.revalidate_pmtu();
@@ -428,23 +487,23 @@ mod tests {
 
     #[test]
     fn pmtud_revalidation_tolerates_random_packet_loss() {
-        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT);
+        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT, None);
 
-        pmtud.successful_probe(1500);
+        pmtud.successful_probe(1500, Instant::now());
         assert_eq!(pmtud.get_pmtu(), Some(1500));
 
         pmtud.revalidate_pmtu();
         assert_eq!(pmtud.get_pmtu(), None);
         assert!(pmtud.largest_successful_probe_size.is_none());
 
-        pmtud.failed_probe(1500);
+        pmtud.failed_probe(1500, Instant::now());
         assert_eq!(pmtud.probe_failure_count, 1);
         assert!(pmtud.pmtu.is_none());
 
-        pmtud.failed_probe(1500);
+        pmtud.failed_probe(1500, Instant::now());
         assert_eq!(pmtud.probe_failure_count, 2);
 
-        pmtud.successful_probe(1500);
+        pmtud.successful_probe(1500, Instant::now());
         assert_eq!(pmtud.get_pmtu(), Some(1500));
         assert_eq!(pmtud.probe_failure_count, 0);
     }
@@ -453,9 +512,9 @@ mod tests {
     /// PMTUD should binary search down, not restart.
     #[test]
     fn pmtud_revalidation_failure_binary_searches_not_restarts() {
-        let mut pmtud = Pmtud::new(1500, 1);
+        let mut pmtud = Pmtud::new(1500, 1, None);
 
-        pmtud.successful_probe(1500);
+        pmtud.successful_probe(1500, Instant::now());
         assert_eq!(pmtud.get_pmtu(), Some(1500));
 
         // Revalidation clears largest_successful_probe_size
@@ -463,7 +522,7 @@ mod tests {
         assert!(pmtud.largest_successful_probe_size.is_none());
 
         // Revalidation probe fails - should binary search down, not restart
-        pmtud.failed_probe(1500);
+        pmtud.failed_probe(1500, Instant::now());
 
         assert_eq!(pmtud.smallest_failed_probe_size, Some(1500));
         assert!(pmtud.largest_successful_probe_size.is_none());
@@ -472,26 +531,26 @@ mod tests {
 
     #[test]
     fn pmtud_tolerates_initial_packet_loss() {
-        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT);
+        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT, None);
 
-        pmtud.failed_probe(1500);
+        pmtud.failed_probe(1500, Instant::now());
         assert_eq!(pmtud.probe_failure_count, 1);
         assert!(pmtud.smallest_failed_probe_size.is_none());
 
-        pmtud.failed_probe(1500);
+        pmtud.failed_probe(1500, Instant::now());
         assert_eq!(pmtud.probe_failure_count, 2);
         assert!(pmtud.smallest_failed_probe_size.is_none());
 
-        pmtud.successful_probe(1500);
+        pmtud.successful_probe(1500, Instant::now());
         assert_eq!(pmtud.get_pmtu(), Some(1500));
         assert_eq!(pmtud.probe_failure_count, 0);
     }
 
     #[test]
     fn pmtud_confirms_failure_after_max_probes() {
-        let mut pmtud = Pmtud::new(1500, 1);
+        let mut pmtud = Pmtud::new(1500, 1, None);
 
-        pmtud.failed_probe(1500);
+        pmtud.failed_probe(1500, Instant::now());
 
         assert_eq!(pmtud.smallest_failed_probe_size, Some(1500));
         assert!(pmtud.pmtu.is_none());
@@ -501,7 +560,7 @@ mod tests {
 
     #[test]
     fn pmtud_binary_search_no_slowdown() {
-        let mut pmtud = Pmtud::new(1500, 2);
+        let mut pmtud = Pmtud::new(1500, 2, None);
 
         fail_probe_max_times(&mut pmtud, 1500);
         assert!(pmtud.pmtu.is_none());
@@ -509,11 +568,11 @@ mod tests {
         let search_size_1 = pmtud.get_probe_size();
         assert!(search_size_1 < 1500);
 
-        pmtud.successful_probe(search_size_1);
+        pmtud.successful_probe(search_size_1, Instant::now());
         assert_eq!(pmtud.probe_failure_count, 0);
 
         let search_size_2 = pmtud.get_probe_size();
-        pmtud.failed_probe(search_size_2);
+        pmtud.failed_probe(search_size_2, Instant::now());
 
         assert!(pmtud.pmtu.is_none());
         assert_eq!(pmtud.probe_failure_count, 1);
@@ -528,7 +587,7 @@ mod tests {
     /// 3. Algorithm converges to the correct MTU of 1337
     #[test]
     fn pmtud_convergence_with_intermittent_loss() {
-        let mut pmtud = Pmtud::new(1500, 3);
+        let mut pmtud = Pmtud::new(1500, 3, None);
         let target_mtu = 1337;
 
         while pmtud.get_pmtu().is_none() {
@@ -536,11 +595,11 @@ mod tests {
 
             if probe_size <= target_mtu {
                 // First probe fails (random loss)
-                pmtud.failed_probe(probe_size);
+                pmtud.failed_probe(probe_size, Instant::now());
                 assert_eq!(pmtud.probe_failure_count, 1);
 
                 // Second probe succeeds
-                pmtud.successful_probe(probe_size);
+                pmtud.successful_probe(probe_size, Instant::now());
                 assert_eq!(pmtud.probe_failure_count, 0); // Reset on success
             } else {
                 // Size exceeds MTU - all probes fail
@@ -560,34 +619,34 @@ mod tests {
 
     #[test]
     fn pmtud_failure_at_min_plpmtu() {
-        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT);
+        let mut pmtud = Pmtud::new(1500, MAX_PROBES_DEFAULT, None);
 
-        pmtud.failed_probe(100);
-        pmtud.failed_probe(100);
-        pmtud.failed_probe(100);
+        pmtud.failed_probe(100, Instant::now());
+        pmtud.failed_probe(100, Instant::now());
+        pmtud.failed_probe(100, Instant::now());
 
         assert_eq!(pmtud.smallest_failed_probe_size, Some(MIN_PLPMTU));
     }
 
     #[test]
     fn pmtud_in_flight_cleared_on_all_outcomes() {
-        let mut pmtud = Pmtud::new(1500, 1);
+        let mut pmtud = Pmtud::new(1500, 1, None);
 
         pmtud.set_in_flight(true);
         assert!(pmtud.in_flight);
 
-        pmtud.failed_probe(1500);
+        pmtud.failed_probe(1500, Instant::now());
         assert!(!pmtud.in_flight);
 
         pmtud.set_in_flight(true);
 
-        pmtud.successful_probe(1500);
+        pmtud.successful_probe(1500, Instant::now());
         assert!(!pmtud.in_flight);
     }
 
     #[test]
     fn pmtud_update_probe_size_initial_state() {
-        let mut pmtud = Pmtud::new(1500, 1);
+        let mut pmtud = Pmtud::new(1500, 1, None);
 
         // Manually set probe_size to something else to verify update_probe_size
         // resets it
@@ -595,16 +654,105 @@ mod tests {
 
         // With no successful or failed probes, should reset to
         // maximum_supported_mtu
-        pmtud.update_probe_size();
+        pmtud.update_probe_size(Instant::now());
 
         assert_eq!(pmtud.probe_size, 1500);
+    }
+
+    #[test]
+    fn pmtud_arms_raise_timer_when_pmtu_found() {
+        let interval = Duration::from_secs(600);
+        let mut pmtud = Pmtud::new(1400, 1, Some(interval));
+        let now = Instant::now();
+
+        assert_eq!(pmtud.raise_timer(), None);
+
+        pmtud.successful_probe(1400, now);
+
+        assert_eq!(pmtud.get_pmtu(), Some(1400));
+        assert_eq!(pmtud.raise_timer(), Some(now + interval));
+    }
+
+    #[test]
+    fn pmtud_raise_timer_disabled_never_arms() {
+        let mut pmtud = Pmtud::new(1400, 1, None);
+
+        pmtud.successful_probe(1400, Instant::now());
+
+        assert_eq!(pmtud.get_pmtu(), Some(1400));
+        assert_eq!(pmtud.raise_timer(), None);
+    }
+
+    #[test]
+    fn pmtud_on_raise_timeout_before_deadline_is_noop() {
+        let interval = Duration::from_secs(600);
+        let mut pmtud = Pmtud::new(1400, 1, Some(interval));
+        let now = Instant::now();
+
+        pmtud.successful_probe(1400, now);
+        pmtud.on_raise_timeout(now + interval - Duration::from_secs(1));
+
+        assert_eq!(pmtud.get_pmtu(), Some(1400));
+        assert_eq!(pmtud.raise_timer(), Some(now + interval));
+        assert!(!pmtud.should_probe());
+    }
+
+    #[test]
+    fn pmtud_on_raise_timeout_reenters_search() {
+        let interval = Duration::from_secs(600);
+        let mut pmtud = Pmtud::new(1400, 1, Some(interval));
+        let now = Instant::now();
+
+        pmtud.successful_probe(1400, now);
+        pmtud.on_raise_timeout(now + interval);
+
+        assert_eq!(pmtud.get_pmtu(), None);
+        assert_eq!(pmtud.raise_timer(), None);
+        assert_eq!(pmtud.get_probe_size(), 1400);
+        assert!(pmtud.should_probe());
+    }
+
+    #[test]
+    fn pmtud_arms_raise_timer_when_search_completes_on_failure() {
+        let interval = Duration::from_secs(600);
+        let mut pmtud = Pmtud::new(1204, 1, Some(interval));
+        let now = Instant::now();
+
+        // Drive the search so its final, gap-closing probe is a failure: the
+        // PMTU is then established through failed_probe, not successful_probe.
+        pmtud.failed_probe(1204, now);
+        pmtud.successful_probe(1202, now);
+        assert_eq!(pmtud.get_pmtu(), None);
+
+        pmtud.failed_probe(1203, now);
+
+        assert_eq!(pmtud.get_pmtu(), Some(1202));
+        assert_eq!(pmtud.raise_timer(), Some(now + interval));
+    }
+
+    #[test]
+    fn pmtud_raise_search_keeps_serving_confirmed_mtu() {
+        let interval = Duration::from_secs(600);
+        let mut pmtud = Pmtud::new(1500, 1, Some(interval));
+
+        // Confirm a PMTU below the maximum, leaving headroom to probe upward.
+        pmtud_test_runner(&mut pmtud, 1400);
+        assert_eq!(pmtud.get_pmtu(), Some(1400));
+        assert_eq!(pmtud.get_current_mtu(), 1400);
+
+        let deadline = pmtud.raise_timer().expect("raise timer armed");
+        pmtud.on_raise_timeout(deadline);
+
+        assert!(pmtud.should_probe());
+        assert_eq!(pmtud.get_pmtu(), None);
+        assert_eq!(pmtud.get_current_mtu(), 1400);
     }
 
     // Test utilities
 
     fn fail_probe_max_times(pmtud: &mut Pmtud, size: usize) {
         for _ in 0..pmtud.max_probes {
-            pmtud.failed_probe(size);
+            pmtud.failed_probe(size, Instant::now());
         }
     }
 
@@ -620,13 +768,13 @@ mod tests {
             let probe_size = pmtud.get_probe_size();
 
             if probe_size <= test_pmtu {
-                pmtud.successful_probe(probe_size);
+                pmtud.successful_probe(probe_size, Instant::now());
             } else {
                 fail_probe_max_times(pmtud, probe_size);
             }
 
             // Update the probe size based on the result
-            pmtud.update_probe_size();
+            pmtud.update_probe_size(Instant::now());
 
             // If the probe size hasn't changed and is equal to the minimum
             // supported MTU, break the loop

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -11941,6 +11941,73 @@ fn pmtud_probe_success(
     assert_eq!(path_stats.pmtu, current_mtu);
 }
 
+fn active_pmtud(conn: &mut Connection) -> &mut pmtud::Pmtud {
+    conn.paths.get_active_mut().unwrap().pmtud.as_mut().unwrap()
+}
+
+#[test]
+fn pmtud_raise_timer_is_disabled_by_default() {
+    let config = Config::new(PROTOCOL_VERSION).expect("valid config");
+
+    assert_eq!(config.pmtud_raise_timer, None);
+}
+
+#[rstest]
+/// The raise timer re-enters the Search Phase once it expires, and a settled
+/// PMTU is re-discovered.
+fn pmtud_raise_timer_reprobes(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let raise_timer = Duration::from_millis(50);
+
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config.set_cc_algorithm_name(cc_algorithm_name).unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config.set_application_protos(&[b"proto1"]).unwrap();
+    config.verify_peer(false);
+    config.set_max_send_udp_payload_size(1400);
+    config.discover_pmtu(true);
+    config.set_pmtud_raise_timer(raise_timer);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // Settle the PMTU and confirm the raise timer is armed.
+    assert_eq!(pipe.advance(), Ok(()));
+
+    let raise_deadline = {
+        let pmtud = active_pmtud(&mut pipe.client);
+        assert!(!pmtud.should_probe());
+        assert_eq!(pmtud.get_pmtu(), Some(1400));
+        pmtud.raise_timer().expect("raise timer armed")
+    };
+    assert_eq!(pipe.client.timeout_instant(), Some(raise_deadline));
+
+    // Once the raise timer expires, the path re-enters the Search Phase.
+    pipe.client.on_timeout_at(raise_deadline);
+
+    {
+        let pmtud = active_pmtud(&mut pipe.client);
+        assert!(pmtud.should_probe());
+        assert_eq!(pmtud.get_pmtu(), None);
+        assert_eq!(pmtud.get_probe_size(), 1400);
+        assert_eq!(pmtud.raise_timer(), None);
+    }
+
+    // The re-probe succeeds and re-arms the raise timer.
+    assert_eq!(pipe.advance(), Ok(()));
+
+    let pmtud = active_pmtud(&mut pipe.client);
+    assert!(!pmtud.should_probe());
+    assert_eq!(pmtud.get_pmtu(), Some(1400));
+    assert!(pmtud.raise_timer().is_some());
+}
+
 #[rstest]
 /// This test verifies that multiple send() calls after handshake completion
 /// only generate one PMTUD probe packet, not multiple identical probes.
@@ -12057,13 +12124,13 @@ fn pmtud_probe_retry_after_loss(
 
     // Simulate probe loss - need 2 failures (configured via set_pmtud_max_probes)
     // before size changes. First failure - should retry at same size
-    pmtud.failed_probe(initial_probe_size);
+    pmtud.failed_probe(initial_probe_size, Instant::now());
     assert_eq!(pmtud.get_current_mtu(), 1200);
     assert!(pmtud.should_probe());
     assert_eq!(pmtud.get_probe_size(), 1400); // Still trying 1400
 
     // Second failure (max_probes reached) - now size should change
-    pmtud.failed_probe(initial_probe_size);
+    pmtud.failed_probe(initial_probe_size, Instant::now());
     assert_eq!(pmtud.get_current_mtu(), 1200);
     assert!(pmtud.should_probe());
     assert_eq!(pmtud.get_probe_size(), 1300);
@@ -12086,8 +12153,8 @@ fn pmtud_probe_retry_after_loss(
     assert!(!pmtud.should_probe());
 
     // Simulate second probe loss (2 failures needed)
-    pmtud.failed_probe(1300);
-    pmtud.failed_probe(1300);
+    pmtud.failed_probe(1300, Instant::now());
+    pmtud.failed_probe(1300, Instant::now());
 
     // Verify MTU is not updated
     assert_eq!(pmtud.get_current_mtu(), 1200);
@@ -12156,6 +12223,7 @@ fn enable_pmtud_mid_handshake(
         server_config.set_cc_algorithm_name(cc_algorithm_name),
         Ok(())
     );
+    server_config.set_pmtud_raise_timer(Duration::from_secs(1200));
 
     let mut client_config = Config::new(PROTOCOL_VERSION).unwrap();
     client_config
@@ -12208,6 +12276,18 @@ fn enable_pmtud_mid_handshake(
         .unwrap()
         .get_current_mtu();
     assert_eq!(current_mtu, 1350);
+
+    // PMTUD enabled mid-handshake inherits the raise timer from Config.
+    assert!(pipe
+        .server
+        .paths
+        .get_active_mut()
+        .unwrap()
+        .pmtud
+        .as_mut()
+        .unwrap()
+        .raise_timer()
+        .is_some());
 
     let path_stats = pipe.server.path_stats().next().unwrap();
     assert_eq!(path_stats.pmtu, current_mtu);

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -707,8 +707,7 @@ pub struct ExData<'a> {
 
     pub tx_cap_factor: f64,
 
-    /// PMTUD configuration: (enable, max_probes)
-    pub pmtud: Option<(bool, u8)>,
+    pub pmtud: Option<crate::pmtud::PmtudParams>,
 
     pub is_server: bool,
 }

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -177,6 +177,9 @@ fn make_quiche_config(
     );
     config.discover_pmtu(quic_settings.discover_path_mtu);
     config.set_pmtud_max_probes(quic_settings.pmtud_max_probes);
+    config.set_pmtud_raise_timer(
+        quic_settings.pmtud_raise_timer.unwrap_or_default(),
+    );
     config.enable_hystart(quic_settings.enable_hystart);
 
     config.enable_pacing(quic_settings.enable_pacing);

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -197,6 +197,14 @@ pub struct QuicSettings {
     #[serde(default = "QuicSettings::default_pmtud_max_probes")]
     pub pmtud_max_probes: u8,
 
+    /// Configures how long PMTUD stays on a discovered PMTU before re-entering
+    /// the Search Phase to probe for a larger path MTU.
+    ///
+    /// Defaults to disabled. `None` or zero disables periodic re-probing.
+    #[serde(rename = "pmtud_raise_timer_ms")]
+    #[serde_as(as = "Option<DurationMilliSeconds>")]
+    pub pmtud_raise_timer: Option<Duration>,
+
     /// Whether to use HyStart++ (only with `cubic` and `reno` CC).
     ///
     /// Defaults to `true`.
@@ -489,11 +497,20 @@ mod test {
     #[test]
     fn timeouts_parse_as_milliseconds() {
         let quic = serde_json::from_str::<QuicSettings>(
-            r#"{ "handshake_timeout_ms": 5000, "max_idle_timeout_ms": 7000 }"#,
+            r#"{ "handshake_timeout_ms": 5000, "max_idle_timeout_ms": 7000, "pmtud_raise_timer_ms": 300000 }"#,
         )
         .unwrap();
 
         assert_eq!(quic.handshake_timeout.unwrap(), Duration::from_secs(5));
         assert_eq!(quic.max_idle_timeout.unwrap(), Duration::from_secs(7));
+        assert_eq!(quic.pmtud_raise_timer.unwrap(), Duration::from_secs(300));
+    }
+
+    #[test]
+    fn pmtud_raise_timer_is_disabled_when_omitted() {
+        let quic = serde_json::from_str::<QuicSettings>("{}")
+            .expect("default settings deserialize");
+
+        assert_eq!(quic.pmtud_raise_timer, None);
     }
 }


### PR DESCRIPTION
Right now PMTUD stops for good once it settles on a PLPMTU. If the path later starts supporting a larger MTU, quiche never notices, because there is no mechanism to go back and look. This adds the RFC 8899 raise timer: once configured and a PMTU is found, the path re-enters the Search Phase when the timer fires and re-runs the existing optimistic binary search. If the path grew, we find the larger MTU; if not, we re-confirm the same one. RFC 8899 recommends a 600-second interval.

It is configurable through Config, the C FFI, and tokio-quiche, including the mid-handshake ex_data path. The tokio-quiche setting is serialized as `pmtud_raise_timer_ms`, so the RFC interval is `600000`; zero or an omitted value disables periodic re-probing.

Periodic re-probing is disabled by default because QUIC PMTU probes are ACK-eliciting. Without RFC 8899's optional idle suppression, they can reset the QUIC idle timer and act as an implicit keepalive when the configured idle timeout exceeds the raise interval. I left idle suppression out for now rather than coupling application-activity tracking into this change.

Risk: low. Existing PMTUD users retain the current settle-and-stop behavior, while users who opt in reuse the existing probe and search machinery.