### PR TITLE
datagram-socket: fix build on musl targets

### DIFF
--- a/datagram-socket/src/mmsg.rs
+++ b/datagram-socket/src/mmsg.rs
@@ -36,6 +36,16 @@ use tokio::io::ReadBuf;
 
 const MAX_MMSG: usize = 16;
 
+// musl's `msghdr` has private padding fields, so it cannot be built with a
+// struct literal. Zeroing covers them and yields the same header on glibc.
+fn single_iov_msghdr(iov: *mut libc::iovec) -> libc::msghdr {
+    // Safety: an all zero `msghdr` is valid; the other fields were zero before.
+    let mut hdr: libc::msghdr = unsafe { std::mem::zeroed() };
+    hdr.msg_iov = iov;
+    hdr.msg_iovlen = 1;
+    hdr
+}
+
 pub fn recvmmsg(fd: BorrowedFd, bufs: &mut [ReadBuf<'_>]) -> io::Result<usize> {
     let mut msgvec: SmallVec<[libc::mmsghdr; MAX_MMSG]> = SmallVec::new();
     let mut slices: SmallVec<[IoSlice; MAX_MMSG]> = SmallVec::new();
@@ -56,15 +66,9 @@ pub fn recvmmsg(fd: BorrowedFd, bufs: &mut [ReadBuf<'_>]) -> io::Result<usize> {
             slices.push(IoSlice::new(b));
 
             msgvec.push(libc::mmsghdr {
-                msg_hdr: libc::msghdr {
-                    msg_name: std::ptr::null_mut(),
-                    msg_namelen: 0,
-                    msg_iov: slices.last_mut().unwrap() as *mut _ as *mut _,
-                    msg_iovlen: 1,
-                    msg_control: std::ptr::null_mut(),
-                    msg_controllen: 0,
-                    msg_flags: 0,
-                },
+                msg_hdr: single_iov_msghdr(
+                    slices.last_mut().unwrap() as *mut _ as *mut _
+                ),
                 msg_len: buf.capacity().try_into().unwrap(),
             });
         }
@@ -116,15 +120,9 @@ pub fn sendmmsg(fd: BorrowedFd, bufs: &[ReadBuf<'_>]) -> io::Result<usize> {
             slices.push(IoSlice::new(buf.filled()));
 
             msgvec.push(libc::mmsghdr {
-                msg_hdr: libc::msghdr {
-                    msg_name: std::ptr::null_mut(),
-                    msg_namelen: 0,
-                    msg_iov: slices.last_mut().unwrap() as *mut _ as *mut _,
-                    msg_iovlen: 1,
-                    msg_control: std::ptr::null_mut(),
-                    msg_controllen: 0,
-                    msg_flags: 0,
-                },
+                msg_hdr: single_iov_msghdr(
+                    slices.last_mut().unwrap() as *mut _ as *mut _
+                ),
                 msg_len: buf.capacity().try_into().unwrap(),
             });
         }


### PR DESCRIPTION
`datagram-socket` does not compile for musl targets, which means nothing that
depends on `tokio-quiche` can be built for Alpine or any other musl based
system.

## The error

On `master`, building the crate for a musl target:

```
$ cargo build -p datagram-socket --target aarch64-unknown-linux-musl

error: cannot construct `msghdr` with struct literal syntax due to private fields
  --> datagram-socket/src/mmsg.rs:59:26
   = note: ...and other private fields `__pad1` and `__pad2` that were not provided

error: cannot construct `msghdr` with struct literal syntax due to private fields
   --> datagram-socket/src/mmsg.rs:119:26
   = note: ...and other private fields `__pad1` and `__pad2` that were not provided

error: could not compile `datagram-socket` (lib) due to 2 previous errors
```

musl's `msghdr` carries padding fields that a struct literal cannot name, while
glibc's does not, so `recvmmsg` and `sendmmsg` build everywhere except musl.

This is present in the published 0.5.0 and 0.8.0 alike, so upgrading does not
avoid it.

## The change

Both call sites now go through a small helper that zeroes the struct and assigns
the two fields that matter. Zeroing gives the padding a defined value and
produces the same header the literal did on glibc, so this is not a musl only
code path and the glibc behaviour is unchanged.

## Verification

On both `aarch64-unknown-linux-musl` and `aarch64-unknown-linux-gnu`:

| Command | Result |
|---|---|
| `cargo build -p datagram-socket` | passes (previously 2 errors on musl) |
| `cargo clippy -p datagram-socket -- -D warnings` | passes |
| `cargo test -p datagram-socket` | 25 passed, 0 failed |
| `cargo fmt -p datagram-socket -- --check` | clean |

No new test is included: the existing `recvmmsg` and `sendmmsg` tests already
drive both call sites over a real `UnixDatagram` pair and assert on the bytes
that arrive, so the patched header is exercised end to end.

## A note on CI

No workflow currently builds for a musl target, which is presumably why this
went unnoticed across releases. A full musl job looks awkward given the existing
note in `stable.yml` that `boring` cannot be linked for foreign targets, but a
narrow `cargo check -p datagram-socket --target x86_64-unknown-linux-musl` would
catch a recurrence cheaply. Happy to add that here if you would like it, or to
leave it out to keep this focused.