### PR TITLE
Porting boringssl bindings over to use bssl-sys with bindgen instead of hardcoding them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ publish = false
 anyhow = { version = "1" }
 assert_matches = { version = "1" }
 boring = { version = "4.3" }
+bssl-sys = { git = "https://boringssl.googlesource.com/boringssl" }
 buffer-pool = { version = "0.2.1", path = "./buffer-pool" }
 bytes = { version = "1.11.1" }
 crossbeam = { version = "0.8.1", default-features = false }

--- a/quiche/Cargo.toml
+++ b/quiche/Cargo.toml
@@ -30,6 +30,9 @@ default = ["boringssl-boring-crate"]
 # Use the BoringSSL library provided by the boring crate.
 boringssl-boring-crate = ["boring", "foreign-types-shared"]
 
+# Use the BoringSSL library provided by the bssl-sys crate.
+boringssl-bssl-sys = ["bssl-sys"]
+
 # Allow client connections to provide a custom DCID when initiating a
 # connection. Be aware that RFC 9000 places requirements for unpredictability and
 # length on the client DCID field. Enabling this feature can be dangerous if these
@@ -69,6 +72,7 @@ cdylib-link-lines = { version = "0.1", optional = true }
 [dependencies]
 bytes = { workspace = true }
 boring = { workspace = true, optional = true }
+bssl-sys = { workspace = true, optional = true }
 debug_panic = { workspace = true }
 either = { version = "1.8", default-features = false }
 foreign-types-shared = { version = "0.3.0", optional = true }

--- a/quiche/src/crypto/boringssl_bssl_sys.rs
+++ b/quiche/src/crypto/boringssl_bssl_sys.rs
@@ -1,0 +1,425 @@
+// Copyright (C) 2018-2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::derive_pkt_iv;
+use super::derive_pkt_key;
+use super::make_nonce;
+use super::Algorithm;
+use super::Error;
+use super::HeaderProtectionMask;
+use super::Result;
+use super::HP_MASK_LEN;
+use crate::ffi_slice::FfiMutSlice;
+use crate::ffi_slice::FfiSlice;
+
+use std::convert::TryFrom;
+
+use std::mem::size_of;
+use std::mem::MaybeUninit;
+
+use bssl_sys::AES_ecb_encrypt;
+use bssl_sys::AES_set_encrypt_key;
+use bssl_sys::CRYPTO_chacha_20;
+use bssl_sys::EVP_AEAD_CTX_cleanup;
+use bssl_sys::EVP_AEAD_CTX_init;
+use bssl_sys::EVP_AEAD_CTX_open;
+use bssl_sys::EVP_AEAD_CTX_seal_scatter;
+use bssl_sys::EVP_aead_aes_128_gcm_tls13;
+use bssl_sys::EVP_aead_aes_256_gcm_tls13;
+use bssl_sys::EVP_aead_chacha20_poly1305;
+use bssl_sys::HKDF_expand;
+use bssl_sys::HKDF_extract;
+use bssl_sys::AES_KEY;
+use bssl_sys::EVP_AEAD;
+use bssl_sys::EVP_AEAD_CTX;
+
+impl Algorithm {
+    fn get_evp_aead(self) -> *const EVP_AEAD {
+        match self {
+            // SAFETY: FFI call, this function returns a static immutable
+            // lifetime object.
+            Algorithm::AES128_GCM => unsafe { EVP_aead_aes_128_gcm_tls13() },
+            // SAFETY: FFI call, this function returns a static immutable
+            // lifetime object.
+            Algorithm::AES256_GCM => unsafe { EVP_aead_aes_256_gcm_tls13() },
+            // SAFETY: FFI call, this function returns a static immutable
+            // lifetime object.
+            Algorithm::ChaCha20_Poly1305 => unsafe {
+                EVP_aead_chacha20_poly1305()
+            },
+        }
+    }
+}
+
+pub(crate) struct PacketKey {
+    alg: Algorithm,
+
+    ctx: EVP_AEAD_CTX,
+
+    nonce: Vec<u8>,
+}
+
+// SAFETY: enable send and sync for PacketKey for testing purposes only.
+// During tests, we don't need to send the key between threads, so this is safe.
+#[cfg(test)]
+unsafe impl Send for PacketKey {}
+#[cfg(test)]
+unsafe impl Sync for PacketKey {}
+
+impl Drop for PacketKey {
+    fn drop(&mut self) {
+        // Safety: `self.ctx` was initialized by `EVP_AEAD_CTX_init` because all
+        // paths to create a `PacketKey` do so.
+        unsafe {
+            EVP_AEAD_CTX_cleanup(&mut self.ctx);
+        }
+    }
+}
+
+impl PacketKey {
+    pub fn new(
+        alg: Algorithm, key: Vec<u8>, iv: Vec<u8>, _enc: u32,
+    ) -> Result<Self> {
+        Ok(Self {
+            alg,
+            ctx: make_aead_ctx(alg, &key)?,
+            nonce: iv,
+        })
+    }
+
+    pub fn from_secret(aead: Algorithm, secret: &[u8], enc: u32) -> Result<Self> {
+        let key_len = aead.key_len();
+        let nonce_len = aead.nonce_len();
+
+        let mut key = vec![0; key_len];
+        let mut iv = vec![0; nonce_len];
+
+        derive_pkt_key(aead, secret, &mut key)?;
+        derive_pkt_iv(aead, secret, &mut iv)?;
+
+        let mut pkt_key = Self::new(aead, key, iv, enc)?;
+
+        // Dummy seal operation to prime the AEAD context with the nonce mask.
+        //
+        // This is needed because BoringCrypto requires the first counter (i.e.
+        // packet number) to be zero, which would not be the case for packet
+        // number spaces after Initial as the same packet number sequence is
+        // shared.
+        let _ = pkt_key.seal_with_u64_counter(0, b"", &mut [0_u8; 16], 0, None);
+
+        Ok(pkt_key)
+    }
+
+    pub fn open_with_u64_counter(
+        &self, counter: u64, ad: &[u8], buf: &mut [u8],
+    ) -> Result<usize> {
+        let tag_len: usize = self.alg.tag_len();
+
+        let mut out_len = match buf.len().checked_sub(tag_len) {
+            Some(n) => n,
+            None => return Err(Error::CryptoFail),
+        };
+
+        let max_out_len = out_len;
+
+        let nonce = make_nonce(&self.nonce, counter);
+
+        // Safety: FFI call, the input buffers are all valid, with corresponding
+        // ptr and length. The output buffer has at least `max_output` bytes of
+        // space and that maximum is passed to `EVP_AEAD_CTX_open` as a
+        // limit.
+        let rc = unsafe {
+            EVP_AEAD_CTX_open(
+                &self.ctx,              // ctx
+                buf.as_mut_ffi_ptr(),   // out
+                &mut out_len,           // out_len
+                max_out_len,            // max_out_len
+                nonce[..].as_ffi_ptr(), // nonce
+                nonce.len(),            // nonce_len
+                buf.as_ffi_ptr(),       // inp
+                buf.len(),              // in_len
+                ad.as_ffi_ptr(),        // ad
+                ad.len(),               // ad_len
+            )
+        };
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        Ok(out_len)
+    }
+
+    pub fn seal_with_u64_counter(
+        &mut self, counter: u64, ad: &[u8], buf: &mut [u8], in_len: usize,
+        extra_in: Option<&[u8]>,
+    ) -> Result<usize> {
+        let tag_len: usize = self.alg.tag_len();
+
+        let mut out_tag_len = tag_len;
+
+        let (extra_in_ptr, extra_in_len) = match extra_in {
+            Some(v) => (v.as_ffi_ptr(), v.len()),
+
+            None => (std::ptr::null(), 0),
+        };
+
+        // Make sure all the outputs combined fit in the buffer.
+        if in_len + tag_len + extra_in_len > buf.len() {
+            return Err(Error::CryptoFail);
+        }
+
+        let nonce = make_nonce(&self.nonce, counter);
+
+        // Safety:
+        // - the buffers are all valid, with corresponding ptr and length.
+        // - `EVP_AEAD_CTX_seal_scatter` internally modifies `ctx` (for the TLS
+        //   variants), so the context passed in must be mutable (as is done here)
+        //   or be in an UnsafeCell.
+        let rc = unsafe {
+            EVP_AEAD_CTX_seal_scatter(
+                &self.ctx,                  // ctx
+                buf.as_mut_ffi_ptr(),       // out
+                buf[in_len..].as_mut_ptr(), // out_tag
+                &mut out_tag_len,           // out_tag_len
+                tag_len + extra_in_len,     // max_out_tag_len
+                nonce[..].as_ffi_ptr(),     // nonce
+                nonce.len(),                // nonce_len
+                buf.as_ffi_ptr(),           // inp
+                in_len,                     // in_len
+                extra_in_ptr,               // extra_in
+                extra_in_len,               // extra_in_len
+                ad.as_ffi_ptr(),            // ad
+                ad.len(),                   // ad_len
+            )
+        };
+
+        if rc != 1 {
+            return Err(Error::CryptoFail);
+        }
+
+        Ok(in_len + out_tag_len)
+    }
+}
+
+#[derive(Clone)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum HeaderProtectionKey {
+    Aes(AES_KEY),
+
+    ChaCha(Vec<u8>),
+}
+
+impl HeaderProtectionKey {
+    pub fn new(alg: Algorithm, hp_key: Vec<u8>) -> Result<Self> {
+        match alg {
+            Algorithm::AES128_GCM | Algorithm::AES256_GCM => {
+                if hp_key.len() != alg.key_len() {
+                    return Err(Error::CryptoFail);
+                }
+
+                let key_len_bits = alg.key_len() as u32 * 8;
+
+                let mut aes_key = MaybeUninit::<AES_KEY>::zeroed();
+
+                // SAFETY: FFI call, `AES_KEY` has a definite size as generated
+                // by `bindgen`, so its allocation is large
+                // enough to hold `hp_key`. The return value of this function
+                // differs from the usual BoringSSL convention.
+                let rc = unsafe {
+                    AES_set_encrypt_key(
+                        hp_key.as_ptr(),
+                        key_len_bits,
+                        aes_key.as_mut_ptr(),
+                    )
+                };
+
+                if rc != 0 {
+                    return Err(Error::CryptoFail);
+                }
+
+                // SAFETY: zeroed memory is safe for AES_KEY as it is a C type.
+                let aes_key = unsafe { aes_key.assume_init() };
+                Ok(Self::Aes(aes_key))
+            },
+
+            Algorithm::ChaCha20_Poly1305 => Ok(Self::ChaCha(hp_key)),
+        }
+    }
+
+    pub fn new_mask(&self, sample: &[u8]) -> Result<HeaderProtectionMask> {
+        match self {
+            Self::Aes(aes_key) => {
+                if sample.len() != 16 {
+                    return Err(Error::CryptoFail);
+                }
+
+                let mut block = [0_u8; 16];
+
+                // SAFETY: FFI call, `sample` and `block` are both 16 bytes
+                // blocks and non-overlapping.
+                unsafe {
+                    AES_ecb_encrypt(
+                        sample.as_ffi_ptr(),
+                        block.as_mut_ffi_ptr(),
+                        aes_key,
+                        1,
+                    )
+                };
+
+                // Downsize the encrypted block to the size of the header
+                // protection mask.
+                //
+                // The length of the slice will always match the size of
+                // `HeaderProtectionMask` so the `unwrap()` is safe.
+                let new_mask =
+                    HeaderProtectionMask::try_from(&block[..HP_MASK_LEN])
+                        .unwrap();
+                Ok(new_mask)
+            },
+
+            Self::ChaCha(key) => {
+                const PLAINTEXT: &[u8; HP_MASK_LEN] = &[0_u8; HP_MASK_LEN];
+
+                // Check that the key and sample are the expected sizes for
+                // ChaCha20.
+                if key.len() != 32 || sample.len() != 16 {
+                    return Err(Error::CryptoFail);
+                }
+
+                let mut new_mask = HeaderProtectionMask::default();
+
+                let counter = u32::from_le_bytes([
+                    sample[0], sample[1], sample[2], sample[3],
+                ]);
+
+                // SAFETY: FFI call, preconditions upheld:
+                // - `new_mask` is valid for writes of at least `PLAINTEXT.len()`
+                //   bytes.
+                // - `PLAINTEXT` is valid for reads of `PLAINTEXT.len()` bytes.
+                // - `key` is valid for reads of 32 bytes (standard ChaCha20 key
+                //   size).
+                // - `sample[size_of::<u32>()..]` is valid for reads of 12 bytes
+                //   (standard ChaCha20 nonce size).
+                // - The input and output buffers (`PLAINTEXT` and `new_mask`) do
+                //   not overlap, or if they do, they are exactly the same pointer
+                //   (in-place encryption).
+                unsafe {
+                    CRYPTO_chacha_20(
+                        new_mask.as_mut_ffi_ptr(),
+                        PLAINTEXT.as_ffi_ptr(),
+                        PLAINTEXT.len(),
+                        key.as_ffi_ptr(),
+                        sample[size_of::<u32>()..].as_ffi_ptr(),
+                        counter,
+                    );
+                };
+
+                Ok(new_mask)
+            },
+        }
+    }
+}
+
+fn make_aead_ctx(alg: Algorithm, key: &[u8]) -> Result<EVP_AEAD_CTX> {
+    if key.len() < alg.key_len() {
+        return Err(Error::CryptoFail);
+    }
+
+    let mut ctx = MaybeUninit::uninit();
+
+    let aead = alg.get_evp_aead();
+
+    // SAFETY: FFI call, `key` points to at least `alg.key_len()` bytes.
+    let rc = unsafe {
+        EVP_AEAD_CTX_init(
+            ctx.as_mut_ptr(),
+            aead as *const _,
+            key.as_ffi_ptr(),
+            alg.key_len(),
+            alg.tag_len(),
+            std::ptr::null_mut(),
+        )
+    };
+
+    if rc != 1 {
+        return Err(Error::CryptoFail);
+    }
+
+    // SAFETY: must guarantee that `ctx` is initialized.
+    let ctx = unsafe { ctx.assume_init() };
+    Ok(ctx)
+}
+
+pub(crate) fn hkdf_extract(
+    alg: Algorithm, out: &mut [u8], secret: &[u8], salt: &[u8],
+) -> Result<()> {
+    let mut out_len = out.len();
+
+    // Safety: `EVP_MAX_MD_SIZE` is the maximum output size of
+    // `HKDF_extract` so it'll never overrun the buffer.
+    let rc = unsafe {
+        HKDF_extract(
+            out.as_mut_ffi_ptr(),
+            &mut out_len,
+            alg.get_evp_digest() as *const _,
+            secret.as_ffi_ptr(),
+            secret.len(),
+            salt.as_ffi_ptr(),
+            salt.len(),
+        )
+    };
+
+    if rc != 1 {
+        return Err(Error::CryptoFail);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn hkdf_expand(
+    alg: Algorithm, out: &mut [u8], secret: &[u8], info: &[u8],
+) -> Result<()> {
+    // Safety: `HKDF_expand` writes exactly `out_len` bytes or else
+    // returns zero. `evp_md` is valid by construction.
+    let rc = unsafe {
+        HKDF_expand(
+            out.as_mut_ffi_ptr(),
+            out.len(),
+            alg.get_evp_digest() as *const _, // evp_md
+            secret.as_ffi_ptr(),
+            secret.len(),
+            info.as_ffi_ptr(),
+            info.len(),
+        )
+    };
+
+    if rc != 1 {
+        return Err(Error::CryptoFail);
+    }
+
+    Ok(())
+}

--- a/quiche/src/crypto/mod.rs
+++ b/quiche/src/crypto/mod.rs
@@ -24,9 +24,13 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 use libc::c_int;
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 use libc::c_void;
 
+#[cfg(feature = "boringssl-bssl-sys")]
+use crate::ffi_slice::FfiSlice;
 use crate::Error;
 use crate::Result;
 
@@ -75,10 +79,24 @@ pub enum Algorithm {
 // submodule.
 impl Algorithm {
     fn get_evp_digest(self) -> *const EVP_MD {
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
         match self {
             Algorithm::AES128_GCM => unsafe { EVP_sha256() },
             Algorithm::AES256_GCM => unsafe { EVP_sha384() },
             Algorithm::ChaCha20_Poly1305 => unsafe { EVP_sha256() },
+        }
+        #[cfg(feature = "boringssl-bssl-sys")]
+        match self {
+            // SAFETY: FFI call, but there are no safety preconditions.
+            Algorithm::AES128_GCM => unsafe {
+                bssl_sys::EVP_sha256() as *const _
+            },
+            Algorithm::AES256_GCM => unsafe {
+                bssl_sys::EVP_sha384() as *const _
+            },
+            Algorithm::ChaCha20_Poly1305 => unsafe {
+                bssl_sys::EVP_sha256() as *const _
+            },
         }
     }
 
@@ -111,17 +129,22 @@ impl Algorithm {
     }
 }
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 pub struct EVP_AEAD {
     _unused: c_void,
 }
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 struct EVP_MD {
     _unused: c_void,
 }
+
+#[cfg(feature = "boringssl-bssl-sys")]
+use bssl_sys::EVP_MD;
 
 type HeaderProtectionMask = [u8; HP_MASK_LEN];
 
@@ -510,7 +533,13 @@ pub fn verify_slices_are_equal(a: &[u8], b: &[u8]) -> Result<()> {
         return Err(Error::CryptoFail);
     }
 
+    #[cfg(not(feature = "boringssl-bssl-sys"))]
     let rc = unsafe { CRYPTO_memcmp(a.as_ptr(), b.as_ptr(), a.len()) };
+    #[cfg(feature = "boringssl-bssl-sys")]
+    // SAFETY: FFI call, but there are no safety preconditions.
+    let rc = unsafe {
+        bssl_sys::CRYPTO_memcmp(a.as_ffi_void_ptr(), b.as_ffi_void_ptr(), a.len())
+    };
 
     if rc == 0 {
         return Ok(());
@@ -519,6 +548,7 @@ pub fn verify_slices_are_equal(a: &[u8], b: &[u8]) -> Result<()> {
     Err(Error::CryptoFail)
 }
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 extern "C" {
     fn EVP_sha256() -> *const EVP_MD;
 
@@ -667,5 +697,12 @@ mod tests {
     }
 }
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 mod boringssl;
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 pub(crate) use boringssl::*;
+
+#[cfg(feature = "boringssl-bssl-sys")]
+mod boringssl_bssl_sys;
+#[cfg(feature = "boringssl-bssl-sys")]
+pub(crate) use boringssl_bssl_sys::*;

--- a/quiche/src/ffi_slice.rs
+++ b/quiche/src/ffi_slice.rs
@@ -1,0 +1,85 @@
+// Copyright (C) 2026, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use core::ffi::c_void;
+
+/// FfiSlice exists to provide `as_ffi_ptr` on slices. Calling `as_ptr` on an
+/// empty Rust slice may return the alignment of the type, rather than NULL, as
+/// the pointer. When passing pointers into C/C++ code, that is not a valid
+/// pointer. Thus this method should be used whenever passing a pointer to a
+/// slice into C/BoringSSL code.
+pub(crate) trait FfiSlice<T> {
+    fn as_ffi_ptr(&self) -> *const T;
+
+    fn as_ffi_void_ptr(&self) -> *const c_void {
+        self.as_ffi_ptr() as *const c_void
+    }
+}
+
+impl<T> FfiSlice<T> for [T] {
+    fn as_ffi_ptr(&self) -> *const T {
+        if self.is_empty() {
+            core::ptr::null()
+        } else {
+            self.as_ptr()
+        }
+    }
+}
+
+impl<T, const N: usize> FfiSlice<T> for [T; N] {
+    fn as_ffi_ptr(&self) -> *const T {
+        if N == 0 {
+            core::ptr::null()
+        } else {
+            self.as_ptr()
+        }
+    }
+}
+
+/// See [`FfiSlice`].
+pub(crate) trait FfiMutSlice {
+    fn as_mut_ffi_ptr(&mut self) -> *mut u8;
+}
+
+impl FfiMutSlice for [u8] {
+    fn as_mut_ffi_ptr(&mut self) -> *mut u8 {
+        if self.is_empty() {
+            core::ptr::null_mut()
+        } else {
+            self.as_mut_ptr()
+        }
+    }
+}
+
+impl<const N: usize> FfiMutSlice for [u8; N] {
+    fn as_mut_ffi_ptr(&mut self) -> *mut u8 {
+        if N == 0 {
+            core::ptr::null_mut()
+        } else {
+            self.as_mut_ptr()
+        }
+    }
+}

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -384,6 +384,9 @@
 #[macro_use]
 extern crate log;
 
+#[cfg(all(feature = "boringssl-boring-crate", feature = "boringssl-bssl-sys"))]
+compile_error!("Features 'boringssl-boring-crate' and 'boringssl-bssl-sys' are mutually exclusive and cannot be enabled together.");
+
 use std::cmp;
 
 use std::collections::VecDeque;
@@ -7610,7 +7613,15 @@ impl<F: BufFactory> Connection<F> {
 
     /// Returns the peer's leaf certificate (if any) as a DER-encoded buffer.
     #[inline]
+    #[cfg(not(feature = "boringssl-bssl-sys"))]
     pub fn peer_cert(&self) -> Option<&[u8]> {
+        self.handshake.peer_cert()
+    }
+
+    /// Returns the peer's leaf certificate (if any) as a DER-encoded buffer.
+    #[inline]
+    #[cfg(feature = "boringssl-bssl-sys")]
+    pub fn peer_cert(&self) -> Option<Vec<u8>> {
         self.handshake.peer_cert()
     }
 
@@ -7621,7 +7632,20 @@ impl<F: BufFactory> Connection<F> {
     /// certificates (if any) are the chain certificate authorities used to
     /// sign the leaf certificate.
     #[inline]
+    #[cfg(not(feature = "boringssl-bssl-sys"))]
     pub fn peer_cert_chain(&self) -> Option<Vec<&[u8]>> {
+        self.handshake.peer_cert_chain()
+    }
+
+    /// Returns the peer's certificate chain (if any) as a vector of DER-encoded
+    /// buffers.
+    ///
+    /// The certificate at index 0 is the peer's leaf certificate, the other
+    /// certificates (if any) are the chain certificate authorities used to
+    /// sign the leaf certificate.
+    #[inline]
+    #[cfg(feature = "boringssl-bssl-sys")]
+    pub fn peer_cert_chain(&self) -> Option<Vec<Vec<u8>>> {
         self.handshake.peer_cert_chain()
     }
 
@@ -9547,3 +9571,6 @@ mod recovery;
 mod stream;
 mod tls;
 mod transport_params;
+
+#[cfg(feature = "boringssl-bssl-sys")]
+mod ffi_slice;

--- a/quiche/src/rand.rs
+++ b/quiche/src/rand.rs
@@ -26,7 +26,10 @@
 
 pub fn rand_bytes(buf: &mut [u8]) {
     unsafe {
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
         RAND_bytes(buf.as_mut_ptr(), buf.len());
+        #[cfg(feature = "boringssl-bssl-sys")]
+        bssl_sys::RAND_bytes(buf.as_mut_ptr(), buf.len());
     }
 }
 
@@ -59,6 +62,7 @@ pub fn rand_u64_uniform(max: u64) -> u64 {
     r / chunk_size
 }
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 extern "C" {
     fn RAND_bytes(buf: *mut u8, len: libc::size_t) -> libc::c_int;
 }

--- a/quiche/src/tls/boringssl_bssl_sys.rs
+++ b/quiche/src/tls/boringssl_bssl_sys.rs
@@ -1,0 +1,309 @@
+// Copyright (C) 2018-2019, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::*;
+
+use crate::ffi_slice::FfiSlice;
+
+use bssl_sys::sk_num;
+use bssl_sys::sk_value;
+use bssl_sys::CRYPTO_BUFFER_data;
+use bssl_sys::CRYPTO_BUFFER_len;
+use bssl_sys::OPENSSL_free;
+use bssl_sys::SSL_CTX_set_early_data_enabled;
+use bssl_sys::SSL_SESSION_free;
+use bssl_sys::SSL_SESSION_from_bytes;
+use bssl_sys::SSL_SESSION_to_bytes;
+use bssl_sys::SSL_get0_peer_certificates;
+use bssl_sys::SSL_get_SSL_CTX;
+use bssl_sys::SSL_get_curve_id;
+use bssl_sys::SSL_get_curve_name;
+use bssl_sys::SSL_get_early_data_reason;
+use bssl_sys::SSL_get_peer_signature_algorithm;
+use bssl_sys::SSL_get_signature_algorithm_name;
+use bssl_sys::SSL_in_early_data;
+use bssl_sys::SSL_reset_early_data_reject;
+use bssl_sys::SSL_set_quic_early_data_context;
+use bssl_sys::SSL_set_session;
+use bssl_sys::CRYPTO_BUFFER;
+
+pub use bssl_sys::SSL_QUIC_METHOD;
+
+#[cfg(test)]
+use bssl_sys::SSL_set_private_key_method;
+#[cfg(test)]
+use bssl_sys::SSL_PRIVATE_KEY_METHOD;
+
+pub(super) static QUICHE_STREAM_METHOD: SSL_QUIC_METHOD = SSL_QUIC_METHOD {
+    set_read_secret: Some(bssl_set_read_secret),
+    set_write_secret: Some(bssl_set_write_secret),
+    add_handshake_data: Some(bssl_add_handshake_data),
+    flush_flight: Some(bssl_flush_flight),
+    send_alert: Some(bssl_send_alert),
+};
+
+impl Context {
+    pub fn set_early_data_enabled(&mut self, enabled: bool) {
+        // SAFETY: FFI call, but there are no safety preconditions.
+        unsafe {
+            SSL_CTX_set_early_data_enabled(self.as_mut_ptr(), i32::from(enabled));
+        }
+    }
+}
+
+impl Handshake {
+    pub fn set_quic_early_data_context(&mut self, context: &[u8]) -> Result<()> {
+        // SAFETY: FFI call, but there are no safety preconditions.
+        map_result(unsafe {
+            SSL_set_quic_early_data_context(
+                self.as_mut_ptr(),
+                context.as_ffi_ptr(),
+                context.len(),
+            )
+        })
+    }
+
+    pub fn set_session(&mut self, session: &[u8]) -> Result<()> {
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let ctx = unsafe { SSL_get_SSL_CTX(self.as_ptr()) };
+
+        if ctx.is_null() {
+            return Err(Error::TlsFail);
+        }
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let session = unsafe {
+            SSL_SESSION_from_bytes(session.as_ffi_ptr(), session.len(), ctx)
+        };
+
+        if session.is_null() {
+            return Err(Error::TlsFail);
+        }
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let rc = unsafe { SSL_set_session(self.as_mut_ptr(), session) };
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        unsafe {
+            SSL_SESSION_free(session);
+        }
+
+        map_result(rc)
+    }
+
+    pub fn reset_early_data_reject(&mut self) {
+        // SAFETY: FFI call, but there are no safety preconditions.
+        unsafe { SSL_reset_early_data_reject(self.as_mut_ptr()) };
+    }
+
+    pub fn curve(&self) -> Option<String> {
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let curve_id = unsafe { SSL_get_curve_id(self.as_ptr()) };
+        if curve_id == 0 {
+            return None;
+        }
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let curve_name = unsafe { SSL_get_curve_name(curve_id) };
+        if curve_name.is_null() {
+            return None;
+        }
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let curve = match unsafe { ffi::CStr::from_ptr(curve_name).to_str() } {
+            Ok(v) => v,
+
+            Err(_) => return None,
+        };
+
+        Some(curve.to_string())
+    }
+
+    pub fn sigalg(&self) -> Option<String> {
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let sigalg_id =
+            unsafe { SSL_get_peer_signature_algorithm(self.as_ptr()) };
+        if sigalg_id == 0 {
+            return None;
+        }
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let sigalg_name =
+            unsafe { SSL_get_signature_algorithm_name(sigalg_id, 1) };
+        if sigalg_name.is_null() {
+            return None;
+        }
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let sigalg = match unsafe { ffi::CStr::from_ptr(sigalg_name).to_str() } {
+            Ok(v) => v,
+
+            Err(_) => return None,
+        };
+
+        Some(sigalg.to_string())
+    }
+
+    pub fn peer_cert_chain(&self) -> Option<Vec<Vec<u8>>> {
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let chain = unsafe {
+            map_result_ptr(SSL_get0_peer_certificates(self.as_ptr())).ok()?
+        };
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let num = unsafe { sk_num(chain as *const _ as *const _) };
+        if num == 0 {
+            return None;
+        }
+
+        let mut cert_chain = vec![];
+        for i in 0..num {
+            // SAFETY: FFI call, but there are no safety preconditions.
+            let buffer = map_result_ptr(unsafe {
+                sk_value(chain as *const _ as *const _, i) as *const CRYPTO_BUFFER
+            })
+            .ok()?;
+
+            // SAFETY: FFI call, but there are no safety preconditions.
+            let out_len = unsafe { CRYPTO_BUFFER_len(buffer) };
+            if out_len == 0 {
+                return None;
+            }
+
+            let out = unsafe { CRYPTO_BUFFER_data(buffer) };
+            // SAFETY: FFI call, but there are no safety preconditions.
+            let slice = unsafe { slice::from_raw_parts(out, out_len) };
+
+            cert_chain.push(slice.to_vec());
+        }
+
+        Some(cert_chain)
+    }
+
+    pub fn peer_cert(&self) -> Option<Vec<u8>> {
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let chain = unsafe {
+            map_result_ptr(SSL_get0_peer_certificates(self.as_ptr())).ok()?
+        };
+        if unsafe { sk_num(chain as *const _ as *const _) == 0 } {
+            return None;
+        }
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let buffer = unsafe {
+            map_result_ptr(sk_value(chain as *const _ as *const _, 0)
+                as *const CRYPTO_BUFFER)
+            .ok()?
+        };
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let out_len = unsafe { CRYPTO_BUFFER_len(buffer) };
+        if out_len == 0 {
+            return None;
+        }
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let out = unsafe { CRYPTO_BUFFER_data(buffer) };
+        let peer_cert = unsafe { slice::from_raw_parts(out, out_len).to_vec() };
+
+        Some(peer_cert)
+    }
+
+    // Only used for testing handling of failure during key signing.
+    #[cfg(test)]
+    pub fn set_failing_private_key_method(&mut self) {
+        // SAFETY: FFI call, but there are no safety preconditions.
+        unsafe extern "C" fn failing_sign(
+            _ssl: *mut SSL, _out: *mut u8, _out_len: *mut usize, _max_out: usize,
+            _signature_algorithm: u16, _in: *const u8, _in_len: usize,
+        ) -> ssl_private_key_result_t {
+            bssl_sys::ssl_private_key_result_t_ssl_private_key_failure
+        }
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        unsafe extern "C" fn failing_decrypt(
+            _ssl: *mut SSL, _out: *mut u8, _out_len: *mut usize, _max_out: usize,
+            _in: *const u8, _in_len: usize,
+        ) -> ssl_private_key_result_t {
+            bssl_sys::ssl_private_key_result_t_ssl_private_key_failure
+        }
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        unsafe extern "C" fn failing_complete(
+            _ssl: *mut SSL, _out: *mut u8, _out_len: *mut usize, _max_out: usize,
+        ) -> ssl_private_key_result_t {
+            bssl_sys::ssl_private_key_result_t_ssl_private_key_failure
+        }
+
+        static QUICHE_PRIVATE_KEY_METHOD: SSL_PRIVATE_KEY_METHOD =
+            SSL_PRIVATE_KEY_METHOD {
+                decrypt: Some(failing_decrypt),
+                sign: Some(failing_sign),
+                complete: Some(failing_complete),
+            };
+
+        // SAFETY: FFI call, but there are no safety preconditions.
+        unsafe {
+            SSL_set_private_key_method(
+                self.as_mut_ptr(),
+                &QUICHE_PRIVATE_KEY_METHOD as *const SSL_PRIVATE_KEY_METHOD,
+            );
+        }
+    }
+
+    pub fn is_in_early_data(&self) -> bool {
+        // SAFETY: FFI call, preconditions:
+        // - self is a valid SSL.
+        unsafe { SSL_in_early_data(self.as_ptr()) == 1 }
+    }
+
+    pub fn early_data_reason(&self) -> u32 {
+        // SAFETY: FFI call, but there are no safety preconditions.
+        let reuse_reason_status =
+            unsafe { SSL_get_early_data_reason(self.as_ptr()) };
+        reuse_reason_status as u32
+    }
+}
+
+pub(super) fn get_session_bytes(session: *mut SSL_SESSION) -> Result<Vec<u8>> {
+    let mut out: *mut u8 = ptr::null_mut();
+    let mut out_len: usize = 0;
+
+    // SAFETY: FFI call, but there are no safety preconditions.
+    if unsafe { SSL_SESSION_to_bytes(session as *mut _, &mut out, &mut out_len) }
+        == 0
+    {
+        return Err(Error::TlsFail);
+    }
+
+    // SAFETY: FFI call, but there are no safety preconditions.
+    let session_bytes = unsafe { slice::from_raw_parts(out, out_len).to_vec() };
+    unsafe { OPENSSL_free(out as *mut c_void) };
+
+    Ok(session_bytes)
+}
+
+pub(super) const TLS_ERROR: c_int = 3;

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -25,6 +25,8 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::ffi;
+#[cfg(feature = "boringssl-bssl-sys")]
+use std::mem;
 use std::mem::ManuallyDrop;
 use std::ptr;
 use std::ptr::NonNull;
@@ -36,6 +38,8 @@ use std::sync::LazyLock;
 
 use libc::c_char;
 use libc::c_int;
+#[cfg(all(feature = "boringssl-bssl-sys", windows))]
+use libc::c_long;
 use libc::c_uint;
 use libc::c_void;
 
@@ -52,68 +56,91 @@ const TLS1_3_VERSION: u16 = 0x0304;
 const TLS_ALERT_ERROR: u64 = 0x100;
 const INTERNAL_ERROR: u64 = 0x01;
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 struct SSL_METHOD {
     _unused: c_void,
 }
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 struct SSL_CTX {
     _unused: c_void,
 }
+#[cfg(feature = "boringssl-bssl-sys")]
+use bssl_sys::SSL_CTX;
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 struct SSL {
     _unused: c_void,
 }
+#[cfg(feature = "boringssl-bssl-sys")]
+use bssl_sys::SSL;
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 struct SSL_CIPHER {
     _unused: c_void,
 }
+#[cfg(feature = "boringssl-bssl-sys")]
+use bssl_sys::SSL_CIPHER;
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 struct SSL_SESSION {
     _unused: c_void,
 }
+#[cfg(feature = "boringssl-bssl-sys")]
+use bssl_sys::SSL_SESSION;
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 struct X509_VERIFY_PARAM {
     _unused: c_void,
 }
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 #[cfg(windows)]
 struct X509_STORE {
     _unused: c_void,
 }
+#[cfg(all(feature = "boringssl-bssl-sys", windows))]
+use bssl_sys::X509_STORE;
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 struct X509_STORE_CTX {
     _unused: c_void,
 }
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 #[cfg(windows)]
 struct X509 {
     _unused: c_void,
 }
+#[cfg(all(feature = "boringssl-bssl-sys", windows))]
+use bssl_sys::X509;
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 struct STACK_OF {
     _unused: c_void,
 }
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 #[cfg(test)]
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -123,10 +150,31 @@ enum ssl_private_key_result_t {
     ssl_private_key_retry,
     ssl_private_key_failure,
 }
+#[cfg(all(feature = "boringssl-bssl-sys", test))]
+use bssl_sys::ssl_private_key_result_t;
 
 /// BoringSSL ex_data index for quiche connections.
 pub static QUICHE_EX_DATA_INDEX: LazyLock<c_int> = LazyLock::new(|| unsafe {
-    SSL_get_ex_new_index(0, ptr::null(), ptr::null(), ptr::null(), ptr::null())
+    #[cfg(not(feature = "boringssl-bssl-sys"))]
+    {
+        SSL_get_ex_new_index(
+            0,
+            ptr::null(),
+            ptr::null(),
+            ptr::null(),
+            ptr::null(),
+        )
+    }
+    #[cfg(feature = "boringssl-bssl-sys")]
+    {
+        bssl_sys::SSL_get_ex_new_index(
+            0,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            None,
+            None,
+        )
+    }
 });
 
 pub struct Context(NonNull<SSL_CTX>);
@@ -136,8 +184,23 @@ impl Context {
     // submodule.
     pub fn new() -> Result<Context> {
         unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
             let ctx_raw =
                 NonNull::new(SSL_CTX_new(TLS_method())).ok_or(Error::TlsFail)?;
+            #[cfg(feature = "boringssl-bssl-sys")]
+            let ctx_raw = NonNull::new(bssl_sys::SSL_CTX_new(
+                bssl_sys::TLS_method(),
+            ) as *mut SSL_CTX)
+            .ok_or(Error::TlsFail)?;
+
+            #[cfg(all(feature = "boringssl-bssl-sys", test))]
+            {
+                let curves = ffi::CString::new("X25519:P-256:P-384").unwrap();
+                bssl_sys::SSL_CTX_set1_curves_list(
+                    ctx_raw.as_ptr() as *mut _,
+                    curves.as_ptr(),
+                );
+            }
 
             let mut ctx = Context(ctx_raw);
 
@@ -166,8 +229,14 @@ impl Context {
 
     pub fn new_handshake(&mut self) -> Result<Handshake> {
         unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
             let ssl =
                 NonNull::new(SSL_new(self.as_mut_ptr())).ok_or(Error::TlsFail)?;
+            #[cfg(feature = "boringssl-bssl-sys")]
+            let ssl = NonNull::new(
+                bssl_sys::SSL_new(self.as_mut_ptr() as *mut _) as *mut SSL,
+            )
+            .ok_or(Error::TlsFail)?;
 
             Ok(Handshake::new(ssl))
         }
@@ -176,11 +245,22 @@ impl Context {
     pub fn load_verify_locations_from_file(&mut self, file: &str) -> Result<()> {
         let file = ffi::CString::new(file).map_err(|_| Error::TlsFail)?;
         map_result(unsafe {
-            SSL_CTX_load_verify_locations(
-                self.as_mut_ptr(),
-                file.as_ptr(),
-                ptr::null(),
-            )
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_CTX_load_verify_locations(
+                    self.as_mut_ptr(),
+                    file.as_ptr(),
+                    ptr::null(),
+                )
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_CTX_load_verify_locations(
+                    self.as_mut_ptr() as *mut _,
+                    file.as_ptr(),
+                    ptr::null(),
+                )
+            }
         })
     }
 
@@ -189,31 +269,83 @@ impl Context {
     ) -> Result<()> {
         let path = ffi::CString::new(path).map_err(|_| Error::TlsFail)?;
         map_result(unsafe {
-            SSL_CTX_load_verify_locations(
-                self.as_mut_ptr(),
-                ptr::null(),
-                path.as_ptr(),
-            )
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_CTX_load_verify_locations(
+                    self.as_mut_ptr(),
+                    ptr::null(),
+                    path.as_ptr(),
+                )
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_CTX_load_verify_locations(
+                    self.as_mut_ptr() as *mut _,
+                    ptr::null(),
+                    path.as_ptr(),
+                )
+            }
         })
     }
 
     pub fn use_certificate_chain_file(&mut self, file: &str) -> Result<()> {
         let cstr = ffi::CString::new(file).map_err(|_| Error::TlsFail)?;
-        map_result(unsafe {
-            SSL_CTX_use_certificate_chain_file(self.as_mut_ptr(), cstr.as_ptr())
-        })
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
+        {
+            map_result(unsafe {
+                SSL_CTX_use_certificate_chain_file(
+                    self.as_mut_ptr(),
+                    cstr.as_ptr(),
+                )
+            })
+        }
+        #[cfg(feature = "boringssl-bssl-sys")]
+        {
+            map_result(unsafe {
+                bssl_sys::SSL_CTX_use_certificate_chain_file(
+                    self.as_mut_ptr() as *mut _,
+                    cstr.as_ptr(),
+                )
+            })
+        }
     }
 
     pub fn use_privkey_file(&mut self, file: &str) -> Result<()> {
         let cstr = ffi::CString::new(file).map_err(|_| Error::TlsFail)?;
-        map_result(unsafe {
-            SSL_CTX_use_PrivateKey_file(self.as_mut_ptr(), cstr.as_ptr(), 1)
-        })
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
+        {
+            map_result(unsafe {
+                SSL_CTX_use_PrivateKey_file(self.as_mut_ptr(), cstr.as_ptr(), 1)
+            })
+        }
+        #[cfg(feature = "boringssl-bssl-sys")]
+        {
+            map_result(unsafe {
+                bssl_sys::SSL_CTX_use_PrivateKey_file(
+                    self.as_mut_ptr() as *mut _,
+                    cstr.as_ptr(),
+                    1,
+                )
+            })
+        }
     }
 
     #[cfg(not(windows))]
     fn load_ca_certs(&mut self) -> Result<()> {
-        unsafe { map_result(SSL_CTX_set_default_verify_paths(self.as_mut_ptr())) }
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
+        {
+            unsafe {
+                map_result(SSL_CTX_set_default_verify_paths(self.as_mut_ptr()))
+            }
+        }
+        #[cfg(feature = "boringssl-bssl-sys")]
+        {
+            map_result(unsafe {
+                bssl_sys::SSL_CTX_set_default_verify_paths(
+                    self.as_mut_ptr() as *mut _
+                )
+            })
+        }
     }
 
     #[cfg(windows)]
@@ -229,7 +361,12 @@ impl Context {
                 return Err(Error::TlsFail);
             }
 
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
             let ctx_store = SSL_CTX_get_cert_store(self.as_mut_ptr());
+            #[cfg(feature = "boringssl-bssl-sys")]
+            let ctx_store =
+                bssl_sys::SSL_CTX_get_cert_store(self.as_mut_ptr() as *mut _);
+
             if ctx_store.is_null() {
                 return Err(Error::TlsFail);
             }
@@ -240,22 +377,44 @@ impl Context {
             );
 
             while !ctx_p.is_null() {
-                let in_p = (*ctx_p).pbCertEncoded as *const u8;
+                #[cfg(not(feature = "boringssl-bssl-sys"))]
+                {
+                    let in_p = (*ctx_p).pbCertEncoded as *const u8;
 
-                let cert = d2i_X509(
-                    ptr::null_mut(),
-                    &in_p,
-                    (*ctx_p).cbCertEncoded as i32,
-                );
-                if !cert.is_null() {
-                    X509_STORE_add_cert(ctx_store, cert);
+                    let cert = d2i_X509(
+                        ptr::null_mut(),
+                        &in_p,
+                        (*ctx_p).cbCertEncoded as i32,
+                    );
+                    if !cert.is_null() {
+                        X509_STORE_add_cert(ctx_store, cert);
+                    }
+
+                    X509_free(cert);
+
+                    ctx_p = windows_sys::Win32::Security::Cryptography::CertEnumCertificatesInStore(
+                        sys_store, ctx_p,
+                    );
                 }
+                #[cfg(feature = "boringssl-bssl-sys")]
+                {
+                    let in_p = (*ctx_p).pbCertEncoded as *const u8;
 
-                X509_free(cert);
+                    let cert = bssl_sys::d2i_X509(
+                        ptr::null_mut(),
+                        &in_p,
+                        (*ctx_p).cbCertEncoded as c_long,
+                    );
+                    if !cert.is_null() {
+                        bssl_sys::X509_STORE_add_cert(ctx_store, cert);
+                    }
 
-                ctx_p = windows_sys::Win32::Security::Cryptography::CertEnumCertificatesInStore(
-                    sys_store, ctx_p,
-                );
+                    bssl_sys::X509_free(cert);
+
+                    ctx_p = windows_sys::Win32::Security::Cryptography::CertEnumCertificatesInStore(
+                        sys_store, ctx_p,
+                    );
+                }
             }
 
             // tidy up
@@ -272,12 +431,26 @@ impl Context {
         unsafe {
             // This is needed to enable the session callback on the client. On
             // the server it doesn't do anything.
-            SSL_CTX_set_session_cache_mode(
-                self.as_mut_ptr(),
-                0x0001, // SSL_SESS_CACHE_CLIENT
-            );
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_CTX_set_session_cache_mode(
+                    self.as_mut_ptr(),
+                    0x0001, // SSL_SESS_CACHE_CLIENT
+                );
 
-            SSL_CTX_sess_set_new_cb(self.as_mut_ptr(), Some(new_session));
+                SSL_CTX_sess_set_new_cb(self.as_mut_ptr(), Some(new_session));
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_CTX_set_session_cache_mode(
+                    self.as_mut_ptr() as *mut _,
+                    0x0001, // SSL_SESS_CACHE_CLIENT
+                );
+                bssl_sys::SSL_CTX_sess_set_new_cb(
+                    self.as_mut_ptr() as *mut _,
+                    Some(new_session),
+                );
+            }
         };
     }
 
@@ -289,13 +462,22 @@ impl Context {
         // Note: Base on two used modes(see above), it seems ok for both, bssl and
         // ossl. If mode needs to be ored then it may need to be adjusted.
         unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
             SSL_CTX_set_verify(self.as_mut_ptr(), mode, None);
+            #[cfg(feature = "boringssl-bssl-sys")]
+            bssl_sys::SSL_CTX_set_verify(self.as_mut_ptr() as *mut _, mode, None);
         }
     }
 
     pub fn enable_keylog(&mut self) {
         unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
             SSL_CTX_set_keylog_callback(self.as_mut_ptr(), Some(keylog));
+            #[cfg(feature = "boringssl-bssl-sys")]
+            bssl_sys::SSL_CTX_set_keylog_callback(
+                self.as_mut_ptr() as *mut _,
+                Some(keylog),
+            );
         }
     }
 
@@ -309,30 +491,80 @@ impl Context {
 
         // Configure ALPN for servers.
         unsafe {
-            SSL_CTX_set_alpn_select_cb(
-                self.as_mut_ptr(),
-                Some(select_alpn),
-                ptr::null_mut(),
-            );
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_CTX_set_alpn_select_cb(
+                    self.as_mut_ptr(),
+                    Some(select_alpn),
+                    ptr::null_mut(),
+                );
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_CTX_set_alpn_select_cb(
+                    self.as_mut_ptr() as *mut _,
+                    Some(mem::transmute::<
+                        extern "C" fn(
+                            *mut SSL,
+                            *mut *const u8,
+                            *mut u8,
+                            *mut u8,
+                            c_uint,
+                            *mut c_void,
+                        ) -> c_int,
+                        unsafe extern "C" fn(
+                            *mut SSL,
+                            *mut *const u8,
+                            *mut u8,
+                            *const u8,
+                            c_uint,
+                            *mut c_void,
+                        ) -> c_int,
+                    >(select_alpn)),
+                    ptr::null_mut(),
+                );
+            }
         }
 
         // Configure ALPN for clients.
         map_result_zero_is_success(unsafe {
-            SSL_CTX_set_alpn_protos(
-                self.as_mut_ptr(),
-                protos.as_ptr(),
-                protos.len(),
-            )
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_CTX_set_alpn_protos(
+                    self.as_mut_ptr(),
+                    protos.as_ptr(),
+                    protos.len(),
+                )
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_CTX_set_alpn_protos(
+                    self.as_mut_ptr() as *mut _,
+                    protos.as_ptr(),
+                    protos.len() as _,
+                )
+            }
         })
     }
 
     pub fn set_ticket_key(&mut self, key: &[u8]) -> Result<()> {
         map_result(unsafe {
-            SSL_CTX_set_tlsext_ticket_keys(
-                self.as_mut_ptr(),
-                key.as_ptr(),
-                key.len(),
-            )
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_CTX_set_tlsext_ticket_keys(
+                    self.as_mut_ptr(),
+                    key.as_ptr(),
+                    key.len(),
+                )
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_CTX_set_tlsext_ticket_keys(
+                    self.as_mut_ptr() as *mut _,
+                    key.as_ptr() as *const _,
+                    key.len() as _,
+                )
+            }
         })
     }
 
@@ -349,7 +581,12 @@ unsafe impl Sync for Context {}
 
 impl Drop for Context {
     fn drop(&mut self) {
-        unsafe { SSL_CTX_free(self.as_mut_ptr()) }
+        unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            SSL_CTX_free(self.as_mut_ptr());
+            #[cfg(feature = "boringssl-bssl-sys")]
+            bssl_sys::SSL_CTX_free(self.as_mut_ptr() as *mut _);
+        }
     }
 }
 
@@ -378,7 +615,12 @@ impl Handshake {
     }
 
     pub fn get_error(&self, ret_code: c_int) -> c_int {
-        unsafe { SSL_get_error(self.as_ptr(), ret_code) }
+        unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            return SSL_get_error(self.as_ptr(), ret_code);
+            #[cfg(feature = "boringssl-bssl-sys")]
+            return bssl_sys::SSL_get_error(self.as_ptr() as *const _, ret_code);
+        }
     }
 
     pub fn init(&mut self, is_server: bool) -> Result<()> {
@@ -400,19 +642,40 @@ impl Handshake {
 
     pub fn use_legacy_codepoint(&mut self, use_legacy: bool) {
         unsafe {
-            SSL_set_quic_use_legacy_codepoint(
-                self.as_mut_ptr(),
-                use_legacy as c_int,
-            );
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_set_quic_use_legacy_codepoint(
+                    self.as_mut_ptr(),
+                    use_legacy as c_int,
+                );
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_set_quic_use_legacy_codepoint(
+                    self.as_mut_ptr() as *mut _,
+                    use_legacy as c_int,
+                );
+            }
         }
     }
 
     pub fn set_state(&mut self, is_server: bool) {
         unsafe {
-            if is_server {
-                SSL_set_accept_state(self.as_mut_ptr());
-            } else {
-                SSL_set_connect_state(self.as_mut_ptr());
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                if is_server {
+                    SSL_set_accept_state(self.as_mut_ptr());
+                } else {
+                    SSL_set_connect_state(self.as_mut_ptr());
+                }
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                if is_server {
+                    bssl_sys::SSL_set_accept_state(self.as_mut_ptr() as *mut _);
+                } else {
+                    bssl_sys::SSL_set_connect_state(self.as_mut_ptr() as *mut _);
+                }
             }
         }
     }
@@ -420,43 +683,128 @@ impl Handshake {
     pub fn set_ex_data<T>(&mut self, idx: c_int, data: *const T) -> Result<()> {
         map_result(unsafe {
             let ptr = data as *mut c_void;
-            SSL_set_ex_data(self.as_mut_ptr(), idx, ptr)
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_set_ex_data(self.as_mut_ptr(), idx, ptr)
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_set_ex_data(
+                    self.as_mut_ptr() as *mut _,
+                    idx,
+                    ptr as *mut _,
+                )
+            }
         })
     }
 
     pub fn set_quic_method(&mut self) -> Result<()> {
-        map_result(unsafe {
-            SSL_set_quic_method(self.as_mut_ptr(), &QUICHE_STREAM_METHOD)
-        })
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
+        {
+            map_result(unsafe {
+                SSL_set_quic_method(self.as_mut_ptr(), &QUICHE_STREAM_METHOD)
+            })
+        }
+        #[cfg(feature = "boringssl-bssl-sys")]
+        {
+            map_result(unsafe {
+                bssl_sys::SSL_set_quic_method(
+                    self.as_mut_ptr() as *mut _,
+                    &QUICHE_STREAM_METHOD as *const SSL_QUIC_METHOD as *const _,
+                )
+            })
+        }
     }
 
     pub fn set_min_proto_version(&mut self, version: u16) -> Result<()> {
-        map_result(unsafe {
-            SSL_set_min_proto_version(self.as_mut_ptr(), version)
-        })
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
+        {
+            map_result(unsafe {
+                SSL_set_min_proto_version(self.as_mut_ptr(), version)
+            })
+        }
+        #[cfg(feature = "boringssl-bssl-sys")]
+        {
+            map_result(unsafe {
+                bssl_sys::SSL_set_min_proto_version(
+                    self.as_mut_ptr() as *mut _,
+                    version,
+                )
+            })
+        }
     }
 
     pub fn set_max_proto_version(&mut self, version: u16) -> Result<()> {
-        map_result(unsafe {
-            SSL_set_max_proto_version(self.as_mut_ptr(), version)
-        })
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
+        {
+            map_result(unsafe {
+                SSL_set_max_proto_version(self.as_mut_ptr(), version)
+            })
+        }
+        #[cfg(feature = "boringssl-bssl-sys")]
+        {
+            map_result(unsafe {
+                bssl_sys::SSL_set_max_proto_version(
+                    self.as_mut_ptr() as *mut _,
+                    version,
+                )
+            })
+        }
     }
 
     pub fn set_quiet_shutdown(&mut self, mode: bool) {
-        unsafe { SSL_set_quiet_shutdown(self.as_mut_ptr(), i32::from(mode)) }
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
+        {
+            unsafe { SSL_set_quiet_shutdown(self.as_mut_ptr(), i32::from(mode)) }
+        }
+        #[cfg(feature = "boringssl-bssl-sys")]
+        {
+            unsafe {
+                bssl_sys::SSL_set_quiet_shutdown(
+                    self.as_mut_ptr() as *mut _,
+                    i32::from(mode),
+                )
+            }
+        }
     }
 
     pub fn set_host_name(&mut self, name: &str) -> Result<()> {
-        let cstr = ffi::CString::new(name).map_err(|_| Error::TlsFail)?;
-        let rc =
-            unsafe { SSL_set_tlsext_host_name(self.as_mut_ptr(), cstr.as_ptr()) };
-        self.map_result_ssl(rc)?;
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
+        {
+            let cstr = ffi::CString::new(name).map_err(|_| Error::TlsFail)?;
+            let rc = unsafe {
+                SSL_set_tlsext_host_name(self.as_mut_ptr(), cstr.as_ptr())
+            };
+            self.map_result_ssl(rc)?;
 
-        let param = unsafe { SSL_get0_param(self.as_mut_ptr()) };
+            let param = unsafe { SSL_get0_param(self.as_mut_ptr()) };
 
-        map_result(unsafe {
-            X509_VERIFY_PARAM_set1_host(param, cstr.as_ptr(), name.len())
-        })
+            map_result(unsafe {
+                X509_VERIFY_PARAM_set1_host(param, cstr.as_ptr(), name.len())
+            })
+        }
+        #[cfg(feature = "boringssl-bssl-sys")]
+        {
+            let cstr = ffi::CString::new(name).map_err(|_| Error::TlsFail)?;
+            let rc = unsafe {
+                bssl_sys::SSL_set_tlsext_host_name(
+                    self.as_mut_ptr() as *mut _,
+                    cstr.as_ptr(),
+                )
+            };
+            self.map_result_ssl(rc)?;
+
+            let param =
+                unsafe { bssl_sys::SSL_get0_param(self.as_mut_ptr() as *mut _) };
+
+            map_result(unsafe {
+                bssl_sys::X509_VERIFY_PARAM_set1_host(
+                    param,
+                    cstr.as_ptr(),
+                    name.len() as _,
+                )
+            })
+        }
     }
 
     pub fn set_quic_transport_params(
@@ -468,11 +816,22 @@ impl Handshake {
             crate::TransportParams::encode(params, is_server, &mut raw_params)?;
 
         let rc = unsafe {
-            SSL_set_quic_transport_params(
-                self.as_mut_ptr(),
-                raw_params.as_ptr(),
-                raw_params.len(),
-            )
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_set_quic_transport_params(
+                    self.as_mut_ptr(),
+                    raw_params.as_ptr(),
+                    raw_params.len(),
+                )
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_set_quic_transport_params(
+                    self.as_mut_ptr() as *mut _,
+                    raw_params.as_ptr(),
+                    raw_params.len() as _,
+                )
+            }
         };
         self.map_result_ssl(rc)
     }
@@ -482,7 +841,22 @@ impl Handshake {
         let mut len: usize = 0;
 
         unsafe {
-            SSL_get_peer_quic_transport_params(self.as_ptr(), &mut ptr, &mut len);
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_get_peer_quic_transport_params(
+                    self.as_ptr(),
+                    &mut ptr,
+                    &mut len,
+                );
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_get_peer_quic_transport_params(
+                    self.as_ptr() as *const _,
+                    &mut ptr,
+                    &mut len,
+                );
+            }
         }
 
         if len == 0 {
@@ -497,7 +871,18 @@ impl Handshake {
         let mut len: u32 = 0;
 
         unsafe {
-            SSL_get0_alpn_selected(self.as_ptr(), &mut ptr, &mut len);
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_get0_alpn_selected(self.as_ptr(), &mut ptr, &mut len);
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_get0_alpn_selected(
+                    self.as_ptr() as *const _,
+                    &mut ptr,
+                    &mut len,
+                );
+            }
         }
 
         if len == 0 {
@@ -509,16 +894,32 @@ impl Handshake {
 
     pub fn server_name(&self) -> Option<&str> {
         let s = unsafe {
-            let ptr = SSL_get_servername(
-                self.as_ptr(),
-                0, // TLSEXT_NAMETYPE_host_name
-            );
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                let ptr = SSL_get_servername(
+                    self.as_ptr(),
+                    0, // TLSEXT_NAMETYPE_host_name
+                );
 
-            if ptr.is_null() {
-                return None;
+                if ptr.is_null() {
+                    return None;
+                }
+
+                ffi::CStr::from_ptr(ptr)
             }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                let ptr = bssl_sys::SSL_get_servername(
+                    self.as_ptr() as *const _,
+                    0, // TLSEXT_NAMETYPE_host_name
+                );
 
-            ffi::CStr::from_ptr(ptr)
+                if ptr.is_null() {
+                    return None;
+                }
+
+                ffi::CStr::from_ptr(ptr)
+            }
         };
 
         s.to_str().ok()
@@ -529,19 +930,34 @@ impl Handshake {
     ) -> Result<()> {
         self.provided_data_outstanding = true;
         let rc = unsafe {
-            SSL_provide_quic_data(
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            let rc = SSL_provide_quic_data(
                 self.as_mut_ptr(),
                 level,
                 buf.as_ptr(),
                 buf.len(),
-            )
+            );
+            #[cfg(feature = "boringssl-bssl-sys")]
+            let rc = bssl_sys::SSL_provide_quic_data(
+                self.as_mut_ptr() as *mut _,
+                level as u32,
+                buf.as_ptr(),
+                buf.len() as _,
+            );
+            rc
         };
         self.map_result_ssl(rc)
     }
 
     pub fn do_handshake(&mut self, ex_data: &mut ExData) -> Result<()> {
         self.set_ex_data(*QUICHE_EX_DATA_INDEX, ex_data)?;
-        let rc = unsafe { SSL_do_handshake(self.as_mut_ptr()) };
+        let rc = unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            let rc = SSL_do_handshake(self.as_mut_ptr());
+            #[cfg(feature = "boringssl-bssl-sys")]
+            let rc = bssl_sys::SSL_do_handshake(self.as_mut_ptr() as *mut _);
+            rc
+        };
         self.set_ex_data::<Connection>(*QUICHE_EX_DATA_INDEX, ptr::null())?;
 
         self.set_transport_error(ex_data, rc);
@@ -557,7 +973,15 @@ impl Handshake {
         self.provided_data_outstanding = false;
 
         self.set_ex_data(*QUICHE_EX_DATA_INDEX, ex_data)?;
-        let rc = unsafe { SSL_process_quic_post_handshake(self.as_mut_ptr()) };
+        let rc = unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            let rc = SSL_process_quic_post_handshake(self.as_mut_ptr());
+            #[cfg(feature = "boringssl-bssl-sys")]
+            let rc = bssl_sys::SSL_process_quic_post_handshake(
+                self.as_mut_ptr() as *mut _
+            );
+            rc
+        };
         self.set_ex_data::<Connection>(*QUICHE_EX_DATA_INDEX, ptr::null())?;
 
         self.set_transport_error(ex_data, rc);
@@ -565,12 +989,29 @@ impl Handshake {
     }
 
     pub fn write_level(&self) -> crypto::Level {
-        unsafe { SSL_quic_write_level(self.as_ptr()) }
+        unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            return SSL_quic_write_level(self.as_ptr());
+            #[cfg(feature = "boringssl-bssl-sys")]
+            return from_bssl_level(bssl_sys::SSL_quic_write_level(
+                self.as_ptr() as *const _,
+            ))
+            .unwrap();
+        }
     }
 
     pub fn cipher(&self) -> Option<crypto::Algorithm> {
-        let cipher =
-            map_result_ptr(unsafe { SSL_get_current_cipher(self.as_ptr()) });
+        let cipher = map_result_ptr(unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            {
+                SSL_get_current_cipher(self.as_ptr())
+            }
+            #[cfg(feature = "boringssl-bssl-sys")]
+            {
+                bssl_sys::SSL_get_current_cipher(self.as_ptr() as *const _)
+                    as *const SSL_CIPHER
+            }
+        });
 
         get_cipher_from_ptr(cipher.ok()?).ok()
     }
@@ -578,20 +1019,39 @@ impl Handshake {
     #[cfg(test)]
     pub fn set_options(&mut self, opts: u32) {
         unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
             SSL_set_options(self.as_mut_ptr(), opts);
+            #[cfg(feature = "boringssl-bssl-sys")]
+            bssl_sys::SSL_set_options(self.as_mut_ptr() as *mut _, opts);
         }
     }
 
     pub fn is_completed(&self) -> bool {
-        unsafe { SSL_in_init(self.as_ptr()) == 0 }
+        unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            return SSL_in_init(self.as_ptr()) == 0;
+            #[cfg(feature = "boringssl-bssl-sys")]
+            return bssl_sys::SSL_in_init(self.as_ptr() as *const _) == 0;
+        }
     }
 
     pub fn is_resumed(&self) -> bool {
-        unsafe { SSL_session_reused(self.as_ptr()) == 1 }
+        unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            return SSL_session_reused(self.as_ptr()) == 1;
+            #[cfg(feature = "boringssl-bssl-sys")]
+            return bssl_sys::SSL_session_reused(self.as_ptr() as *const _) == 1;
+        }
     }
 
     pub fn clear(&mut self) -> Result<()> {
-        let rc = unsafe { SSL_clear(self.as_mut_ptr()) };
+        let rc = unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            let rc = SSL_clear(self.as_mut_ptr());
+            #[cfg(feature = "boringssl-bssl-sys")]
+            let rc = bssl_sys::SSL_clear(self.as_mut_ptr() as *mut _);
+            rc
+        };
         self.map_result_ssl(rc)
     }
 
@@ -688,7 +1148,12 @@ unsafe impl Sync for Handshake {}
 
 impl Drop for Handshake {
     fn drop(&mut self) {
-        unsafe { SSL_free(self.as_mut_ptr()) }
+        unsafe {
+            #[cfg(not(feature = "boringssl-bssl-sys"))]
+            SSL_free(self.as_mut_ptr());
+            #[cfg(feature = "boringssl-bssl-sys")]
+            bssl_sys::SSL_free(self.as_mut_ptr() as *mut _);
+        }
     }
 }
 
@@ -737,13 +1202,26 @@ impl<'a> ExData<'a> {
 
 fn get_ex_data_from_ptr<'a, T>(ptr: *const SSL, idx: c_int) -> Option<&'a mut T> {
     unsafe {
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
         let data = SSL_get_ex_data(ptr, idx) as *mut T;
+        #[cfg(feature = "boringssl-bssl-sys")]
+        let data = bssl_sys::SSL_get_ex_data(ptr as *const _, idx) as *mut T;
+
         data.as_mut()
     }
 }
 
 fn get_cipher_from_ptr(cipher: *const SSL_CIPHER) -> Result<crypto::Algorithm> {
-    let cipher_id = unsafe { SSL_CIPHER_get_id(cipher) };
+    let cipher_id = unsafe {
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
+        {
+            SSL_CIPHER_get_id(cipher)
+        }
+        #[cfg(feature = "boringssl-bssl-sys")]
+        {
+            bssl_sys::SSL_CIPHER_get_id(cipher as *const _)
+        }
+    };
 
     let alg = match cipher_id {
         0x0300_1301 => crypto::Algorithm::AES128_GCM,
@@ -753,6 +1231,39 @@ fn get_cipher_from_ptr(cipher: *const SSL_CIPHER) -> Result<crypto::Algorithm> {
     };
 
     Ok(alg)
+}
+
+#[cfg(feature = "boringssl-bssl-sys")]
+fn from_bssl_level(
+    level: bssl_sys::ssl_encryption_level_t,
+) -> Option<crypto::Level> {
+    match level {
+        bssl_sys::ssl_encryption_level_t_ssl_encryption_initial => {
+            Some(crypto::Level::Initial)
+        },
+        bssl_sys::ssl_encryption_level_t_ssl_encryption_early_data => {
+            Some(crypto::Level::ZeroRTT)
+        },
+        bssl_sys::ssl_encryption_level_t_ssl_encryption_handshake => {
+            Some(crypto::Level::Handshake)
+        },
+        bssl_sys::ssl_encryption_level_t_ssl_encryption_application => {
+            Some(crypto::Level::OneRTT)
+        },
+        _ => None,
+    }
+}
+
+#[cfg(feature = "boringssl-bssl-sys")]
+unsafe extern "C" fn bssl_set_read_secret(
+    ssl: *mut SSL, level: bssl_sys::ssl_encryption_level_t,
+    cipher: *const SSL_CIPHER, secret: *const u8, secret_len: usize,
+) -> c_int {
+    let level = match from_bssl_level(level) {
+        Some(v) => v,
+        None => return 0,
+    };
+    set_read_secret(ssl, level, cipher, secret, secret_len)
 }
 
 extern "C" fn set_read_secret(
@@ -769,12 +1280,15 @@ extern "C" fn set_read_secret(
 
     let space = match level {
         crypto::Level::Initial => &mut ex_data.crypto_ctx[packet::Epoch::Initial],
-        crypto::Level::ZeroRTT =>
-            &mut ex_data.crypto_ctx[packet::Epoch::Application],
-        crypto::Level::Handshake =>
-            &mut ex_data.crypto_ctx[packet::Epoch::Handshake],
-        crypto::Level::OneRTT =>
-            &mut ex_data.crypto_ctx[packet::Epoch::Application],
+        crypto::Level::ZeroRTT => {
+            &mut ex_data.crypto_ctx[packet::Epoch::Application]
+        },
+        crypto::Level::Handshake => {
+            &mut ex_data.crypto_ctx[packet::Epoch::Handshake]
+        },
+        crypto::Level::OneRTT => {
+            &mut ex_data.crypto_ctx[packet::Epoch::Application]
+        },
     };
 
     let aead = match get_cipher_from_ptr(cipher) {
@@ -802,6 +1316,18 @@ extern "C" fn set_read_secret(
     }
 
     1
+}
+
+#[cfg(feature = "boringssl-bssl-sys")]
+unsafe extern "C" fn bssl_set_write_secret(
+    ssl: *mut SSL, level: bssl_sys::ssl_encryption_level_t,
+    cipher: *const SSL_CIPHER, secret: *const u8, secret_len: usize,
+) -> c_int {
+    let level = match from_bssl_level(level) {
+        Some(v) => v,
+        None => return 0,
+    };
+    set_write_secret(ssl, level, cipher, secret, secret_len)
 }
 
 extern "C" fn set_write_secret(
@@ -848,6 +1374,18 @@ extern "C" fn set_write_secret(
     1
 }
 
+#[cfg(feature = "boringssl-bssl-sys")]
+unsafe extern "C" fn bssl_add_handshake_data(
+    ssl: *mut SSL, level: bssl_sys::ssl_encryption_level_t, data: *const u8,
+    len: usize,
+) -> c_int {
+    let level = match from_bssl_level(level) {
+        Some(v) => v,
+        None => return 0,
+    };
+    add_handshake_data(ssl, level, data, len)
+}
+
 extern "C" fn add_handshake_data(
     ssl: *mut SSL, level: crypto::Level, data: *const u8, len: usize,
 ) -> c_int {
@@ -882,11 +1420,27 @@ extern "C" fn add_handshake_data(
     1
 }
 
+#[cfg(feature = "boringssl-bssl-sys")]
+unsafe extern "C" fn bssl_flush_flight(ssl: *mut SSL) -> c_int {
+    flush_flight(ssl)
+}
+
 extern "C" fn flush_flight(_ssl: *mut SSL) -> c_int {
     // We don't really need to anything here since the output packets are
     // generated separately, when conn.send() is called.
 
     1
+}
+
+#[cfg(feature = "boringssl-bssl-sys")]
+unsafe extern "C" fn bssl_send_alert(
+    ssl: *mut SSL, level: bssl_sys::ssl_encryption_level_t, alert: u8,
+) -> c_int {
+    let level = match from_bssl_level(level) {
+        Some(v) => v,
+        None => return 0,
+    };
+    send_alert(ssl, level, alert)
 }
 
 extern "C" fn send_alert(
@@ -1067,8 +1621,20 @@ fn log_ssl_error() {
     let mut err = [0u8; 1024];
 
     unsafe {
-        let e = ERR_peek_error();
-        ERR_error_string_n(e, err.as_mut_ptr() as *mut c_char, err.len());
+        #[cfg(not(feature = "boringssl-bssl-sys"))]
+        {
+            let e = ERR_peek_error();
+            ERR_error_string_n(e, err.as_mut_ptr() as *mut c_char, err.len());
+        }
+        #[cfg(feature = "boringssl-bssl-sys")]
+        {
+            let e = bssl_sys::ERR_peek_error();
+            bssl_sys::ERR_error_string_n(
+                e,
+                err.as_mut_ptr() as *mut c_char,
+                err.len(),
+            );
+        }
     }
 
     let cstr = ffi::CStr::from_bytes_until_nul(&err)
@@ -1081,6 +1647,7 @@ fn log_ssl_error() {
     );
 }
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 extern "C" {
     // Note: some vendor-specific methods are implemented in the boringssl
     // submodule.
@@ -1248,5 +1815,12 @@ extern "C" {
 
 }
 
+#[cfg(not(feature = "boringssl-bssl-sys"))]
 mod boringssl;
-use boringssl::*;
+#[cfg(not(feature = "boringssl-bssl-sys"))]
+pub(crate) use boringssl::*;
+
+#[cfg(feature = "boringssl-bssl-sys")]
+mod boringssl_bssl_sys;
+#[cfg(feature = "boringssl-bssl-sys")]
+pub(crate) use boringssl_bssl_sys::*;


### PR DESCRIPTION
1. Install `bindgen`: ```bash cargo install bindgen-cli

2. Build BoringSSL with Rust bindings: cmake -B /path/to/boringssl/build -S /path/to/boringssl \ -DRUST_BINDINGS=$(rustc -vV | sed -n 's/host: //p') cmake --build /path/to/boringssl/build -j$(nproc)
Note: you can use the path to boringssl that is included through cargo

3. Build / test quiche with --no-default-features --features boringssl-bssl-sys: BORINGSSL_BUILD_DIR="/path/to/boringssl/build" \ cargo test --no-default-features --features boringssl-bssl-sys -p quiche