### PR TITLE
Don't collect a stream before its fin has been sent

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -3593,7 +3593,7 @@ impl<F: BufFactory> Connection<F> {
                         stream_id,
                         offset,
                         length,
-                        ..
+                        fin,
                     } => {
                         // Emit qlog before checking if the stream still exists.
                         // The client does need to ACK frames that were received
@@ -3624,6 +3624,11 @@ impl<F: BufFactory> Connection<F> {
                         };
 
                         let dropped = stream.send.ack_and_drop(offset, length);
+
+                        if fin {
+                            stream.send.ack_fin();
+                        }
+
                         let priority_key = Arc::clone(&stream.priority_key);
 
                         // Only collect the stream if it is complete and not

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -1452,6 +1452,11 @@ mod tests {
         assert!(!stream.send.is_complete());
 
         stream.send.ack(0, 1);
+        // Every byte is acked, but the peer has not acked the fin that tells it
+        // where the stream ends.
+        assert!(!stream.send.is_complete());
+
+        stream.send.ack_fin();
         assert!(stream.send.is_complete());
 
         assert!(!stream.is_complete());

--- a/quiche/src/stream/send_buf.rs
+++ b/quiche/src/stream/send_buf.rs
@@ -122,6 +122,13 @@ where
     /// The final stream offset written to the stream, if any.
     fin_off: Option<u64>,
 
+    /// Whether the peer acked the `fin` itself, rather than just the stream
+    /// data up to the final offset.
+    ///
+    /// Tracked separately because a `fin` carries no bytes of its own, so it
+    /// leaves no trace in `acked`.
+    fin_acked: bool,
+
     /// Whether the stream's send-side has been shut down.
     shutdown: bool,
 
@@ -324,6 +331,14 @@ impl<F: BufFactory> SendBuf<F> {
         self.acked.insert(off..off + len as u64);
     }
 
+    /// Records that the peer acked a frame carrying the `fin`.
+    ///
+    /// Only the `fin` conveys the final size, and it occupies no offset of its
+    /// own, so it has to be tracked apart from the acked ranges.
+    pub fn ack_fin(&mut self) {
+        self.fin_acked = true;
+    }
+
     pub fn ack_and_drop(&mut self, off: u64, len: usize) -> usize {
         self.ack(off, len);
 
@@ -441,6 +456,11 @@ impl<F: BufFactory> SendBuf<F> {
 
         self.fin_off = Some(unsent_off);
 
+        // A RESET_STREAM carries the final size in place of the `fin`, so the
+        // stream can complete without one ever being sent. Without this the
+        // stream would never be collected.
+        self.fin_acked = true;
+
         // Drop all buffered data.
         self.data.clear();
 
@@ -520,9 +540,20 @@ impl<F: BufFactory> SendBuf<F> {
 
     /// Returns true if the send-side of the stream is complete.
     ///
-    /// This happens when the stream's send final size is known, and the peer
-    /// has already acked all stream data up to that point.
+    /// This happens when the stream's send final size is known, the peer has
+    /// acked all stream data up to that point, and it has acked the `fin` that
+    /// carries the final size.
     pub fn is_complete(&self) -> bool {
+        // A `fin` adds no bytes, so acking the data up to the final offset says
+        // nothing about whether the peer learned the final size. A zero-length
+        // `fin` written at an already-acked offset would otherwise report the
+        // stream complete before the frame carrying it has even been built, and
+        // the caller collects the stream on the strength of that, dropping the
+        // `fin` for good.
+        if !self.fin_acked {
+            return false;
+        }
+
         if let Some(fin_off) = self.fin_off {
             if self.acked == (0..fin_off) {
                 return true;

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -5477,6 +5477,60 @@ fn stream_zero_length_fin_deferred_collection(
 }
 
 #[rstest]
+/// Tests that a zero-length fin is not dropped when the ack for the stream
+/// data arrives between the fin being written and the frame carrying it being
+/// built.
+///
+/// The fin sets the final offset to one that is already fully acked, which used
+/// to make the send side report itself complete. Collecting the stream on the
+/// strength of that discarded the queued fin, and the peer read every byte but
+/// never saw the end of the stream.
+fn stream_zero_length_fin_not_collected_before_sent(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // A local unidirectional stream: its completion depends only on the send
+    // side, so nothing else keeps it alive.
+    assert_eq!(pipe.client.stream_send(2, b"hello", false), Ok(5));
+
+    // Put the data on the wire, holding back the server's ack.
+    let flight = test_utils::emit_flight(&mut pipe.client).unwrap();
+    test_utils::process_flight(&mut pipe.server, flight).unwrap();
+
+    // Write the fin. It is queued but has not been built into a frame yet.
+    assert_eq!(pipe.client.stream_send(2, b"", true), Ok(0));
+
+    // Let the ack in. Every byte is now acked, but the fin still has to be sent.
+    let flight = test_utils::emit_flight(&mut pipe.server).unwrap();
+    test_utils::process_flight(&mut pipe.client, flight).unwrap();
+
+    // A collected stream is gone from the connection, which stream_capacity()
+    // reports as an invalid state.
+    assert!(
+        pipe.client.stream_capacity(2).is_ok(),
+        "stream was collected with the fin still unsent"
+    );
+
+    // Flush the fin.
+    let flight = test_utils::emit_flight(&mut pipe.client).unwrap();
+    test_utils::process_flight(&mut pipe.server, flight).unwrap();
+
+    let mut buf = [0; 16];
+    assert_eq!(pipe.server.stream_recv(2, &mut buf), Ok((5, true)));
+    assert_eq!(&buf[..5], b"hello");
+
+    // Now that the fin is delivered and acked, the stream can be collected.
+    let flight = test_utils::emit_flight(&mut pipe.server).unwrap();
+    test_utils::process_flight(&mut pipe.client, flight).unwrap();
+    assert_eq!(
+        pipe.client.stream_capacity(2),
+        Err(Error::InvalidStreamState(2))
+    );
+}
+
+#[rstest]
 /// Tests that the stream gets created with stream_send() even if there's
 /// no data in the buffer and the fin flag is not set.
 fn stream_zero_length_non_fin(


### PR DESCRIPTION
(AI generated but reviewed)

A `fin` carries no bytes of its own, so acking the stream data up to the final offset says nothing about whether the peer learned the final size. SendBuf::is_complete() checked only the acked ranges, which meant a zero-length `fin` written at an already-acked offset reported the send side complete the moment it was written.

That is enough for the caller to collect the stream, and collecting it discards the queued `fin` before any frame carrying it is built. The peer reads every byte and never sees the end of the stream, while the sender believes it delivered one. stream_send() returns Ok, so nothing surfaces the loss.

Reaching it needs the ack for the stream data to land between the `fin` being written and the next send(), which is routine for an application that writes its payload and finishes the stream on a later turn of its event loop.

Track the `fin` ack separately and require it. RESET_STREAM carries the final size in place of a `fin`, so SendBuf::reset() sets the flag too; without that a reset stream would never be collected.

Fixes #2525