### PR TITLE
Expose TLS exporter keying material

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -7614,6 +7614,18 @@ impl<F: BufFactory> Connection<F> {
         self.handshake.peer_cert()
     }
 
+    /// Fills the provided buffer with TLS exporter keying material.
+    ///
+    /// The exporter is available after the TLS handshake completes. The label
+    /// identifies the protocol usage, while the optional context can separate
+    /// exporter instances within that usage.
+    #[inline]
+    pub fn export_keying_material(
+        &self, out: &mut [u8], label: &[u8], context: Option<&[u8]>,
+    ) -> Result<()> {
+        self.handshake.export_keying_material(out, label, context)
+    }
+
     /// Returns the peer's certificate chain (if any) as a vector of DER-encoded
     /// buffers.
     ///

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -461,6 +461,42 @@ fn handshake(#[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str) {
     assert_eq!(pipe.server.server_name(), Some("quic.tech"));
 }
 
+#[test]
+fn export_keying_material() {
+    let mut pipe = test_utils::Pipe::new("cubic").unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    let mut client = [0; 32];
+    let mut server = [0; 32];
+    pipe.client
+        .export_keying_material(&mut client, b"EXPORTER-quiche-test", None)
+        .unwrap();
+    pipe.server
+        .export_keying_material(&mut server, b"EXPORTER-quiche-test", None)
+        .unwrap();
+    assert_eq!(client, server);
+
+    let mut other_label = [0; 32];
+    pipe.client
+        .export_keying_material(
+            &mut other_label,
+            b"EXPORTER-quiche-other-test",
+            None,
+        )
+        .unwrap();
+    assert_ne!(client, other_label);
+
+    let mut with_context = [0; 32];
+    pipe.client
+        .export_keying_material(
+            &mut with_context,
+            b"EXPORTER-quiche-test",
+            Some(b"context"),
+        )
+        .unwrap();
+    assert_ne!(client, with_context);
+}
+
 #[rstest]
 fn handshake_done(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -575,6 +575,28 @@ impl Handshake {
         get_cipher_from_ptr(cipher.ok()?).ok()
     }
 
+    pub fn export_keying_material(
+        &self, out: &mut [u8], label: &[u8], context: Option<&[u8]>,
+    ) -> Result<()> {
+        let (context_ptr, context_len, use_context) = match context {
+            Some(context) => (context.as_ptr(), context.len(), 1),
+            None => (ptr::null(), 0, 0),
+        };
+
+        map_result(unsafe {
+            SSL_export_keying_material(
+                self.as_ptr(),
+                out.as_mut_ptr(),
+                out.len(),
+                label.as_ptr().cast(),
+                label.len(),
+                context_ptr,
+                context_len,
+                use_context,
+            )
+        })
+    }
+
     #[cfg(test)]
     pub fn set_options(&mut self, opts: u32) {
         unsafe {
@@ -1167,6 +1189,12 @@ extern "C" {
     fn SSL_get_ex_data(ssl: *const SSL, idx: c_int) -> *mut c_void;
 
     fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
+
+    fn SSL_export_keying_material(
+        ssl: *const SSL, out: *mut u8, out_len: usize, label: *const c_char,
+        label_len: usize, context: *const u8, context_len: usize,
+        use_context: c_int,
+    ) -> c_int;
 
     fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int;
 


### PR DESCRIPTION
## Summary

- expose BoringSSL TLS exporter keying material through `Connection`
- preserve the distinction between an absent exporter context and a present context
- verify that connected peers derive the same material and that labels and contexts domain-separate outputs

The API accepts a caller-owned output buffer and does not allocate.

## Validation

- `cargo +nightly-2026-07-15 fmt --all -- --check`
- `BINDGEN_EXTRA_CLANG_ARGS=-I/usr/lib/gcc/x86_64-linux-gnu/13/include cargo +nightly-2026-07-15 test -p quiche`
- `BINDGEN_EXTRA_CLANG_ARGS=-I/usr/lib/gcc/x86_64-linux-gnu/13/include cargo +nightly-2026-07-15 clippy -p quiche --lib -- -D warnings`

Local results: 1,090 unit tests and 45 doctests passed.