### PR TITLE
tokio-quiche: don't set UDP_SEGMENT cmsg for single-segment sends

### DIFF
--- a/tokio-quiche/src/quic/io/gso.rs
+++ b/tokio-quiche/src/quic/io/gso.rs
@@ -138,8 +138,17 @@ pub async fn send_to(
 
         let mut cmsgs: SmallVec<[ControlMessage; 3]> = SmallVec::new();
 
-        // Create cmsg for UDP_SEGMENT.
-        cmsgs.push(ControlMessage::UdpGsoSegments(&segment_size_u16));
+        // Only attach the UDP_SEGMENT cmsg when the buffer actually spans more
+        // than one segment. A single-segment send needs no segmentation, and
+        // attaching the cmsg anyway makes sendmsg() return EIO on NICs that
+        // accept the UDP_SEGMENT sockopt but cannot segment (e.g. virtio-net
+        // with scatter-gather off). Since GSO is initialized with a u16::MAX
+        // segment size, omitting the cmsg here cannot cause a truncating
+        // fallback to a smaller socket-level segment size.
+        if send_buf.len() > segment_size {
+            // Create cmsg for UDP_SEGMENT.
+            cmsgs.push(ControlMessage::UdpGsoSegments(&segment_size_u16));
+        }
 
         if tx_time.is_some() {
             // Create cmsg for TXTIME.


### PR DESCRIPTION
## Problem

`gso::send_to` attaches a `UDP_SEGMENT` control message to every `sendmsg()`, even single-packet sends. On a NIC that accepts the `UDP_SEGMENT` sockopt but cannot actually segment — e.g. `virtio-net` with `scatter-gather` fixed off, as found on some lightweight cloud VPS instances — such a send fails with `EIO`.

The server acceptor's `handshake_reply()` routes stateless-Retry and version-negotiation replies through `gso::send_to`, so on such a NIC the server can never send them and **no handshake completes** (IPv4 and IPv6 alike). Full analysis, `strace` evidence, and how it regressed in #2060 are in #2551.

Notably the client path already avoids GSO for this reason:

```rust
// quic/mod.rs
// Don't apply_max_capabilities(): some NICs don't support GSO
```

…but the acceptor path does not, and the `has_gso` capability only gates the io-worker's sends — not the acceptor's — so building the listener without GSO doesn't help either.

## Fix

Only attach the `UDP_SEGMENT` cmsg when the buffer actually spans more than one segment (`send_buf.len() > segment_size`). A single-segment send needs no segmentation. This restores the single-segment fast-path that existed before #2060 (which passed `num_pkts` and only set the cmsg when `num_pkts > 1`).

It does **not** reintroduce the truncation footgun #2060 fixed: GSO is now initialized with a `u16::MAX` segment size, so a single packet sent without the cmsg uses that size as the fallback and is never truncated. Multi-segment sends are unaffected — they still carry the cmsg.

`cargo check -p tokio-quiche` passes.

Fixes #2551.
