### PR TITLE
apps: apply initial cwnd setting to quiche-client

### DIFF
--- a/apps/src/client.rs
+++ b/apps/src/client.rs
@@ -123,6 +123,9 @@ pub fn connect(
     config.set_initial_max_streams_uni(conn_args.max_streams_uni);
     config.set_disable_active_migration(!conn_args.enable_active_migration);
     config.set_active_connection_id_limit(conn_args.max_active_cids);
+    config.set_initial_congestion_window_packets(
+        usize::try_from(conn_args.initial_cwnd_packets).unwrap(),
+    );
 
     config.set_max_connection_window(conn_args.max_window);
     config.set_max_stream_window(conn_args.max_stream_window);


### PR DESCRIPTION
`quiche-client` parses `initial_cwnd_packets` but does not apply it to quiche::Config before creating the connection. As a result, configured CWND values are silently ignored and the library default is used.

This PR is a simple change to configure the `initial_cwnd_packets` value from the args to the quiche config 