### PR TITLE
 tokio-quiche: make body_recv_buf max size configurable, default 16 KiB

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6385,28 +6385,28 @@ impl<F: BufFactory> Connection<F> {
         stream.is_readable()
     }
 
-    /// Returns the number of bytes that can currently be read from a stream
-    /// without gaps.
+    /// Returns the number of contiguous bytes buffered for a stream, up to
+    /// `max_len`.
     ///
     /// This is the length of the contiguous, in-order data buffered at the
-    /// stream's current read offset, up to 64 KiB, i.e. the bytes a call to
-    /// [`stream_recv`] would return right now. Data received out of order that
-    /// sits behind a gap is not counted, so this never reports bytes that are
-    /// not yet readable.
+    /// stream's current read offset, i.e. the bytes a call to [`stream_recv`]
+    /// would return right now. Data received out of order that sits behind a
+    /// gap is not counted, so this never reports bytes that are not yet
+    /// readable.
     ///
     /// This is a companion to [`stream_readable`], which only reports *whether*
     /// data is available; this reports *how much*. It is intended for sizing a
     /// receive buffer. The cost is proportional to the number of contiguous
-    /// buffered chunks at the front of the stream, up to 64 KiB, and no data is
-    /// copied.
+    /// buffered chunks at the front of the stream, up to `max_len`, and no data
+    /// is copied.
     ///
-    /// Returns 0 if the stream does not exist or has no data ready to read.
+    /// Returns 0 if the stream does not exist.
     ///
     /// [`stream_recv`]: struct.Connection.html#method.stream_recv
     /// [`stream_readable`]: struct.Connection.html#method.stream_readable
-    pub fn stream_readable_len(&self, stream_id: u64) -> usize {
+    pub fn stream_readable_len(&self, stream_id: u64, max_len: usize) -> usize {
         match self.streams.get(stream_id) {
-            Some(s) => s.recv.readable_len(),
+            Some(s) => s.recv.readable_len(max_len),
 
             None => 0,
         }

--- a/quiche/src/stream/recv_buf.rs
+++ b/quiche/src/stream/recv_buf.rs
@@ -420,17 +420,14 @@ impl RecvBuf {
     }
 
     /// Returns the number of bytes that can be read contiguously from the
-    /// current read offset.
+    /// current read offset, up to `max_len`.
     ///
-    /// This is the amount of in-order data available to read right now, up to
-    /// 64 KiB. Data buffered behind a gap (received out of order) is not
-    /// counted, so this never reports bytes that are not yet readable. The cost
-    /// is proportional to the number of contiguous buffered chunks at the front
-    /// of the buffer, up to 64 KiB; no data is copied.
-    pub fn readable_len(&self) -> usize {
-        const MAX_READABLE_LEN: usize = 64 * 1024;
-
-        let mut contiguous = 0;
+    /// Data buffered behind a gap (received out of order) is not counted, so
+    /// this never reports bytes that are not yet readable. The cost is
+    /// proportional to the number of contiguous buffered chunks at the front
+    /// of the buffer, up to `max_len`; no data is copied.
+    pub fn readable_len(&self, max_len: usize) -> usize {
+        let mut contiguous = 0usize;
         let mut next_off = self.off;
 
         // `data` is ordered by offset, so walk from the front and stop at the
@@ -441,10 +438,10 @@ impl RecvBuf {
                 break;
             }
 
-            contiguous = (contiguous + buf.len()).min(MAX_READABLE_LEN);
+            contiguous = contiguous.saturating_add(buf.len()).min(max_len);
             next_off = buf.max_off();
 
-            if contiguous == MAX_READABLE_LEN {
+            if contiguous == max_len {
                 break;
             }
         }
@@ -627,42 +624,23 @@ mod tests {
     }
 
     #[test]
-    /// `readable_len` counts only contiguous in-order data, ignoring bytes
-    /// buffered behind a gap.
+    /// `readable_len` counts only contiguous in-order data, up to its limit.
     fn readable_len() {
         let mut recv =
             RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW, DEFAULT_STREAM_WINDOW);
 
         // Empty buffer: nothing readable.
-        assert_eq!(recv.readable_len(), 0);
+        assert_eq!(recv.readable_len(64 * 1024), 0);
 
-        // Contiguous data at the front is readable.
+        // Data buffered behind a gap is not readable.
         assert!(recv.write(RangeBuf::from(b"hello", 0, false)).is_ok());
-        assert_eq!(recv.readable_len(), 5);
-
-        // Data buffered behind a gap ([5, 10) is missing) is NOT counted, even
-        // though `max_off` has advanced to 19.
         assert!(recv.write(RangeBuf::from(b"something", 10, false)).is_ok());
-        assert_eq!(recv.max_off(), 19);
-        assert_eq!(recv.readable_len(), 5);
+        assert_eq!(recv.readable_len(64 * 1024), 5);
 
-        // Filling the gap makes the whole range contiguous and readable.
+        // Filling the gap makes the full range readable, bounded by the limit.
         assert!(recv.write(RangeBuf::from(b"world", 5, false)).is_ok());
-        assert_eq!(recv.readable_len(), 19);
-
-        // Reading part of the data shrinks the readable count accordingly.
-        let mut buf = [0; 4];
-        assert_eq!(recv.emit(&mut buf), Ok((4, false)));
-        assert_eq!(recv.readable_len(), 15);
-
-        // Traversal stops at the maximum body receive buffer size.
-        let mut recv =
-            RecvBuf::new(u64::MAX, DEFAULT_STREAM_WINDOW, DEFAULT_STREAM_WINDOW);
-        assert!(recv
-            .write(RangeBuf::from(&[0; 64 * 1024], 0, false))
-            .is_ok());
-        assert!(recv.write(RangeBuf::from(&[0], 64 * 1024, false)).is_ok());
-        assert_eq!(recv.readable_len(), 64 * 1024);
+        assert_eq!(recv.readable_len(64 * 1024), 19);
+        assert_eq!(recv.readable_len(10), 10);
     }
 
     /// Test shutdown behavior

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -4438,28 +4438,29 @@ fn stream_readable_len(
     assert_eq!(pipe.handshake(), Ok(()));
 
     // Unknown stream has no readable data.
-    assert_eq!(pipe.server.stream_readable_len(0), 0);
+    assert_eq!(pipe.server.stream_readable_len(0, 64 * 1024), 0);
 
     assert_eq!(pipe.client.stream_send(0, b"aaaaa", false), Ok(5));
     assert_eq!(pipe.advance(), Ok(()));
 
     // Server has 5 buffered bytes to read.
-    assert_eq!(pipe.server.stream_readable_len(0), 5);
+    assert_eq!(pipe.server.stream_readable_len(0, 64 * 1024), 5);
+    assert_eq!(pipe.server.stream_readable_len(0, 3), 3);
 
     // Sending more data grows the readable count.
     assert_eq!(pipe.client.stream_send(0, b"bbbbb", false), Ok(5));
     assert_eq!(pipe.advance(), Ok(()));
-    assert_eq!(pipe.server.stream_readable_len(0), 10);
+    assert_eq!(pipe.server.stream_readable_len(0, 64 * 1024), 10);
 
     // Reading some data shrinks the readable count.
     let mut b = [0; 4];
     assert_eq!(pipe.server.stream_recv(0, &mut b), Ok((4, false)));
-    assert_eq!(pipe.server.stream_readable_len(0), 6);
+    assert_eq!(pipe.server.stream_readable_len(0, 64 * 1024), 6);
 
     // Draining the rest brings it back to 0.
     let mut b = [0; 6];
     assert_eq!(pipe.server.stream_recv(0, &mut b), Ok((6, false)));
-    assert_eq!(pipe.server.stream_readable_len(0), 0);
+    assert_eq!(pipe.server.stream_readable_len(0, 64 * 1024), 0);
 }
 
 #[rstest]

--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -74,7 +74,6 @@ use self::streams::StreamReady;
 use self::streams::WaitForDownstreamData;
 use self::streams::WaitForStream;
 use self::streams::WaitForUpstreamCapacity;
-use crate::buf_factory::BufFactory;
 use crate::http3::settings::Http3Settings;
 use crate::http3::H3AuditStats;
 use crate::metrics::Metrics;
@@ -125,17 +124,36 @@ const FLOW_CAPACITY: usize = 2048;
 //   reallocate the buffer on every read. Allocating at least this many bytes
 //   lets a single allocation absorb many small reads (each `split()` off)
 //   before it is exhausted and reallocated.
+//
+// The floor is a soft hint, not a hard minimum: it never overrides the
+// configured cap, so a cap smaller than the floor still bounds the allocation
+// (see [`body_recv_buf_size`]).
 const MIN_BODY_RECV_BUF_SIZE: usize = 1024;
 
+// Default cap for the body receive buffer when
+// [`Http3Settings::max_recv_body_buf_size`] is unset or zero. Chosen well below
+// `BufFactory::MAX_BUF_SIZE` (64 KiB) so a request that carries a body doesn't
+// pin a large allocation for the life of the stream; a larger streamed body
+// simply reallocates once per driver read-cycle.
+const DEFAULT_MAX_BODY_RECV_BUF_SIZE: usize = 16 * 1024;
+
 /// Computes the capacity to use for the body receive buffer given the number of
-/// bytes currently readable on the stream.
+/// bytes currently readable on the stream and the configured maximum.
 ///
-/// The result is clamped to `[MIN_BODY_RECV_BUF_SIZE, MAX_BUF_SIZE]`: reads
-/// below the floor still allocate the floor (so a trickle of tiny reads reuses
-/// one allocation instead of reallocating each time), while a single
-/// (potentially adversarial) read never allocates more than `MAX_BUF_SIZE`.
-fn body_recv_buf_size(readable: usize) -> usize {
-    readable.clamp(MIN_BODY_RECV_BUF_SIZE, BufFactory::MAX_BUF_SIZE)
+/// The result is clamped to `[floor, max]`, where `floor` is
+/// [`MIN_BODY_RECV_BUF_SIZE`] capped by `max`. Reads below the floor still
+/// allocate the floor (so a trickle of tiny reads reuses one allocation instead
+/// of reallocating each time), while a single (potentially adversarial) read
+/// never allocates more than `max`. `max` is derived from
+/// [`Http3Settings::max_recv_body_buf_size`], defaulting to
+/// [`DEFAULT_MAX_BODY_RECV_BUF_SIZE`] when the setting is unset or zero.
+///
+/// `max` is the hard upper bound: when it is smaller than the floor it wins, so
+/// the range passed to `clamp` is always valid (`floor <= max`). The
+/// constructor guarantees `max >= 1`, so the result is never zero.
+fn body_recv_buf_size(readable: usize, max: usize) -> usize {
+    let floor = MIN_BODY_RECV_BUF_SIZE.min(max);
+    readable.clamp(floor, max)
 }
 
 /// Used by a local task to send [`OutboundFrame`]s to a peer on the
@@ -379,6 +397,10 @@ pub struct H3Driver<H: DriverHooks> {
     /// connections hold no receive buffer. We `split()` off filled parts until
     /// we need to reallocate.
     body_recv_buf: Option<bytes::buf::Limit<BytesMut>>,
+    /// Upper bound on the capacity of `body_recv_buf`, from
+    /// [`Http3Settings::max_recv_body_buf_size`]. Unset or `0` defaults to
+    /// [`DEFAULT_MAX_BODY_RECV_BUF_SIZE`], so this is always non-zero.
+    max_recv_body_buf_size: usize,
 
     /// The maximum HTTP/3 stream ID seen on this connection.
     max_stream_seen: u64,
@@ -418,6 +440,12 @@ impl<H: DriverHooks> H3Driver<H> {
                 dgram_send: PollSender::new(dgram_send),
                 max_stream_seen: 0,
                 body_recv_buf: None,
+                // `Some(0)` would make `recv_body_buf` a no-op, so treat it as
+                // unset.
+                max_recv_body_buf_size: http3_settings
+                    .max_recv_body_buf_size
+                    .filter(|&size| size > 0)
+                    .unwrap_or(DEFAULT_MAX_BODY_RECV_BUF_SIZE),
 
                 waiting_streams: FuturesUnordered::new(),
 
@@ -543,16 +571,18 @@ impl<H: DriverHooks> H3Driver<H> {
                 };
             }
 
-            // Size the receive buffer to the amount of data currently readable
-            // on the stream, capped at `MAX_BUF_SIZE`, so small or idle bodies
-            // don't pay for a full 64 KiB allocation. `stream_readable_len`
-            // returns the contiguous, in-order bytes available to read now (it
-            // includes H3 framing overhead but never counts data behind a gap),
-            // so the buffer is sized to what a single drain can actually read.
-            // The floor (`MIN_BODY_RECV_BUF_SIZE`) keeps the allocation non-zero
-            // and large enough that a trickle of tiny reads reuses a single
-            // allocation instead of reallocating each time.
-            let want = body_recv_buf_size(qconn.stream_readable_len(stream_id));
+            // Size the receive buffer to the contiguous, in-order data currently
+            // readable on the stream, capped at the configured maximum, so small
+            // or idle bodies don't pay for a full allocation.
+            // The readable length includes H3 framing, so it is enough to drain
+            // all currently readable body bytes. The floor
+            // (`MIN_BODY_RECV_BUF_SIZE`) keeps the allocation non-zero and large
+            // enough that a trickle of tiny reads reuses a single allocation
+            // instead of reallocating each time.
+            let want = body_recv_buf_size(
+                qconn.stream_readable_len(stream_id, self.max_recv_body_buf_size),
+                self.max_recv_body_buf_size,
+            );
             // Lazily allocate the receive buffer on first use; idle
             // connections never receive body bytes and never allocate it.
             let body_recv_buf = self

--- a/tokio-quiche/src/http3/driver/tests.rs
+++ b/tokio-quiche/src/http3/driver/tests.rs
@@ -1,3 +1,4 @@
+use crate::buf_factory::BufFactory;
 use crate::http3::driver::client::ClientHooks;
 use crate::http3::driver::server::ServerHooks;
 use assert_matches::assert_matches;
@@ -9,19 +10,21 @@ use super::*;
 mod body_recv_buf_size {
     use super::*;
 
+    const MAX: usize = BufFactory::MAX_BUF_SIZE;
+
     #[test]
     fn zero_readable_uses_floor() {
         // Never build a zero-capacity buffer.
-        assert_eq!(body_recv_buf_size(0), MIN_BODY_RECV_BUF_SIZE);
+        assert_eq!(body_recv_buf_size(0, MAX), MIN_BODY_RECV_BUF_SIZE);
     }
 
     #[test]
     fn small_readable_uses_floor() {
         // A read below the floor is raised to the floor so a trickle of tiny
         // reads reuses one allocation instead of reallocating each time.
-        assert_eq!(body_recv_buf_size(10), MIN_BODY_RECV_BUF_SIZE);
+        assert_eq!(body_recv_buf_size(10, MAX), MIN_BODY_RECV_BUF_SIZE);
         assert_eq!(
-            body_recv_buf_size(MIN_BODY_RECV_BUF_SIZE),
+            body_recv_buf_size(MIN_BODY_RECV_BUF_SIZE, MAX),
             MIN_BODY_RECV_BUF_SIZE
         );
     }
@@ -30,25 +33,74 @@ mod body_recv_buf_size {
     fn readable_above_floor_tracks_size() {
         // Between the floor and the cap the buffer tracks the readable length.
         let readable = MIN_BODY_RECV_BUF_SIZE + 500;
-        assert_eq!(body_recv_buf_size(readable), readable);
+        assert_eq!(body_recv_buf_size(readable, MAX), readable);
     }
 
     #[test]
     fn large_readable_caps_at_max() {
+        assert_eq!(body_recv_buf_size(MAX, MAX), MAX);
+        // Readable beyond the configured max is capped.
+        assert_eq!(body_recv_buf_size(MAX + 1, MAX), MAX);
+        assert_eq!(body_recv_buf_size(10 * MAX, MAX), MAX);
+    }
+
+    #[test]
+    fn respects_configured_max() {
+        // A configured cap above the floor bounds the buffer below
+        // MAX_BUF_SIZE.
+        let cap = MIN_BODY_RECV_BUF_SIZE * 4;
+        assert_eq!(body_recv_buf_size(MAX, cap), cap);
+        assert_eq!(body_recv_buf_size(cap / 2, cap), cap / 2);
+        // A larger configured cap allows the buffer to grow past
+        // MAX_BUF_SIZE.
+        assert_eq!(body_recv_buf_size(2 * MAX, 4 * MAX), 2 * MAX);
+    }
+
+    #[test]
+    fn cap_below_floor_wins() {
+        // The cap is the hard upper bound: when it is smaller than the floor,
+        // the floor yields to it and `clamp` never sees an inverted range.
+        let cap = MIN_BODY_RECV_BUF_SIZE / 2;
+        assert_eq!(body_recv_buf_size(0, cap), cap);
+        assert_eq!(body_recv_buf_size(10, cap), cap);
+        assert_eq!(body_recv_buf_size(MAX, cap), cap);
+    }
+
+    #[test]
+    fn default_cap_is_16kib() {
+        assert_eq!(DEFAULT_MAX_BODY_RECV_BUF_SIZE, 16 * 1024);
+        // A body larger than the default is capped at 16 KiB.
         assert_eq!(
-            body_recv_buf_size(BufFactory::MAX_BUF_SIZE),
-            BufFactory::MAX_BUF_SIZE
-        );
-        // Readable beyond MAX_BUF_SIZE is capped.
-        assert_eq!(
-            body_recv_buf_size(BufFactory::MAX_BUF_SIZE + 1),
-            BufFactory::MAX_BUF_SIZE
-        );
-        assert_eq!(
-            body_recv_buf_size(10 * BufFactory::MAX_BUF_SIZE),
-            BufFactory::MAX_BUF_SIZE
+            body_recv_buf_size(MAX, DEFAULT_MAX_BODY_RECV_BUF_SIZE),
+            DEFAULT_MAX_BODY_RECV_BUF_SIZE
         );
     }
+}
+
+/// `Some(0)` is normalized to the default (it would make `recv_body_buf` a
+/// no-op); non-zero overrides are kept as-is.
+#[test]
+fn zero_configured_max_recv_body_buf_size_falls_back_to_default() {
+    let settings_max = |max: Option<usize>| {
+        let (driver, _controller) = H3Driver::<ClientHooks>::new(Http3Settings {
+            max_recv_body_buf_size: max,
+            ..Default::default()
+        });
+        driver.max_recv_body_buf_size
+    };
+
+    // `Some(0)` and unset both fall back to the default.
+    assert_eq!(settings_max(Some(0)), DEFAULT_MAX_BODY_RECV_BUF_SIZE);
+    assert_eq!(settings_max(None), DEFAULT_MAX_BODY_RECV_BUF_SIZE);
+    // A non-zero override is kept as-is, even below the sizing floor.
+    assert_eq!(
+        settings_max(Some(MIN_BODY_RECV_BUF_SIZE / 2)),
+        MIN_BODY_RECV_BUF_SIZE / 2
+    );
+    assert_eq!(
+        settings_max(Some(BufFactory::MAX_BUF_SIZE)),
+        BufFactory::MAX_BUF_SIZE
+    );
 }
 
 /// Tests for connection close error metrics recorded by

--- a/tokio-quiche/src/http3/settings.rs
+++ b/tokio-quiche/src/http3/settings.rs
@@ -61,6 +61,18 @@ pub struct Http3Settings {
     /// Set the `SETTINGS_ENABLE_CONNECT_PROTOCOL` HTTP/3 setting.
     /// See <https://www.rfc-editor.org/rfc/rfc9220#section-3-2>
     pub enable_extended_connect: bool,
+    /// Maximum size, in bytes, of the buffer the driver uses to read HTTP/3
+    /// body data out of quiche before forwarding it upstream.
+    ///
+    /// The buffer is sized dynamically to the amount of data currently
+    /// readable on a stream (which is itself bounded by the QUIC flow-control
+    /// window and the size of the buffered QUIC STREAM frames), but a single
+    /// read will never allocate more than this cap. This bounds the memory a
+    /// single (potentially adversarial) stream can force the driver to
+    /// allocate.
+    ///
+    /// When unset or `Some(0)`, the driver defaults to 16 KiB.
+    pub max_recv_body_buf_size: Option<usize>,
 }
 
 impl From<&Http3Settings> for quiche::h3::Config {


### PR DESCRIPTION
### Summary

Follow-up to !2547 (size `body_recv_buf` to readable length). This change makes the upper bound of the H3 body receive buffer configurable instead of hardcoding it to `BufFactory::MAX_BUF_SIZE` (64 KiB), and lowers the default when unset to 16 KiB.

### Motivation

Previously the driver clamped the body receive buffer to a fixed 64 KiB ceiling. A request that carries a body could pin a large allocation for the entire life of the stream. By making the cap configurable and lowering the default, idle/small bodies
no longer pay for a large allocation; a larger streamed body simply reallocates once per driver read-cycle.

### Changes

- Add `Http3Settings::max_recv_body_buf_size: Option<usize>` to let downstream users override the cap.
- Introduce `DEFAULT_MAX_BODY_RECV_BUF_SIZE` (16 KiB), used when the setting is unset.
- `body_recv_buf_size(readable)` now takes an explicit `max` argument; the buffer is clamped to `[MIN_BODY_RECV_BUF_SIZE, max]`.
- `H3Driver` stores `max_recv_body_buf_size`, resolved from `Http3Settings` in the constructor.
- The buffer remains sized to the amount currently readable on the stream (an upper bound that includes H3 framing), so we never under-allocate; the cap only bounds the worst case.

### Behavior

- **Default (unset):** body receive buffer capped at 16 KiB (down from 64 KiB).
- **Configured:** cap may be set below or above `MAX_BUF_SIZE` as needed.
- Floor of `MIN_BODY_RECV_BUF_SIZE` still guarantees non-zero capacity.

### Testing

- Updated `body_recv_buf_size` unit tests to pass an explicit `max`.
- Added `respects_configured_max`: smaller cap bounds the buffer below `MAX_BUF_SIZE`; larger cap allows growth past it.
- Added `default_cap_is_16kib`: verifies the default and that a larger body is capped at 16 KiB.

### Assumptions & Validation

Data (Bastion continuous-profiling flamegraphs): https://drive.google.com/drive/folders/1zvP2zze7xui1pAC_wU-QhMd6vMfIGuks

This change lowers the default cap (64 KiB -> 16 KiB) and makes it configurable. The primary memory win is already delivered by sizing-to-readable (#2547): heap **-23.5%** under 10k conns x 1-byte POST bodies, and **-23%** for 10k idle conns (`H3Driver::new` allocations -40%). Because most reads are well below 16 KiB, the lower default rarely changes the sized allocation; it only tightens the worst case a single (potentially adversarial) read can force, from 64 KiB down to 16 KiB.

**Assumptions**
- 16 KiB is a conservative default: large enough that typical bodies still fill one allocation per read-cycle, small enough to bound per-connection worst-case memory. It is overridable via `Http3Settings::max_recv_body_buf_size` for services that stream large bodies and prefer fewer reallocations.
- `Some(0)` is normalized to the default so a misconfiguration cannot create a zero-limit (no-op) buffer.

**No CPU regression**
- Active-streaming profile (1000 conns x 8 chunked streams) shows the `recv_body_buf` CPU share flat (~2.8-2.9%); the extra reallocations from a smaller cap did not appear as a CPU regression in the profiled workloads.

**Residual risk / mitigation**
- The main theoretical cost is more frequent reallocation on large streamed bodies (cap-sized chunks). The configurable cap lets latency/throughput-sensitive services raise it, and the 1 KiB floor bounds churn on the small-read end.

