### PR TITLE
crypto: let BoringSSL allocate EVP_AEAD_CTX

### DIFF
--- a/quiche/src/crypto/boringssl.rs
+++ b/quiche/src/crypto/boringssl.rs
@@ -4,19 +4,16 @@ use std::convert::TryFrom;
 
 use std::mem::MaybeUninit;
 
+use std::ptr::NonNull;
+
 use libc::c_int;
 use libc::c_uint;
 use libc::c_void;
 
-// NOTE: This structure is copied from <openssl/aead.h> in order to be able to
-// statically allocate it. While it is not often modified upstream, it needs to
-// be kept in sync.
-#[repr(C)]
+#[allow(non_camel_case_types)]
+#[repr(transparent)]
 struct EVP_AEAD_CTX {
-    aead: libc::uintptr_t,
-    opaque: [u8; 580],
-    alignment: u64,
-    tag_len: u8,
+    _unused: c_void,
 }
 
 #[derive(Clone)]
@@ -41,7 +38,7 @@ impl Algorithm {
 pub(crate) struct PacketKey {
     alg: Algorithm,
 
-    ctx: EVP_AEAD_CTX,
+    ctx: NonNull<EVP_AEAD_CTX>,
 
     nonce: Vec<u8>,
 }
@@ -96,7 +93,7 @@ impl PacketKey {
 
         let rc = unsafe {
             EVP_AEAD_CTX_open(
-                &self.ctx,          // ctx
+                self.ctx.as_ptr(),  // ctx
                 buf.as_mut_ptr(),   // out
                 &mut out_len,       // out_len
                 max_out_len,        // max_out_len
@@ -139,7 +136,7 @@ impl PacketKey {
 
         let rc = unsafe {
             EVP_AEAD_CTX_seal_scatter(
-                &mut self.ctx,              // ctx
+                self.ctx.as_ptr(),          // ctx
                 buf.as_mut_ptr(),           // out
                 buf[in_len..].as_mut_ptr(), // out_tag
                 &mut out_tag_len,           // out_tag_len
@@ -160,6 +157,17 @@ impl PacketKey {
         }
 
         Ok(in_len + out_tag_len)
+    }
+}
+
+// PacketKey uniquely owns the context. Its API requires exclusive access for
+// stateful seal operations, while open operations support shared access.
+unsafe impl Send for PacketKey {}
+unsafe impl Sync for PacketKey {}
+
+impl Drop for PacketKey {
+    fn drop(&mut self) {
+        unsafe { EVP_AEAD_CTX_free(self.ctx.as_ptr()) }
     }
 }
 
@@ -248,29 +256,14 @@ impl HeaderProtectionKey {
     }
 }
 
-fn make_aead_ctx(alg: Algorithm, key: &[u8]) -> Result<EVP_AEAD_CTX> {
-    let mut ctx = MaybeUninit::uninit();
-
+fn make_aead_ctx(alg: Algorithm, key: &[u8]) -> Result<NonNull<EVP_AEAD_CTX>> {
     let ctx = unsafe {
         let aead = alg.get_evp_aead();
 
-        let rc = EVP_AEAD_CTX_init(
-            ctx.as_mut_ptr(),
-            aead,
-            key.as_ptr(),
-            alg.key_len(),
-            alg.tag_len(),
-            std::ptr::null_mut(),
-        );
-
-        if rc != 1 {
-            return Err(Error::CryptoFail);
-        }
-
-        ctx.assume_init()
+        EVP_AEAD_CTX_new(aead, key.as_ptr(), alg.key_len(), alg.tag_len())
     };
 
-    Ok(ctx)
+    NonNull::new(ctx).ok_or(Error::CryptoFail)
 }
 
 pub(crate) fn hkdf_extract(
@@ -338,10 +331,11 @@ extern "C" {
     ) -> c_int;
 
     // EVP_AEAD_CTX
-    fn EVP_AEAD_CTX_init(
-        ctx: *mut EVP_AEAD_CTX, aead: *const EVP_AEAD, key: *const u8,
-        key_len: usize, tag_len: usize, engine: *mut c_void,
-    ) -> c_int;
+    fn EVP_AEAD_CTX_new(
+        aead: *const EVP_AEAD, key: *const u8, key_len: usize, tag_len: usize,
+    ) -> *mut EVP_AEAD_CTX;
+
+    fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 
     fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX, out: *mut u8, out_len: *mut usize,


### PR DESCRIPTION
Use EVP_AEAD_CTX_new() and EVP_AEAD_CTX_free() so BoringSSL owns the context layout and cleanup. This removes the copied layout that needed to track upstream changes.