### PR TITLE
extract: add pto_backoff() helper for PTO * 3 calculations

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3367,7 +3367,7 @@ impl<F: BufFactory> Connection<F> {
                 crypto_open: open_prev,
                 pn_on_update: pn,
                 update_acked: false,
-                timer: now + (recv_path.recovery.pto() * 3),
+                timer: now + (recv_path.recovery.pto_backoff()),
             });
 
             self.key_phase = !self.key_phase;
@@ -4980,8 +4980,7 @@ impl<F: BufFactory> Connection<F> {
                         };
 
                         if push_frame_to_pkt!(b, frames, frame, left) {
-                            let pto = path.recovery.pto();
-                            self.draining_timer = Some(now + (pto * 3));
+                            self.draining_timer = Some(now + path.recovery.pto_backoff());
 
                             ack_eliciting = true;
                             in_flight = true;
@@ -4996,8 +4995,7 @@ impl<F: BufFactory> Connection<F> {
                     };
 
                     if push_frame_to_pkt!(b, frames, frame, left) {
-                        let pto = path.recovery.pto();
-                        self.draining_timer = Some(now + (pto * 3));
+                        self.draining_timer = Some(now + path.recovery.pto_backoff());
 
                         ack_eliciting = true;
                         in_flight = true;
@@ -8788,7 +8786,7 @@ impl<F: BufFactory> Connection<F> {
                 });
 
                 let path = self.paths.get_active()?;
-                self.draining_timer = Some(now + (path.recovery.pto() * 3));
+                self.draining_timer = Some(now + (path.recovery.pto_backoff()));
             },
 
             frame::Frame::ApplicationClose { error_code, reason } => {
@@ -8799,7 +8797,7 @@ impl<F: BufFactory> Connection<F> {
                 });
 
                 let path = self.paths.get_active()?;
-                self.draining_timer = Some(now + (path.recovery.pto() * 3));
+                self.draining_timer = Some(now + (path.recovery.pto_backoff()));
             },
 
             frame::Frame::HandshakeDone => {

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -245,6 +245,11 @@ pub trait RecoveryOps {
 
     fn pto(&self) -> Duration;
 
+    /// Returns the PTO backoff duration (PTO * 3).
+    fn pto_backoff(&self) -> Duration {
+        self.pto() * 3
+    }
+
     /// The most recent data delivery rate estimate.
     fn delivery_rate(&self) -> Bandwidth;
 


### PR DESCRIPTION
## Summary

Extracts the repeated `pto() * 3` pattern into a `pto_backoff()` method on the `RecoveryOps` trait.

Fixes #2369

## Changes

- **`recovery/mod.rs`**: Added `pto_backoff()` default method to `RecoveryOps` trait that returns `self.pto() * 3`
- **`lib.rs`**: Replaced 5 occurrences of `pto() * 3` with `pto_backoff()`:
  - `recv_path.recovery.pto_backoff()` (key update timer)
  - `path.recovery.pto_backoff()` x3 (draining timers)
  - Removed 2 unnecessary intermediate `let pto` bindings

## Testing

The behavior is identical -- `pto_backoff()` simply returns `pto() * 3`. No functional change.
