### PR TITLE
tokio-quiche: make logging calls statements

### DIFF
--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -445,7 +445,7 @@ where
             match handshake_fut.await {
                 Ok(running) => Self::resume(running),
                 Err(e) => {
-                    log::error!("QUIC handshake failed in IQC::start"; "error" => e)
+                    log::error!("QUIC handshake failed in IQC::start"; "error" => e);
                 },
             }
         };

--- a/tokio-quiche/src/quic/mod.rs
+++ b/tokio-quiche/src/quic/mod.rs
@@ -269,9 +269,11 @@ where
     // drive the packet router:
     tokio::spawn(async move {
         match router.await {
-            Ok(()) => log::debug!("incoming packet router finished"),
+            Ok(()) => {
+                log::debug!("incoming packet router finished");
+            },
             Err(error) => {
-                log::error!("incoming packet router failed"; "error"=>error)
+                log::error!("incoming packet router failed"; "error"=>error);
             },
         }
     });
@@ -334,9 +336,11 @@ where
 
     crate::metrics::tokio_task::spawn("quic_udp_listener", metrics, async move {
         match socket_driver.await {
-            Ok(()) => log::trace!("incoming packet router finished"),
+            Ok(()) => {
+                log::trace!("incoming packet router finished");
+            },
             Err(error) => {
-                log::error!("incoming packet router failed"; "error"=>error)
+                log::error!("incoming packet router failed"; "error"=>error);
             },
         }
     });

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -75,7 +75,9 @@ impl Config {
         };
         let keylog_file = keylog_path.and_then(|path| if KEYLOGFILE_ENABLED {
                 File::options().create(true).append(true).open(path)
-                    .inspect_err(|e| log::warn!("failed to open SSLKEYLOGFILE"; "error" => e))
+                    .inspect_err(|e| {
+                        log::warn!("failed to open SSLKEYLOGFILE"; "error" => e);
+                    })
                     .ok()
             } else {
                 log::warn!("SSLKEYLOGFILE is set, but `--cfg capture_keylogs` was not enabled. No keys will be logged.");


### PR DESCRIPTION
Nightly Rust now denies logging macros in expression position because their expansions contain trailing semicolons. Wrap the affected calls in blocks and terminate each macro explicitly.