### PR TITLE
tokio-quiche: size H3 body_recv_buf to readable length

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6385,6 +6385,33 @@ impl<F: BufFactory> Connection<F> {
         stream.is_readable()
     }
 
+    /// Returns the number of bytes that can currently be read from a stream
+    /// without gaps.
+    ///
+    /// This is the length of the contiguous, in-order data buffered at the
+    /// stream's current read offset, up to 64 KiB, i.e. the bytes a call to
+    /// [`stream_recv`] would return right now. Data received out of order that
+    /// sits behind a gap is not counted, so this never reports bytes that are
+    /// not yet readable.
+    ///
+    /// This is a companion to [`stream_readable`], which only reports *whether*
+    /// data is available; this reports *how much*. It is intended for sizing a
+    /// receive buffer. The cost is proportional to the number of contiguous
+    /// buffered chunks at the front of the stream, up to 64 KiB, and no data is
+    /// copied.
+    ///
+    /// Returns 0 if the stream does not exist or has no data ready to read.
+    ///
+    /// [`stream_recv`]: struct.Connection.html#method.stream_recv
+    /// [`stream_readable`]: struct.Connection.html#method.stream_readable
+    pub fn stream_readable_len(&self, stream_id: u64) -> usize {
+        match self.streams.get(stream_id) {
+            Some(s) => s.recv.readable_len(),
+
+            None => 0,
+        }
+    }
+
     /// Returns the next stream that can be written to.
     ///
     /// Note that once returned by this method, a stream ID will not be returned

--- a/quiche/src/stream/recv_buf.rs
+++ b/quiche/src/stream/recv_buf.rs
@@ -419,6 +419,39 @@ impl RecvBuf {
         buf.off() == self.off
     }
 
+    /// Returns the number of bytes that can be read contiguously from the
+    /// current read offset.
+    ///
+    /// This is the amount of in-order data available to read right now, up to
+    /// 64 KiB. Data buffered behind a gap (received out of order) is not
+    /// counted, so this never reports bytes that are not yet readable. The cost
+    /// is proportional to the number of contiguous buffered chunks at the front
+    /// of the buffer, up to 64 KiB; no data is copied.
+    pub fn readable_len(&self) -> usize {
+        const MAX_READABLE_LEN: usize = 64 * 1024;
+
+        let mut contiguous = 0;
+        let mut next_off = self.off;
+
+        // `data` is ordered by offset, so walk from the front and stop at the
+        // first gap (a chunk that does not start where the contiguous run so
+        // far leaves off).
+        for buf in self.data.values() {
+            if buf.off() != next_off {
+                break;
+            }
+
+            contiguous = (contiguous + buf.len()).min(MAX_READABLE_LEN);
+            next_off = buf.max_off();
+
+            if contiguous == MAX_READABLE_LEN {
+                break;
+            }
+        }
+
+        contiguous
+    }
+
     #[cfg(test)]
     pub(crate) fn flow_control_for_tests(&self) -> &flowcontrol::FlowControl {
         &self.flow_control
@@ -591,6 +624,45 @@ mod tests {
         assert_eq!(recv.off, 19);
 
         assert_emit_discard_done(&mut recv, emit);
+    }
+
+    #[test]
+    /// `readable_len` counts only contiguous in-order data, ignoring bytes
+    /// buffered behind a gap.
+    fn readable_len() {
+        let mut recv =
+            RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW, DEFAULT_STREAM_WINDOW);
+
+        // Empty buffer: nothing readable.
+        assert_eq!(recv.readable_len(), 0);
+
+        // Contiguous data at the front is readable.
+        assert!(recv.write(RangeBuf::from(b"hello", 0, false)).is_ok());
+        assert_eq!(recv.readable_len(), 5);
+
+        // Data buffered behind a gap ([5, 10) is missing) is NOT counted, even
+        // though `max_off` has advanced to 19.
+        assert!(recv.write(RangeBuf::from(b"something", 10, false)).is_ok());
+        assert_eq!(recv.max_off(), 19);
+        assert_eq!(recv.readable_len(), 5);
+
+        // Filling the gap makes the whole range contiguous and readable.
+        assert!(recv.write(RangeBuf::from(b"world", 5, false)).is_ok());
+        assert_eq!(recv.readable_len(), 19);
+
+        // Reading part of the data shrinks the readable count accordingly.
+        let mut buf = [0; 4];
+        assert_eq!(recv.emit(&mut buf), Ok((4, false)));
+        assert_eq!(recv.readable_len(), 15);
+
+        // Traversal stops at the maximum body receive buffer size.
+        let mut recv =
+            RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW, DEFAULT_STREAM_WINDOW);
+        assert!(recv
+            .write(RangeBuf::from(&[0; 64 * 1024], 0, false))
+            .is_ok());
+        assert!(recv.write(RangeBuf::from(&[0], 64 * 1024, false)).is_ok());
+        assert_eq!(recv.readable_len(), 64 * 1024);
     }
 
     /// Test shutdown behavior

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -4430,6 +4430,39 @@ fn stream_readable(
 }
 
 #[rstest]
+/// Tests `stream_readable_len`.
+fn stream_readable_len(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // Unknown stream has no readable data.
+    assert_eq!(pipe.server.stream_readable_len(0), 0);
+
+    assert_eq!(pipe.client.stream_send(0, b"aaaaa", false), Ok(5));
+    assert_eq!(pipe.advance(), Ok(()));
+
+    // Server has 5 buffered bytes to read.
+    assert_eq!(pipe.server.stream_readable_len(0), 5);
+
+    // Sending more data grows the readable count.
+    assert_eq!(pipe.client.stream_send(0, b"bbbbb", false), Ok(5));
+    assert_eq!(pipe.advance(), Ok(()));
+    assert_eq!(pipe.server.stream_readable_len(0), 10);
+
+    // Reading some data shrinks the readable count.
+    let mut b = [0; 4];
+    assert_eq!(pipe.server.stream_recv(0, &mut b), Ok((4, false)));
+    assert_eq!(pipe.server.stream_readable_len(0), 6);
+
+    // Draining the rest brings it back to 0.
+    let mut b = [0; 6];
+    assert_eq!(pipe.server.stream_recv(0, &mut b), Ok((6, false)));
+    assert_eq!(pipe.server.stream_readable_len(0), 0);
+}
+
+#[rstest]
 /// Tests the writable iterator.
 fn stream_writable(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,

--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -114,6 +114,30 @@ const STREAM_CAPACITY: usize = 1; // Set to 1 to stress write_pending under test
 // to 3MB of max buffered data at 1500 bytes per datagram.
 const FLOW_CAPACITY: usize = 2048;
 
+// Floor for the lazily-allocated body receive buffer. The buffer is sized to
+// the amount currently readable on the stream (see [`process_h3_data`]), but we
+// never allocate below this floor, for two reasons:
+//
+// - A `Limit<BytesMut>` with a zero limit reports no remaining capacity and
+//   would make `recv_body_buf` a no-op.
+// - Sizing strictly to the readable length defeats allocation amortization: a
+//   body that trickles in a few bytes at a time (e.g. one byte per read) would
+//   reallocate the buffer on every read. Allocating at least this many bytes
+//   lets a single allocation absorb many small reads (each `split()` off)
+//   before it is exhausted and reallocated.
+const MIN_BODY_RECV_BUF_SIZE: usize = 1024;
+
+/// Computes the capacity to use for the body receive buffer given the number of
+/// bytes currently readable on the stream.
+///
+/// The result is clamped to `[MIN_BODY_RECV_BUF_SIZE, MAX_BUF_SIZE]`: reads
+/// below the floor still allocate the floor (so a trickle of tiny reads reuses
+/// one allocation instead of reallocating each time), while a single
+/// (potentially adversarial) read never allocates more than `MAX_BUF_SIZE`.
+fn body_recv_buf_size(readable: usize) -> usize {
+    readable.clamp(MIN_BODY_RECV_BUF_SIZE, BufFactory::MAX_BUF_SIZE)
+}
+
 /// Used by a local task to send [`OutboundFrame`]s to a peer on the
 /// stream or flow associated with this channel.
 pub type OutboundFrameSender = PollSender<OutboundFrame>;
@@ -522,21 +546,33 @@ impl<H: DriverHooks> H3Driver<H> {
                 };
             }
 
+            // Size the receive buffer to the amount of data currently readable
+            // on the stream, capped at `MAX_BUF_SIZE`, so small or idle bodies
+            // don't pay for a full 64 KiB allocation. `stream_readable_len`
+            // returns the contiguous, in-order bytes available to read now (it
+            // includes H3 framing overhead but never counts data behind a gap),
+            // so the buffer is sized to what a single drain can actually read.
+            // The floor (`MIN_BODY_RECV_BUF_SIZE`) keeps the allocation non-zero
+            // and large enough that a trickle of tiny reads reuses a single
+            // allocation instead of reallocating each time.
+            let want = body_recv_buf_size(qconn.stream_readable_len(stream_id));
             // Lazily allocate the receive buffer on first use; idle
             // connections never receive body bytes and never allocate it.
-            let body_recv_buf = self.body_recv_buf.get_or_insert_with(|| {
-                BytesMut::with_capacity(BufFactory::MAX_BUF_SIZE)
-                    .limit(BufFactory::MAX_BUF_SIZE)
-            });
-            // NOTE: `body_recv_buf` is `Limit<BytesMut>` so
-            // `has_remaining_mut()` will indicate if the buffer
-            // has space available until the *limit* is
-            //  reached. (A plain `BytesMut` can reallocate and would always
-            // return true)
-            if !body_recv_buf.has_remaining_mut() {
-                *body_recv_buf =
-                    BytesMut::with_capacity(BufFactory::MAX_BUF_SIZE)
-                        .limit(BufFactory::MAX_BUF_SIZE);
+            let body_recv_buf = self
+                .body_recv_buf
+                .get_or_insert_with(|| BytesMut::with_capacity(want).limit(want));
+            // NOTE: `body_recv_buf` is `Limit<BytesMut>` so `remaining_mut()`
+            // reports the space left until the *limit* is reached. (A plain
+            // `BytesMut` can reallocate and would always report space available.)
+            //
+            // Reallocate whenever the room left is smaller than what we want for
+            // this read. This covers an exhausted buffer, but also grows a
+            // buffer that was previously sized to a smaller readable length so a
+            // later, larger read is not throttled by leftover capacity. Capacity
+            // is kept equal to the limit so the `split()` invariant asserted
+            // below (spare capacity == remaining_mut) continues to hold.
+            if body_recv_buf.remaining_mut() < want {
+                *body_recv_buf = BytesMut::with_capacity(want).limit(want);
             }
             match conn.recv_body_buf(qconn, stream_id, &mut *body_recv_buf) {
                 Ok(n) => {

--- a/tokio-quiche/src/http3/driver/tests.rs
+++ b/tokio-quiche/src/http3/driver/tests.rs
@@ -5,6 +5,52 @@ use assert_matches::assert_matches;
 use super::test_utils::*;
 use super::*;
 
+/// Tests for the body receive buffer sizing helper.
+mod body_recv_buf_size {
+    use super::*;
+
+    #[test]
+    fn zero_readable_uses_floor() {
+        // Never build a zero-capacity buffer.
+        assert_eq!(body_recv_buf_size(0), MIN_BODY_RECV_BUF_SIZE);
+    }
+
+    #[test]
+    fn small_readable_uses_floor() {
+        // A read below the floor is raised to the floor so a trickle of tiny
+        // reads reuses one allocation instead of reallocating each time.
+        assert_eq!(body_recv_buf_size(10), MIN_BODY_RECV_BUF_SIZE);
+        assert_eq!(
+            body_recv_buf_size(MIN_BODY_RECV_BUF_SIZE),
+            MIN_BODY_RECV_BUF_SIZE
+        );
+    }
+
+    #[test]
+    fn readable_above_floor_tracks_size() {
+        // Between the floor and the cap the buffer tracks the readable length.
+        let readable = MIN_BODY_RECV_BUF_SIZE + 500;
+        assert_eq!(body_recv_buf_size(readable), readable);
+    }
+
+    #[test]
+    fn large_readable_caps_at_max() {
+        assert_eq!(
+            body_recv_buf_size(BufFactory::MAX_BUF_SIZE),
+            BufFactory::MAX_BUF_SIZE
+        );
+        // Readable beyond MAX_BUF_SIZE is capped.
+        assert_eq!(
+            body_recv_buf_size(BufFactory::MAX_BUF_SIZE + 1),
+            BufFactory::MAX_BUF_SIZE
+        );
+        assert_eq!(
+            body_recv_buf_size(10 * BufFactory::MAX_BUF_SIZE),
+            BufFactory::MAX_BUF_SIZE
+        );
+    }
+}
+
 /// Tests for connection close error metrics recorded by
 /// [`H3Driver::on_conn_close`].
 mod conn_close_metrics {
@@ -318,8 +364,22 @@ mod client_side_driver {
         helper.advance_and_run_loop().unwrap();
         assert_eq!(helper.driver_try_recv_body(&mut from_server).0, vec![7; 10]);
 
-        // The first body read lazily allocated the buffer.
+        // The body read lazily allocated the buffer at the floor
+        // (`MIN_BODY_RECV_BUF_SIZE`) rather than a fixed 64 KiB, because the
+        // readable length was below the floor. The buffer therefore tracks the
+        // floor -- far below the 64 KiB a fixed allocation would use.
         assert!(helper.driver.body_recv_buf.is_some());
+        let cap = helper
+            .driver
+            .body_recv_buf
+            .as_ref()
+            .unwrap()
+            .get_ref()
+            .capacity();
+        assert!(
+            cap <= MIN_BODY_RECV_BUF_SIZE,
+            "body buffer should track the floor, not a fixed 64 KiB; cap = {cap}"
+        );
 
         // Server finishes the stream.
         helper.peer_server_send_body(0, &[8; 10], true).unwrap();
@@ -361,11 +421,12 @@ mod client_side_driver {
         assert_eq!(resp.stream_id, stream_id);
         let mut from_server = resp.recv;
 
-        // Force a small receive buffer so the body exhausts it and the
-        // reallocation branch (`*body_recv_buf = ...`) runs.
+        // Force a small receive buffer so it is smaller than the size we want
+        // for each read, exercising the reallocation branch
+        // (`*body_recv_buf = ...`).
         helper.driver_set_body_buf_size(20);
 
-        // Send 40 bytes across the 20-byte buffer, exhausting it repeatedly.
+        // Send 40 bytes across four chunks, reallocating on the way.
         helper.peer_server_send_body(0, &[1; 10], false).unwrap();
         helper.advance_and_run_loop().unwrap();
         assert_eq!(helper.driver_try_recv_body(&mut from_server).0, vec![1; 10]);
@@ -1255,14 +1316,24 @@ mod server_side_driver {
         );
         assert_matches!(helper.peer_client_poll(), Ok((0, h3::Event::Data)));
         assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
-        assert_eq!(helper.peer_client_send_body(0, &[1; 10], false), Ok(10));
+        // The client sends the first half of the body.
+        assert_eq!(helper.peer_client_send_body(0, &[1; 5], false), Ok(5));
 
-        // Advance the pipe and let the driver read a part of the body and
-        // put it into the `from_client` channel
+        // Advance the pipe and let the driver read the buffered body into the
+        // `from_client` channel, filling it (`STREAM_CAPACITY` is 1 in tests).
         helper.pipe.advance().unwrap();
-        // Limit the amount of data we read from the stream.
-        helper.driver_set_body_buf_size(5);
         helper.work_loop_iter().unwrap();
+
+        // The client sends the second half. With the downstream channel full
+        // and the stream readable again, the driver blocks the stream waiting
+        // for capacity (registering it in `waiting_streams`) without reading
+        // further.
+        assert_eq!(helper.peer_client_send_body(0, &[1; 5], false), Ok(5));
+        helper.pipe.advance().unwrap();
+        helper.work_loop_iter().unwrap();
+
+        // Drain the first body frame; this frees downstream capacity so the
+        // blocked stream can make progress on the next `wait_for_data`.
         assert_matches!(from_client.try_recv(), Ok(InboundFrame::Body(buf, fin)) => {
             assert_eq!(buf.to_vec(), &[1; 5]);
             assert!(!fin);
@@ -1280,11 +1351,12 @@ mod server_side_driver {
             Err(TryRecvError::Empty)
         );
 
-        // client sends a reset.
-        // TODO: This is a bit finnicky to test properly. We don't want to
-        // run a full `work_loop_iter()` because that would call `process_reads()`
-        // first.
-        helper.pipe.advance().unwrap();
+        // The client resets the stream; the buffered-but-unread second half is
+        // dropped when the reset is processed.
+        // TODO: This is a bit finnicky to test properly. We don't want to run a
+        // full `work_loop_iter()` because that would call `process_reads()`
+        // first; we exercise the path where `wait_for_data` / `upstream_ready`
+        // observes the reset while reading.
         assert_eq!(
             helper
                 .pipe
@@ -1370,13 +1442,12 @@ mod server_side_driver {
             Ok((0, h3::Event::Headers { .. }))
         );
         assert_eq!(helper.peer_client_poll(), Err(h3::Error::Done));
-        assert_eq!(helper.peer_client_send_body(0, &[1; 10], false), Ok(10));
+        // The client sends the first half of the body.
+        assert_eq!(helper.peer_client_send_body(0, &[1; 5], false), Ok(5));
 
-        // Advance the pipe and let the driver read a part of the body and
-        // put it into the `from_client` channel
+        // Advance the pipe and let the driver read the buffered body and put
+        // it into the `from_client` channel.
         helper.pipe.advance().unwrap();
-        // Limit the amount of data we read from the stream.
-        helper.driver_set_body_buf_size(5);
         helper.work_loop_iter().unwrap();
         assert_matches!(from_client.try_recv(), Ok(InboundFrame::Body(buf, fin)) => {
             assert_eq!(buf.to_vec(), &[1; 5]);
@@ -1391,7 +1462,12 @@ mod server_side_driver {
             })
         );
 
-        // client sends a reset.
+        // The client sends the second half of the body (delivered to the
+        // server but not yet read by the driver), then resets the stream. The
+        // buffered-but-unread bytes are dropped when the reset is processed, so
+        // they are never counted.
+        assert_eq!(helper.peer_client_send_body(0, &[1; 5], false), Ok(5));
+        helper.pipe.advance().unwrap();
         assert_eq!(
             helper
                 .pipe


### PR DESCRIPTION
## Summary

Follow-up to the lazy `body_recv_buf` allocation in #2546. Previously, once a body buffer was needed it always allocated the fixed 64 KiB `BufFactory::MAX_BUF_SIZE`, so even a 10-byte body paid for 64 KiB on its first read.

This PR sizes the allocation to data that is immediately readable from the stream, with a 1 KiB floor and the existing 64 KiB cap.

## Changes

- Add `quiche::Connection::stream_readable_len(stream_id)`, backed by `RecvBuf::readable_len()`. It returns the contiguous, in-order unread bytes starting at the current read offset, or 0 when the stream is absent or has no readable data. Bytes buffered behind a gap are not counted.
- Bound that scan at 64 KiB. Its cost is proportional to contiguous front chunks only up to the maximum body buffer size, and it copies no data.
- In `H3Driver::process_h3_data`, set the lazy allocation target to `body_recv_buf_size(stream_readable_len(stream_id))`, clamped to `[1 KiB, MAX_BUF_SIZE]`.
- Reallocate whenever `remaining_mut() < want`, rather than only after exhaustion. A buffer previously sized for a small read can therefore grow before a later larger read instead of throttling it. Capacity remains equal to the limit, preserving the `split()` invariant that spare capacity equals `remaining_mut()`.

## Rationale

`stream_readable_len` reports exactly the contiguous QUIC stream bytes a read can consume now. It includes HTTP/3 frame bytes, which can make the allocation conservatively larger than the body payload, but it never includes out-of-order data behind a gap. The 64 KiB cap bounds both the allocation and the scan.

`body_recv_buf` is shared per connection rather than per stream. The 1 KiB floor preserves allocation amortization for trickle traffic: after each `split()`, a 1-byte-at-a-time body can reuse the allocation for roughly 1024 reads instead of reallocating on every read.

## Testing

- `Connection::stream_readable_len` test covers an absent stream, growth after receives, shrinkage after reads, and draining to zero.
- `RecvBuf::readable_len` test verifies that data behind a gap is ignored and that the scan stops at 64 KiB.
- `body_recv_buf_size` tests cover the floor, exact tracking between the bounds, and the cap.
- Driver tests verify lazy small-body allocation at the floor, reallocation, and release on stream cleanup.

## Validation

Bastion continuous-profiling flamegraphs for heap `inuse_space` and CPU are available at https://drive.google.com/drive/folders/1zvP2zze7xui1pAC_wU-QhMd6vMfIGuks.

- For 10k connections with 1-byte POST bodies (`stalled_active_requests`), total heap fell from **3.25 GB** to **2.49 GB** (-23.5%).
- With the lazy-allocation prerequisite (#2546), 10k idle connections fell from **1.93 GB** to **1.49 GB** (-23%); `H3Driver::new` allocations fell from **1.25 GB (64.6%)** to **0.75 GB (50.3%)**.
- On 1000 connections with 8 chunked streams, heap remained approximately flat and the CPU shares of `recv_body_buf` (~2.8-2.9%) and `process_h3_data` (~4.5%) were unchanged.

## Residual Risk

A large body delivered in small increments can require more reallocations than the previous fixed 64 KiB buffer, but the 1 KiB floor bounds tiny-read churn. The new readable-length scan is not O(1), but its work is bounded by 64 KiB of contiguous data.