### PR TITLE
tokio-quiche: release exhausted H3 body buffer

### DIFF
--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -591,6 +591,11 @@ impl<H: DriverHooks> H3Driver<H> {
                         body_recv_buf.get_mut().spare_capacity_mut().len(),
                         body_recv_buf.remaining_mut()
                     );
+                    // A full split leaves only an empty shared handle, so let
+                    // the forwarded frame own the allocation.
+                    if !body_recv_buf.has_remaining_mut() {
+                        self.body_recv_buf = None;
+                    }
                     permit.send(InboundFrame::Body(filled_body, false));
                 },
                 Err(h3::Error::Done) =>

--- a/tokio-quiche/src/http3/driver/tests.rs
+++ b/tokio-quiche/src/http3/driver/tests.rs
@@ -455,7 +455,17 @@ mod client_side_driver {
     /// active, then allocated again for subsequent body data.
     #[test]
     fn client_body_recv_buf_releases_when_exhausted() {
-        let mut helper = DriverTestHelper::<ClientHooks>::new().unwrap();
+        // Permit one full floor-sized body in a single H3 DATA frame.
+        let mut config = default_quiche_config();
+        let max_data = 2 * MIN_BODY_RECV_BUF_SIZE as u64;
+        config.set_initial_max_data(max_data);
+        config.set_initial_max_stream_data_bidi_local(max_data);
+        config.set_initial_max_stream_data_bidi_remote(max_data);
+        config.set_initial_max_stream_data_uni(max_data);
+        let mut helper = DriverTestHelper::<ClientHooks>::with_pipe(
+            quiche::test_utils::Pipe::with_config_and_buf(&mut config).unwrap(),
+        )
+        .unwrap();
         helper.complete_handshake().unwrap();
         helper.advance_and_run_loop().unwrap();
 

--- a/tokio-quiche/src/http3/driver/tests.rs
+++ b/tokio-quiche/src/http3/driver/tests.rs
@@ -451,6 +451,58 @@ mod client_side_driver {
         assert!(helper.driver.body_recv_buf.is_none());
     }
 
+    /// An exhausted receive buffer is released while its stream remains
+    /// active, then allocated again for subsequent body data.
+    #[test]
+    fn client_body_recv_buf_releases_when_exhausted() {
+        let mut helper = DriverTestHelper::<ClientHooks>::new().unwrap();
+        helper.complete_handshake().unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        let stream_id = helper
+            .driver_send_request(make_request_headers("GET"), true)
+            .unwrap();
+
+        helper.advance_and_run_loop().unwrap();
+        assert_matches!(
+            helper.peer_server_poll().unwrap(),
+            (0, h3::Event::Headers { .. })
+        );
+        helper.peer_server_send_response(0, false).unwrap();
+        helper.advance_and_run_loop().unwrap();
+
+        let resp = assert_matches!(
+            helper.driver_recv_core_event().unwrap(),
+            H3Event::IncomingHeaders(headers) => { headers }
+        );
+        assert_eq!(resp.stream_id, stream_id);
+        let mut from_server = resp.recv;
+
+        let full_body = vec![1; MIN_BODY_RECV_BUF_SIZE];
+        assert_eq!(
+            helper.peer_server_send_body(0, &full_body, false),
+            Ok(full_body.len())
+        );
+        helper.advance_and_run_loop().unwrap();
+        assert_eq!(helper.driver_try_recv_body(&mut from_server).0, full_body);
+        assert_eq!(helper.driver.stream_map.len(), 1);
+        assert!(helper.driver.body_recv_buf.is_none());
+
+        // The next body chunk allocates a fresh buffer.
+        helper.peer_server_send_body(0, &[2; 10], false).unwrap();
+        helper.advance_and_run_loop().unwrap();
+        assert_eq!(helper.driver_try_recv_body(&mut from_server).0, vec![2; 10]);
+        assert!(helper.driver.body_recv_buf.is_some());
+
+        helper.peer_server_send_body(0, &[3; 10], true).unwrap();
+        helper.advance_and_run_loop().unwrap();
+        let (body, fin, _) = helper.driver_try_recv_body(&mut from_server);
+        assert_eq!(body, vec![3; 10]);
+        assert!(fin);
+        assert_eq!(helper.driver.stream_map.len(), 0);
+        assert!(helper.driver.body_recv_buf.is_none());
+    }
+
     /// Test that dropping the OutboundFrame channel causes the driver to
     /// send a RESET_STREAM frame to the peer.
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #2547.

- Clear `body_recv_buf` after `split()` exhausts it.
- Add regression coverage that keeps the stream active, verifies the buffer is released, and verifies later data allocates a fresh buffer.

`BytesMut::split()` retains shared ownership of the backing allocation even when the remainder has zero capacity. Dropping the exhausted driver handle lets the allocation be released once the forwarded frame is dropped. The next read must allocate regardless.

## Testing

- `cargo test -p tokio-quiche`