### PR TITLE
Add Connection::stream_send_complete()

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -458,6 +458,11 @@ int64_t quiche_conn_stream_writable_next(quiche_conn *conn);
 // Returns true if all the data has been read from the specified stream.
 bool quiche_conn_stream_finished(const quiche_conn *conn, uint64_t stream_id);
 
+// Returns true if the peer has acked all the data sent on the specified
+// stream, including the fin flag.
+bool quiche_conn_stream_send_complete(const quiche_conn *conn,
+                                      uint64_t stream_id);
+
 typedef struct quiche_stream_iter quiche_stream_iter;
 
 // Returns an iterator over streams that have outstanding data to read.

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1056,6 +1056,13 @@ pub extern "C" fn quiche_conn_stream_finished(
 }
 
 #[no_mangle]
+pub extern "C" fn quiche_conn_stream_send_complete(
+    conn: &Connection, stream_id: u64,
+) -> bool {
+    conn.stream_send_complete(stream_id)
+}
+
+#[no_mangle]
 pub extern "C" fn quiche_conn_readable(conn: &Connection) -> *mut StreamIter {
     Box::into_raw(Box::new(conn.readable()))
 }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6547,6 +6547,50 @@ impl<F: BufFactory> Connection<F> {
         stream.recv.is_fin()
     }
 
+    /// Returns true if the peer has acked all the data sent on the specified
+    /// stream, including the `fin` flag.
+    ///
+    /// This is the send-side counterpart to [`stream_finished()`]. Where
+    /// [`stream_send()`] returning with `fin` set only means the FIN was
+    /// queued, this reports that it actually reached the peer, so an
+    /// application can tell a delivered stream apart from one that is still
+    /// retransmitting. That distinction matters when the stream is about to be
+    /// reset: [`stream_shutdown()`] on a stream with unacked data discards it,
+    /// whereas on a completed stream it cannot lose anything.
+    ///
+    /// Returns false while data or the FIN are still in flight, and while the
+    /// final size is unknown because `fin` hasn't been sent yet. A stream that
+    /// was reset locally, or stopped by the peer, also reads as incomplete:
+    /// neither delivers the FIN.
+    ///
+    /// Note that an unknown stream ID reads as complete, mirroring
+    /// [`stream_finished()`]. quiche drops a stream's state once it can make no
+    /// further progress, so a stream that completed cleanly and one that was
+    /// reset are indistinguishable after collection. An application that resets
+    /// a stream is expected to remember it did.
+    ///
+    /// [`stream_finished()`]: struct.Connection.html#method.stream_finished
+    /// [`stream_send()`]: struct.Connection.html#method.stream_send
+    /// [`stream_shutdown()`]: struct.Connection.html#method.stream_shutdown
+    #[inline]
+    pub fn stream_send_complete(&self, stream_id: u64) -> bool {
+        let stream = match self.streams.get(stream_id) {
+            Some(v) => v,
+
+            None => return true,
+        };
+
+        // `send.is_complete()` is what decides whether the stream can be
+        // collected, so a reset counts as complete there: there is nothing left
+        // to send either way. Here it would be a lie, because the FIN never
+        // reached the peer.
+        if stream.send.is_shutdown() || stream.send.is_stopped() {
+            return false;
+        }
+
+        stream.send.is_complete()
+    }
+
     /// Returns true if the specified stream is closed.
     ///
     /// For bidirectional streams this happens when both the receive and send

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -5477,6 +5477,105 @@ fn stream_zero_length_fin_deferred_collection(
 }
 
 #[rstest]
+/// Tests that stream_send_complete() only reports true once the peer has
+/// acked the fin, and not merely when it has been queued or sent.
+fn stream_send_complete_waits_for_ack(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // The final size is unknown until the fin is sent, so an acked stream
+    // with more data to come is not complete.
+    assert_eq!(pipe.client.stream_send(4, b"hello, ", false), Ok(7));
+    assert!(!pipe.client.stream_send_complete(4));
+    assert_eq!(pipe.advance(), Ok(()));
+    assert!(!pipe.client.stream_send_complete(4));
+
+    // Queueing the fin is not enough: it hasn't left the connection.
+    assert_eq!(pipe.client.stream_send(4, b"world", true), Ok(5));
+    assert!(!pipe.client.stream_send_complete(4));
+
+    // Deliver the fin to the server, but hold on to its ack. This is the state
+    // that distinguishes this from stream_capacity(): the peer has the data,
+    // but we can't know that yet, and the frames are still eligible for
+    // retransmission.
+    let flight = test_utils::emit_flight(&mut pipe.client).unwrap();
+    test_utils::process_flight(&mut pipe.server, flight).unwrap();
+    assert!(!pipe.client.stream_send_complete(4));
+
+    // Deliver the ack.
+    let flight = test_utils::emit_flight(&mut pipe.server).unwrap();
+    test_utils::process_flight(&mut pipe.client, flight).unwrap();
+    assert!(pipe.client.stream_send_complete(4));
+}
+
+#[rstest]
+/// Tests that stream_send_complete() reports a zero-length fin, which has no
+/// stream data to ack, as complete.
+fn stream_send_complete_zero_length_fin(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    assert_eq!(pipe.client.stream_send(4, b"", true), Ok(0));
+    assert!(!pipe.client.stream_send_complete(4));
+
+    assert_eq!(pipe.advance(), Ok(()));
+    assert!(pipe.client.stream_send_complete(4));
+}
+
+#[rstest]
+/// Tests that stream_send_complete() reports a stream reset by the local
+/// endpoint, or stopped by the peer, as incomplete: neither delivers the fin.
+fn stream_send_complete_reset(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    // Locally reset before the fin is sent.
+    assert_eq!(pipe.client.stream_send(4, b"hello", false), Ok(5));
+    assert_eq!(pipe.client.stream_shutdown(4, Shutdown::Write, 42), Ok(()));
+    assert_eq!(pipe.advance(), Ok(()));
+    assert!(!pipe.client.stream_send_complete(4));
+
+    // Stopped by the peer before the fin is sent.
+    assert_eq!(pipe.client.stream_send(8, b"hello", false), Ok(5));
+    assert_eq!(pipe.advance(), Ok(()));
+    assert_eq!(pipe.server.stream_shutdown(8, Shutdown::Read, 42), Ok(()));
+    assert_eq!(pipe.advance(), Ok(()));
+    assert!(!pipe.client.stream_send_complete(8));
+}
+
+#[rstest]
+/// Tests that stream_send_complete() reports a collected stream as complete.
+/// A local unidirectional stream is dropped as soon as the fin is acked, so
+/// the state it would otherwise read is already gone.
+fn stream_send_complete_collected(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    assert_eq!(pipe.client.stream_send(2, b"hello", true), Ok(5));
+    assert!(!pipe.client.stream_send_complete(2));
+
+    assert_eq!(pipe.advance(), Ok(()));
+
+    // The stream is gone, so stream_capacity() no longer answers for it.
+    assert_eq!(
+        pipe.client.stream_capacity(2),
+        Err(Error::InvalidStreamState(2))
+    );
+    assert!(pipe.client.stream_send_complete(2));
+
+    // A stream that was never opened reads the same way.
+    assert!(pipe.client.stream_send_complete(6));
+}
+
+#[rstest]
 /// Tests that the stream gets created with stream_send() even if there's
 /// no data in the buffer and the fin flag is not set.
 fn stream_zero_length_non_fin(


### PR DESCRIPTION
(AI generated but reviewed)

quiche can report that the peer finished sending on a stream (stream_finished), but not that the peer acknowledged what we sent. The send-side state exists internally as SendBuf::is_complete(), where it gates stream collection, but nothing exposes it.

Without it an application cannot tell a stream whose FIN was merely queued from one the peer actually received. That matters before a reset: RESET_STREAM on a stream still in DataSent discards the unacknowledged data, so a final message can be dropped even though stream_send() reported it written. Callers that want a delivery guarantee currently have to avoid resetting streams entirely, or invent an application-level acknowledgement.

Report is_shutdown()/is_stopped() streams as incomplete rather than deferring to is_complete(). A reset counts as complete for collection purposes, since there is nothing left to send either way, but as an answer to "did the peer get my FIN" it would be wrong.

Fixes #1722