### PR TITLE
Expose TLS exporter keying material

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -7614,6 +7614,18 @@ impl<F: BufFactory> Connection<F> {
         self.handshake.peer_cert()
     }
 
+    /// Fills the provided buffer with TLS exporter keying material.
+    ///
+    /// The exporter is available after the TLS handshake completes. The label
+    /// identifies the protocol usage, while the optional context can separate
+    /// exporter instances within that usage.
+    #[inline]
+    pub fn export_keying_material(
+        &self, out: &mut [u8], label: &[u8], context: Option<&[u8]>,
+    ) -> Result<()> {
+        self.handshake.export_keying_material(out, label, context)
+    }
+
     /// Returns the peer's certificate chain (if any) as a vector of DER-encoded
     /// buffers.
     ///

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -7618,11 +7618,18 @@ impl<F: BufFactory> Connection<F> {
     ///
     /// The exporter is available after the TLS handshake completes. The label
     /// identifies the protocol usage, while the optional context can separate
-    /// exporter instances within that usage.
+    /// exporter instances within that usage. Returns [`InvalidState`] until
+    /// the connection is established.
+    ///
+    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
     #[inline]
     pub fn export_keying_material(
         &self, out: &mut [u8], label: &[u8], context: Option<&[u8]>,
     ) -> Result<()> {
+        if !self.is_established() {
+            return Err(Error::InvalidState);
+        }
+
         self.handshake.export_keying_material(out, label, context)
     }
 

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -461,6 +461,42 @@ fn handshake(#[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str) {
     assert_eq!(pipe.server.server_name(), Some("quic.tech"));
 }
 
+#[test]
+fn export_keying_material() {
+    let mut pipe = test_utils::Pipe::new("cubic").unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    let mut client = [0; 32];
+    let mut server = [0; 32];
+    pipe.client
+        .export_keying_material(&mut client, b"EXPORTER-quiche-test", None)
+        .unwrap();
+    pipe.server
+        .export_keying_material(&mut server, b"EXPORTER-quiche-test", None)
+        .unwrap();
+    assert_eq!(client, server);
+
+    let mut other_label = [0; 32];
+    pipe.client
+        .export_keying_material(
+            &mut other_label,
+            b"EXPORTER-quiche-other-test",
+            None,
+        )
+        .unwrap();
+    assert_ne!(client, other_label);
+
+    let mut with_context = [0; 32];
+    pipe.client
+        .export_keying_material(
+            &mut with_context,
+            b"EXPORTER-quiche-test",
+            Some(b"context"),
+        )
+        .unwrap();
+    assert_ne!(client, with_context);
+}
+
 #[rstest]
 fn handshake_done(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -464,6 +464,15 @@ fn handshake(#[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str) {
 #[test]
 fn export_keying_material() {
     let mut pipe = test_utils::Pipe::new("cubic").unwrap();
+    let mut before_handshake = [0; 32];
+    assert!(pipe
+        .client
+        .export_keying_material(
+            &mut before_handshake,
+            b"EXPORTER-quiche-test",
+            None,
+        )
+        .is_err());
     assert_eq!(pipe.handshake(), Ok(()));
 
     let mut client = [0; 32];
@@ -495,6 +504,24 @@ fn export_keying_material() {
         )
         .unwrap();
     assert_ne!(client, with_context);
+
+    let mut client_with_empty_context = [0; 32];
+    let mut server_with_empty_context = [0; 32];
+    pipe.client
+        .export_keying_material(
+            &mut client_with_empty_context,
+            b"EXPORTER-quiche-test",
+            Some(b""),
+        )
+        .unwrap();
+    pipe.server
+        .export_keying_material(
+            &mut server_with_empty_context,
+            b"EXPORTER-quiche-test",
+            Some(b""),
+        )
+        .unwrap();
+    assert_eq!(client_with_empty_context, server_with_empty_context);
 }
 
 #[rstest]

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -465,14 +465,14 @@ fn handshake(#[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str) {
 fn export_keying_material() {
     let mut pipe = test_utils::Pipe::new("cubic").unwrap();
     let mut before_handshake = [0; 32];
-    assert!(pipe
-        .client
-        .export_keying_material(
+    assert_eq!(
+        pipe.client.export_keying_material(
             &mut before_handshake,
             b"EXPORTER-quiche-test",
             None,
-        )
-        .is_err());
+        ),
+        Err(Error::InvalidState),
+    );
     assert_eq!(pipe.handshake(), Ok(()));
 
     let mut client = [0; 32];
@@ -557,6 +557,15 @@ fn handshake_confirmation(
 
     assert!(!pipe.server.is_established());
     assert!(!pipe.server.handshake_confirmed);
+    let mut server_exporter = [0; 32];
+    assert_eq!(
+        pipe.server.export_keying_material(
+            &mut server_exporter,
+            b"EXPORTER-quiche-test",
+            None,
+        ),
+        Err(Error::InvalidState),
+    );
 
     test_utils::process_flight(&mut pipe.client, flight).unwrap();
 

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -575,6 +575,28 @@ impl Handshake {
         get_cipher_from_ptr(cipher.ok()?).ok()
     }
 
+    pub fn export_keying_material(
+        &self, out: &mut [u8], label: &[u8], context: Option<&[u8]>,
+    ) -> Result<()> {
+        let (context_ptr, context_len, use_context) = match context {
+            Some(context) => (context.as_ptr(), context.len(), 1),
+            None => (ptr::null(), 0, 0),
+        };
+
+        map_result(unsafe {
+            SSL_export_keying_material(
+                self.as_ptr(),
+                out.as_mut_ptr(),
+                out.len(),
+                label.as_ptr().cast(),
+                label.len(),
+                context_ptr,
+                context_len,
+                use_context,
+            )
+        })
+    }
+
     #[cfg(test)]
     pub fn set_options(&mut self, opts: u32) {
         unsafe {
@@ -1167,6 +1189,12 @@ extern "C" {
     fn SSL_get_ex_data(ssl: *const SSL, idx: c_int) -> *mut c_void;
 
     fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
+
+    fn SSL_export_keying_material(
+        ssl: *const SSL, out: *mut u8, out_len: usize, label: *const c_char,
+        label_len: usize, context: *const u8, context_len: usize,
+        use_context: c_int,
+    ) -> c_int;
 
     fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int;
 


### PR DESCRIPTION
Adds Connection::export_keying_material, backed by SSL_export_keying_material, with caller-owned output, an explicit label, and optional context. This lets application protocols derive channel-binding material without exposing the TLS session or allocating in quiche.\n\nThe public operation returns InvalidState until quiche marks the TLS handshake established, preventing access during the server interval after its Finished message but before the peer Finished is authenticated.\n\nTests verify pre-handshake and partial-handshake rejection, matching client/server output, label and non-empty-context separation, and peer agreement for an explicitly empty context.\n\nValidated with nightly rustfmt, 1,090 quiche tests, 45 doctests, and deny-warnings Clippy with only the current upstream uninlined_format_args baseline allowed. The change introduces no new Clippy warning.