### PR TITLE
recovery: fix loss time selection across packet number spaces

### DIFF
--- a/quiche/src/recovery/congestion/recovery.rs
+++ b/quiche/src/recovery/congestion/recovery.rs
@@ -444,7 +444,11 @@ impl LegacyRecovery {
         // Iterate over all packet number spaces starting from Handshake.
         for e in [Epoch::Handshake, Epoch::Application] {
             let new_time = self.epochs[e].loss_time;
-            if time.is_none() || new_time < time {
+
+            // Skip spaces without a loss time: comparing the options
+            // directly would let None, which sorts before Some(_),
+            // overwrite an existing deadline.
+            if new_time.is_some() && (time.is_none() || new_time < time) {
                 time = new_time;
                 epoch = e;
             }
@@ -1156,7 +1160,33 @@ mod tests {
     use super::*;
     use crate::recovery::HandshakeStatus;
     use crate::recovery::RecoveryConfig;
+    use std::time::Duration;
     use std::time::Instant;
+
+    // Regression test for the loss time selection across packet number
+    // spaces: a space without a loss time must not overwrite the deadline
+    // of an earlier space, per RFC 9002 Section 6.2.1.
+    //
+    // https://github.com/cloudflare/quiche/issues/2694
+    #[test]
+    fn loss_time_and_space_ignores_empty_spaces() {
+        let config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        let recovery_config = RecoveryConfig::from_config(&config);
+        let mut r = LegacyRecovery::new_with_config(&recovery_config);
+
+        let now = Instant::now();
+
+        r.epochs[Epoch::Initial].loss_time =
+            Some(now + Duration::from_millis(30));
+        r.epochs[Epoch::Handshake].loss_time =
+            Some(now + Duration::from_millis(10));
+        r.epochs[Epoch::Application].loss_time = None;
+
+        let (loss_time, epoch) = r.loss_time_and_space();
+
+        assert_eq!(loss_time, Some(now + Duration::from_millis(10)));
+        assert_eq!(epoch, Epoch::Handshake);
+    }
 
     #[test]
     fn test_high_pto_count_no_panic() {

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -601,7 +601,11 @@ impl GRecovery {
         // Iterate over all packet number spaces starting from Handshake.
         for e in [packet::Epoch::Handshake, packet::Epoch::Application] {
             let new_time = self.epochs[e].loss_time;
-            if time.is_none() || new_time < time {
+
+            // Skip spaces without a loss time: comparing the options
+            // directly would let None, which sorts before Some(_),
+            // overwrite an existing deadline.
+            if new_time.is_some() && (time.is_none() || new_time < time) {
                 time = new_time;
                 epoch = e;
             }
@@ -1263,6 +1267,36 @@ impl std::fmt::Debug for GRecovery {
 mod tests {
     use super::*;
     use crate::Config;
+    use std::time::Duration;
+    use std::time::Instant;
+
+    // Regression test for the loss time selection across packet number
+    // spaces: a space without a loss time must not overwrite the deadline
+    // of an earlier space, per RFC 9002 Section 6.2.1.
+    //
+    // https://github.com/cloudflare/quiche/issues/2694
+    #[test]
+    fn loss_time_and_space_ignores_empty_spaces() {
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config.set_cc_algorithm(
+            crate::recovery::CongestionControlAlgorithm::Bbr2Gcongestion,
+        );
+        let recovery_config = RecoveryConfig::from_config(&config);
+        let mut r = GRecovery::new(&recovery_config).unwrap();
+
+        let now = Instant::now();
+
+        r.epochs[packet::Epoch::Initial].loss_time =
+            Some(now + Duration::from_millis(30));
+        r.epochs[packet::Epoch::Handshake].loss_time =
+            Some(now + Duration::from_millis(10));
+        r.epochs[packet::Epoch::Application].loss_time = None;
+
+        let (loss_time, epoch) = r.loss_time_and_space();
+
+        assert_eq!(loss_time, Some(now + Duration::from_millis(10)));
+        assert_eq!(epoch, packet::Epoch::Handshake);
+    }
 
     #[test]
     fn loss_threshold() {


### PR DESCRIPTION
Fixes #2694

## Summary

`loss_time_and_space()` in both recovery implementations compared `Option<Instant>` values directly:

```rust
if time.is_none() || new_time < time {
```

In Rust, `None < Some(_)` is `true`, so a packet number space with no loss time could overwrite an earlier space's valid deadline. The RFC 9002 Section 6.2.1 `GetLossTimeAndSpace()` pseudocode guards this with `time == 0` checks: an absent deadline (0) must never replace an existing one.

Concretely, with `Initial = Some(t+30ms)`, `Handshake = Some(t+10ms)`, `Application = None`, the helper returned `(None, Application)` instead of `(Some(t+10ms), Handshake)`. Both `set_loss_detection_timer()` and `on_loss_detection_timeout()` then missed the time-threshold loss-detection branch: the timer fell through to the PTO path and pending time-threshold loss detection was delayed or skipped.

## Solution

Skip spaces without a loss time during the scan instead of comparing the options directly:

```rust
if new_time.is_some() && (time.is_none() || new_time < time) {
```

Applied identically to `quiche/src/recovery/congestion/recovery.rs` and `quiche/src/recovery/gcongestion/recovery.rs`, which share the same helper logic but intentionally keep parallel implementations.

## Testing

- Added `loss_time_and_space_ignores_empty_spaces` to both implementations' test modules, reproducing the exact scenario from the issue. Verified it fails against the pre-fix code (`left: None`, matching the reported behavior) and passes after the fix.
- `cargo test -p quiche --lib`: 1091 passed
- `cargo test --workspace --all-targets --features=async,ffi,qlog`: all passed (including BBR2-gcongestion parameterized tests)
- `cargo test --doc --features=async,ffi,qlog --workspace`: all passed
- `cargo +nightly fmt -- --check`: clean
- `cargo clippy --features=async,ffi,qlog --workspace -- -D warnings`: clean
