### PR TITLE
crypto/boringssl: drop c_void return from void FFI

### DIFF
--- a/quiche/src/crypto/boringssl.rs
+++ b/quiche/src/crypto/boringssl.rs
@@ -363,11 +363,11 @@ extern "C" {
 
     fn AES_ecb_encrypt(
         inp: *const u8, out: *mut u8, key: *const AES_KEY, enc: c_int,
-    ) -> c_void;
+    );
 
     // ChaCha20
     fn CRYPTO_chacha_20(
         out: *mut u8, inp: *const u8, in_len: usize, key: *const u8,
         nonce: *const u8, counter: u32,
-    ) -> c_void;
+    );
 }


### PR DESCRIPTION
`AES_ecb_encrypt` and `CRYPTO_chacha_20` are declared as returning `c_void`, but the underlying C functions return `void`. Nightly clippy recently added the `c_void_returns` lint, which rejects this and currently breaks `cargo clippy -D warnings` on master. Dropping the return type so the declarations implicitly return `()` clears the lint; both call sites already ignore the result, so there's no behavioral change.

Risk: none — FFI signature only, no runtime effect.