### PR TITLE
lib: reject invalid connection close error codes

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -7538,6 +7538,8 @@ impl<F: BufFactory> Connection<F> {
     /// cleared.
     ///
     /// Returns [`Done`] if the connection had already been closed.
+    /// Returns [`InvalidState`] if `err` is not a valid QUIC variable-length
+    /// integer.
     ///
     /// Note that the connection will not be closed immediately. An application
     /// should continue calling the [`recv()`], [`send()`], [`timeout()`] and
@@ -7545,6 +7547,7 @@ impl<F: BufFactory> Connection<F> {
     /// returns `true`.
     ///
     /// [`Done`]: enum.Error.html#variant.Done
+    /// [`InvalidState`]: enum.Error.html#variant.InvalidState
     /// [`recv()`]: struct.Connection.html#method.recv
     /// [`send()`]: struct.Connection.html#method.send
     /// [`timeout()`]: struct.Connection.html#method.timeout
@@ -7557,6 +7560,10 @@ impl<F: BufFactory> Connection<F> {
 
         if self.local_error.is_some() {
             return Err(Error::Done);
+        }
+
+        if err > octets::MAX_VAR_INT {
+            return Err(Error::InvalidState);
         }
 
         let is_safe_to_send_app_data =

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -8752,6 +8752,51 @@ fn close(#[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str) {
 }
 
 #[rstest]
+fn close_rejects_out_of_range_error_code(
+    #[values(false, true)] app: bool,
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut buf = [0; 65535];
+
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    assert_eq!(
+        pipe.client.close(app, octets::MAX_VAR_INT + 1, b"invalid"),
+        Err(Error::InvalidState)
+    );
+    assert_eq!(pipe.client.local_error(), None);
+
+    assert_eq!(
+        pipe.client.close(app, octets::MAX_VAR_INT, b"valid"),
+        Ok(())
+    );
+    assert_eq!(
+        pipe.client.close(app, octets::MAX_VAR_INT + 1, b"invalid"),
+        Err(Error::Done)
+    );
+
+    let (len, _) = pipe.client.send(&mut buf).unwrap();
+    let frames =
+        test_utils::decode_pkt(&mut pipe.server, &mut buf[..len]).unwrap();
+
+    let expected = if app {
+        frame::Frame::ApplicationClose {
+            error_code: octets::MAX_VAR_INT,
+            reason: b"valid".to_vec(),
+        }
+    } else {
+        frame::Frame::ConnectionClose {
+            error_code: octets::MAX_VAR_INT,
+            frame_type: 0,
+            reason: b"valid".to_vec(),
+        }
+    };
+
+    assert_eq!(frames.first(), Some(&expected));
+}
+
+#[rstest]
 fn app_close_by_client(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
 ) {


### PR DESCRIPTION
## Summary

- reject connection-close error codes outside the QUIC variable-length integer range
- leave connection close state untouched when an invalid code is supplied
- preserve `Error::Done` precedence once a close is already pending
- cover transport and application closes at both sides of the 62-bit boundary with Cubic and BBR2

## Testing

- `cargo +nightly fmt -- --check`
- `cargo clippy --release --features=async,ffi,qlog --workspace -- -D warnings`
- `cargo test --release --all-targets --features=async,ffi,qlog --workspace`
- `cargo test --release --doc --features=async,ffi,qlog --workspace`

Fixes #2634