### PR TITLE
count persistent RTT jumps - global min detector

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -9477,6 +9477,8 @@ pub use crate::path::SocketAddrIter;
 
 pub use crate::recovery::BbrBwLoReductionStrategy;
 pub use crate::recovery::BbrParams;
+#[cfg(feature = "internal")]
+pub use crate::recovery::BbrRttJumpDetector;
 pub use crate::recovery::CongestionControlAlgorithm;
 pub use crate::recovery::StartupExit;
 pub use crate::recovery::StartupExitReason;

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -579,6 +579,7 @@ impl Path {
                 .recovery
                 .max_bandwidth()
                 .map(Bandwidth::to_bytes_per_second),
+            rtt_persistent_jump_count: self.recovery.rtt_persistent_jump_count(),
             startup_exit: self.recovery.startup_exit(),
         }
     }
@@ -1020,6 +1021,9 @@ pub struct PathStats {
     /// it is currently only implemented for bbr2_gcongestion.
     pub max_bandwidth: Option<u64>,
 
+    /// The total number of confirmed persistent RTT jump episodes.
+    pub rtt_persistent_jump_count: u64,
+
     /// Statistics from when a CCA first exited the startup phase.
     pub startup_exit: Option<StartupExit>,
 }
@@ -1051,8 +1055,11 @@ impl std::fmt::Debug for PathStats {
 
         write!(
             f,
-            " stream_retrans_bytes={} pmtu={} delivery_rate={}",
-            self.stream_retrans_bytes, self.pmtu, self.delivery_rate,
+            " stream_retrans_bytes={} pmtu={} delivery_rate={} rtt_persistent_jump_count={}",
+            self.stream_retrans_bytes,
+            self.pmtu,
+            self.delivery_rate,
+            self.rtt_persistent_jump_count,
         )
     }
 }

--- a/quiche/src/recovery/AGENTS.md
+++ b/quiche/src/recovery/AGENTS.md
@@ -39,6 +39,7 @@ gcongestion/        Next-gen CC (BBR2)
     probe_bw.rs     ProbeBW mode (bandwidth probing cycles)
     probe_rtt.rs    ProbeRTT mode (min RTT measurement)
     network_model.rs  Bandwidth/RTT model, BbrParams application
+    rtt_jump_detector.rs  Global-min RTT jump detection
   bbr.rs            BBR (v1, not actively used)
 ```
 

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -923,6 +923,16 @@ impl RecoveryOps for LegacyRecovery {
         None
     }
 
+    fn rtt_persistent_jump_count(&self) -> u64 {
+        // Persistent RTT jump counts are produced by the BBR2 global-min RTT
+        // jump detector. Legacy Reno/CUBIC recovery does not own a BBR2
+        // network model or run that detector, but it still implements
+        // RecoveryOps so PathStats can be populated through one shared
+        // interface. Report zero to indicate that no detector is active on
+        // this path.
+        0
+    }
+
     /// Statistics from when a CCA first exited the startup phase.
     fn startup_exit(&self) -> Option<StartupExit> {
         self.congestion.ssthresh.startup_exit()

--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -33,6 +33,7 @@ mod mode;
 mod network_model;
 mod probe_bw;
 mod probe_rtt;
+mod rtt_jump_detector;
 mod startup;
 
 use std::time::Duration;
@@ -50,6 +51,7 @@ use super::bbr::SendTimeState;
 use super::Acked;
 use super::BbrBwLoReductionStrategy;
 use super::BbrParams;
+use super::BbrRttJumpDetector;
 use super::CongestionControl;
 use super::Lost;
 use super::RttStats;
@@ -207,6 +209,9 @@ struct Params {
     /// 1/8th of an RTT into the future, so the error introduced by
     /// setting `time_sent` to `now` is bounded.
     time_sent_set_to_now: bool,
+
+    /// Selects the RTT jump detector implementation.
+    rtt_jump_detector: BbrRttJumpDetector,
 }
 
 impl Params {
@@ -252,6 +257,13 @@ impl Params {
         apply_override!(disable_probe_down_early_exit);
         apply_override!(time_sent_set_to_now);
         apply_optional_override!(initial_pacing_rate_bytes_per_second);
+
+        #[cfg(feature = "internal")]
+        {
+            if let Some(custom_value) = custom_bbr_settings.rtt_jump_detector {
+                self.rtt_jump_detector = custom_value;
+            }
+        }
 
         if let Some(custom_value) = custom_bbr_settings.bw_lo_reduction_strategy {
             self.bw_lo_mode = custom_value.into();
@@ -347,6 +359,8 @@ const DEFAULT_PARAMS: Params = Params {
     disable_probe_down_early_exit: false,
 
     time_sent_set_to_now: true,
+
+    rtt_jump_detector: BbrRttJumpDetector::Disabled,
 };
 
 #[derive(Debug, PartialEq)]
@@ -638,6 +652,10 @@ impl BBRv2 {
     #[cfg(feature = "qlog")]
     pub(crate) fn ack_rate(&self) -> Option<Bandwidth> {
         self.mode.network_model().ack_rate()
+    }
+
+    pub(crate) fn rtt_persistent_jump_count(&self) -> u64 {
+        self.mode.network_model().rtt_persistent_jump_count()
     }
 }
 

--- a/quiche/src/recovery/gcongestion/bbr2/network_model.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/network_model.rs
@@ -37,6 +37,7 @@ use crate::recovery::gcongestion::bbr2::Params;
 use crate::recovery::gcongestion::Bandwidth;
 use crate::recovery::gcongestion::Lost;
 
+use super::rtt_jump_detector::RttJumpDetector;
 use super::Acked;
 use super::BBRv2CongestionEvent;
 use super::BwLoMode;
@@ -191,6 +192,8 @@ pub(super) struct BBRv2NetworkModel {
     latest_send_rate: Option<Bandwidth>,
     /// The most recent ack rate from the BandwidthSampler.
     latest_ack_rate: Option<Bandwidth>,
+
+    rtt_jump_detector: RttJumpDetector,
 }
 
 impl BBRv2NetworkModel {
@@ -238,6 +241,8 @@ impl BBRv2NetworkModel {
 
             latest_send_rate: None,
             latest_ack_rate: None,
+
+            rtt_jump_detector: RttJumpDetector::new(),
         }
     }
 
@@ -363,6 +368,14 @@ impl BBRv2NetworkModel {
 
         if let Some(rtt_sample) = sample.sample_rtt {
             congestion_event.sample_min_rtt = Some(rtt_sample);
+
+            self.rtt_jump_detector.on_rtt_sample_with_mode(
+                params.rtt_jump_detector,
+                rtt_sample,
+                event_time,
+                self.full_bandwidth_reached,
+            );
+
             self.min_rtt_filter.update(rtt_sample, event_time);
         }
 
@@ -697,6 +710,33 @@ impl BBRv2NetworkModel {
         self.bandwidth_sampler.total_bytes_lost()
     }
 
+    /// Total number of confirmed persistent RTT jump episodes over the
+    /// lifetime of the connection.
+    pub(super) fn rtt_persistent_jump_count(&self) -> u64 {
+        self.rtt_jump_detector.rtt_persistent_jump_count()
+    }
+
+    /// The start time of the most recently confirmed persistent RTT jump
+    /// episode, if any.
+    #[cfg(test)]
+    pub(super) fn last_persistent_jump_time(&self) -> Option<Instant> {
+        self.rtt_jump_detector.last_persistent_jump_time()
+    }
+
+    /// Whether an RTT jump episode is currently active (elevated but not yet
+    /// resolved), regardless of whether it has been confirmed persistent.
+    #[cfg(test)]
+    pub(super) fn is_rtt_jump_active(&self) -> bool {
+        self.rtt_jump_detector.is_rtt_jump_active()
+    }
+
+    /// Whether the current RTT jump episode has been confirmed as a persistent
+    /// network condition.
+    #[cfg(test)]
+    pub(super) fn is_rtt_jump_persistent(&self) -> bool {
+        self.rtt_jump_detector.is_rtt_jump_persistent()
+    }
+
     fn round_trip_count(&self) -> usize {
         self.round_trip_counter.round_trip_count
     }
@@ -780,5 +820,196 @@ impl BBRv2NetworkModel {
 
     pub(super) fn rounds_with_queueing(&self) -> usize {
         self.rounds_with_queueing
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recovery::gcongestion::bbr2::DEFAULT_PARAMS;
+    use crate::recovery::gcongestion::BbrRttJumpDetector;
+
+    fn ms(millis: u64) -> Duration {
+        Duration::from_millis(millis)
+    }
+
+    const RTT: Duration = Duration::from_millis(50);
+    const RTT_3X: Duration = Duration::from_millis(150);
+    const RTT_JUMP: Duration = Duration::from_millis(151);
+
+    /// Ack a packet with the given RTT through the real congestion-event path.
+    fn ack_with_rtt(
+        model: &mut BBRv2NetworkModel, params: &Params, pkt_num: u64,
+        base: Instant, sent_offset: Duration, rtt: Duration,
+    ) -> BBRv2CongestionEvent {
+        ack_with_rtt_util(
+            model,
+            params,
+            pkt_num,
+            base,
+            sent_offset,
+            rtt,
+            100_000,
+            1200,
+        )
+    }
+
+    /// As `ack_with_rtt`, but with explicit cwnd and inflight inputs.
+    // Test harness: the extra cwnd/inflight knobs push this one over the
+    // argument-count lint, which is not worth a builder struct in tests.
+    #[allow(clippy::too_many_arguments)]
+    fn ack_with_rtt_util(
+        model: &mut BBRv2NetworkModel, params: &Params, pkt_num: u64,
+        base: Instant, sent_offset: Duration, rtt: Duration, prior_cwnd: usize,
+        prior_in_flight: usize,
+    ) -> BBRv2CongestionEvent {
+        let bytes = 1200;
+        let sent_time = base + sent_offset;
+        model.on_packet_sent(sent_time, 0, pkt_num, bytes, true);
+
+        let ack_time = sent_time + rtt;
+        let acked = [Acked {
+            pkt_num,
+            time_sent: sent_time,
+        }];
+        let mut event = BBRv2CongestionEvent::new(
+            ack_time,
+            prior_cwnd,
+            prior_in_flight,
+            false,
+        );
+        model.on_congestion_event_start(&acked, &[], &mut event, params);
+        event
+    }
+
+    fn rtt_jump_params(detector: BbrRttJumpDetector) -> Params {
+        Params {
+            rtt_jump_detector: detector,
+            ..DEFAULT_PARAMS
+        }
+    }
+
+    #[test]
+    fn rtt_jump_detector_is_disabled_by_default() {
+        let params = &DEFAULT_PARAMS;
+        let mut model = BBRv2NetworkModel::new(params, RTT);
+        let base = Instant::now();
+
+        for pkt in 1..5 {
+            ack_with_rtt(&mut model, params, pkt, base, ms(pkt * 10), RTT);
+        }
+
+        let mut offset = 100;
+        for pkt in 5..20 {
+            ack_with_rtt(&mut model, params, pkt, base, ms(offset), RTT_3X);
+            offset += 100;
+        }
+
+        assert_eq!(model.rtt_persistent_jump_count(), 0);
+        assert!(!model.is_rtt_jump_active());
+        assert_eq!(model.last_persistent_jump_time(), None);
+    }
+
+    #[test]
+    fn global_min_detector_can_be_enabled() {
+        let params = &rtt_jump_params(BbrRttJumpDetector::GlobalMin);
+        let mut model = BBRv2NetworkModel::new(params, RTT);
+        let base = Instant::now();
+
+        for pkt in 1..5 {
+            ack_with_rtt(&mut model, params, pkt, base, ms(pkt * 10), RTT);
+        }
+        model.set_full_bandwidth_reached();
+
+        ack_with_rtt(&mut model, params, 5, base, ms(100), RTT_JUMP);
+        ack_with_rtt(&mut model, params, 6, base, ms(110), RTT_JUMP);
+        ack_with_rtt(&mut model, params, 7, base, ms(300), RTT_JUMP);
+
+        assert_eq!(model.rtt_persistent_jump_count(), 1);
+        assert!(model.is_rtt_jump_persistent());
+        assert!(model.last_persistent_jump_time().is_some());
+    }
+
+    #[test]
+    fn global_min_detector_sustained_step_becomes_persistent() {
+        let params = &rtt_jump_params(BbrRttJumpDetector::GlobalMin);
+        let mut model = BBRv2NetworkModel::new(params, RTT);
+        let base = Instant::now();
+
+        for pkt in 1..5 {
+            ack_with_rtt(&mut model, params, pkt, base, ms(pkt * 10), RTT);
+        }
+        model.set_full_bandwidth_reached();
+
+        ack_with_rtt(&mut model, params, 5, base, ms(100), RTT_JUMP);
+        assert!(model.is_rtt_jump_active());
+        assert!(!model.is_rtt_jump_persistent());
+
+        ack_with_rtt(&mut model, params, 6, base, ms(110), RTT_JUMP);
+        assert!(!model.is_rtt_jump_persistent());
+
+        ack_with_rtt(&mut model, params, 7, base, ms(300), RTT_JUMP);
+        assert!(model.is_rtt_jump_persistent());
+        assert_eq!(model.rtt_persistent_jump_count(), 1);
+        assert!(model.last_persistent_jump_time().is_some());
+    }
+
+    #[test]
+    fn global_min_detector_uses_strict_3x_threshold() {
+        let params = &rtt_jump_params(BbrRttJumpDetector::GlobalMin);
+        let base = Instant::now();
+
+        let mut at_edge = BBRv2NetworkModel::new(params, RTT);
+        ack_with_rtt(&mut at_edge, params, 1, base, ms(10), RTT);
+        at_edge.set_full_bandwidth_reached();
+        ack_with_rtt(&mut at_edge, params, 2, base, ms(20), RTT_3X);
+        assert!(!at_edge.is_rtt_jump_active());
+
+        let mut just_above = BBRv2NetworkModel::new(params, RTT);
+        ack_with_rtt(&mut just_above, params, 1, base, ms(10), RTT);
+        just_above.set_full_bandwidth_reached();
+        ack_with_rtt(&mut just_above, params, 2, base, ms(20), RTT_JUMP);
+        assert!(just_above.is_rtt_jump_active());
+    }
+
+    #[test]
+    fn global_min_detector_tracks_downward_baseline() {
+        let params = &rtt_jump_params(BbrRttJumpDetector::GlobalMin);
+        let mut model = BBRv2NetworkModel::new(params, RTT);
+        let base = Instant::now();
+
+        ack_with_rtt(&mut model, params, 1, base, ms(100), ms(100));
+        ack_with_rtt(&mut model, params, 2, base, ms(200), ms(299));
+        assert!(!model.is_rtt_jump_active());
+
+        ack_with_rtt(&mut model, params, 3, base, ms(300), RTT);
+        assert!(!model.is_rtt_jump_active());
+
+        model.set_full_bandwidth_reached();
+        ack_with_rtt(&mut model, params, 4, base, ms(400), RTT_JUMP);
+        assert!(model.is_rtt_jump_active());
+    }
+
+    #[test]
+    fn global_min_detector_ignores_startup_rtt_jump_until_full_bandwidth() {
+        let params = &rtt_jump_params(BbrRttJumpDetector::GlobalMin);
+        let mut model = BBRv2NetworkModel::new(params, RTT);
+        let base = Instant::now();
+
+        ack_with_rtt(&mut model, params, 1, base, ms(10), RTT);
+        ack_with_rtt(&mut model, params, 2, base, ms(20), RTT_JUMP);
+        ack_with_rtt(&mut model, params, 3, base, ms(30), RTT_JUMP);
+        ack_with_rtt(&mut model, params, 4, base, ms(200), RTT_JUMP);
+
+        assert_eq!(model.rtt_persistent_jump_count(), 0);
+        assert!(!model.is_rtt_jump_active());
+
+        model.set_full_bandwidth_reached();
+        ack_with_rtt(&mut model, params, 5, base, ms(210), RTT_JUMP);
+        ack_with_rtt(&mut model, params, 6, base, ms(220), RTT_JUMP);
+        ack_with_rtt(&mut model, params, 7, base, ms(360), RTT_JUMP);
+
+        assert_eq!(model.rtt_persistent_jump_count(), 1);
+        assert!(model.is_rtt_jump_persistent());
     }
 }

--- a/quiche/src/recovery/gcongestion/bbr2/rtt_jump_detector.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/rtt_jump_detector.rs
@@ -1,0 +1,406 @@
+// Copyright (C) 2026, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::time::Duration;
+use std::time::Instant;
+
+use crate::recovery::gcongestion::BbrRttJumpDetector;
+
+// An RTT jump is a sustained RTT increase above the connection-lifetime minimum
+// RTT baseline. The GlobalMin detector treats samples above 3x that baseline as
+// elevated, counts a jump only after repeated elevated samples persist for a
+// baseline-scaled dwell period, and clears the episode when RTT falls back to
+// 3x baseline or below.
+//
+// GlobalMin episode lifecycle:
+//
+//     elevated        sustained elevated       clear
+// Idle -------> Active -----------------> Persistent
+//   ^              |                           |
+//   |              | clear                     | clear
+//   +--------------+---------------------------+
+//
+// Sample trace:
+//
+//             __A__                __P__
+//       __A__|    |       __A__A__|     |__P__
+//       |         |       |                   |
+//    I__|         |___I___|                   |___I
+// I__|
+//
+// I = Idle
+// A = Active
+// P = Persistent
+
+/// Tracks the lifecycle of a global-min RTT jump episode.
+#[derive(Debug, Default, Clone, Copy)]
+enum GlobalMinEpisode {
+    /// No elevation currently observed.
+    #[default]
+    Idle,
+    /// A jump has been observed but not yet sustained long enough to be
+    /// considered persistent.
+    Active {
+        elevated_samples: usize,
+        episode_start_time: Instant,
+    },
+    /// The elevated RTT has been confirmed as a persistent network condition.
+    Persistent,
+}
+
+/// Multiplicative factor over the global-min RTT baseline above which a sample
+/// is classified as an RTT jump.
+const GLOBAL_MIN_JUMP_THRESHOLD: f32 = 3.0;
+
+/// Elevated RTT samples required before an active episode becomes persistent.
+const GLOBAL_MIN_CONFIRM_SAMPLES: usize = 3;
+
+/// Minimum episode duration, expressed as a multiple of the global-min RTT
+/// baseline, required before an active episode becomes persistent.
+const GLOBAL_MIN_CONFIRM_DURATION_MULTIPLIER: u32 = 3;
+
+#[derive(Debug, Default)]
+pub(super) struct RttJumpDetector {
+    /// Connection-lifetime minimum RTT sample used by the detector.
+    baseline: Option<Duration>,
+    /// Lifecycle state used to distinguish transient RTT spikes from persistent
+    /// increases.
+    episode: GlobalMinEpisode,
+    /// Total number of confirmed persistent RTT jump episodes.
+    persistent_jump_count: u64,
+    /// The start time of the most recently confirmed persistent RTT jump
+    /// episode, if any.
+    last_persistent_jump_time: Option<Instant>,
+}
+
+impl RttJumpDetector {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Runs the selected RTT jump detector for one RTT sample.
+    pub(super) fn on_rtt_sample_with_mode(
+        &mut self, mode: BbrRttJumpDetector, rtt_sample: Duration,
+        event_time: Instant, full_bandwidth_reached: bool,
+    ) {
+        match mode {
+            BbrRttJumpDetector::Disabled => {},
+            BbrRttJumpDetector::GlobalMin => self.on_rtt_sample_global_min(
+                rtt_sample,
+                event_time,
+                full_bandwidth_reached,
+            ),
+        }
+    }
+
+    /// Global-min RTT jump detector step: connection-lifetime minimum baseline
+    /// with a strict multiplicative jump test and a sample/duration
+    /// confirmation gate.
+    fn on_rtt_sample_global_min(
+        &mut self, rtt_sample: Duration, event_time: Instant,
+        full_bandwidth_reached: bool,
+    ) {
+        if !full_bandwidth_reached {
+            self.update_baseline(rtt_sample);
+            return;
+        }
+
+        let Some(baseline) = self.baseline else {
+            self.update_baseline(rtt_sample);
+            return;
+        };
+
+        let is_jump = rtt_sample > baseline.mul_f32(GLOBAL_MIN_JUMP_THRESHOLD);
+        let is_clear = !is_jump;
+
+        match self.episode {
+            GlobalMinEpisode::Idle =>
+                if is_jump {
+                    self.episode = GlobalMinEpisode::Active {
+                        elevated_samples: 1,
+                        episode_start_time: event_time,
+                    };
+                },
+
+            GlobalMinEpisode::Active {
+                elevated_samples,
+                episode_start_time,
+            } =>
+                if is_clear {
+                    self.episode = GlobalMinEpisode::Idle;
+                } else {
+                    let elevated_samples = elevated_samples + 1;
+                    let dwell = baseline * GLOBAL_MIN_CONFIRM_DURATION_MULTIPLIER;
+                    let samples_ok =
+                        elevated_samples >= GLOBAL_MIN_CONFIRM_SAMPLES;
+                    let time_ok = event_time
+                        .saturating_duration_since(episode_start_time) >=
+                        dwell;
+
+                    if samples_ok && time_ok {
+                        self.persistent_jump_count += 1;
+                        self.last_persistent_jump_time = Some(episode_start_time);
+                        self.episode = GlobalMinEpisode::Persistent;
+                    } else {
+                        self.episode = GlobalMinEpisode::Active {
+                            elevated_samples,
+                            episode_start_time,
+                        };
+                    }
+                },
+
+            GlobalMinEpisode::Persistent =>
+                if is_clear {
+                    self.episode = GlobalMinEpisode::Idle;
+                },
+        }
+
+        self.update_baseline(rtt_sample);
+    }
+
+    fn update_baseline(&mut self, rtt_sample: Duration) {
+        self.baseline =
+            Some(self.baseline.map_or(rtt_sample, |min| min.min(rtt_sample)));
+    }
+
+    /// Total number of confirmed persistent RTT jump episodes.
+    pub(super) fn rtt_persistent_jump_count(&self) -> u64 {
+        self.persistent_jump_count
+    }
+
+    /// The start time of the most recently confirmed persistent RTT jump
+    /// episode, if any.
+    #[cfg(test)]
+    pub(super) fn last_persistent_jump_time(&self) -> Option<Instant> {
+        self.last_persistent_jump_time
+    }
+
+    /// Whether an RTT jump episode is currently active.
+    #[cfg(test)]
+    pub(super) fn is_rtt_jump_active(&self) -> bool {
+        !matches!(self.episode, GlobalMinEpisode::Idle)
+    }
+
+    /// Whether the current RTT jump episode has been confirmed as persistent.
+    #[cfg(test)]
+    pub(super) fn is_rtt_jump_persistent(&self) -> bool {
+        matches!(self.episode, GlobalMinEpisode::Persistent)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RTT: Duration = Duration::from_millis(50);
+    const RTT_3X: Duration = Duration::from_millis(150);
+    const RTT_JUMP: Duration = Duration::from_millis(151);
+    const LOW_RTT: Duration = Duration::from_millis(10);
+    const HIGH_RTT: Duration = Duration::from_millis(500);
+
+    fn ms(millis: u64) -> Duration {
+        Duration::from_millis(millis)
+    }
+
+    fn sample(
+        detector: &mut RttJumpDetector, base: Instant, offset: Duration,
+        rtt: Duration,
+    ) {
+        sample_with_full_bandwidth(detector, base, offset, rtt, true);
+    }
+
+    fn sample_with_full_bandwidth(
+        detector: &mut RttJumpDetector, base: Instant, offset: Duration,
+        rtt: Duration, full_bandwidth_reached: bool,
+    ) {
+        detector.on_rtt_sample_with_mode(
+            BbrRttJumpDetector::GlobalMin,
+            rtt,
+            base + offset,
+            full_bandwidth_reached,
+        );
+    }
+
+    #[test]
+    fn global_min_detector_uses_strict_3x_threshold() {
+        let base = Instant::now();
+
+        let mut at_edge = RttJumpDetector::new();
+        sample(&mut at_edge, base, ms(10), RTT);
+        sample(&mut at_edge, base, ms(20), RTT_3X);
+        assert!(!at_edge.is_rtt_jump_active());
+
+        let mut just_above = RttJumpDetector::new();
+        sample(&mut just_above, base, ms(10), RTT);
+        sample(&mut just_above, base, ms(20), RTT_JUMP);
+        assert!(just_above.is_rtt_jump_active());
+    }
+
+    #[test]
+    fn global_min_detector_clears_active_at_or_below_threshold() {
+        let base = Instant::now();
+
+        let mut at_edge = RttJumpDetector::new();
+        sample(&mut at_edge, base, ms(10), RTT);
+        sample(&mut at_edge, base, ms(20), RTT_JUMP);
+        assert!(at_edge.is_rtt_jump_active());
+        sample(&mut at_edge, base, ms(30), RTT_3X);
+        assert!(!at_edge.is_rtt_jump_active());
+
+        let mut below_edge = RttJumpDetector::new();
+        sample(&mut below_edge, base, ms(10), RTT);
+        sample(&mut below_edge, base, ms(20), RTT_JUMP);
+        assert!(below_edge.is_rtt_jump_active());
+        sample(&mut below_edge, base, ms(30), RTT);
+        assert!(!below_edge.is_rtt_jump_active());
+    }
+
+    #[test]
+    fn global_min_detector_sustained_step_becomes_persistent() {
+        let mut detector = RttJumpDetector::new();
+        let base = Instant::now();
+
+        sample(&mut detector, base, ms(10), RTT);
+        sample(&mut detector, base, ms(20), RTT_JUMP);
+        assert!(detector.is_rtt_jump_active());
+        assert!(!detector.is_rtt_jump_persistent());
+
+        sample(&mut detector, base, ms(30), RTT_JUMP);
+        assert!(!detector.is_rtt_jump_persistent());
+
+        sample(&mut detector, base, ms(170), RTT_JUMP);
+        assert!(detector.is_rtt_jump_persistent());
+        assert_eq!(detector.rtt_persistent_jump_count(), 1);
+        assert_eq!(detector.last_persistent_jump_time(), Some(base + ms(20)));
+    }
+
+    #[test]
+    fn global_min_detector_clears_persistent_at_or_below_threshold() {
+        let mut detector = RttJumpDetector::new();
+        let base = Instant::now();
+
+        sample(&mut detector, base, ms(10), RTT);
+        sample(&mut detector, base, ms(20), RTT_JUMP);
+        sample(&mut detector, base, ms(30), RTT_JUMP);
+        sample(&mut detector, base, ms(170), RTT_JUMP);
+        assert!(detector.is_rtt_jump_persistent());
+
+        sample(&mut detector, base, ms(180), RTT_3X);
+        assert!(!detector.is_rtt_jump_active());
+        assert!(!detector.is_rtt_jump_persistent());
+        assert_eq!(detector.rtt_persistent_jump_count(), 1);
+    }
+
+    #[test]
+    fn global_min_detector_tracks_downward_baseline() {
+        let mut detector = RttJumpDetector::new();
+        let base = Instant::now();
+
+        sample(&mut detector, base, ms(100), ms(100));
+        sample(&mut detector, base, ms(200), ms(299));
+        assert!(!detector.is_rtt_jump_active());
+
+        sample(&mut detector, base, ms(300), RTT);
+        assert!(!detector.is_rtt_jump_active());
+
+        sample(&mut detector, base, ms(400), RTT_JUMP);
+        assert!(detector.is_rtt_jump_active());
+    }
+
+    #[test]
+    fn global_min_detector_repeated_elevation_waits_for_dwell() {
+        let mut detector = RttJumpDetector::new();
+        let base = Instant::now();
+
+        sample(&mut detector, base, ms(10), RTT);
+        sample(&mut detector, base, ms(20), RTT_JUMP);
+        sample(&mut detector, base, ms(30), RTT_JUMP);
+        sample(&mut detector, base, ms(40), RTT_JUMP);
+
+        assert!(detector.is_rtt_jump_active());
+        assert!(!detector.is_rtt_jump_persistent());
+        assert_eq!(detector.rtt_persistent_jump_count(), 0);
+    }
+
+    #[test]
+    fn global_min_detector_ignores_jumps_before_full_bandwidth() {
+        let mut detector = RttJumpDetector::new();
+        let base = Instant::now();
+
+        sample_with_full_bandwidth(&mut detector, base, ms(10), RTT, false);
+        sample_with_full_bandwidth(&mut detector, base, ms(20), RTT_JUMP, false);
+        sample_with_full_bandwidth(&mut detector, base, ms(30), RTT_JUMP, false);
+        sample_with_full_bandwidth(&mut detector, base, ms(170), RTT_JUMP, false);
+
+        assert!(!detector.is_rtt_jump_active());
+        assert!(!detector.is_rtt_jump_persistent());
+        assert_eq!(detector.rtt_persistent_jump_count(), 0);
+
+        sample(&mut detector, base, ms(180), RTT_JUMP);
+        assert!(detector.is_rtt_jump_active());
+        assert!(!detector.is_rtt_jump_persistent());
+
+        sample(&mut detector, base, ms(190), RTT_JUMP);
+        assert!(!detector.is_rtt_jump_persistent());
+
+        sample(&mut detector, base, ms(330), RTT_JUMP);
+        assert!(detector.is_rtt_jump_persistent());
+        assert_eq!(detector.rtt_persistent_jump_count(), 1);
+    }
+
+    #[test]
+    fn global_min_detector_uses_baseline_scaled_dwell() {
+        let mut detector = RttJumpDetector::new();
+        let base = Instant::now();
+        let jump = HIGH_RTT.mul_f32(GLOBAL_MIN_JUMP_THRESHOLD) + ms(1);
+
+        sample(&mut detector, base, ms(10), HIGH_RTT);
+        sample(&mut detector, base, ms(20), jump);
+        sample(&mut detector, base, ms(100), jump);
+        sample(&mut detector, base, ms(200), jump);
+
+        assert!(detector.is_rtt_jump_active());
+        assert!(!detector.is_rtt_jump_persistent());
+
+        sample(&mut detector, base, ms(1520), jump);
+        assert!(detector.is_rtt_jump_persistent());
+    }
+
+    #[test]
+    fn global_min_detector_handles_low_rtt_dwell() {
+        let mut detector = RttJumpDetector::new();
+        let base = Instant::now();
+        let jump = LOW_RTT.mul_f32(GLOBAL_MIN_JUMP_THRESHOLD) + ms(1);
+
+        sample(&mut detector, base, ms(10), LOW_RTT);
+        sample(&mut detector, base, ms(20), jump);
+        sample(&mut detector, base, ms(30), jump);
+        assert!(!detector.is_rtt_jump_persistent());
+
+        sample(&mut detector, base, ms(50), jump);
+        assert!(detector.is_rtt_jump_persistent());
+    }
+}

--- a/quiche/src/recovery/gcongestion/mod.rs
+++ b/quiche/src/recovery/gcongestion/mod.rs
@@ -233,6 +233,43 @@ pub struct BbrParams {
     /// on `get_next_release_time()` can result in artificially low
     /// minRTT measurements which will make BBR misbehave.
     pub time_sent_set_to_now: Option<bool>,
+
+    /// Selects the RTT jump detector implementation.
+    #[cfg(feature = "internal")]
+    pub rtt_jump_detector: Option<BbrRttJumpDetector>,
+}
+
+/// Selects which RTT jump detector BBR uses.
+///
+/// This functionality is experimental and will be removed in the future.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+#[doc(hidden)]
+pub enum BbrRttJumpDetector {
+    /// Disables RTT jump detection.
+    #[default]
+    Disabled  = 0,
+
+    /// Connection-lifetime minimum baseline with a strict multiplicative jump
+    /// test and a sample/duration confirmation gate.
+    GlobalMin = 1,
+}
+
+#[doc(hidden)]
+impl FromStr for BbrRttJumpDetector {
+    type Err = crate::Error;
+
+    /// Converts a string to `BbrRttJumpDetector`.
+    ///
+    /// If `name` is not valid, `Error::CongestionControl` is returned.
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        match name {
+            "none" => Ok(BbrRttJumpDetector::Disabled),
+            "global_min" => Ok(BbrRttJumpDetector::GlobalMin),
+
+            _ => Err(crate::Error::CongestionControl),
+        }
+    }
 }
 
 /// Controls BBR's bandwidth reduction strategy on congestion event.

--- a/quiche/src/recovery/gcongestion/pacer.rs
+++ b/quiche/src/recovery/gcongestion/pacer.rs
@@ -258,6 +258,10 @@ impl Pacer {
         self.sender.max_bandwidth()
     }
 
+    pub fn rtt_persistent_jump_count(&self) -> u64 {
+        self.sender.rtt_persistent_jump_count()
+    }
+
     #[cfg(feature = "qlog")]
     pub fn send_rate(&self) -> Option<Bandwidth> {
         self.sender.send_rate()

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -1071,6 +1071,10 @@ impl RecoveryOps for GRecovery {
         Some(self.pacer.max_bandwidth())
     }
 
+    fn rtt_persistent_jump_count(&self) -> u64 {
+        self.pacer.rtt_persistent_jump_count()
+    }
+
     /// Statistics from when a CCA first exited the startup phase.
     fn startup_exit(&self) -> Option<StartupExit> {
         self.recovery_stats.startup_exit

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -46,6 +46,8 @@ use self::congestion::recovery::LegacyRecovery;
 use self::gcongestion::GRecovery;
 pub use gcongestion::BbrBwLoReductionStrategy;
 pub use gcongestion::BbrParams;
+#[cfg(feature = "internal")]
+pub use gcongestion::BbrRttJumpDetector;
 
 // Loss Recovery
 const INITIAL_PACKET_THRESHOLD: u64 = 3;
@@ -248,6 +250,9 @@ pub trait RecoveryOps {
 
     /// Maximum bandwidth estimate, if one is available.
     fn max_bandwidth(&self) -> Option<Bandwidth>;
+
+    /// Total number of confirmed persistent RTT jump episodes.
+    fn rtt_persistent_jump_count(&self) -> u64;
 
     /// Statistics from when a CCA first exited the startup phase.
     fn startup_exit(&self) -> Option<StartupExit>;


### PR DESCRIPTION
Goal: Add a detector for counting persistent jumps in RTT. 

Detector Logic: This detector defines a jump in RTT as an RTT sample that is >3x the minimum RTT encountered (min_rtt). The detector moves between three states: idle, active, and persistent. The detector begins in idle and then moves into active if it encounters an RTT sample that is >3*min_rtt. For an RTT jump to move to persistent, at least three RTT samples that are >3*min_rtt must occur in a row, and no sample below this threshold must occur for 3*min_rtt seconds after the first elevated RTT sample. The detector returns to idle from active or persistent when it encounters a sample that is  <=3*min_rtt.

Structure: The detector lives in a dedicated file, and there is a selector to activate the model or keep it disabled, with disabled as the default.