### PR TITLE
quic: expose handshake confirmation state

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -519,6 +519,11 @@ void quiche_conn_server_name(const quiche_conn *conn, const uint8_t **out, size_
 // Returns true if the connection handshake is complete.
 bool quiche_conn_is_established(const quiche_conn *conn);
 
+// Returns true if the connection handshake is confirmed. The handshake is
+// confirmed immediately after it completes on the server. On the client, it is
+// confirmed after receiving a HANDSHAKE_DONE frame from the server.
+bool quiche_conn_is_handshake_confirmed(const quiche_conn *conn);
+
 // Returns true if the connection is resumed.
 bool quiche_conn_is_resumed(const quiche_conn *conn);
 

--- a/quiche/src/ffi.rs
+++ b/quiche/src/ffi.rs
@@ -1248,6 +1248,11 @@ pub extern "C" fn quiche_conn_is_established(conn: &Connection) -> bool {
 }
 
 #[no_mangle]
+pub extern "C" fn quiche_conn_is_handshake_confirmed(conn: &Connection) -> bool {
+    conn.is_handshake_confirmed()
+}
+
+#[no_mangle]
 pub extern "C" fn quiche_conn_is_resumed(conn: &Connection) -> bool {
     conn.is_resumed()
 }
@@ -2364,6 +2369,31 @@ mod tests {
         ));
 
         quiche_connection_id_iter_free(iter);
+    }
+
+    #[test]
+    fn handshake_confirmation_matches_rust_api() {
+        let mut pipe = test_utils::Pipe::new("cubic").unwrap();
+
+        assert_eq!(
+            quiche_conn_is_handshake_confirmed(&pipe.client),
+            pipe.client.is_handshake_confirmed()
+        );
+        assert_eq!(
+            quiche_conn_is_handshake_confirmed(&pipe.server),
+            pipe.server.is_handshake_confirmed()
+        );
+
+        assert_eq!(pipe.handshake(), Ok(()));
+
+        assert_eq!(
+            quiche_conn_is_handshake_confirmed(&pipe.client),
+            pipe.client.is_handshake_confirmed()
+        );
+        assert_eq!(
+            quiche_conn_is_handshake_confirmed(&pipe.server),
+            pipe.server.is_handshake_confirmed()
+        );
     }
 
     #[cfg(not(windows))]

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -7707,6 +7707,16 @@ impl<F: BufFactory> Connection<F> {
         self.handshake_completed
     }
 
+    /// Returns true if the connection handshake is confirmed.
+    ///
+    /// The handshake is confirmed immediately after it completes on the
+    /// server. On the client, it is confirmed after receiving a
+    /// `HANDSHAKE_DONE` frame from the server.
+    #[inline]
+    pub fn is_handshake_confirmed(&self) -> bool {
+        self.handshake_confirmed
+    }
+
     /// Returns true if the connection is resumed.
     #[inline]
     pub fn is_resumed(&self) -> bool {

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -490,10 +490,10 @@ fn handshake_confirmation(
     let flight = test_utils::emit_flight(&mut pipe.server).unwrap();
 
     assert!(!pipe.client.is_established());
-    assert!(!pipe.client.handshake_confirmed);
+    assert!(!pipe.client.is_handshake_confirmed());
 
     assert!(!pipe.server.is_established());
-    assert!(!pipe.server.handshake_confirmed);
+    assert!(!pipe.server.is_handshake_confirmed());
 
     test_utils::process_flight(&mut pipe.client, flight).unwrap();
 
@@ -501,10 +501,10 @@ fn handshake_confirmation(
     let flight = test_utils::emit_flight(&mut pipe.client).unwrap();
 
     assert!(pipe.client.is_established());
-    assert!(!pipe.client.handshake_confirmed);
+    assert!(!pipe.client.is_handshake_confirmed());
 
     assert!(!pipe.server.is_established());
-    assert!(!pipe.server.handshake_confirmed);
+    assert!(!pipe.server.is_handshake_confirmed());
 
     test_utils::process_flight(&mut pipe.server, flight).unwrap();
 
@@ -512,10 +512,10 @@ fn handshake_confirmation(
     let flight = test_utils::emit_flight(&mut pipe.server).unwrap();
 
     assert!(pipe.client.is_established());
-    assert!(!pipe.client.handshake_confirmed);
+    assert!(!pipe.client.is_handshake_confirmed());
 
     assert!(pipe.server.is_established());
-    assert!(pipe.server.handshake_confirmed);
+    assert!(pipe.server.is_handshake_confirmed());
 
     test_utils::process_flight(&mut pipe.client, flight).unwrap();
 
@@ -523,18 +523,18 @@ fn handshake_confirmation(
     let flight = test_utils::emit_flight(&mut pipe.client).unwrap();
 
     assert!(pipe.client.is_established());
-    assert!(pipe.client.handshake_confirmed);
+    assert!(pipe.client.is_handshake_confirmed());
 
     assert!(pipe.server.is_established());
-    assert!(pipe.server.handshake_confirmed);
+    assert!(pipe.server.is_handshake_confirmed());
 
     test_utils::process_flight(&mut pipe.server, flight).unwrap();
 
     assert!(pipe.client.is_established());
-    assert!(pipe.client.handshake_confirmed);
+    assert!(pipe.client.is_handshake_confirmed());
 
     assert!(pipe.server.is_established());
-    assert!(pipe.server.handshake_confirmed);
+    assert!(pipe.server.is_handshake_confirmed());
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

Expose QUIC handshake confirmation through the public Rust and C APIs.

This adds:

- `Connection::is_handshake_confirmed()` to the Rust API;
- `quiche_conn_is_handshake_confirmed()` to the C API; and
- documentation describing the difference between handshake completion and confirmation.

For servers, the handshake is confirmed immediately after it completes. For clients, it is confirmed after receiving `HANDSHAKE_DONE`.

## Motivation

`Connection::is_established()` reports that the TLS handshake is complete, but applications may need to know when the QUIC handshake is confirmed. In particular, clients may need to wait for confirmation before performing operations such as connection migration.

The confirmation state already exists internally, but callers currently cannot inspect it. This addresses the API request in #1489 and supports use cases related to the migration requirements discussed in #2631.

This PR only exposes the existing state; it does not change migration enforcement or handshake behavior.

## Testing

- Updated the existing handshake-confirmation test to use the public Rust accessor.
- Added an FFI test verifying that the C and Rust APIs report the same state before and after the handshake.
