### PR TITLE
Fix double counting of remotly reset streams

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -8396,6 +8396,8 @@ impl<F: BufFactory> Connection<F> {
                 let was_readable = stream.is_readable();
                 let priority_key = Arc::clone(&stream.priority_key);
 
+                let was_reset = stream.recv.is_reset();
+
                 let stream::RecvBufResetReturn {
                     max_data_delta,
                     consumed_flowcontrol,
@@ -8414,8 +8416,10 @@ impl<F: BufFactory> Connection<F> {
                 // flow-control
                 self.flow_control.add_consumed(consumed_flowcontrol);
 
-                self.reset_stream_remote_count =
-                    self.reset_stream_remote_count.saturating_add(1);
+                if !was_reset {
+                    self.reset_stream_remote_count =
+                        self.reset_stream_remote_count.saturating_add(1);
+                }
             },
 
             frame::Frame::StopSending {

--- a/quiche/src/stream/recv_buf.rs
+++ b/quiche/src/stream/recv_buf.rs
@@ -409,6 +409,11 @@ impl RecvBuf {
         self.drain
     }
 
+    /// Returns true if the stream has been reset by the peer.
+    pub fn is_reset(&self) -> bool {
+        self.error.is_some()
+    }
+
     /// Returns true if the stream has data to be read.
     pub fn ready(&self) -> bool {
         let (_, buf) = match self.data.first_key_value() {

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -2313,6 +2313,36 @@ fn stream_reset_counts(
 }
 
 #[rstest]
+/// A retransmitted RESET_STREAM for an already-reset stream must not increase
+/// the remote reset counter more than once.
+fn stream_reset_count_remote_retransmit(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut buf = [0; 65535];
+
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    let frames = [frame::Frame::ResetStream {
+        stream_id: 0,
+        error_code: 42,
+        final_size: 0,
+    }];
+
+    let written =
+        test_utils::encode_pkt(&mut pipe.client, Type::Short, &frames, &mut buf)
+            .unwrap();
+    assert_eq!(pipe.server_recv(&mut buf[..written]), Ok(written));
+    assert_eq!(pipe.server.stats().reset_stream_count_remote, 1);
+
+    let written =
+        test_utils::encode_pkt(&mut pipe.client, Type::Short, &frames, &mut buf)
+            .unwrap();
+    assert_eq!(pipe.server_recv(&mut buf[..written]), Ok(written));
+    assert_eq!(pipe.server.stats().reset_stream_count_remote, 1);
+}
+
+#[rstest]
 fn stream_stop_counts(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
 ) {


### PR DESCRIPTION
`reset_stream_remote_count` is documented as the number of streams reset by remote. However it was incremented on every processed RESET_STREAM frame, so a retransmitted RESET_STREAM for a stream that was already reset, but not yet collected, counted the same stream more than once.
