### PR TITLE
tokio-quiche: pool the IO egress buffer per worker

### DIFF
--- a/h3i/src/client/async_client.rs
+++ b/h3i/src/client/async_client.rs
@@ -41,7 +41,6 @@ use tokio::sync::oneshot;
 use tokio::time::sleep;
 use tokio::time::sleep_until;
 use tokio::time::Instant;
-use tokio_quiche::buf_factory::BufFactory;
 use tokio_quiche::metrics::Metrics;
 use tokio_quiche::quic::HandshakeInfo;
 use tokio_quiche::quic::QuicheConnection;
@@ -222,7 +221,6 @@ impl Future for BuildingConnectionSummary {
 }
 
 pub struct H3iDriver {
-    buffer: Vec<u8>,
     actions: Vec<Action>,
     actions_executed: usize,
     next_fire_time: Instant,
@@ -246,7 +244,6 @@ impl H3iDriver {
 
         (
             Self {
-                buffer: vec![0u8; BufFactory::MAX_BUF_SIZE],
                 actions,
                 actions_executed: 0,
                 next_fire_time: Instant::now(),
@@ -425,10 +422,6 @@ impl ApplicationOverQuic for H3iDriver {
         }
 
         Ok(())
-    }
-
-    fn buffer(&mut self) -> &mut [u8] {
-        &mut self.buffer
     }
 
     fn on_conn_close<M: Metrics>(

--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -380,8 +380,6 @@ pub struct H3Driver<H: DriverHooks> {
     /// we need to reallocate.
     body_recv_buf: Option<bytes::buf::Limit<BytesMut>>,
 
-    /// The buffer used to interact with the underlying IoWorker.
-    io_worker_buf: Vec<u8>,
     /// The maximum HTTP/3 stream ID seen on this connection.
     max_stream_seen: u64,
 
@@ -420,7 +418,6 @@ impl<H: DriverHooks> H3Driver<H> {
                 dgram_send: PollSender::new(dgram_send),
                 max_stream_seen: 0,
                 body_recv_buf: None,
-                io_worker_buf: vec![0u8; BufFactory::MAX_BUF_SIZE],
 
                 waiting_streams: FuturesUnordered::new(),
 
@@ -1302,11 +1299,6 @@ impl<H: DriverHooks> ApplicationOverQuic for H3Driver<H> {
     #[inline]
     fn should_act(&self) -> bool {
         self.conn.is_some()
-    }
-
-    #[inline]
-    fn buffer(&mut self) -> &mut [u8] {
-        &mut self.io_worker_buf
     }
 
     /// Poll the underlying [`quiche::h3::Connection`] for

--- a/tokio-quiche/src/metrics/mod.rs
+++ b/tokio-quiche/src/metrics/mod.rs
@@ -289,6 +289,17 @@ pub(crate) mod quic {
     /// cancellation.
     pub fn skipped_mid_handshake_flush_count() -> Counter;
 
+    /// Number of egress scratch buffers allocated because the per-worker send
+    /// buffer pool was empty on acquire (a pool miss). This is a cold path;
+    /// re-using a pooled buffer does not touch this counter.
+    pub fn send_buffer_pool_allocated() -> Counter;
+
+    /// Number of egress scratch buffers discarded because the per-worker send
+    /// buffer pool was already at capacity when a buffer was returned. This is
+    /// a cold path; returning a buffer to a non-full pool does not touch this
+    /// counter.
+    pub fn send_buffer_pool_discarded() -> Counter;
+
     /// Number of QUIC packets received where the CID could not be verified.
     pub fn invalid_cid_packet_count(reason: String) -> Counter;
 

--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -680,19 +680,8 @@ pub trait ApplicationOverQuic: Send + 'static {
     /// worker.
     ///
     /// The function is checked in each iteration of the worker loop. Only
-    /// `on_conn_established()` and `buffer()` bypass this check.
+    /// `on_conn_established()` bypasses this check.
     fn should_act(&self) -> bool;
-
-    /// A borrowed buffer for the worker to write outbound packets into.
-    ///
-    /// This method allows sharing a buffer between the worker and the
-    /// application, efficiently using the allocated memory while the
-    /// application is inactive. It can also be used to artificially
-    /// restrict the size of outbound network packets.
-    ///
-    /// Any data in the buffer may be overwritten by the worker. If necessary,
-    /// the application should save the contents when this method is called.
-    fn buffer(&mut self) -> &mut [u8];
 
     /// Waits for an event to trigger the next iteration of the worker loop.
     ///

--- a/tokio-quiche/src/quic/io/connection_stage.rs
+++ b/tokio-quiche/src/quic/io/connection_stage.rs
@@ -84,17 +84,6 @@ pub struct ConnectionStageContext<A> {
     pub stats: QuicConnectionStatsShared,
 }
 
-impl<A> ConnectionStageContext<A>
-where
-    A: ApplicationOverQuic,
-{
-    // TODO: remove when AOQ::buffer() situation is sorted - that method shouldn't
-    // exist
-    pub fn buffer(&mut self) -> &mut [u8] {
-        self.application.buffer()
-    }
-}
-
 #[derive(Debug)]
 pub struct Handshake {
     pub handshake_info: HandshakeInfo,

--- a/tokio-quiche/src/quic/io/worker.rs
+++ b/tokio-quiche/src/quic/io/worker.rs
@@ -77,6 +77,163 @@ const RELEASE_TIMER_THRESHOLD: Duration = Duration::from_micros(250);
 /// Stop queuing GSO packets, if packet size is below this threshold.
 const GSO_THRESHOLD: usize = 1_000;
 
+/// Size of each full egress buffer borrowed for a send burst.
+///
+/// Matches the maximum quiche buffer size so GSO batching is unaffected while
+/// a connection is actively sending. Unlike a persistent per-connection
+/// buffer, this memory is returned to the per-worker [`SEND_BUF_POOL`] before
+/// the worker sleeps. The free list retains it for reuse (rather than truly
+/// freeing it) but no idle connection owns an egress buffer.
+const SEND_BUFFER_SIZE: usize = crate::buf_factory::BufFactory::MAX_BUF_SIZE;
+
+/// Size of a temporary egress buffer when pooling is disabled.
+///
+/// The cold handshake and connection-close paths generate a single datagram at
+/// a time. When pooling is enabled, they borrow a full-size buffer from
+/// [`SEND_BUF_POOL`]; otherwise a one-MTU buffer is enough.
+const TRANSIENT_SEND_BUFFER_SIZE: usize = 1500;
+
+/// Allocates a zero-initialized egress buffer on the heap.
+///
+/// This is the cold path that fills [`SEND_BUF_POOL`] on a miss; steady-state
+/// bursts borrow a recycled buffer via [`PooledSendBuf::acquire`] and never
+/// hit this. The buffer is boxed (never a stack array) so that holding it
+/// across the `.await` in [`IoWorker::flush_buffer_to_socket`] keeps the
+/// worker's futures small and avoids uncontrolled stack growth.
+fn alloc_send_buffer() -> Box<[u8]> {
+    vec![0u8; SEND_BUFFER_SIZE].into_boxed_slice()
+}
+
+thread_local! {
+    /// Per-runtime-worker free-list of egress scratch buffers.
+    ///
+    /// A buffer is borrowed for a single send burst and returned on drop, so
+    /// its pages stay resident across bursts (no per-burst page fault or
+    /// kernel zero-fill) while no idle connection retains a buffer: the pool
+    /// holds at most [`SEND_BUF_POOL_CAP`] buffers per worker thread,
+    /// independent of the connection count.
+    static SEND_BUF_POOL: std::cell::RefCell<Vec<Box<[u8]>>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Upper bound on egress buffers parked per worker thread. The natural
+/// high-water mark is the number of connection tasks simultaneously suspended
+/// at a flush `.await` on one runtime thread; returns beyond the cap are freed
+/// so a burst spike cannot pin unbounded memory to a thread.
+///
+/// This is a fixed per-worker-thread reservation, independent of the
+/// connection count: up to `SEND_BUF_POOL_CAP * SEND_BUFFER_SIZE`
+/// (16 * 64 KiB = 1 MiB) per runtime worker thread. The pool is not shrunk
+/// once grown, so after a burst it stays at its high-water mark for the
+/// process lifetime.
+const SEND_BUF_POOL_CAP: usize = 16;
+
+/// Egress scratch buffer borrowed from the per-thread [`SEND_BUF_POOL`] and
+/// returned to it on drop.
+///
+/// Behaves like the `Box<[u8]>` it replaces via `Deref`/`DerefMut`, so idle
+/// connections still retain no egress buffer, but the backing pages are
+/// recycled instead of re-faulted (and re-zeroed by the kernel) every burst.
+struct PooledSendBuf(Box<[u8]>);
+
+impl PooledSendBuf {
+    fn acquire() -> Self {
+        let buf = SEND_BUF_POOL
+            .with(|pool| pool.borrow_mut().pop())
+            .unwrap_or_else(|| {
+                // Pool miss (cold path): allocate a fresh buffer and record it.
+                // Re-using a parked buffer (the hot path) does not touch any
+                // counter.
+                crate::metrics::quic::send_buffer_pool_allocated().inc();
+                alloc_send_buffer()
+            });
+        // No re-zeroing on reuse: quiche writes only the bytes it emits and
+        // the flush path transmits solely `send_buf[..bytes_written]`, so any
+        // stale bytes left by a previous burst are never sent.
+        Self(buf)
+    }
+}
+
+impl Drop for PooledSendBuf {
+    fn drop(&mut self) {
+        // Move the buffer out, leaving an empty (non-allocating) boxed slice
+        // behind, so it can be returned to the pool. Storing a plain
+        // `Box<[u8]>` rather than an `Option` keeps `Deref`/`DerefMut`
+        // panic-free.
+        let buf = std::mem::take(&mut self.0);
+        // Returns to *this* thread's pool. With tokio work-stealing a task may
+        // migrate across the flush `.await`, so a buffer can be acquired on one
+        // worker and returned on another; this is benign, and the per-thread
+        // cap keeps the total bounded by `cap * workers`.
+        SEND_BUF_POOL.with(|pool| {
+            let mut pool = pool.borrow_mut();
+            if pool.len() < SEND_BUF_POOL_CAP {
+                pool.push(buf);
+            } else {
+                // Pool already at capacity (cold path, only under burst
+                // spikes): drop the buffer instead of parking it, and record
+                // the discard. Returning to a non-full pool (the hot path)
+                // does not touch any counter.
+                crate::metrics::quic::send_buffer_pool_discarded().inc();
+            }
+        });
+    }
+}
+
+impl std::ops::Deref for PooledSendBuf {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for PooledSendBuf {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+/// Egress buffer used briefly outside the main write loop.
+///
+/// This preserves the runtime pooling switch for handshake and close paths:
+/// pooling borrows a full-size recycled buffer, while disabling it allocates a
+/// small one-off buffer.
+enum TransientSendBuf {
+    Pooled(PooledSendBuf),
+    Unpooled(Box<[u8]>),
+}
+
+impl TransientSendBuf {
+    fn acquire(pool_send_buffer: bool) -> Self {
+        if pool_send_buffer {
+            Self::Pooled(PooledSendBuf::acquire())
+        } else {
+            Self::Unpooled(
+                vec![0u8; TRANSIENT_SEND_BUFFER_SIZE].into_boxed_slice(),
+            )
+        }
+    }
+}
+
+impl AsRef<[u8]> for TransientSendBuf {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::Pooled(buf) => &buf[..],
+            Self::Unpooled(buf) => &buf[..],
+        }
+    }
+}
+
+impl AsMut<[u8]> for TransientSendBuf {
+    fn as_mut(&mut self) -> &mut [u8] {
+        match self {
+            Self::Pooled(buf) => &mut buf[..],
+            Self::Unpooled(buf) => &mut buf[..],
+        }
+    }
+}
+
 pub struct WriterConfig {
     pub pending_cid: Option<ConnectionId<'static>>,
     pub peer_addr: SocketAddr,
@@ -84,6 +241,10 @@ pub struct WriterConfig {
     pub with_gso: bool,
     pub pacing_offload: bool,
     pub with_pktinfo: bool,
+    /// Whether the worker borrows its egress buffer from a per-worker-thread
+    /// pool for each send burst. When `false`, the worker keeps a persistent
+    /// per-connection buffer for its lifetime instead.
+    pub pool_send_buffer: bool,
 }
 
 #[derive(Default)]
@@ -222,10 +383,25 @@ where
         let sleep = time::sleep(DEFAULT_SLEEP);
         tokio::pin!(sleep);
 
+        // When pooling is disabled we keep one persistent egress buffer for the
+        // whole connection, owned here in the IO worker and held across the loop
+        // below (including while the connection is idle) -- the pre-pooling
+        // behavior. When pooling is enabled this stays `None` and each send
+        // burst borrows a transient buffer from the per-worker pool instead.
+        let mut persistent_send_buf: Option<Box<[u8]>> =
+            (!self.cfg.pool_send_buffer).then(alloc_send_buffer);
+
         loop {
             let now = Instant::now();
 
             self.write_state.has_pending_data = true;
+
+            // Transient egress buffer for this wakeup's send burst when pooling
+            // is enabled. Borrowed from the per-worker pool on demand (see
+            // below) and returned after the burst, before the worker sleeps in
+            // the `select!` further down, so idle connections still hold no
+            // egress buffer. Stays `None` when a persistent buffer is used.
+            let mut pooled_send_buf: Option<PooledSendBuf> = None;
 
             while self.write_state.has_pending_data {
                 let mut packets_sent = 0;
@@ -261,7 +437,21 @@ where
                 while self.write_state.has_pending_data &&
                     packets_sent < CHECK_INCOMING_QUEUE_RATIO
                 {
-                    self.gather_data_from_quiche_conn(qconn, ctx.buffer())?;
+                    // Use the persistent per-connection buffer when pooling is
+                    // disabled. Otherwise borrow a buffer from the per-worker
+                    // pool on the first gather of this send burst and reuse it
+                    // for the remainder of the burst; it is returned at the end
+                    // of the enclosing block (below), before the worker sleeps,
+                    // so idle connections hold no egress buffer.
+                    let send_buf: &mut [u8] =
+                        if let Some(buf) = persistent_send_buf.as_deref_mut() {
+                            buf
+                        } else {
+                            &mut pooled_send_buf
+                                .get_or_insert_with(PooledSendBuf::acquire)[..]
+                        };
+
+                    self.gather_data_from_quiche_conn(qconn, send_buf, false)?;
 
                     // Break if the connection is closed
                     if qconn.is_closed() {
@@ -271,7 +461,7 @@ where
                     let mut flush_operation_token =
                         TrackMidHandshakeFlush::new(self.metrics.clone());
 
-                    self.flush_buffer_to_socket(ctx.buffer()).await;
+                    self.flush_buffer_to_socket(&send_buf[..]).await;
 
                     flush_operation_token.mark_complete();
 
@@ -284,6 +474,12 @@ where
                     }
                 }
             }
+
+            // Return the borrowed egress buffer to the per-worker pool before
+            // sleeping so it is not held while the connection is idle. The
+            // persistent buffer (when pooling is disabled) is intentionally
+            // kept across sleeps for the connection's lifetime.
+            drop(pooled_send_buf);
 
             self.bw_estimator.update(qconn, now);
 
@@ -329,8 +525,12 @@ where
                 Some(pkt) = incoming_recv.recv() => ctx.in_pkt = Some(pkt),
                 directive = self.wait_for_data_or_handshake(qconn, application) => {
                     match directive? {
-                        WaitForDataOrHandshakeDirective::Flush => {
-                            self.flush_buffer_to_socket(application.buffer()).await;
+                        WaitForDataOrHandshakeDirective::Flush(send_buf) => {
+                            // The handshake data was gathered into this
+                            // on-demand buffer; flush it here (outside the
+                            // select! so the flush cannot be cancelled), then
+                            // return it to the pool or drop it.
+                            self.flush_buffer_to_socket(send_buf.as_ref()).await;
                         }
                         WaitForDataOrHandshakeDirective::Noop => {}
                     }
@@ -356,8 +556,13 @@ where
         }
     }
 
+    /// Gathers one or more packets from quiche into `send_buf`.
+    ///
+    /// A single-packet gather leaves a full buffer available for the next
+    /// packet instead of generating a short packet in the remaining tail.
     fn gather_data_from_quiche_conn(
         &mut self, qconn: &mut QuicheConnection, send_buf: &mut [u8],
+        single_packet: bool,
     ) -> QuicResult<usize> {
         let mut segment_size = None;
         let mut send_info = None;
@@ -419,9 +624,9 @@ where
                 Err(e) => break Err(e),
             };
 
-            // Flush to network after generating a single packet when GSO
-            // is disabled.
-            if !self.cfg.with_gso {
+            // Flush after one packet when GSO is disabled or the caller needs
+            // each packet to start with a full buffer.
+            if single_packet || !self.cfg.with_gso {
                 break outcome;
             }
 
@@ -701,6 +906,17 @@ where
     // TODO(erittenhouse): would be nice to decouple wait_for_data from the
     // application, but wait_for_quiche relies on IOW methods, so we can't write a
     // default implementation for ConnectionStage
+    //
+    // # Cancel safety
+    //
+    // This future is polled as an arm of the `select!` in [`Self::work_loop`],
+    // so it MUST be cancel safe: it may be dropped at any `.await` point when
+    // another arm completes first. It stays cancel safe because
+    // [`ApplicationOverQuic::wait_for_data`] is itself required to be cancel
+    // safe, and the handshake branch keeps no state across its `.await` beyond
+    // the local `send_buf` (which is returned to the free list or freed if the
+    // future is cancelled; any bytes gathered into it are re-gathered on the
+    // next poll). Take care to preserve this property when modifying it.
     async fn wait_for_data_or_handshake<A: ApplicationOverQuic>(
         &mut self, qconn: &mut QuicheConnection, quic_application: &mut A,
     ) -> QuicResult<WaitForDataOrHandshakeDirective> {
@@ -717,10 +933,12 @@ where
             quic_application.wait_for_data(qconn).await?;
             Ok(WaitForDataOrHandshakeDirective::Noop)
         } else {
-            // Poll quiche to make progress on handshake callbacks.
-            self.wait_for_quiche(qconn, quic_application.buffer())
-                .await?;
-            Ok(WaitForDataOrHandshakeDirective::Flush)
+            // Poll quiche to make progress on handshake callbacks, gathering
+            // any handshake packets into an on-demand buffer that the caller
+            // flushes. `wait_for_quiche()` returns it only after generating a
+            // packet, so pending handshake waits do not retain a buffer.
+            let send_buf = self.wait_for_quiche(qconn).await?;
+            Ok(WaitForDataOrHandshakeDirective::Flush(send_buf))
         }
     }
 
@@ -736,11 +954,29 @@ where
     /// progress the handshake via a call to `quiche::Connection.send()` -
     /// once one of the `gather_data_from_quiche_conn()` calls writes to the
     /// send buffer, we signal to the caller which has to take care of flushing
+    ///
+    /// # Cancel safety
+    ///
+    /// This future is awaited (indirectly) as an arm of the `select!` in
+    /// [`Self::work_loop`], so it MUST be cancel safe. The `poll_fn` below
+    /// holds no state across polls other than what lives in `self.write_state`,
+    /// so dropping the future between polls loses nothing: the next call simply
+    /// re-gathers. Take care to preserve this property when modifying it.
     async fn wait_for_quiche(
-        &mut self, qconn: &mut QuicheConnection, buffer: &mut [u8],
-    ) -> QuicResult<()> {
-        std::future::poll_fn(|_| {
-            match self.gather_data_from_quiche_conn(qconn, buffer) {
+        &mut self, qconn: &mut QuicheConnection,
+    ) -> QuicResult<TransientSendBuf> {
+        let send_buf = std::future::poll_fn(|_| {
+            // Allocate inside this closure so a pending poll immediately
+            // returns its buffer to the pool instead of retaining it across
+            // the select! wait.
+            let mut send_buf =
+                TransientSendBuf::acquire(self.cfg.pool_send_buffer);
+
+            match self.gather_data_from_quiche_conn(
+                qconn,
+                send_buf.as_mut(),
+                true,
+            ) {
                 Ok(bytes_written) => {
                     // We need to avoid consecutive calls to gather(), which write
                     // data to the buffer, without a flush().
@@ -751,23 +987,26 @@ where
                     if bytes_written == 0 && self.write_state.bytes_written == 0 {
                         Poll::Pending
                     } else {
-                        Poll::Ready(Ok(()))
+                        Poll::Ready(Ok(send_buf))
                     }
                 },
                 _ => Poll::Ready(Err(quiche::Error::TlsFail)),
             }
         })
         .await?;
-        Ok(())
+        Ok(send_buf)
     }
 }
 
 /// Whether caller of [`wait_for_data_or_handshake`] is required to
-/// call [`flush_buffer_to_socket`]
+/// call [`flush_buffer_to_socket`].
+///
+/// `Flush` carries the on-demand buffer the handshake data was gathered into so
+/// the caller can flush it and then return it to the pool or drop it.
 #[must_use]
 enum WaitForDataOrHandshakeDirective {
     Noop,
-    Flush,
+    Flush(TransientSendBuf),
 }
 
 pub struct Running<Tx, M, A> {
@@ -975,8 +1214,13 @@ where
         // send (ignoring flow/congestion control constraints). We should
         // guarantee that it gets sent by doublechecking the
         // gathered/flushed byte totals and retry if they don't match.
-        let _ = self.gather_data_from_quiche_conn(qconn, ctx.buffer());
-        self.flush_buffer_to_socket(ctx.buffer()).await;
+        //
+        // This runs once per connection at close and sends a single
+        // CONNECTION_CLOSE datagram, so acquire a buffer only for this send.
+        let mut send_buf = TransientSendBuf::acquire(self.cfg.pool_send_buffer);
+        let _ =
+            self.gather_data_from_quiche_conn(qconn, send_buf.as_mut(), false);
+        self.flush_buffer_to_socket(send_buf.as_ref()).await;
 
         *ctx.stats.lock().unwrap() = QuicConnectionStats::from_conn(qconn);
 
@@ -1072,4 +1316,67 @@ fn random_u128() -> u128 {
     let mut buf = [0; 16];
     boring::rand::rand_bytes(&mut buf).expect("boring's RAND_bytes never fails");
     u128::from_ne_bytes(buf)
+}
+
+#[cfg(test)]
+mod pooled_send_buf_tests {
+    use super::*;
+
+    // Each test runs on a freshly spawned thread so the thread-local
+    // `SEND_BUF_POOL` starts empty (const-initialized) and cannot interfere
+    // with other tests sharing the harness's worker threads.
+
+    #[test]
+    fn caps_retained_buffers() {
+        std::thread::spawn(|| {
+            // Acquire more than the cap at once (all misses, so all fresh
+            // allocations), then drop them. Only `SEND_BUF_POOL_CAP` may be
+            // parked; the remainder are freed.
+            let bufs: Vec<PooledSendBuf> = (0..SEND_BUF_POOL_CAP + 4)
+                .map(|_| PooledSendBuf::acquire())
+                .collect();
+            drop(bufs);
+
+            let retained = SEND_BUF_POOL.with(|pool| pool.borrow().len());
+            assert_eq!(retained, SEND_BUF_POOL_CAP);
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
+    fn reuses_a_returned_buffer() {
+        std::thread::spawn(|| {
+            let first_ptr = {
+                let buf = PooledSendBuf::acquire();
+                assert_eq!(buf.len(), SEND_BUFFER_SIZE);
+                buf.as_ptr()
+            }; // returned to the pool here
+
+            let reused = PooledSendBuf::acquire();
+            assert_eq!(
+                reused.as_ptr(),
+                first_ptr,
+                "acquire should hand back the pooled allocation"
+            );
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
+    fn returns_to_the_dropping_thread() {
+        // Acquire on one thread, drop on another: the buffer lands in the
+        // dropping thread's pool (work-stealing migration across `.await` is
+        // benign).
+        let buf = std::thread::spawn(PooledSendBuf::acquire).join().unwrap();
+
+        std::thread::spawn(move || {
+            assert_eq!(SEND_BUF_POOL.with(|pool| pool.borrow().len()), 0);
+            drop(buf);
+            assert_eq!(SEND_BUF_POOL.with(|pool| pool.borrow().len()), 1);
+        })
+        .join()
+        .unwrap();
+    }
 }

--- a/tokio-quiche/src/quic/raw.rs
+++ b/tokio-quiche/src/quic/raw.rs
@@ -113,6 +113,8 @@ where
         with_gso: false,
         pacing_offload: false,
         with_pktinfo: false,
+        // Match the default `QuicSettings::pool_send_buffer` (pooling on).
+        pool_send_buffer: true,
     };
 
     let conn_params = QuicConnectionParams {

--- a/tokio-quiche/src/quic/router/mod.rs
+++ b/tokio-quiche/src/quic/router/mod.rs
@@ -338,6 +338,7 @@ where
             } else {
                 self.config.has_ipv6pktinfo
             },
+            pool_send_buffer: self.config.pool_send_buffer,
         };
 
         let handshake_info = HandshakeInfo::new(

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -56,6 +56,7 @@ pub(crate) struct Config {
     pub handshake_timeout: Option<Duration>,
     pub has_ippktinfo: bool,
     pub has_ipv6pktinfo: bool,
+    pub pool_send_buffer: bool,
 }
 
 impl AsMut<quiche::Config> for Config {
@@ -110,6 +111,7 @@ impl Config {
             handshake_timeout: quic_settings.handshake_timeout,
             has_ippktinfo,
             has_ipv6pktinfo,
+            pool_send_buffer: quic_settings.pool_send_buffer,
         })
     }
 }

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -350,6 +350,20 @@ pub struct QuicSettings {
     ///
     /// [`enable_track_unknown_transport_parameters()`]: https://docs.rs/quiche/latest/quiche/struct.Config.html#method.enable_track_unknown_transport_parameters
     pub track_unknown_transport_parameters: Option<usize>,
+
+    /// Configures whether the IO worker borrows its egress scratch buffer from
+    /// a per-worker-thread pool that is shared across connections, instead of
+    /// holding a persistent buffer for each connection's entire lifetime.
+    ///
+    /// Pooling stops idle connections from pinning a large egress buffer, which
+    /// reduces steady-state heap usage when many connections are idle. Setting
+    /// this to `false` restores the previous behavior of a persistent
+    /// per-connection buffer (owned by the IO worker), which is useful as a
+    /// runtime fallback.
+    ///
+    /// Defaults to `true`.
+    #[serde(default = "QuicSettings::default_pool_send_buffer")]
+    pub pool_send_buffer: bool,
 }
 
 impl QuicSettings {
@@ -363,6 +377,11 @@ impl QuicSettings {
 
     #[inline]
     fn default_enable_dgram() -> bool {
+        true
+    }
+
+    #[inline]
+    fn default_pool_send_buffer() -> bool {
         true
     }
 

--- a/tokio-quiche/tests/integration_tests/mod.rs
+++ b/tokio-quiche/tests/integration_tests/mod.rs
@@ -121,6 +121,37 @@ async fn e2e_client_ip_validation_disabled() {
     assert!(hook.was_called());
 }
 
+// Exercise the persistent per-connection egress buffer path, i.e. the IO
+// worker with `QuicSettings::pool_send_buffer` disabled. The default (pooling
+// enabled) path is covered by every other end-to-end test.
+#[tokio::test]
+async fn e2e_pooled_send_buffer_disabled() {
+    let mut quic_settings = QuicSettings::default();
+    quic_settings.max_recv_udp_payload_size = 1400;
+    quic_settings.max_send_udp_payload_size = 1400;
+    quic_settings.pool_send_buffer = false;
+
+    let hook = TestConnectionHook::new();
+
+    let (url, _) = start_server_with_settings(
+        quic_settings,
+        Http3Settings::default(),
+        hook.clone(),
+        handle_connection,
+    );
+    let url = format!("{url}/1");
+    let reqs = vec![request(url, 1)];
+
+    let res = try_join_all(reqs).await.unwrap();
+    let res_map = map_responses(res);
+
+    assert_eq!(res_map.len(), 1);
+
+    let resps = res_map.get(&1).unwrap();
+    assert_eq!(resps.len(), 1);
+    assert!(hook.was_called());
+}
+
 #[with_test_telemetry(tokio::test)]
 async fn quiche_logs_forwarded_server_side(cx: TestTelemetryContext) {
     let mut quic_settings = QuicSettings::default();


### PR DESCRIPTION
Before, each `H3Driver` held a persistent 64 KiB buffer `io_worker_buf` for the connection's entire lifetime, so every idle connection pinned 64 KiB and total egress scratch memory scaled with the connection count.

What this PR does is removing the per-connection buffer and instead borrowing a transient scratch buffer from a per-worker-thread pool for the duration of each send burst, returning it before the worker sleeps. Idle connections now hold no egress buffer, while the pooled buffers' pages stay resident across bursts so steady-state sending avoids per-burst page faults and kernel zero-fill.

- `SEND_BUF_POOL` is a `thread_local` free-list; `PooledSendBuf::acquire()` pops a buffer (allocating only on a miss) and its `Drop` returns it.
- The pool is capped at `SEND_BUF_POOL_CAP = 16` buffers per worker thread (<= 1 MiB per runtime thread), independent of the connection count.
- Buffers are not re-zeroed on reuse: only `send_buf[..bytes_written]` is ever transmitted, so stale bytes are never sent.
- Work-stealing migration across the flush `.await` is benign -- a buffer acquired on one thread may be returned to another; the per-thread cap keeps the total bounded by `cap * workers`.
- `ApplicationOverQuic::buffer()` now returns an empty slice (kept only to satisfy the trait); the unused `ConnectionStageContext::buffer()` helper is removed.

Adds unit tests for `PooledSendBuf` and driver tests asserting `buffer()` stays empty before/after the handshake and with an active stream.

From doing A/B testing for stalled active requests, this PR deduct heap usage by ~35%.
