### PR TITLE
recovery: floor loss delay at observed ack latency

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -576,6 +576,7 @@ pub struct Config {
     enable_relaxed_loss_threshold: bool,
     enable_cubic_idle_restart_fix: bool,
     enable_send_streams_blocked: bool,
+    enable_ack_latency_loss_floor: bool,
 
     pmtud: bool,
     pmtud_max_probes: u8,
@@ -658,6 +659,7 @@ impl Config {
             enable_relaxed_loss_threshold: false,
             enable_cubic_idle_restart_fix: true,
             enable_send_streams_blocked: false,
+            enable_ack_latency_loss_floor: false,
             pmtud: false,
             pmtud_max_probes: pmtud::MAX_PROBES_DEFAULT,
             hystart: true,
@@ -1148,6 +1150,23 @@ impl Config {
     /// The default value is false.
     pub fn set_enable_send_streams_blocked(&mut self, enable: bool) {
         self.enable_send_streams_blocked = enable;
+    }
+
+    /// Configure whether the loss delay is floored at the ack latency the
+    /// connection has observed.
+    ///
+    /// Acknowledgements are processed in batches, and the RTT estimate only
+    /// samples the freshest packet of each batch. On a path whose RTT is
+    /// close to or below the granularity of ack processing, the time and
+    /// packet thresholds declare packets lost whose acknowledgements have
+    /// not had a chance to be processed yet. With this enabled, the loss
+    /// delay is never lower than the slowest send-to-processed-ack loop
+    /// observed in the last half second, and the packet reordering
+    /// threshold only applies to packets older than that loop.
+    ///
+    /// The default value is false.
+    pub fn set_enable_ack_latency_loss_floor(&mut self, enable: bool) {
+        self.enable_ack_latency_loss_floor = enable;
     }
 
     /// Configures whether to enable HyStart++.

--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -59,6 +59,7 @@ use crate::recovery::LossDetectionTimer;
 use crate::recovery::OnAckReceivedOutcome;
 use crate::recovery::ReleaseDecision;
 use crate::recovery::ReleaseTime;
+use crate::recovery::ACK_LOOP_WINDOW;
 use crate::recovery::GRANULARITY;
 use crate::recovery::INITIAL_PACKET_THRESHOLD;
 use crate::recovery::INITIAL_TIME_THRESHOLD;
@@ -221,8 +222,8 @@ impl RecoveryEpoch {
     }
 
     fn detect_lost_packets(
-        &mut self, loss_delay: Duration, pkt_thresh: u64, now: Instant,
-        trace_id: &str, epoch: Epoch,
+        &mut self, loss_delay: Duration, pkt_thresh: u64, pkt_age_gate: Duration,
+        now: Instant, trace_id: &str, epoch: Epoch,
     ) -> LossDetectionResult {
         self.loss_time = None;
 
@@ -232,6 +233,9 @@ impl RecoveryEpoch {
 
         // Packets sent before this time are deemed lost.
         let lost_send_time = now.checked_sub(loss_delay).unwrap();
+        // The reordering threshold only convicts a packet old enough
+        // that its acknowledgement had a fair chance to be processed.
+        let pkt_gate_time = now.checked_sub(pkt_age_gate).unwrap();
 
         let mut lost_packets = 0;
         let mut lost_bytes = 0;
@@ -249,7 +253,8 @@ impl RecoveryEpoch {
         for unacked in unacked_iter {
             // Mark packet as lost, or set time when it should be marked.
             if unacked.time_sent <= lost_send_time ||
-                largest_acked >= unacked.pkt_num + pkt_thresh
+                (largest_acked >= unacked.pkt_num + pkt_thresh &&
+                    unacked.time_sent <= pkt_gate_time)
             {
                 self.lost_frames_ack.extend(unacked.frames.drain(..));
 
@@ -357,6 +362,16 @@ pub struct LegacyRecovery {
 
     loss_timer: LossDetectionTimer,
 
+    // The worst full-loop ack latency (send to processed acknowledgement)
+    // seen in the current window, and when it was recorded. A loss delay
+    // below this declares packets whose acknowledgements could not have
+    // been processed yet whatever the RTT estimate says, because RTT is
+    // sampled from the freshest packet of each ack batch and batched ack
+    // processing hides exactly the latency that matters here.
+    ack_loop_max: Duration,
+    ack_loop_at: Option<Instant>,
+    ack_latency_loss_floor: bool,
+
     pto_count: u32,
 
     rtt_stats: RttStats,
@@ -396,6 +411,9 @@ impl LegacyRecovery {
             epochs: Default::default(),
 
             loss_timer: Default::default(),
+            ack_loop_max: Duration::ZERO,
+            ack_loop_at: None,
+            ack_latency_loss_floor: recovery_config.enable_ack_latency_loss_floor,
 
             pto_count: 0,
 
@@ -531,12 +549,19 @@ impl LegacyRecovery {
     fn detect_lost_packets(
         &mut self, epoch: Epoch, now: Instant, trace_id: &str,
     ) -> (usize, usize) {
-        let loss_delay = cmp::max(self.rtt_stats.latest_rtt, self.rtt())
+        let mut loss_delay = cmp::max(self.rtt_stats.latest_rtt, self.rtt())
             .mul_f64(self.time_thresh);
+        if self.ack_latency_loss_floor {
+            loss_delay = cmp::max(
+                loss_delay,
+                self.ack_loop_max.saturating_add(GRANULARITY),
+            );
+        }
 
         let loss = self.epochs[epoch].detect_lost_packets(
             loss_delay,
             self.pkt_thresh,
+            self.ack_loop_max,
             now,
             trace_id,
             epoch,
@@ -703,6 +728,25 @@ impl RecoveryOps for LegacyRecovery {
 
         if self.newly_acked.is_empty() {
             return Ok(OnAckReceivedOutcome::default());
+        }
+
+        // The slowest acknowledgement in this batch proves how late an
+        // honest ack can currently be. Windowed so a transient stall
+        // stops inflating the loss delay shortly after it passes.
+        if self.ack_latency_loss_floor {
+            let batch_loop = self
+                .newly_acked
+                .iter()
+                .map(|acked| now.saturating_duration_since(acked.time_sent))
+                .max()
+                .unwrap_or(Duration::ZERO);
+            let expired = self.ack_loop_at.is_none_or(|at| {
+                now.saturating_duration_since(at) > ACK_LOOP_WINDOW
+            });
+            if expired || batch_loop >= self.ack_loop_max {
+                self.ack_loop_max = batch_loop;
+                self.ack_loop_at = Some(now);
+            }
         }
 
         let largest_newly_acked = self.newly_acked.last().unwrap();

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -33,6 +33,7 @@ use crate::recovery::RecoveryStats;
 use crate::recovery::ReleaseDecision;
 use crate::recovery::Sent;
 use crate::recovery::StartupExit;
+use crate::recovery::ACK_LOOP_WINDOW;
 use crate::recovery::GRANULARITY;
 use crate::recovery::INITIAL_PACKET_THRESHOLD;
 use crate::recovery::INITIAL_TIME_THRESHOLD;
@@ -267,14 +268,17 @@ impl RecoveryEpoch {
     }
 
     fn detect_and_remove_lost_packets(
-        &mut self, loss_delay: Duration, pkt_thresh: Option<u64>, now: Instant,
-        newly_lost: &mut Vec<Lost>,
+        &mut self, loss_delay: Duration, pkt_thresh: Option<u64>,
+        pkt_age_gate: Duration, now: Instant, newly_lost: &mut Vec<Lost>,
     ) -> LossDetectionResult {
         newly_lost.clear();
         let mut lost_bytes = 0;
         self.loss_time = None;
 
         let lost_send_time = now.checked_sub(loss_delay).unwrap();
+        // The reordering threshold only convicts a packet old enough
+        // that its acknowledgement had a fair chance to be processed.
+        let pkt_gate_time = now.checked_sub(pkt_age_gate).unwrap();
         let largest_acked = self.largest_acked_packet.unwrap_or(0);
         let mut pmtud_lost_bytes = 0;
         let mut pmtud_lost_packets = SmallVec::new();
@@ -287,7 +291,9 @@ impl RecoveryEpoch {
             if let SentStatus::Sent { time_sent, .. } = status {
                 let loss_by_time = *time_sent <= lost_send_time;
                 let loss_by_pkt = match pkt_thresh {
-                    Some(pkt_thresh) => largest_acked >= *pkt_num + pkt_thresh,
+                    Some(pkt_thresh) =>
+                        largest_acked >= *pkt_num + pkt_thresh &&
+                            *time_sent <= pkt_gate_time,
                     None => false,
                 };
 
@@ -460,6 +466,13 @@ pub struct GRecovery {
 
     loss_timer: LossDetectionTimer,
 
+    // The worst full-loop ack latency (send to processed acknowledgement)
+    // seen in the current window, and when it was recorded. Only used
+    // when `enable_ack_latency_loss_floor` is set.
+    ack_loop_max: Duration,
+    ack_loop_at: Option<Instant>,
+    ack_latency_loss_floor: bool,
+
     pto_count: u32,
 
     rtt_stats: RttStats,
@@ -531,6 +544,9 @@ impl GRecovery {
             ),
             recovery_stats: RecoveryStats::default(),
             loss_timer: Default::default(),
+            ack_loop_max: Duration::ZERO,
+            ack_loop_at: None,
+            ack_latency_loss_floor: recovery_config.enable_ack_latency_loss_floor,
             pto_count: 0,
 
             lost_count: 0,
@@ -568,8 +584,12 @@ impl GRecovery {
     fn detect_and_remove_lost_packets(
         &mut self, epoch: packet::Epoch, now: Instant,
     ) -> (usize, usize) {
-        let loss_delay =
+        let mut loss_delay =
             self.rtt_stats.loss_delay(self.loss_thresh.time_thresh());
+        if self.ack_latency_loss_floor {
+            loss_delay =
+                loss_delay.max(self.ack_loop_max.saturating_add(GRANULARITY));
+        }
         let lost = &mut self.lost_reuse;
 
         let LossDetectionResult {
@@ -580,6 +600,7 @@ impl GRecovery {
         } = self.epochs[epoch].detect_and_remove_lost_packets(
             loss_delay,
             self.loss_thresh.pkt_thresh(),
+            self.ack_loop_max,
             now,
             lost,
         );
@@ -838,6 +859,25 @@ impl RecoveryOps for GRecovery {
                 spurious_losses,
                 ..Default::default()
             });
+        }
+
+        // The slowest acknowledgement in this batch proves how late an
+        // honest ack can currently be. Windowed so a transient stall
+        // stops inflating the loss delay shortly after it passes.
+        if self.ack_latency_loss_floor {
+            let batch_loop = self
+                .newly_acked
+                .iter()
+                .map(|acked| now.saturating_duration_since(acked.time_sent))
+                .max()
+                .unwrap_or(Duration::ZERO);
+            let expired = self.ack_loop_at.is_none_or(|at| {
+                now.saturating_duration_since(at) > ACK_LOOP_WINDOW
+            });
+            if expired || batch_loop >= self.ack_loop_max {
+                self.ack_loop_max = batch_loop;
+                self.ack_loop_at = Some(now);
+            }
         }
 
         self.bytes_in_flight.saturating_subtract(acked_bytes, now);

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -86,6 +86,9 @@ const TIME_THRESHOLD_OVERHEAD_MULTIPLIER: f64 = 2.0;
 
 const GRANULARITY: Duration = Duration::from_millis(1);
 
+// How long an observed ack-loop latency keeps flooring the loss delay.
+const ACK_LOOP_WINDOW: Duration = Duration::from_millis(512);
+
 const MAX_PTO_PROBES_COUNT: usize = 2;
 
 const MINIMUM_WINDOW_PACKETS: usize = 2;
@@ -141,6 +144,7 @@ pub struct RecoveryConfig {
     pub initial_congestion_window_packets: usize,
     pub enable_relaxed_loss_threshold: bool,
     pub enable_cubic_idle_restart_fix: bool,
+    pub enable_ack_latency_loss_floor: bool,
 }
 
 impl RecoveryConfig {
@@ -158,6 +162,7 @@ impl RecoveryConfig {
                 .initial_congestion_window_packets,
             enable_relaxed_loss_threshold: config.enable_relaxed_loss_threshold,
             enable_cubic_idle_restart_fix: config.enable_cubic_idle_restart_fix,
+            enable_ack_latency_loss_floor: config.enable_ack_latency_loss_floor,
         }
     }
 }
@@ -1474,6 +1479,206 @@ mod tests {
         } else {
             assert_eq!(r.startup_exit(), None);
         }
+    }
+
+    #[rstest]
+    fn ack_latency_floor_spares_packets_younger_than_the_ack_loop(
+        #[values("reno", "cubic", "bbr2", "bbr2_gcongestion")]
+        cc_algorithm_name: &str,
+    ) {
+        let mut cfg = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
+        cfg.set_enable_ack_latency_loss_floor(true);
+
+        let mut r = Recovery::new(&cfg);
+        let mut now = Instant::now();
+
+        // Two packets whose acks take 4ms to come back, which teaches the
+        // recovery how late an honest ack can be on this path.
+        for i in 0..2 {
+            let p = test_utils::helper_packet_sent(i, now, 1000);
+            r.on_packet_sent(
+                p,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+            );
+        }
+
+        now += Duration::from_millis(4);
+
+        let mut acked = RangeSet::default();
+        acked.insert(0..2);
+        assert_eq!(
+            r.on_ack_received(
+                &acked,
+                25,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                None,
+                "",
+            )
+            .unwrap(),
+            OnAckReceivedOutcome {
+                lost_packets: 0,
+                lost_bytes: 0,
+                acked_bytes: 1000 * 2,
+                spurious_losses: 0,
+            }
+        );
+
+        // Six more packets, followed 1ms later by an ack batch that only
+        // covers the last three. Without the floor the packet threshold
+        // declares 2, 3 and 4 lost on the spot; with it they are younger
+        // than the 4ms ack loop just observed, so they are spared.
+        for i in 2..8 {
+            let p = test_utils::helper_packet_sent(i, now, 1000);
+            r.on_packet_sent(
+                p,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+            );
+        }
+
+        now += Duration::from_millis(1);
+
+        let mut acked = RangeSet::default();
+        acked.insert(5..8);
+        assert_eq!(
+            r.on_ack_received(
+                &acked,
+                25,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                None,
+                "",
+            )
+            .unwrap(),
+            OnAckReceivedOutcome {
+                lost_packets: 0,
+                lost_bytes: 0,
+                acked_bytes: 1000 * 3,
+                spurious_losses: 0,
+            }
+        );
+
+        // The late acks arrive and nothing was ever declared.
+        now += Duration::from_millis(1);
+
+        let mut acked = RangeSet::default();
+        acked.insert(2..5);
+        assert_eq!(
+            r.on_ack_received(
+                &acked,
+                25,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                None,
+                "",
+            )
+            .unwrap(),
+            OnAckReceivedOutcome {
+                lost_packets: 0,
+                lost_bytes: 0,
+                acked_bytes: 1000 * 3,
+                spurious_losses: 0,
+            }
+        );
+
+        assert_eq!(r.lost_count(), 0);
+        assert_eq!(r.lost_spurious_count(), 0);
+        assert_eq!(r.bytes_in_flight(), 0);
+    }
+
+    #[rstest]
+    fn ack_latency_floor_still_detects_loss_by_time(
+        #[values("reno", "cubic", "bbr2", "bbr2_gcongestion")]
+        cc_algorithm_name: &str,
+    ) {
+        let mut cfg = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
+        cfg.set_enable_ack_latency_loss_floor(true);
+
+        let mut r = Recovery::new(&cfg);
+        let mut now = Instant::now();
+
+        for i in 0..2 {
+            let p = test_utils::helper_packet_sent(i, now, 1000);
+            r.on_packet_sent(
+                p,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+            );
+        }
+
+        // Packet 1 is acked 2ms after sending; packet 0 stays out. The
+        // floor lifts the loss delay to 3ms (2ms observed loop plus the
+        // granularity), so packet 0 is not declared here.
+        now += Duration::from_millis(2);
+
+        let mut acked = RangeSet::default();
+        acked.insert(1..2);
+        assert_eq!(
+            r.on_ack_received(
+                &acked,
+                25,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                None,
+                "",
+            )
+            .unwrap(),
+            OnAckReceivedOutcome {
+                lost_packets: 0,
+                lost_bytes: 0,
+                acked_bytes: 1000,
+                spurious_losses: 0,
+            }
+        );
+
+        // A third packet is sent and acked past the floored delay, and
+        // the time threshold convicts packet 0 on that ack.
+        let p = test_utils::helper_packet_sent(2, now, 1000);
+        r.on_packet_sent(
+            p,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+            now,
+            "",
+        );
+
+        now += Duration::from_millis(2);
+
+        let mut acked = RangeSet::default();
+        acked.insert(2..3);
+        assert_eq!(
+            r.on_ack_received(
+                &acked,
+                25,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                None,
+                "",
+            )
+            .unwrap(),
+            OnAckReceivedOutcome {
+                lost_packets: 1,
+                lost_bytes: 1000,
+                acked_bytes: 1000,
+                spurious_losses: 0,
+            }
+        );
+        assert_eq!(r.lost_count(), 1);
     }
 
     // TODO: This should run agains both `congestion` and `gcongestion`.


### PR DESCRIPTION
Acknowledgements are processed in batches and the RTT estimate only samples the freshest packet of each batch. On a path whose RTT is close to or below the granularity of ack processing, the time and packet thresholds declare packets lost whose acknowledgements have not had a chance to be processed yet. Each spurious declaration triggers a retransmission and a congestion event for a packet that was delivered.

This adds `enable_ack_latency_loss_floor`, off by default. When enabled, the loss delay is floored at the slowest send-to-processed-ack loop observed in the last 512ms, and the packet reordering threshold only applies to packets older than that loop. Both recovery implementations are covered. Behavior with the flag off is unchanged.

## Testing

New tests in `recovery/mod.rs` run against reno, cubic, bbr2 and bbr2_gcongestion: a late ack batch no longer convicts packets younger than the observed loop, and time based detection still fires once a packet outlives the floored delay.

Measured on a 10GbE path with 0.2-0.6ms RTT, six connections carrying 1GB per run with CUBIC, five runs per arm: declared losses fell from 25-30k per run to 1.3-2.3k, spurious losses (declared and later acked) fell from 8-10k to 100-200, and goodput rose from 7.9 to 8.8 Gbit/s median. Packet captures at the receiver NIC showed zero actual path loss in both arms, so the declarations were detector artifacts.