### PR TITLE
Reset the PTO backoff when a packet number space is discarded

### DIFF
--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -864,6 +864,10 @@ impl RecoveryOps for LegacyRecovery {
         epoch.loss_probes = 0;
         epoch.in_flight_count = 0;
 
+        // Discarding a packet number space is forward progress, so the PTO
+        // backoff starts over (RFC 9002, Appendix A.11).
+        self.pto_count = 0;
+
         self.set_loss_detection_timer(handshake_status, now);
     }
 
@@ -1157,6 +1161,25 @@ mod tests {
     use crate::recovery::HandshakeStatus;
     use crate::recovery::RecoveryConfig;
     use std::time::Instant;
+
+    #[test]
+    fn test_pkt_num_space_discard_resets_pto_count() {
+        let config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        let recovery_config = RecoveryConfig::from_config(&config);
+        let mut r = LegacyRecovery::new_with_config(&recovery_config);
+
+        let handshake_status = HandshakeStatus {
+            completed: false,
+            has_handshake_keys: true,
+            peer_verified_address: true,
+        };
+        let now = Instant::now();
+
+        r.pto_count = 3;
+        r.on_pkt_num_space_discarded(Epoch::Initial, handshake_status, now);
+
+        assert_eq!(r.pto_count(), 0);
+    }
 
     #[test]
     fn test_high_pto_count_no_panic() {

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -1012,6 +1012,11 @@ impl RecoveryOps for GRecovery {
         let epoch = &mut self.epochs[epoch];
         self.bytes_in_flight
             .saturating_subtract(epoch.discard(&mut self.pacer), now);
+
+        // Discarding a packet number space is forward progress, so the PTO
+        // backoff starts over (RFC 9002, Appendix A.11).
+        self.pto_count = 0;
+
         self.set_loss_detection_timer(handshake_status, now);
     }
 
@@ -1363,6 +1368,30 @@ mod tests {
         // Time threshold is capped at 2.0.
         assert_eq!(loss_thresh.pkt_thresh(), None);
         assert_eq!(loss_thresh.time_thresh(), MAX_TIME_THRESHOLD);
+    }
+
+    #[test]
+    fn test_pkt_num_space_discard_resets_pto_count() {
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config.set_cc_algorithm(CongestionControlAlgorithm::Bbr2Gcongestion);
+        let recovery_config = RecoveryConfig::from_config(&config);
+        let mut r = GRecovery::new(&recovery_config).unwrap();
+
+        let handshake_status = HandshakeStatus {
+            completed: false,
+            has_handshake_keys: true,
+            peer_verified_address: true,
+        };
+        let now = Instant::now();
+
+        r.pto_count = 3;
+        r.on_pkt_num_space_discarded(
+            packet::Epoch::Initial,
+            handshake_status,
+            now,
+        );
+
+        assert_eq!(r.pto_count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2690.

`on_pkt_num_space_discarded` clears the epoch's sent packets, loss time and probe count and then recomputes the loss detection timer, but it leaves `pto_count` where it was. RFC 9002 Appendix A.11 resets that counter as part of `OnPacketNumberSpaceDiscarded`, on the grounds that discarding keys is forward progress, so a client that took one PTO during the Initial exchange keeps computing `pto() * 2^pto_count` off the old backoff after the handshake moves on. The same path handles Retry, where Section 6.3 asks for loss recovery state to be reset outright.

Both recovery implementations had the omission, so the line goes in twice. Nothing else in either function changes.

Each implementation gets a test next to the existing `test_high_pto_count_no_panic`: set `pto_count` to 3, discard the Initial space, expect the accessor to read 0. Without the fix both fail with `left: 3, right: 0`. `cargo test -p quiche --lib` is 1091 passing with the change in.
