### PR TITLE
bbr2: exit ProbeRTT when in-flight cannot drop below the cwnd floor

### DIFF
--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -729,6 +729,7 @@ impl CongestionControl for BBRv2 {
                 &self.params,
                 recovery_stats,
                 self.get_congestion_window(),
+                self.cwnd_limits.min(),
             )
         {
             mode_changes_allowed -= 1;

--- a/quiche/src/recovery/gcongestion/bbr2/drain.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/drain.rs
@@ -63,7 +63,7 @@ impl ModeImpl for Drain {
         _acked_packets: &[Acked], _lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         _target_bytes_inflight: usize, params: &Params,
-        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize, _min_cwnd: usize,
     ) -> Mode {
         self.model.set_pacing_gain(params.drain_pacing_gain);
         // Only STARTUP can transition to DRAIN, both of them use the same cwnd

--- a/quiche/src/recovery/gcongestion/bbr2/mode.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/mode.rs
@@ -139,7 +139,7 @@ pub(super) trait ModeImpl: Debug {
         acked_packets: &[Acked], lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
-        recovery_stats: &mut RecoveryStats, cwnd: usize,
+        recovery_stats: &mut RecoveryStats, cwnd: usize, min_cwnd: usize,
     ) -> Mode;
 
     fn get_cwnd_limits(&self, params: &Params) -> Limits<usize>;
@@ -191,7 +191,7 @@ impl Mode {
         acked_packets: &[Acked], lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
-        recovery_stats: &mut RecoveryStats, cwnd: usize,
+        recovery_stats: &mut RecoveryStats, cwnd: usize, min_cwnd: usize,
     ) -> bool {
         let mode_before = std::mem::discriminant(self);
 
@@ -205,6 +205,7 @@ impl Mode {
             params,
             recovery_stats,
             cwnd,
+            min_cwnd,
         );
 
         let mode_after = std::mem::discriminant(self);
@@ -269,7 +270,7 @@ impl ModeImpl for Placeholder {
     fn on_congestion_event(
         self, _: usize, _: Instant, _: &[Acked], _: &[Lost],
         _: &mut BBRv2CongestionEvent, _: usize, _params: &Params,
-        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize, _min_cwnd: usize,
     ) -> Mode {
         unreachable!()
     }

--- a/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
@@ -95,7 +95,7 @@ impl ModeImpl for ProbeBW {
         mut self, prior_in_flight: usize, event_time: Instant, _: &[Acked],
         _: &[Lost], congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
-        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize, _min_cwnd: usize,
     ) -> Mode {
         if congestion_event.end_of_round_trip {
             if self.cycle.start_time != event_time {

--- a/quiche/src/recovery/gcongestion/bbr2/probe_rtt.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_rtt.rs
@@ -91,12 +91,17 @@ impl ModeImpl for ProbeRTT {
         _acked_packets: &[Acked], _lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         _target_bytes_inflight: usize, params: &Params,
-        _recovery_stats: &mut RecoveryStats, _cwnd: usize,
+        _recovery_stats: &mut RecoveryStats, _cwnd: usize, min_cwnd: usize,
     ) -> Mode {
         match self.exit_time {
             None => {
+                // The sender's cwnd never drops below `min_cwnd`, so when the
+                // inflight target is below that floor in-flight can't reach
+                // it. Start the exit timer at the floor as well, otherwise the
+                // connection would stay in ProbeRTT indefinitely.
                 if congestion_event.bytes_in_flight <=
-                    self.inflight_target(params)
+                    self.inflight_target(params) ||
+                    congestion_event.bytes_in_flight <= min_cwnd
                 {
                     self.exit_time = Some(
                         congestion_event.event_time + params.probe_rtt_duration,

--- a/quiche/src/recovery/gcongestion/bbr2/startup.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/startup.rs
@@ -63,7 +63,7 @@ impl ModeImpl for Startup {
         _acked_packets: &[Acked], _lost_packets: &[Lost],
         congestion_event: &mut BBRv2CongestionEvent,
         _target_bytes_inflight: usize, params: &Params,
-        recovery_stats: &mut RecoveryStats, cwnd: usize,
+        recovery_stats: &mut RecoveryStats, cwnd: usize, _min_cwnd: usize,
     ) -> Mode {
         if self.model.full_bandwidth_reached() {
             return self.into_drain(event_time, Some(congestion_event), params);


### PR DESCRIPTION
Fixes #2698.

In BBRv2 the only way to leave PROBE_RTT is to see `bytes_in_flight` at or below the inflight target (0.5 × BDP), which arms the 200ms exit timer. But the sender's cwnd is floored at `cwnd_limits.min()` (the initial window), and that floor is applied *after* the PROBE_RTT cap. When the target is below the floor, a saturated sender keeps in-flight pinned at the floor, the timer is never armed, and the connection stays in PROBE_RTT indefinitely with cwnd stuck at the initial window.

Google's reference implementation guards against this with a second clause in the exit check (`bbr2_probe_rtt.cc`):

```cpp
if (congestion_event.bytes_in_flight <= InflightTarget() ||
    congestion_event.bytes_in_flight <= sender_->GetMinimumCongestionWindow()) {
  exit_time_ = congestion_event.event_time + Params().probe_rtt_duration;
```

The port dropped it. This PR restores it: the sender's `cwnd_limits.min()` is passed into `ModeImpl::on_congestion_event` as `min_cwnd` (next to the existing `cwnd` argument) and `ProbeRTT` arms the exit timer when in-flight reaches either the target or that floor. When the target is below the floor PROBE_RTT degrades to a plain 200ms dwell, matching the reference.

Not changed here: the floor itself is still the initial window rather than Google's constant `4 × MSS`. That is a separate, wider behavioral change.
