### PR TITLE
PMTUD state is consumed by wrong path when sending on probing path

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -4587,8 +4587,8 @@ impl<F: BufFactory> Connection<F> {
             // In addition, the PMTUD probe is only generated when the handshake
             // is confirmed, to avoid interfering with the handshake
             // (e.g. due to the anti-amplification limits).
-            if let Ok(active_path) = self.paths.get_active_mut() {
-                let should_probe_pmtu = active_path.should_send_pmtu_probe(
+            if let Ok(send_path) = self.paths.get_mut(send_pid) {
+                let should_probe_pmtu = send_path.should_send_pmtu_probe(
                     self.handshake_confirmed,
                     self.handshake_completed,
                     out_len,
@@ -4597,7 +4597,7 @@ impl<F: BufFactory> Connection<F> {
                 );
 
                 if should_probe_pmtu {
-                    if let Some(pmtud) = active_path.pmtud.as_mut() {
+                    if let Some(pmtud) = send_path.pmtud.as_mut() {
                         let probe_size = pmtud.get_probe_size();
                         trace!(
                         "{} sending pmtud probe pmtu_probe={} estimated_pmtu={}",
@@ -4620,7 +4620,7 @@ impl<F: BufFactory> Connection<F> {
                                 //
                                 // In such case app_limited is set to false here
                                 // to make cwnd grow when ACK is received.
-                                active_path.recovery.update_app_limited(false);
+                                send_path.recovery.update_app_limited(false);
                                 return Err(Error::Done);
                             },
                         }

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -12930,3 +12930,95 @@ fn server_qlog() {
         panic!("expected Qlog event");
     }
 }
+
+#[test]
+fn sending_on_probing_path_does_not_consume_active_path_pmtud_probe() {
+    const PROBE_SIZE: usize = 1400;
+
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+
+    config.set_application_protos(&[b"proto1"]).unwrap();
+    config.verify_peer(false);
+    config.set_active_connection_id_limit(2);
+    config.set_max_send_udp_payload_size(PROBE_SIZE);
+    config.discover_pmtu(true);
+
+    let mut pipe = pipe_with_exchanged_cids(&mut config, 16, 16, 1);
+
+    // `old_path` is the current active path.
+    let old_path_id = pipe.server.paths.get_active_path_id().unwrap();
+
+    // PMTU revalidation is requested on `old_path`.
+    pipe.server.revalidate_pmtu();
+
+    // `old_path` now has a pending PMTUD probe.
+    assert!(
+        pipe.server
+            .paths
+            .get(old_path_id)
+            .unwrap()
+            .pmtud
+            .as_ref()
+            .unwrap()
+            .should_probe(),
+        "`old_path` should have a pending PMTUD probe"
+    );
+
+    let server_addr = test_utils::Pipe::server_addr();
+    let new_client_addr = "127.0.0.1:5678".parse().unwrap();
+    let mut out = vec![0; PROBE_SIZE];
+
+    // The client starts validating `new_path`.
+    pipe.client
+        .probe_path(new_client_addr, server_addr)
+        .unwrap();
+
+    // The client sends a PATH_CHALLENGE frame on `new_path`.
+    let (written, info) = pipe
+        .client
+        .send_on_path(&mut out, Some(new_client_addr), Some(server_addr))
+        .unwrap();
+
+    assert_eq!(info.from, new_client_addr);
+    assert_eq!(info.to, server_addr);
+
+    // The server receives the PATH_CHALLENGE, creates `new_path`, and
+    // queues a PATH_RESPONSE frame.
+    pipe.server
+        .recv(&mut out[..written], RecvInfo {
+            from: info.from,
+            to: info.to,
+        })
+        .unwrap();
+
+    // `new_path` is being validated, but `old_path` remains active.
+    assert_eq!(pipe.server.paths.get_active_path_id().unwrap(), old_path_id);
+
+    // The next server packet is sent on `new_path`.
+    let (_, info) = pipe.server.send(&mut out).unwrap();
+
+    assert_eq!(info.from, server_addr);
+    assert_eq!(info.to, new_client_addr);
+
+    // Sending on `new_path` must not consume the pending PMTUD probe
+    // associated with `old_path`.
+    assert!(
+        pipe.server
+            .paths
+            .get(old_path_id)
+            .unwrap()
+            .pmtud
+            .as_ref()
+            .unwrap()
+            .should_probe(),
+        "sending on `new_path` consumed `old_path`'s PMTUD probe"
+    );
+}


### PR DESCRIPTION
Fixes #2565 