### PR TITLE
quiche: gate stopped-stream collection on is_stopped(), not writable linkage

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3624,35 +3624,39 @@ impl<F: BufFactory> Connection<F> {
                         };
 
                         let dropped = stream.send.ack_and_drop(offset, length);
-                        let priority_key = Arc::clone(&stream.priority_key);
 
                         // Only collect the stream if it is complete and not
-                        // readable or writable.
+                        // readable or stopped.
                         //
                         // If it is readable, it will get collected when
                         // stream_recv() is next used.
                         //
-                        // If it is writable, it might mean that the stream
-                        // has been stopped by the peer (i.e. a STOP_SENDING
-                        // frame is received), in which case before collecting
-                        // the stream we will need to propagate the
+                        // If the stream has been stopped by the peer (i.e. a
+                        // STOP_SENDING frame is received), before collecting
+                        // the stream we need to propagate the
                         // `StreamStopped` error to the application. It will
                         // instead get collected when one of stream_capacity(),
                         // stream_writable(), stream_send(), ... is next called.
                         //
                         // Note that we can't use `is_writable()` here because
                         // it returns false if the stream is stopped. Instead,
-                        // since the stream is marked as writable when a
-                        // STOP_SENDING frame is received, we check the writable
-                        // queue directly instead.
-                        let is_writable = priority_key.writable.is_linked() &&
-                            // Ensure that the stream is actually stopped.
-                            stream.send.is_stopped();
-
+                        // we check `stream.send.is_stopped()` directly. We
+                        // can't check the writable queue instead:
+                        // `stream_writable_next()` unlinks the stream from
+                        // the writable queue on its very next poll, which
+                        // happens every `IoWorker` iteration before any
+                        // network round trip completes. By the time an ack
+                        // for a stopped stream arrives, the stream is
+                        // already unlinked from the writable queue
+                        // regardless of whether the app observed it as
+                        // writable.
                         let is_complete = stream.is_complete();
                         let is_readable = stream.is_readable();
 
-                        if is_complete && !is_readable && !is_writable {
+                        if is_complete &&
+                            !is_readable &&
+                            !stream.send.is_stopped()
+                        {
                             let local = stream.local;
                             self.streams.collect(stream_id, local);
                         }
@@ -3681,35 +3685,38 @@ impl<F: BufFactory> Connection<F> {
                             None => continue,
                         };
 
-                        let priority_key = Arc::clone(&stream.priority_key);
-
                         // Only collect the stream if it is complete and not
-                        // readable or writable.
+                        // readable or stopped.
                         //
                         // If it is readable, it will get collected when
                         // stream_recv() is next used.
                         //
-                        // If it is writable, it might mean that the stream
-                        // has been stopped by the peer (i.e. a STOP_SENDING
-                        // frame is received), in which case before collecting
-                        // the stream we will need to propagate the
+                        // If the stream has been stopped by the peer (i.e. a
+                        // STOP_SENDING frame is received), before collecting
+                        // the stream we need to propagate the
                         // `StreamStopped` error to the application. It will
                         // instead get collected when one of stream_capacity(),
                         // stream_writable(), stream_send(), ... is next called.
                         //
                         // Note that we can't use `is_writable()` here because
                         // it returns false if the stream is stopped. Instead,
-                        // since the stream is marked as writable when a
-                        // STOP_SENDING frame is received, we check the writable
-                        // queue directly instead.
-                        let is_writable = priority_key.writable.is_linked() &&
-                            // Ensure that the stream is actually stopped.
-                            stream.send.is_stopped();
-
+                        // we check `stream.send.is_stopped()` directly. We
+                        // can't check the writable queue instead:
+                        // `stream_writable_next()` unlinks the stream from
+                        // the writable queue on its very next poll, which
+                        // happens every `IoWorker` iteration before any
+                        // network round trip completes. By the time an ack
+                        // for a stopped stream arrives, the stream is
+                        // already unlinked from the writable queue
+                        // regardless of whether the app observed it as
+                        // writable.
                         let is_complete = stream.is_complete();
                         let is_readable = stream.is_readable();
 
-                        if is_complete && !is_readable && !is_writable {
+                        if is_complete &&
+                            !is_readable &&
+                            !stream.send.is_stopped()
+                        {
                             let local = stream.local;
                             self.streams.collect(stream_id, local);
                         }

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -11797,6 +11797,74 @@ fn stop_sending_stream_send_after_reset_stream_ack(
     assert!(!w.any(|s| s == 0));
 }
 
+/// Verify that a stream stopped by the peer still surfaces `StreamStopped`
+/// to the application when it was unlinked from the writable queue before
+/// the RESET_STREAM ack arrived.
+///
+/// Poll `stream_writable_next()` to unlink the stopped stream, then deliver
+/// the RESET_STREAM ack. The stream stays uncollected and the next
+/// `stream_send()` returns `StreamStopped`.
+#[test]
+fn stop_sending_signal_survives_writable_unlink_before_ack() {
+    let mut buf = [0; 65535];
+
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config
+        .set_application_protos(&[b"proto1", b"proto2"])
+        .unwrap();
+    config.set_initial_max_data(999999999);
+    config.set_initial_max_stream_data_bidi_local(30);
+    config.set_initial_max_stream_data_bidi_remote(30);
+    config.set_initial_max_streams_bidi(10);
+    config.set_initial_max_streams_uni(0);
+    config.verify_peer(false);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // Client opens a bidi stream with fin; the server reads the whole
+    // request so the stream's receive side is complete.
+    assert_eq!(pipe.client.stream_send(0, b"req", true), Ok(3));
+    assert_eq!(pipe.advance(), Ok(()));
+    assert_eq!(pipe.server.stream_recv(0, &mut buf), Ok((3, true)));
+
+    // Client no longer wants the response and sends STOP_SENDING. Deliver
+    // only that packet to the server, without letting the server's
+    // RESET_STREAM reply or its ack go anywhere yet.
+    assert_eq!(pipe.client.stream_shutdown(0, Shutdown::Read, 42), Ok(()));
+    let flight = test_utils::emit_flight(&mut pipe.client).unwrap();
+    test_utils::process_flight(&mut pipe.server, flight).unwrap();
+
+    // The application polls the stream as writable, which unlinks it from
+    // the writable queue, before sending anything on it. This mirrors an
+    // async driver's write loop running before the RESET_STREAM ack.
+    assert_eq!(pipe.server.stream_writable_next(), Some(0));
+
+    // Let the RESET_STREAM reach the client and its ack come back to the
+    // server, which processes the ack with the stream already unlinked.
+    let flight = test_utils::emit_flight(&mut pipe.server).unwrap();
+    test_utils::process_flight(&mut pipe.client, flight).unwrap();
+    let flight = test_utils::emit_flight(&mut pipe.client).unwrap();
+    test_utils::process_flight(&mut pipe.server, flight).unwrap();
+
+    // The stream must not have been collected yet: the application has not
+    // observed the STOP_SENDING.
+    assert_eq!(pipe.server.streams.len(), 1);
+
+    // The application finally writes its response and must see
+    // StreamStopped, not Done.
+    assert_eq!(
+        pipe.server.stream_send(0, b"resp", true),
+        Err(Error::StreamStopped(42))
+    );
+}
+
 #[rstest]
 fn challenge_no_cids(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -11831,6 +11831,74 @@ fn stop_sending_stream_send_after_reset_stream_ack(
     assert!(!w.any(|s| s == 0));
 }
 
+/// Verify that a stream stopped by the peer still surfaces `StreamStopped`
+/// to the application when it was unlinked from the writable queue before
+/// the RESET_STREAM ack arrived.
+///
+/// Poll `stream_writable_next()` to unlink the stopped stream, then deliver
+/// the RESET_STREAM ack. The stream stays uncollected and the next
+/// `stream_send()` returns `StreamStopped`.
+#[test]
+fn stop_sending_signal_survives_writable_unlink_before_ack() {
+    let mut buf = [0; 65535];
+
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config
+        .set_application_protos(&[b"proto1", b"proto2"])
+        .unwrap();
+    config.set_initial_max_data(999999999);
+    config.set_initial_max_stream_data_bidi_local(30);
+    config.set_initial_max_stream_data_bidi_remote(30);
+    config.set_initial_max_streams_bidi(10);
+    config.set_initial_max_streams_uni(0);
+    config.verify_peer(false);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // Client opens a bidi stream with fin; the server reads the whole
+    // request so the stream's receive side is complete.
+    assert_eq!(pipe.client.stream_send(0, b"req", true), Ok(3));
+    assert_eq!(pipe.advance(), Ok(()));
+    assert_eq!(pipe.server.stream_recv(0, &mut buf), Ok((3, true)));
+
+    // Client no longer wants the response and sends STOP_SENDING. Deliver
+    // only that packet to the server, without letting the server's
+    // RESET_STREAM reply or its ack go anywhere yet.
+    assert_eq!(pipe.client.stream_shutdown(0, Shutdown::Read, 42), Ok(()));
+    let flight = test_utils::emit_flight(&mut pipe.client).unwrap();
+    test_utils::process_flight(&mut pipe.server, flight).unwrap();
+
+    // The application polls the stream as writable, which unlinks it from
+    // the writable queue, before sending anything on it. This mirrors an
+    // async driver's write loop running before the RESET_STREAM ack.
+    assert_eq!(pipe.server.stream_writable_next(), Some(0));
+
+    // Let the RESET_STREAM reach the client and its ack come back to the
+    // server, which processes the ack with the stream already unlinked.
+    let flight = test_utils::emit_flight(&mut pipe.server).unwrap();
+    test_utils::process_flight(&mut pipe.client, flight).unwrap();
+    let flight = test_utils::emit_flight(&mut pipe.client).unwrap();
+    test_utils::process_flight(&mut pipe.server, flight).unwrap();
+
+    // The stream must not have been collected yet: the application has not
+    // observed the STOP_SENDING.
+    assert_eq!(pipe.server.streams.len(), 1);
+
+    // The application finally writes its response and must see
+    // StreamStopped, not Done.
+    assert_eq!(
+        pipe.server.stream_send(0, b"resp", true),
+        Err(Error::StreamStopped(42))
+    );
+}
+
 #[rstest]
 fn challenge_no_cids(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,

--- a/tokio-quiche/src/http3/driver/tests.rs
+++ b/tokio-quiche/src/http3/driver/tests.rs
@@ -656,6 +656,8 @@ mod client_side_driver {
 /// the client side.
 mod server_side_driver {
 
+    use crate::ApplicationOverQuic as _;
+
     use super::*;
 
     #[test]
@@ -842,6 +844,131 @@ mod server_side_driver {
         assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::None);
         assert_eq!(audit_stats.downstream_bytes_recvd(), 3);
         assert_eq!(audit_stats.downstream_bytes_sent(), 0);
+    }
+
+    /// Test the case where the server's outbound channel closes and
+    /// `audit_stats` records the STOP_SENDING error code from the client
+    /// sent before the server has written any response to a `fin=true` request
+    #[test]
+    fn client_sends_stop_sending_before_first_write() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), true)
+            .unwrap();
+
+        // server reads the request and creates the StreamCtx
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let audit_stats = req.h3_audit_stats;
+
+        // client sends a STOP_SENDING before the server has written any
+        // response bytes
+        assert_eq!(
+            helper.pipe.client.stream_shutdown(
+                stream_id,
+                quiche::Shutdown::Read,
+                4242
+            ),
+            Ok(())
+        );
+        helper.advance_and_run_loop().unwrap();
+
+        // the app produces a response, unaware the peer already gave up
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+        helper.work_loop_iter().unwrap();
+
+        assert!(to_client.is_closed());
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), 4242);
+    }
+
+    /// A client sends a headers-only request with fin, then STOP_SENDING,
+    /// before the server writes any response. The server's process_writes()
+    /// pops the stream via stream_writable_next() with nothing queued,
+    /// unlinking it, before the RESET_STREAM ack arrives. Verifies the app
+    /// still observes StreamStopped: recv_single()'s ack arms must gate
+    /// stream collection on send.is_stopped(), not on writable-queue linkage.
+    #[test]
+    fn client_sends_stop_sending_before_first_writable_poll() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), true)
+            .unwrap();
+
+        // server reads the request and creates the StreamCtx
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let audit_stats = req.h3_audit_stats;
+
+        // Client sends STOP_SENDING before the server has written any
+        // response bytes. Deliver only this packet to the server --
+        // unlike advance_and_run_loop(), this does not let the server's
+        // RESET_STREAM reply or its ack go anywhere yet.
+        assert_eq!(
+            helper.pipe.client.stream_shutdown(
+                stream_id,
+                quiche::Shutdown::Read,
+                4242
+            ),
+            Ok(())
+        );
+        let flight =
+            quiche::test_utils::emit_flight(&mut helper.pipe.client).unwrap();
+        quiche::test_utils::process_flight(&mut helper.pipe.server, flight)
+            .unwrap();
+
+        // Run process_reads() and process_writes() back to back, exactly
+        // as RunningApplication::on_read() does. process_writes() calls
+        // stream_writable_next(), which pops the stream with nothing
+        // queued to write, before the RESET_STREAM we just queued has
+        // even reached the client.
+        helper
+            .driver
+            .process_reads(&mut helper.pipe.server)
+            .unwrap();
+        helper
+            .driver
+            .process_writes(&mut helper.pipe.server)
+            .unwrap();
+
+        // Only now let the RESET_STREAM reach the client, and the
+        // client's ack come back to the server.
+        let flight =
+            quiche::test_utils::emit_flight(&mut helper.pipe.server).unwrap();
+        quiche::test_utils::process_flight(&mut helper.pipe.client, flight)
+            .unwrap();
+        let flight =
+            quiche::test_utils::emit_flight(&mut helper.pipe.client).unwrap();
+        quiche::test_utils::process_flight(&mut helper.pipe.server, flight)
+            .unwrap();
+
+        // the app produces a response, unaware the peer already gave up
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+        helper.work_loop_iter().unwrap();
+
+        assert!(to_client.is_closed());
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), 4242);
     }
 
     /// Test the case where the client sends a RESET_STREAM quiche frame.

--- a/tokio-quiche/src/http3/driver/tests.rs
+++ b/tokio-quiche/src/http3/driver/tests.rs
@@ -978,6 +978,8 @@ mod client_side_driver {
 /// the client side.
 mod server_side_driver {
 
+    use crate::ApplicationOverQuic as _;
+
     use super::*;
 
     /// Server-side equivalent of
@@ -1223,6 +1225,131 @@ mod server_side_driver {
         assert_eq!(audit_stats.sent_stream_fin(), StreamClosureKind::None);
         assert_eq!(audit_stats.downstream_bytes_recvd(), 3);
         assert_eq!(audit_stats.downstream_bytes_sent(), 0);
+    }
+
+    /// Test the case where the server's outbound channel closes and
+    /// `audit_stats` records the STOP_SENDING error code from the client
+    /// sent before the server has written any response to a `fin=true` request
+    #[test]
+    fn client_sends_stop_sending_before_first_write() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), true)
+            .unwrap();
+
+        // server reads the request and creates the StreamCtx
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let audit_stats = req.h3_audit_stats;
+
+        // client sends a STOP_SENDING before the server has written any
+        // response bytes
+        assert_eq!(
+            helper.pipe.client.stream_shutdown(
+                stream_id,
+                quiche::Shutdown::Read,
+                4242
+            ),
+            Ok(())
+        );
+        helper.advance_and_run_loop().unwrap();
+
+        // the app produces a response, unaware the peer already gave up
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+        helper.work_loop_iter().unwrap();
+
+        assert!(to_client.is_closed());
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), 4242);
+    }
+
+    /// A client sends a headers-only request with fin, then STOP_SENDING,
+    /// before the server writes any response. The server's process_writes()
+    /// pops the stream via stream_writable_next() with nothing queued,
+    /// unlinking it, before the RESET_STREAM ack arrives. Verifies the app
+    /// still observes StreamStopped: recv_single()'s ack arms must gate
+    /// stream collection on send.is_stopped(), not on writable-queue linkage.
+    #[test]
+    fn client_sends_stop_sending_before_first_writable_poll() {
+        let mut helper = DriverTestHelper::<ServerHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        // client sends a request
+        let stream_id = helper
+            .peer_client_send_request(make_request_headers("GET"), true)
+            .unwrap();
+
+        // server reads the request and creates the StreamCtx
+        helper.advance_and_run_loop().unwrap();
+        let req = assert_matches!(
+            helper.driver_recv_server_event().unwrap(),
+            ServerH3Event::Headers{incoming_headers, ..} => { incoming_headers }
+        );
+        assert_eq!(req.stream_id, stream_id);
+        let to_client = req.send.get_ref().unwrap().clone();
+        let audit_stats = req.h3_audit_stats;
+
+        // Client sends STOP_SENDING before the server has written any
+        // response bytes. Deliver only this packet to the server --
+        // unlike advance_and_run_loop(), this does not let the server's
+        // RESET_STREAM reply or its ack go anywhere yet.
+        assert_eq!(
+            helper.pipe.client.stream_shutdown(
+                stream_id,
+                quiche::Shutdown::Read,
+                4242
+            ),
+            Ok(())
+        );
+        let flight =
+            quiche::test_utils::emit_flight(&mut helper.pipe.client).unwrap();
+        quiche::test_utils::process_flight(&mut helper.pipe.server, flight)
+            .unwrap();
+
+        // Run process_reads() and process_writes() back to back, exactly
+        // as RunningApplication::on_read() does. process_writes() calls
+        // stream_writable_next(), which pops the stream with nothing
+        // queued to write, before the RESET_STREAM we just queued has
+        // even reached the client.
+        helper
+            .driver
+            .process_reads(&mut helper.pipe.server)
+            .unwrap();
+        helper
+            .driver
+            .process_writes(&mut helper.pipe.server)
+            .unwrap();
+
+        // Only now let the RESET_STREAM reach the client, and the
+        // client's ack come back to the server.
+        let flight =
+            quiche::test_utils::emit_flight(&mut helper.pipe.server).unwrap();
+        quiche::test_utils::process_flight(&mut helper.pipe.client, flight)
+            .unwrap();
+        let flight =
+            quiche::test_utils::emit_flight(&mut helper.pipe.client).unwrap();
+        quiche::test_utils::process_flight(&mut helper.pipe.server, flight)
+            .unwrap();
+
+        // the app produces a response, unaware the peer already gave up
+        to_client
+            .try_send(OutboundFrame::Headers(make_response_headers(), None))
+            .unwrap();
+        helper.work_loop_iter().unwrap();
+
+        assert!(to_client.is_closed());
+        assert_eq!(audit_stats.recvd_stop_sending_error_code(), 4242);
     }
 
     /// Test the case where the client sends a RESET_STREAM quiche frame.


### PR DESCRIPTION
quiche: gate stopped-stream collection on is_stopped(), not writable linkage
recv_single()'s ack-processing arms for STREAM-data and RESET_STREAM
decided whether to collect a completed stream using
`priority_key.writable.is_linked() && stream.send.is_stopped()`. The
intent was to defer collecting a peer-stopped stream so the application
can still observe `StreamStopped` on its next write attempt, rather than
having the stream silently garbage-collected out from under it.

Gating on `writable.is_linked()` is wrong: the writable queue is only a
delivery mechanism for `stream_writable_next()`, which unlinks whatever
stream it returns on every poll. An IoWorker calls `stream_writable_next()`
via `process_writes()` on each loop iteration, immediately after
`process_reads()` and before any network round trip. So a stream stopped
by a STOP_SENDING frame is unlinked again long before the RESET_STREAM
ack that runs these arms arrives, leaving `is_linked()` false and causing
the stream to be collected prematurely. The application's next write then
sees a generic `Done`/`InvalidStreamState` instead of `StreamStopped`,
silently losing the peer's cancellation signal.

Gate on `stream.send.is_stopped()` alone. A stopped stream is deferred
until the application observes `StreamStopped`, independent of the
transient writable-queue link state.

Adds a quiche-core regression test that reproduces the ordering directly
via Pipe: poll stream_writable_next() to unlink the stopped stream, then
deliver the RESET_STREAM ack, and check the next stream_send() returns
StreamStopped instead of Done.

Also adds two tokio-quiche H3 driver regression tests that reproduce the
same failure through the driver: one via the ordinary advance-and-run
loop, and one that hand-stages the real IoWorker ordering with hop-by-hop
packet delivery (emit_flight/process_flight interleaved with direct
process_reads()/process_writes() calls).