### PR TITLE
quiche: inherit PMTUD on runtime paths

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1356,6 +1356,12 @@ where
     /// The configuration for recovery.
     recovery_config: recovery::RecoveryConfig,
 
+    /// Whether newly-created runtime paths inherit PMTU discovery.
+    discover_pmtu: bool,
+
+    /// Maximum probe attempts inherited by newly-created runtime paths.
+    pmtud_max_probes: u8,
+
     /// The path manager.
     paths: path::PathMap,
 
@@ -2079,6 +2085,9 @@ impl<F: BufFactory> Connection<F> {
             session: None,
 
             recovery_config,
+
+            discover_pmtu: config.pmtud,
+            pmtud_max_probes: config.pmtud_max_probes,
 
             paths,
             path_challenge_recv_max_queue_len: config
@@ -4005,19 +4014,23 @@ impl<F: BufFactory> Connection<F> {
         let send_path = self.paths.get_mut(send_pid)?;
 
         // Update max datagram size to allow path MTU discovery probe to be sent.
-        if let Some(pmtud) = send_path.pmtud.as_mut() {
-            if pmtud.should_probe() {
-                let size = if self.handshake_confirmed || self.handshake_completed
-                {
-                    pmtud.get_probe_size()
-                } else {
-                    pmtud.get_current_mtu()
-                };
+        if send_path.validated() {
+            if let Some(pmtud) = send_path.pmtud.as_mut() {
+                if pmtud.should_probe() {
+                    let size =
+                        if self.handshake_confirmed || self.handshake_completed {
+                            pmtud.get_probe_size()
+                        } else {
+                            pmtud.get_current_mtu()
+                        };
 
-                send_path.recovery.pmtud_update_max_datagram_size(size);
+                    send_path.recovery.pmtud_update_max_datagram_size(size);
 
-                left =
-                    cmp::min(out.len(), send_path.recovery.max_datagram_size());
+                    left = cmp::min(
+                        out.len(),
+                        send_path.recovery.max_datagram_size(),
+                    );
+                }
             }
         }
 
@@ -8062,6 +8075,8 @@ impl<F: BufFactory> Connection<F> {
                     }
 
                     if let Some((discover, max_probes)) = ex_data.pmtud {
+                        self.discover_pmtu = discover;
+                        self.pmtud_max_probes = max_probes;
                         self.paths.set_discover_pmtu_on_existing_paths(
                             discover,
                             self.recovery_config.max_send_udp_payload_size,
@@ -9052,6 +9067,13 @@ impl<F: BufFactory> Connection<F> {
             None,
         );
 
+        if self.discover_pmtu {
+            path.pmtud = Some(pmtud::Pmtud::new(
+                self.recovery_config.max_send_udp_payload_size,
+                self.pmtud_max_probes,
+            ));
+        }
+
         path.max_send_bytes = buf_len * self.max_amplification_factor;
         path.active_scid_seq = Some(in_scid_seq);
 
@@ -9202,6 +9224,12 @@ impl<F: BufFactory> Connection<F> {
             false,
             None,
         );
+        if self.discover_pmtu {
+            path.pmtud = Some(pmtud::Pmtud::new(
+                self.recovery_config.max_send_udp_payload_size,
+                self.pmtud_max_probes,
+            ));
+        }
         path.active_dcid_seq = Some(dcid_seq);
 
         let pid = self

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -381,6 +381,10 @@ impl Path {
         &mut self, hs_confirmed: bool, hs_done: bool, out_len: usize,
         is_closing: bool, frames_empty: bool,
     ) -> bool {
+        if !self.validated() {
+            return false;
+        }
+
         let Some(pmtud) = self.pmtud.as_mut() else {
             return false;
         };

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -11185,6 +11185,50 @@ fn connection_migration(
     );
 }
 
+#[test]
+fn runtime_paths_inherit_pmtud_configuration() {
+    const PROBE_SIZE: usize = 1350;
+
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config.set_application_protos(&[b"proto1"]).unwrap();
+    config.verify_peer(false);
+    config.set_active_connection_id_limit(2);
+    config.set_max_send_udp_payload_size(PROBE_SIZE);
+    config.discover_pmtu(true);
+
+    let mut pipe = pipe_with_exchanged_cids(&mut config, 16, 16, 1);
+    let server_addr = test_utils::Pipe::server_addr();
+    let client_addr = "127.0.0.1:5678".parse().unwrap();
+
+    assert_eq!(pipe.client.probe_path(client_addr, server_addr), Ok(1));
+    let client_path = pipe
+        .client
+        .paths
+        .path_id_from_addrs(&(client_addr, server_addr))
+        .and_then(|id| pipe.client.paths.get(id).ok())
+        .expect("client runtime path");
+    let client_pmtud = client_path.pmtud.as_ref().expect("client PMTUD state");
+    assert_eq!(client_pmtud.get_probe_size(), PROBE_SIZE);
+
+    assert_eq!(pipe.advance(), Ok(()));
+    let server_path = pipe
+        .server
+        .paths
+        .path_id_from_addrs(&(server_addr, client_addr))
+        .and_then(|id| pipe.server.paths.get(id).ok())
+        .expect("server runtime path");
+    assert!(
+        server_path.pmtud.is_some(),
+        "server runtime path must inherit PMTUD state"
+    );
+}
+
 #[rstest]
 fn connection_migration_zero_length_cid(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,


### PR DESCRIPTION
## What changed

- retain the effective PMTUD enablement and maximum-probe settings on each connection;
- initialize PMTUD state on client- and server-created runtime paths;
- defer PMTU probes until the new path completes QUIC path validation; and
- cover both runtime path constructors with a migration regression test.

## Why

The initial path is created with `Some(config)` and receives PMTUD state, but
paths created after the handshake pass `None` to `Path::new`. A migrated
connection therefore cannot discover or revalidate the replacement path's MTU.

This intentionally does not include the send-path state correction proposed in
#2566.

Closes #2572.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test -p quiche runtime_paths_inherit_pmtud_configuration --lib`
