### PR TITLE
Allow send capacity buffering beyond a full congestion window

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -8922,14 +8922,24 @@ impl<F: BufFactory> Connection<F> {
 
     /// Updates send capacity.
     fn update_tx_cap(&mut self) {
-        let cwin_available = match self.paths.get_active() {
-            Ok(p) => p.recovery.cwnd_available() as u64,
-            Err(_) => 0,
+        let (cwin, cwin_available) = match self.paths.get_active() {
+            Ok(p) => (p.recovery.cwnd(), p.recovery.cwnd_available()),
+            Err(_) => (0, 0),
         };
 
-        let cap =
-            cmp::min(cwin_available, self.max_tx_data - self.tx_data) as usize;
-        self.tx_cap = (cap as f64 * self.tx_cap_factor).ceil() as usize;
+        let flow_cap = self.max_tx_data - self.tx_data;
+
+        let base_cap = (cmp::min(cwin_available as u64, flow_cap) as f64 *
+            self.tx_cap_factor.min(1.0))
+        .ceil() as usize;
+
+        let extra_cap = ((cwin as f64 * (self.tx_cap_factor - 1.0).max(0.0))
+            .ceil() as usize)
+            .saturating_sub(self.streams.tx_buffered());
+
+        self.tx_cap =
+            cmp::min(base_cap.saturating_add(extra_cap) as u64, flow_cap)
+                as usize;
     }
 
     fn delivery_rate_check_if_app_limited(&self) -> bool {

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -6415,6 +6415,106 @@ fn tx_cap_factor(#[values(true, false)] discard: bool) {
     assert_eq!(r.next(), None);
 }
 
+#[test]
+fn tx_cap_factor_with_full_cwnd() {
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config
+        .set_application_protos(&[b"proto1", b"proto2"])
+        .unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config.set_initial_max_data(100000);
+    config.set_initial_max_stream_data_bidi_local(100000);
+    config.set_initial_max_stream_data_bidi_remote(100000);
+    config.set_initial_max_streams_bidi(1);
+    config.set_max_recv_udp_payload_size(1200);
+    config.verify_peer(false);
+    config.set_send_capacity_factor(2.0);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    assert_eq!(pipe.client.stream_send(0, b"a", false), Ok(1));
+    assert_eq!(pipe.advance(), Ok(()));
+
+    let cwin = pipe
+        .server
+        .paths
+        .get_active()
+        .expect("no active")
+        .recovery
+        .cwnd();
+
+    // Fill one congestion window and emit it without delivering the packets,
+    // so no ACK can free congestion window capacity. Some stream data can stay
+    // buffered because packet overhead also consumes congestion window space.
+    let send_buf = vec![0; cwin];
+    assert_eq!(pipe.server.stream_send(0, &send_buf, false), Ok(cwin));
+    assert!(test_utils::emit_flight(&mut pipe.server).is_ok());
+
+    assert_eq!(
+        pipe.server
+            .paths
+            .get_active()
+            .expect("no active")
+            .recovery
+            .cwnd_available(),
+        0
+    );
+
+    let expected = cwin.saturating_sub(pipe.server.streams.tx_buffered());
+    assert!(expected > 0);
+
+    // Recalculate the cap while cwnd is full. With a factor of 2 there must
+    // still be capacity to pre-buffer up to one additional congestion window.
+    pipe.server.update_tx_cap();
+    assert_eq!(pipe.server.tx_cap, expected);
+
+    let send_buf = vec![0; expected];
+    assert_eq!(pipe.server.stream_send(0, &send_buf, false), Ok(expected));
+
+    // Updating the cap again must not grant the extra buffering allowance a
+    // second time while the congestion window is still full.
+    pipe.server.update_tx_cap();
+    assert_eq!(pipe.server.tx_cap, 0);
+    assert_eq!(pipe.server.stream_send(0, b"a", false), Err(Error::Done));
+}
+
+#[test]
+fn tx_cap_factor_does_not_scale_flow_control() {
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    config
+        .set_application_protos(&[b"proto1", b"proto2"])
+        .unwrap();
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config.set_initial_max_data(10000);
+    config.set_initial_max_stream_data_bidi_local(50000);
+    config.set_initial_max_stream_data_bidi_remote(50000);
+    config.set_initial_max_streams_bidi(1);
+    config.set_max_recv_udp_payload_size(1200);
+    config.verify_peer(false);
+    config.set_send_capacity_factor(2.0);
+
+    let mut pipe = test_utils::Pipe::with_config(&mut config).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    assert_eq!(pipe.client.stream_send(0, b"a", false), Ok(1));
+    assert_eq!(pipe.advance(), Ok(()));
+
+    let send_buf = [0; 20000];
+    assert_eq!(pipe.server.stream_send(0, &send_buf, false), Ok(10000));
+    assert_eq!(pipe.server.stream_send(0, b"a", false), Err(Error::Done));
+}
+
 #[rstest]
 fn client_rst_stream_while_bytes_in_flight(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,


### PR DESCRIPTION
`tx_cap_factor` is intended to allow applications to buffer additional stream data ahead of the congestion window. Currently, `tx_cap` is calculated as minimum of available congestion window and available flow control multiplied by `tx_cap_factor`. This means that once `cwnd_available` reaches zero, `tx_cap` also becomes zero regardless of `tx_cap_factor`. As a result, the application cannot pre buffer additional stream data while the congestion window is full and quiche needs to wait for more application data after ACKs make congestion window capacity available again.

This change keeps the existing `cwnd_available()` as the base capacity and adds an extra buffering allowance derived from the total congestion window:

```text
base_cap =
    min(cwnd_available, flow_control_available)
    * min(tx_cap_factor, 1)

extra_cap =
    max((tx_cap_factor - 1) * cwnd - tx_buffered, 0)

tx_cap =
    min(base_cap + extra_cap, flow_control_available)
```

For values greater than one, the additional capacity no longer depends on `cwnd_available` being non-zero and quiche can keep stream data buffered even when the current congestion window is fully occupied.

Already buffered stream data is deducted only from the additional buffering allowance, preventing repeated `tx_cap` updates from granting the same extra capacity again.

The peer's connection-level flow-control limit remains an absolute upper bound and is not scaled by `tx_cap_factor`.