### PR TITLE
reformat comments

### DIFF
--- a/apps/src/bin/quiche-server.rs
+++ b/apps/src/bin/quiche-server.rs
@@ -495,8 +495,8 @@ fn main() {
                 let conn = &mut client.conn;
                 let partial_responses = &mut client.partial_responses;
 
-                // Visit all writable response streams to send any remaining HTTP
-                // content.
+                // Visit all writable response streams to send any remaining
+                // HTTP content.
                 for stream_id in writable_response_streams(conn) {
                     http_conn.handle_writable(conn, partial_responses, stream_id);
                 }
@@ -540,7 +540,7 @@ fn main() {
         // packets to be sent.
         continue_write = false;
         for client in clients.values_mut() {
-            // Reduce max_send_burst by 25% if loss is increasing more than 0.1%.
+            // Reduce `max_send_burst` by 25% when loss rises by more than 0.1%.
             let loss_rate =
                 client.conn.stats().lost as f64 / client.conn.stats().sent as f64;
             if loss_rate > client.loss_rate + 0.001 {

--- a/buffer-pool/src/buffer.rs
+++ b/buffer-pool/src/buffer.rs
@@ -85,10 +85,9 @@ impl ConsumeBuffer {
     }
 
     pub fn into_vec(mut self) -> Vec<u8> {
-        // As ConsumeBuffer has a Drop impl we have use `take` to get at the inner
-        // vec out instead of being able to move it out directly. This also means
-        // we need to update the metrics by hand as the buffer is no longer owned
-        // by us.
+        // `ConsumeBuffer` implements Drop, so use `take` instead of moving the
+        // vector out directly. Update metrics manually because this object no
+        // longer owns the buffer.
         let mut inner = std::mem::take(&mut self.inner);
         consume_buffer_total_bytes().dec_by(inner.capacity() as u64);
         inner.drain(0..self.head);

--- a/buffer-pool/src/lib.rs
+++ b/buffer-pool/src/lib.rs
@@ -312,9 +312,8 @@ mod tests {
             bufs.len() as u64
         );
 
-        // Now drop the buffers, they will not go into the pool because they have
-        // no capacity, so reuse returns false. What is the point in
-        // pooling empty buffers?
+        // Empty buffers cannot be reused, so dropping them does not return them
+        // to the pool.
         drop(bufs);
         assert_eq!(buffer_pool::pool_active_count(POOL_NAME).get(), 0);
         assert_eq!(buffer_pool::pool_idle_count(POOL_NAME).get(), 0);

--- a/datagram-socket/src/buffer.rs
+++ b/datagram-socket/src/buffer.rs
@@ -188,8 +188,8 @@ impl std::fmt::Debug for DgramBuffer {
         }
 
         write!(f, "[0x")?;
-        // Render payload bytes as two-char hex, underscore-separated after every
-        // 4.
+        // Render bytes as two hexadecimal digits, separated every four bytes by
+        // an underscore.
         for (i, byte) in self.as_slice().iter().enumerate() {
             if i > 0 && i % 4 == 0 {
                 f.write_str("_")?;

--- a/h3i/examples/content_length_mismatch.rs
+++ b/h3i/examples/content_length_mismatch.rs
@@ -69,8 +69,8 @@ fn main() {
         },
     ];
 
-    // This example doesn't use close trigger frames, since we manually close the
-    // connection upon receiving a HEADERS frame on stream 0.
+    // This example needs no close-trigger frames because it closes the
+    // connection after receiving HEADERS on stream 0.
     let close_trigger_frames = None;
 
     let summary = sync_client::connect(config, actions, close_trigger_frames)

--- a/h3i/src/client/async_client.rs
+++ b/h3i/src/client/async_client.rs
@@ -185,8 +185,8 @@ impl Future for BuildingConnectionSummary {
         mut self: Pin<&mut Self>, cx: &mut Context<'_>,
     ) -> Poll<Self::Output> {
         while let Poll::Ready(Some(record)) = self.rx.poll_recv(cx) {
-            // Grab all records received from the current event loop iteration and
-            // insert them into the in-progress summary
+            // Add all records from the current event loop iteration to the
+            // in-progress summary.
             let summary = self.summary.as_mut().expect("summary already taken");
 
             match record {
@@ -319,17 +319,16 @@ impl ApplicationOverQuic for H3iDriver {
     }
 
     fn should_act(&self) -> bool {
-        // Even if the connection wasn't established, we should still send
-        // terminal records to the summary
+        // Send terminal records even without an established connection.
         true
     }
 
     fn process_reads(&mut self, qconn: &mut QuicheConnection) -> QuicResult<()> {
         log::trace!("h3i: process_reads");
 
-        // This is executed in process_reads so that work_loop can clear any waits
-        // on the current event loop iteration - if it was in process_writes, we
-        // could potentially miss waits and hang the client.
+        // Register waits during `process_reads()` so `work_loop()` can clear
+        // them during the current event loop iteration. Registering them during
+        // `process_writes()` could miss waits and hang the client.
         self.register_waits();
 
         let stream_events = parse_streams(qconn, self);
@@ -379,10 +378,9 @@ impl ApplicationOverQuic for H3iDriver {
                     }
                 },
                 Action::Wait { .. } => {
-                    // Break out of the write phase if we see a wait, since waits
-                    // have to be registered in the read
-                    // phase. The actions_executed pointer will be
-                    // incremented there as well
+                    // Waits are registered during the read phase. Stop here so
+                    // that phase can register this wait and increment
+                    // `actions_executed`.
                     break;
                 },
                 Action::FlushPackets => {
@@ -403,8 +401,8 @@ impl ApplicationOverQuic for H3iDriver {
         let sleep_fut = if !self.should_fire() {
             sleep_until(self.next_fire_time)
         } else {
-            // If we have nothing to send, allow the IOW to resolve wait_for_data
-            // on its own (whether via Quiche timer or incoming data).
+            // If there is nothing to send, let the IOW resolve `wait_for_data`
+            // through a QUIC timer or incoming data.
             sleep(Duration::MAX)
         };
 

--- a/h3i/src/client/mod.rs
+++ b/h3i/src/client/mod.rs
@@ -316,9 +316,8 @@ pub(crate) fn execute_action<F: quiche::BufFactory>(
                 *error_code,
             ) {
                 log::error!("can't send reset_stream: {e}");
-                // Clients can't reset streams they don't own. If we attempt to do
-                // this, stream_shutdown would fail, and we
-                // shouldn't create a parser.
+                // Clients cannot reset streams they do not own. If attempted,
+                // `stream_shutdown()` fails and no parser should be created.
                 return;
             }
 
@@ -343,8 +342,8 @@ pub(crate) fn execute_action<F: quiche::BufFactory>(
                 log::error!("can't send stop_sending: {e}");
             }
 
-            // A `STOP_SENDING` should elicit a `RESET_STREAM` in response, which
-            // the frame parser can automatically handle.
+            // A `STOP_SENDING` should elicit a `RESET_STREAM` in response,
+            // which the frame parser can automatically handle.
             stream_parsers
                 .entry(*stream_id)
                 .or_insert_with(|| FrameParser::new(*stream_id));

--- a/h3i/src/frame_parser.rs
+++ b/h3i/src/frame_parser.rs
@@ -141,8 +141,8 @@ impl FrameParser {
             match self.curr_state {
                 FrameState::Type => {
                     let Ok(varint) = self.try_consume_varint() else {
-                        // Map Error::Done's to Retry's because state_buf must be
-                        // resized to fit a larger varint
+                        // Map `Error::Done` to `Retry` because `state_buf` must
+                        // be resized before it can hold a larger varint.
                         return Ok(FrameParseResult::Retry);
                     };
 
@@ -151,8 +151,8 @@ impl FrameParser {
                 },
                 FrameState::Len => {
                     let Ok(varint) = self.try_consume_varint() else {
-                        // Map Error::Done's to Retry's because state_buf must be
-                        // resized to fit a larger varint
+                        // Map `Error::Done` to `Retry` because `state_buf` must
+                        // be resized before it can hold a larger varint.
                         return Ok(FrameParseResult::Retry);
                     };
 

--- a/netlog/src/quic.rs
+++ b/netlog/src/quic.rs
@@ -107,8 +107,8 @@ pub struct TransportParameters {
 impl From<String> for TransportParameters {
     // Example string:
     // [Client legacy[version 00000001] [chosen_version 00000001 other_versions
-    // 00000001] max_idle_timeout 30000 max_udp_payload_size 1472 initial_max_data
-    // 15728640 initial_max_stream_data_bidi_local 6291456
+    // 00000001] max_idle_timeout 30000 max_udp_payload_size 1472
+    // initial_max_data 15728640 initial_max_stream_data_bidi_local 6291456
     // initial_max_stream_data_bidi_remote 6291456 initial_max_stream_data_uni
     // 6291456 initial_max_streams_bidi 100 initial_max_streams_uni 103
     // initial_source_connection_id 0 max_datagram_frame_size 65536]

--- a/qlog-dancer/src/datastore.rs
+++ b/qlog-dancer/src/datastore.rs
@@ -836,8 +836,8 @@ impl Datastore {
 
                 if let Some(sb) = stream_bind.get(&e.params.source_dependency.id)
                 {
-                    // Hat-tip Olivia Trewin: this one cool trick allows u64's to
-                    // be substracted into a correct i64.
+                    // Wrapping subtraction before casting preserves the signed
+                    // difference between the two `u64` timestamps.
                     req.time_discovery = Some(
                         (sb.request_discovery_time
                             .wrapping_sub(session_start_time)

--- a/qlog-dancer/src/plots/stream_multiplex.rs
+++ b/qlog-dancer/src/plots/stream_multiplex.rs
@@ -429,13 +429,13 @@ pub fn plot_stream_multiplexing(
         let bubble_sizes = [1, 6, 11, 16, 21, 26, 31];
 
         for (time, length) in data_frames {
-            // TODO: replace with div_ceil once stablized- https://github.com/rust-lang/rust/issues/88581
+            // TODO: Replace this calculation with `div_ceil`.
             let i: usize = (length / bucket_size) as usize +
                 usize::from(length % bucket_size != 0);
             let i = i.saturating_sub(1);
 
-            // TODO: there seems to be a bug if the bubble is greater th x_max it
-            // would still apear. So let's just avoid that.
+            // Bubbles beyond `x_max` still appear due to a plotting bug, so
+            // omit them.
             if time > &x_max {
                 continue;
             }

--- a/qlog-dancer/src/seriesstore.rs
+++ b/qlog-dancer/src/seriesstore.rs
@@ -267,8 +267,7 @@ impl SeriesStore {
         if let Some(onertt_pkts) =
             &data_store.packet_sent.get(&crate::PacketType::OneRtt)
         {
-            // TODO: perhaps better to take these counts when processing recovery
-            // metrics
+            // TODO: Gather these counts during recovery-metric processing.
             let mut sent_count = 0;
             let mut delivered_count = 0;
             let mut lost_count = 0;
@@ -284,8 +283,8 @@ impl SeriesStore {
                     (pkt_info.created_time, sent_count),
                 );
 
-                // Hacky way to detect lost packets. We don't have the actual
-                // time the loss happened, so just reuse the packet creation time
+                // The actual loss time is unavailable, so use the packet's
+                // creation time.
                 if pkt_info.acked.is_none() {
                     self.onertt_packet_lost_hacky
                         .push((pkt_info.created_time, *pkt_num));

--- a/qlog-dancer/src/wirefilter.rs
+++ b/qlog-dancer/src/wirefilter.rs
@@ -186,8 +186,7 @@ mod tests {
         }
     }
 
-    // Events aren't clonable in the version of qlog we have, so lazy solution for
-    // now
+    // Events are not cloneable in this qlog version, so use a helper.
     fn events() -> Vec<Event> {
         let mut events = vec![];
         let scid = [0x7e, 0x37, 0xe4, 0xdc, 0xc6, 0x68, 0x2d, 0xa8];

--- a/qlog/src/testing/event_tests.rs
+++ b/qlog/src/testing/event_tests.rs
@@ -347,8 +347,8 @@ fn ack_frame_serialize_mixed_ranges() {
 
 #[test]
 fn ack_frame_serialize_unordered_ranges() {
-    // draft-ietf-quic-qlog-quic-events-12 specified that ack ranges can be in any
-    // order
+    // `draft-ietf-quic-qlog-quic-events-12` specified that ACK ranges can
+    // appear in any order.
     let frame = QuicFrame::Ack {
         ack_delay: None,
         acked_ranges: Some(vec![
@@ -389,8 +389,8 @@ fn ack_frame_roundtrip() {
 
 #[test]
 fn ack_frame_roundtrip_preserve_order() {
-    // draft-ietf-quic-qlog-quic-events-12 specifies that ack ranges may appear in
-    // any order.
+    // `draft-ietf-quic-qlog-quic-events-12` specifies that ACK ranges may
+    // appear in any order.
     let frame = QuicFrame::Ack {
         ack_delay: Some(1.5),
         acked_ranges: Some(vec![

--- a/quiche/examples/http3-client.rs
+++ b/quiche/examples/http3-client.rs
@@ -213,7 +213,7 @@ fn main() {
             break;
         }
 
-        // Create a new HTTP/3 connection once the QUIC connection is established.
+        // Create an HTTP/3 connection after QUIC is established.
         if conn.is_established() && http3_conn.is_none() {
             http3_conn = Some(
                 quiche::h3::Connection::with_transport(&mut conn, &h3_config)

--- a/quiche/src/cid.rs
+++ b/quiche/src/cid.rs
@@ -509,8 +509,8 @@ impl ConnectionIdentifiers {
         // After processing a NEW_CONNECTION_ID frame and adding and retiring
         // active connection IDs, if the number of active connection IDs exceeds
         // the value advertised in its active_connection_id_limit transport
-        // parameter, an endpoint MUST close the connection with an error of type
-        // CONNECTION_ID_LIMIT_ERROR.
+        // parameter, an endpoint MUST close the connection with an error of
+        // type CONNECTION_ID_LIMIT_ERROR.
         if retire_prior_to > self.largest_peer_retire_prior_to {
             let retired = &mut self.retire_dcid_seqs;
 

--- a/quiche/src/h3/frame.rs
+++ b/quiche/src/h3/frame.rs
@@ -1103,9 +1103,8 @@ mod tests {
 
     #[test]
     fn settings_h2_prohibited() {
-        // We need to test the prohibited values (0x0 | 0x2 | 0x3 | 0x4 | 0x5)
-        // but the quiche API doesn't support that, so use a manually created
-        // frame data buffer where d[frame_header_len] is the SETTING type field.
+        // Test prohibited values manually because the quiche API cannot create
+        // them. `d[frame_header_len]` contains the SETTINGS type.
         let frame_payload_len = 2u64;
         let frame_header_len = 2;
         let mut d = [

--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -1650,10 +1650,8 @@ impl Connection {
                 let (mut n, rem) =
                     conn.stream_send_zc(stream_id, body.clone(), fin)?;
                 if rem.as_ref().is_some_and(|v| !v.as_ref().is_empty()) {
-                    // `rem` should always be None or empty.
-                    // `do_send_body()` should have checked the capacity and
-                    // ensured that there is enough capacity to write the header +
-                    // fully body.
+                    // `do_send_body()` checked capacity before this write, so
+                    // `rem` should always be `None` or empty.
                     debug_assert!(false);
                     return Err(Error::InternalError);
                 }
@@ -2798,8 +2796,8 @@ impl Connection {
                         Err(_) => continue,
                     };
 
-                    // DATA frames are handled uniquely. After this point we lose
-                    // visibility of DATA framing, so just log here.
+                    // DATA frames are handled uniquely. Log them here because
+                    // DATA framing is no longer visible after this point.
                     if Some(frame::DATA_FRAME_TYPE_ID) == stream.frame_type() {
                         trace!(
                             "{} rx frm DATA stream={} wire_payload_len={}",
@@ -2860,10 +2858,8 @@ impl Connection {
                         Ok(ev) => return Ok(ev),
 
                         Err(Error::Done) => {
-                            // This might be a frame that is processed internally
-                            // without needing to bubble up to the user as an
-                            // event. Check whether the frame has FIN'd by QUIC
-                            // to prevent trying to read again on a closed stream.
+                            // Internal frames do not produce events. Avoid
+                            // reading again if QUIC marked the stream finished.
                             if conn.stream_finished(stream_id) {
                                 break;
                             }
@@ -4017,9 +4013,8 @@ mod tests {
         assert_eq!(s.poll_client(), Ok((stream, Event::Data)));
         assert_eq!(s.poll_client(), Err(Error::Done));
 
-        // We expect to be able to read multiple data frames in a single call and
-        // reads don't have to end on frame boundaries. So let's try to read
-        // 1.5 times the amount we sent in one frame.
+        // Reads may span multiple DATA frames and need not end at frame
+        // boundaries. Read one and a half times the payload of one frame.
         let how_much_to_read_per_call = data.len() * 2 / 3;
         let mut remaining_to_read = total_data_frames * data.len();
         let mut recv_buf = Vec::new().limit(how_much_to_read_per_call);
@@ -6314,8 +6309,8 @@ mod tests {
         s.handshake().unwrap();
 
         // After the HTTP handshake, some bytes of connection flow control have
-        // been consumed. Fill the connection with more grease data on the control
-        // stream.
+        // been consumed. Fill the connection with more grease data on the
+        // control stream.
         let d = [42; 28];
         assert_eq!(s.pipe.client.stream_send(2, &d, false), Ok(23));
 
@@ -6440,7 +6435,8 @@ mod tests {
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
         config.set_application_protos(&[b"h3"]).unwrap();
-        config.set_initial_max_data(10000); // large connection-level flow control
+        // Use generous connection-level flow control.
+        config.set_initial_max_data(10000);
         config.set_initial_max_stream_data_bidi_local(80);
         config.set_initial_max_stream_data_bidi_remote(80);
         config.set_initial_max_stream_data_uni(150);
@@ -6574,7 +6570,8 @@ mod tests {
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
         config.set_application_protos(&[b"h3"]).unwrap();
-        config.set_initial_max_data(100000); // large connection-level flow control
+        // Use generous connection-level flow control.
+        config.set_initial_max_data(100000);
         config.set_initial_max_stream_data_bidi_local(100000);
         config.set_initial_max_stream_data_bidi_remote(50000);
         config.set_initial_max_stream_data_uni(150);
@@ -6646,7 +6643,8 @@ mod tests {
             .load_priv_key_from_pem_file("examples/cert.key")
             .unwrap();
         config.set_application_protos(&[b"h3"]).unwrap();
-        config.set_initial_max_data(100000); // large connection-level flow control
+        // Use generous connection-level flow control.
+        config.set_initial_max_data(100000);
         config.set_initial_max_stream_data_bidi_local(100000);
         config.set_initial_max_stream_data_bidi_remote(50000);
         config.set_initial_max_stream_data_uni(150);
@@ -6818,7 +6816,7 @@ mod tests {
 
         s.advance().ok();
 
-        // Once the server gives flow control credits back, we can send the body.
+        // Flow-control credit from the server allows the body to be sent.
         assert_eq!(s.pipe.client.stream_writable_next(), Some(0));
         assert_eq!(s.client.send_body(&mut s.pipe.client, 0, b"", true), Ok(0));
     }
@@ -7780,7 +7778,7 @@ mod tests {
 
         assert_eq!(s.recv_body_server(r1_id, &mut recv_buf), Ok(r1_body.len()));
 
-        // Send a new request to ensure cross-stream events don't break rearming.
+        // Send a new request to test cross-stream event rearming.
         let (r2_id, r2_hdrs) = s.send_request(false).unwrap();
         let r2_ev_headers = Event::Headers {
             list: r2_hdrs,
@@ -7844,7 +7842,7 @@ mod tests {
             more_frames: true,
         };
 
-        // Manually send an incomplete DATA frame (i.e. only the header is sent).
+        // Manually send an incomplete DATA frame containing only its header.
         {
             let mut d = [42; 10];
             let mut b = octets::OctetsMut::with_slice(&mut d);

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1619,18 +1619,17 @@ pub fn accept(
     accept_with_buf_factory(scid, odcid, local, peer, config)
 }
 
-/// Creates a new server-side connection, with a custom buffer generation
-/// method.
+/// Creates a server-side connection with custom buffer generation.
 ///
-/// The buffers generated can be anything that can be drereferenced as a byte
-/// slice. See [`accept`] and [`BufFactory`] for more info.
+/// The buffers generated can be anything that can be dereferenced as a byte
+/// slice. See [`accept`] and [`BufFactory`] for more information.
 #[inline]
 pub fn accept_with_buf_factory<F: BufFactory>(
     scid: &ConnectionId, odcid: Option<&ConnectionId>, local: SocketAddr,
     peer: SocketAddr, config: &mut Config,
 ) -> Result<Connection<F>> {
-    // For connections with `odcid` set, we historically used `retry_source_cid =
-    // scid`. Keep this behavior to preserve backwards compatibility.
+    // Connections with `odcid` historically used `scid` as the retry source
+    // CID. Preserve this behavior for backwards compatibility.
     // `accept_with_retry` allows the SCIDs to be specified separately.
     let retry_cids = odcid.map(|odcid| RetryConnectionIds {
         original_destination_cid: odcid,
@@ -3303,8 +3302,8 @@ impl<F: BufFactory> Connection<F> {
                         .derive_next_packet_key()?,
                 ));
 
-                // `aead_next` is always `Some()` at this point, so the `unwrap()`
-                // will never fail.
+                // `aead_next` is always `Some` at this point, so the
+                // `unwrap()` will never fail.
                 aead = &aead_next.as_ref().unwrap().0;
             }
         }
@@ -3535,8 +3534,8 @@ impl<F: BufFactory> Connection<F> {
                                 mtu_probe
                             );
 
-                            // Ensure the probe is within the supported MTU range
-                            // before updating the max datagram size
+                            // Update the datagram size only after validating
+                            // the MTU.
                             if let Some(current_mtu) =
                                 pmtud.successful_probe(mtu_probe)
                             {
@@ -3657,10 +3656,9 @@ impl<F: BufFactory> Connection<F> {
                             self.streams.collect(stream_id, local);
                         }
 
-                        // Update tx_bufferd to reflect any data that was dropped
-                        // from stream buffers (e.g., data
-                        // marked for retransmission but then
-                        // acked before it could be resent).
+                        // Update `tx_buffered` for data dropped from stream
+                        // buffers, such as retransmission data acknowledged
+                        // before it could be resent.
                         if dropped > 0 {
                             self.streams.sub_tx_buffered(dropped);
                         }
@@ -4004,7 +4002,7 @@ impl<F: BufFactory> Connection<F> {
 
         let send_path = self.paths.get_mut(send_pid)?;
 
-        // Update max datagram size to allow path MTU discovery probe to be sent.
+        // Increase the maximum datagram size for a PMTUD probe.
         if let Some(pmtud) = send_path.pmtud.as_mut() {
             if pmtud.should_probe() {
                 let size = if self.handshake_confirmed || self.handshake_completed
@@ -4496,8 +4494,8 @@ impl<F: BufFactory> Connection<F> {
         let mut is_pmtud_probe = false;
         let mut has_data = false;
 
-        // Whether or not we should explicitly elicit an ACK via PING frame if we
-        // implicitly elicit one otherwise.
+        // Whether a PING frame must explicitly elicit an ACK when no other
+        // frame does so implicitly.
         let ack_elicit_required = path.recovery.should_elicit_ack(epoch);
 
         let header_offset = b.off();
@@ -4578,15 +4576,12 @@ impl<F: BufFactory> Connection<F> {
         if pkt_type == Type::Short {
             // Create PMTUD probe.
             //
-            // In order to send a PMTUD probe the current `left` value, which was
-            // already limited by the current PMTU measure, needs to be ignored,
-            // but the outgoing packet still needs to be limited by
-            // the output buffer size, as well as the congestion
-            // window.
+            // A PMTUD probe must ignore `left`, which is already limited by the
+            // current PMTU. The probe remains limited by the output buffer and
+            // congestion window.
             //
-            // In addition, the PMTUD probe is only generated when the handshake
-            // is confirmed, to avoid interfering with the handshake
-            // (e.g. due to the anti-amplification limits).
+            // Generate PMTUD probes only after handshake confirmation to avoid
+            // interference from anti-amplification limits.
             if let Ok(active_path) = self.paths.get_active_mut() {
                 let should_probe_pmtu = active_path.should_send_pmtu_probe(
                     self.handshake_confirmed,
@@ -4615,11 +4610,11 @@ impl<F: BufFactory> Connection<F> {
                                 // We can't send more because there isn't enough
                                 // space available in the output buffer.
                                 //
-                                // This usually happens when we try to send a new
-                                // packet but failed because cwnd is almost full.
+                                // The congestion window is nearly full. A new
+                                // packet does not fit.
                                 //
-                                // In such case app_limited is set to false here
-                                // to make cwnd grow when ACK is received.
+                                // Clear the app-limited state so ACKs can grow
+                                // the congestion window.
                                 active_path.recovery.update_app_limited(false);
                                 return Err(Error::Done);
                             },
@@ -5262,7 +5257,7 @@ impl<F: BufFactory> Connection<F> {
                 }
 
                 let priority_key = Arc::clone(&stream.priority_key);
-                // If the stream is no longer flushable, remove it from the queue
+                // Remove the stream when it is no longer flushable.
                 if !stream.is_flushable() {
                     self.streams.remove_flushable(&priority_key);
                 } else if stream.incremental {
@@ -5531,7 +5526,7 @@ impl<F: BufFactory> Connection<F> {
     ) -> Result<()> {
         let path = self.paths.get_mut(send_pid)?;
 
-        // It's fine to set the skip counter based on a non-active path's values.
+        // The skip counter may use values from an inactive path.
         let cwnd = path.recovery.cwnd();
         let max_datagram_size = path.recovery.max_datagram_size();
         self.pkt_num_spaces[epoch].on_packet_sent(&sent_pkt);
@@ -6271,12 +6266,9 @@ impl<F: BufFactory> Connection<F> {
                 // inflight data.
                 self.streams.sub_tx_buffered(buffered_len);
 
-                // These drops in qlog are a bit weird, but the only way to ensure
-                // that all bytes that are moved from App to Transport in
-                // stream_do_send are eventually moved from Transport to Dropped.
-                // Ideally we would add a Transport to Network transition also as
-                // a way to indicate when bytes were transmitted vs dropped
-                // without ever being sent.
+                // Match App-to-Transport moves with Transport-to-Dropped moves.
+                // A Network transition would distinguish sent bytes from drops
+                // before transmission.
                 qlog_with_type!(QLOG_DATA_MV, self.qlog, q, {
                     let ev_data = EventData::QuicStreamDataMoved(
                         qlog::events::quic::StreamDataMoved {
@@ -6699,8 +6691,8 @@ impl<F: BufFactory> Connection<F> {
 
         if let Some(max_datagram_size) = max_datagram_size {
             if self.is_established() {
-                // We cap the maximum packet size to 16KB or so, so that it can be
-                // always encoded with a 2-byte varint.
+                // Cap the packet size at 16,383 bytes so a two-byte varint can
+                // always encode it.
                 return cmp::min(16383, max_datagram_size);
             }
         }
@@ -7577,7 +7569,7 @@ impl<F: BufFactory> Connection<F> {
             });
         }
 
-        // When no packet was successfully processed close connection immediately.
+        // Close immediately if no packet was processed successfully.
         if self.recv_count == 0 {
             self.mark_closed();
         }
@@ -8344,8 +8336,7 @@ impl<F: BufFactory> Connection<F> {
                     let largest_acked =
                         p.recovery.get_largest_acked_on_epoch(epoch);
 
-                    // Consider the skip_pn validated if the peer has sent an ack
-                    // for a larger pkt number.
+                    // A higher ACK validates `skip_pn`.
                     if let Some((largest_acked, skip_pn)) =
                         largest_acked.zip(skip_pn)
                     {
@@ -8469,12 +8460,10 @@ impl<F: BufFactory> Connection<F> {
                     // inflight data.
                     self.streams.sub_tx_buffered(buffered_len);
 
-                    // These drops in qlog are a bit weird, but the only way to
-                    // ensure that all bytes that are moved from App to Transport
-                    // in stream_do_send are eventually moved from Transport to
-                    // Dropped.  Ideally we would add a Transport to Network
-                    // transition also as a way to indicate when bytes were
-                    // transmitted vs dropped without ever being sent.
+                    // Match moves from App to Transport with moves from
+                    // Transport to Dropped.
+                    // A Network transition would distinguish sent bytes from
+                    // drops before transmission.
                     qlog_with_type!(QLOG_DATA_MV, self.qlog, q, {
                         let ev_data = EventData::QuicStreamDataMoved(
                             qlog::events::quic::StreamDataMoved {
@@ -8636,8 +8625,8 @@ impl<F: BufFactory> Connection<F> {
 
                 let priority_key = Arc::clone(&stream.priority_key);
 
-                // If the stream is now flushable push it to the flushable queue,
-                // but only if it wasn't already queued.
+                // If the stream became flushable, add it to the queue unless it
+                // is already present.
                 if stream.is_flushable() && !was_flushable {
                     let priority_key = Arc::clone(&stream.priority_key);
                     self.streams.insert_flushable(&priority_key);
@@ -8936,18 +8925,18 @@ impl<F: BufFactory> Connection<F> {
         // Enter the app-limited phase of delivery rate when these conditions
         // are met:
         //
-        // - The remaining capacity is higher than available bytes in cwnd (there
+        // - The remaining capacity exceeds the available bytes in CWND (there
         //   is more room to send).
-        // - New data since the last send() is smaller than available bytes in
-        //   cwnd (we queued less than what we can send).
-        // - There is room to send more data in cwnd.
+        // - New data since the last `send()` is smaller than available bytes in
+        //   CWND (we queued less than what we can send).
+        // - CWND has room for more data.
         //
         // In application-limited phases the transmission rate is limited by the
         // application rather than the congestion control algorithm.
         //
-        // Note that this is equivalent to CheckIfApplicationLimited() from the
-        // delivery rate draft. This is also separate from `recovery.app_limited`
-        // and only applies to delivery rate calculation.
+        // This mirrors `CheckIfApplicationLimited()` from the delivery-rate
+        // draft but affects only delivery-rate calculation, not
+        // `recovery.app_limited`.
         let cwin_available = self
             .paths
             .iter()

--- a/quiche/src/packet.rs
+++ b/quiche/src/packet.rs
@@ -1058,9 +1058,9 @@ impl PktNumManager {
     }
 
     pub fn should_skip_pn(&self, handshake_completed: bool) -> bool {
-        // Only skip a new packet once we have validated  the peer hasn't sent the
-        // current skip packet.  For the purposes of OACK, a skip_pn is
-        // considered validated once we receive an ACK for pn > skip_pn.
+        // Only skip after confirming the peer did not send the current skip
+        // packet. For OACK, an ACK for a higher packet number validates
+        // `skip_pn`.
         let no_current_skip_packet = self.skip_pn.is_none();
         let counter_expired = match self.skip_pn_counter {
             // Skip if counter has expired

--- a/quiche/src/path.rs
+++ b/quiche/src/path.rs
@@ -528,12 +528,10 @@ impl Path {
     /// packets, and it is still OK to fully reinitialize the recovery module to
     /// pickup changes to congestion control config.
     pub fn can_reinit_recovery(&self) -> bool {
-        // The recovery module can be reinitialized until the connection attempts
-        // to send a packet with inflight data. The congestion
-        // controller doesn't track anything interesting until inflight
-        // data is sent. Handshake ACKs may be sent prior to arrival of
-        // the full ClientHello, but the send of ACK only packets
-        // shouldn't prevent the reinit of the recovery module.
+        // Recovery can be reinitialized until the connection sends in-flight
+        // data. The congestion controller has no relevant state before then.
+        // ACK-only packets sent before the full ClientHello arrives should not
+        // prevent reinitialization.
         self.recovery.bytes_in_flight() == 0 &&
             self.recovery.bytes_in_flight_duration() == Duration::ZERO
     }
@@ -640,7 +638,8 @@ impl PathMap {
     pub fn new(
         mut initial_path: Path, max_concurrent_paths: usize, is_server: bool,
     ) -> Self {
-        let mut paths = Slab::with_capacity(1); // most connections only have one path
+        // Most connections only have one path.
+        let mut paths = Slab::with_capacity(1);
         let mut addrs_to_paths = BTreeMap::new();
 
         let local_addr = initial_path.local_addr;
@@ -1110,8 +1109,7 @@ mod tests {
         assert!(path_mgr.get_mut(pid).unwrap().validation_requested());
         assert!(path_mgr.get_mut(pid).unwrap().probing_required());
 
-        // Fake sending of PathChallenge in a packet of MIN_CLIENT_INITIAL_LEN - 1
-        // bytes.
+        // Send `PathChallenge` one byte below `MIN_CLIENT_INITIAL_LEN`.
         let data = rand::rand_u64().to_be_bytes();
         path_mgr.get_mut(pid).unwrap().add_challenge_sent(
             data,

--- a/quiche/src/pmtud.rs
+++ b/quiche/src/pmtud.rs
@@ -535,19 +535,21 @@ mod tests {
             let probe_size = pmtud.get_probe_size();
 
             if probe_size <= target_mtu {
-                // First probe fails (random loss)
+                // The first probe fails due to random loss.
                 pmtud.failed_probe(probe_size);
                 assert_eq!(pmtud.probe_failure_count, 1);
 
-                // Second probe succeeds
+                // The second probe succeeds.
                 pmtud.successful_probe(probe_size);
-                assert_eq!(pmtud.probe_failure_count, 0); // Reset on success
+                // A successful probe resets the failure count.
+                assert_eq!(pmtud.probe_failure_count, 0);
             } else {
-                // Size exceeds MTU - all probes fail
+                // All probes fail because their size exceeds the MTU.
                 let old_probe_size = probe_size;
                 fail_probe_max_times(&mut pmtud, probe_size);
 
-                // After max failures, probe_failure_count resets and size changes
+                // After the maximum failures, `probe_failure_count` resets and
+                // the probe size changes.
                 assert_eq!(pmtud.probe_failure_count, 0);
                 if pmtud.get_pmtu().is_none() {
                     assert!(pmtud.get_probe_size() < old_probe_size);

--- a/quiche/src/ranges.rs
+++ b/quiche/src/ranges.rs
@@ -209,16 +209,16 @@ impl InlineRangeSet {
                         return;
                     }
 
-                    // At this point we know (start <= *e)
+                    // At this point, `start <= *e`.
                     if start < *s {
                         // We know we are completely past the previous range, so
-                        // we can simply adjust the lower bound
+                        // we can simply adjust the lower bound.
                         *s = start;
                     }
 
                     if end > *e {
-                        // We adjusted the upper bound of an existing range, we
-                        // must now check it does not overlap with the next range
+                        // Check for overlap between the expanded range and the
+                        // next range.
                         *e = end;
                         break;
                     } else {

--- a/quiche/src/recovery/bytes_in_flight.rs
+++ b/quiche/src/recovery/bytes_in_flight.rs
@@ -150,8 +150,8 @@ mod tests {
         now += Duration::from_secs(5);
         bytes_in_flight.saturating_subtract(10, now);
         assert_eq!(bytes_in_flight.get(), 0);
-        // Expect the time to be the 7sec + 5sec since those were the open time of
-        // the two bytes in flight intervals.
+        // The two in-flight intervals lasted seven and five seconds, for an
+        // expected total of twelve seconds.
         assert_eq!(bytes_in_flight.get_duration(), Duration::from_secs(12));
     }
 

--- a/quiche/src/recovery/congestion/cubic.rs
+++ b/quiche/src/recovery/congestion/cubic.rs
@@ -232,9 +232,9 @@ fn on_packet_acked(
     // Detecting spurious congestion events.
     // <https://tools.ietf.org/id/draft-ietf-tcpm-rfc8312bis-00.html#section-4.9>
     //
-    // When the recovery episode ends with recovering
-    // a few packets (less than cwnd / mss * ROLLBACK_THRESHOLD_PERCENT(%)), it's
-    // considered as spurious and restore to the previous state.
+    // If recovery ends after fewer than
+    // `cwnd / mss * ROLLBACK_THRESHOLD_PERCENT` packets, treat the congestion
+    // event as spurious and restore the previous state.
     if r.congestion_recovery_start_time.is_some() {
         let new_lost = r.lost_count - r.cubic_state.prior.lost_count;
 

--- a/quiche/src/recovery/congestion/delivery_rate.rs
+++ b/quiche/src/recovery/congestion/delivery_rate.rs
@@ -254,11 +254,10 @@ mod tests {
     use crate::OnAckReceivedOutcome;
     use std::ops::Range;
 
-    // A [RateSample](delivery_rate::RateSample) is app_limited if it was
-    // generated when the [Rate](delivery_rate::Rate) was app_limited.
+    // A `RateSample` generated while `Rate` is app-limited inherits that state.
     //
-    // The following test generates RateSamples before and after Rate is
-    // app_limited and asserts on app_limited status for samples.
+    // This test generates samples before and after `Rate` becomes app-limited
+    // and checks each sample's state.
     #[test]
     fn sample_is_app_limited() {
         let config = Config::new(0xbabababa).unwrap();
@@ -266,57 +265,56 @@ mod tests {
         let mut now = Instant::now();
         let mss = r.max_datagram_size();
 
-        // Not App Limited prior to any activity
+        // `Rate` is not app-limited before any activity.
         assert!(!r.congestion.delivery_rate.app_limited());
         assert_eq!(r.congestion.delivery_rate.end_of_app_limited, 0);
         assert!(!r.congestion.delivery_rate.sample_is_app_limited());
 
-        // Send/Ack first batch to generate a new delivery_rate sample.
+        // Generate a delivery-rate sample from the first batch.
         let rtt = Duration::from_secs(2);
         helper_send_and_ack_packets(&mut r, 0..4, now, rtt, mss);
 
-        // Marking Rate as app_limited.
+        // Mark `Rate` as app-limited.
         r.delivery_rate_update_app_limited(true);
         assert!(r.congestion.delivery_rate.app_limited());
         assert_eq!(r.congestion.delivery_rate.end_of_app_limited, 3);
 
-        // Rate is app_limited.
+        // `Rate` is app-limited.
         assert!(r.congestion.delivery_rate.app_limited());
         assert!(!r.congestion.delivery_rate.sample_is_app_limited());
 
-        // Send/Ack second batch to generate a new delivery_rate sample.
+        // Send and acknowledge the second batch to generate another sample.
         now += rtt;
         helper_send_and_ack_packets(&mut r, 4..8, now, rtt, mss);
 
-        // Rate is no longer app limited since we sent a packet larger than
-        // `end_of_app_limited`
+        // `Rate` is no longer app-limited after sending a packet beyond
+        // `end_of_app_limited`.
         assert!(!r.congestion.delivery_rate.app_limited());
         assert_eq!(r.congestion.delivery_rate.end_of_app_limited, 0);
-        // The RateSample is also app_limited
+        // The resulting `RateSample` remains app-limited.
         assert!(r.congestion.delivery_rate.sample_is_app_limited());
     }
 
-    // A [RateSample](delivery_rate::RateSample) is is only updated if either not
-    // app_limited or greater than the previous value.
+    // A `RateSample` updates the delivery rate only when it is not app-limited
+    // or its rate exceeds the previous value.
     #[test]
     fn app_limited_delivery_rate() {
-        // confirm that rate sample is not generated when app limited
+        // Confirm that a rate sample is not generated when app-limited.
         let config = Config::new(0xbabababa).unwrap();
         let mut r = LegacyRecovery::new(&config);
         let mut now = Instant::now();
         let mss = r.max_datagram_size();
 
-        // Not App Limited prior to any activity
+        // `Rate` is not app-limited before any activity.
         assert!(!r.congestion.delivery_rate.app_limited());
         assert_eq!(r.congestion.delivery_rate.end_of_app_limited, 0);
         assert!(!r.congestion.delivery_rate.sample_is_app_limited());
 
-        // First batch
-        // Send/Ack first batch to generate a new delivery_rate sample.
+        // Generate a delivery-rate sample from the first batch.
         let mut rtt = Duration::from_secs(2);
         helper_send_and_ack_packets(&mut r, 0..2, now, rtt, mss);
 
-        // Marking Rate as app_limited.
+        // Mark `Rate` as app-limited.
         r.delivery_rate_update_app_limited(true);
         assert!(r.congestion.delivery_rate.app_limited());
         assert_eq!(r.congestion.delivery_rate.end_of_app_limited, 1);
@@ -327,50 +325,46 @@ mod tests {
         assert_eq!(expected_delivery_rate, 1200);
         assert_eq!(first_delivery_rate, expected_delivery_rate);
 
-        // Second batch
-        // Since Rtt is larger, the delivery_rate will be smaller and not generate
-        // a new RateSample.
+        // A larger RTT produces a lower delivery rate, which does not replace
+        // the app-limited sample.
         now += rtt;
         rtt = Duration::from_secs(4);
         helper_send_and_ack_packets(&mut r, 2..4, now, rtt, mss);
 
-        // Rate is no longer app limited since we sent a packet larger than
-        // `end_of_app_limited`
+        // `Rate` is no longer app-limited after sending a packet beyond
+        // `end_of_app_limited`.
         assert!(!r.congestion.delivery_rate.app_limited());
         assert_eq!(r.congestion.delivery_rate.end_of_app_limited, 0);
-        // The RateSample is also app_limited
+        // The resulting `RateSample` remains app-limited.
         assert!(r.congestion.delivery_rate.sample_is_app_limited());
 
-        // Delivery rate NOT updated since the delivery rate is less than previous
-        // value
+        // The lower delivery rate does not replace the previous value.
         let expected_delivery_rate = (mss * 2) as u64 / rtt.as_secs();
         assert_eq!(expected_delivery_rate, 600);
         let app_limited_delivery_rate = r.delivery_rate().to_bytes_per_second();
         assert_eq!(app_limited_delivery_rate, first_delivery_rate);
 
-        // Marking Rate as app_limited.
+        // Mark `Rate` as app-limited.
         r.delivery_rate_update_app_limited(true);
         assert!(r.congestion.delivery_rate.app_limited());
         assert_eq!(r.congestion.delivery_rate.end_of_app_limited, 3);
-        // The RateSample is also app_limited
+        // The resulting `RateSample` remains app-limited.
         assert!(r.congestion.delivery_rate.sample_is_app_limited());
 
-        // Third batch
-        // Since Rtt is smaller, the delivery_rate will be larger and not generate
-        // a new RateSample even when app_limited.
+        // A smaller RTT produces a higher delivery rate, which replaces the
+        // previous value even while app-limited.
         now += rtt;
         rtt = Duration::from_secs(1);
         helper_send_and_ack_packets(&mut r, 4..6, now, rtt, mss);
 
-        // Rate is no longer app limited since we sent a packet larger than
-        // `end_of_app_limited`
+        // `Rate` is no longer app-limited after sending a packet beyond
+        // `end_of_app_limited`.
         assert!(!r.congestion.delivery_rate.app_limited());
         assert_eq!(r.congestion.delivery_rate.end_of_app_limited, 0);
-        // The RateSample is also app_limited
+        // The resulting `RateSample` remains app-limited.
         assert!(r.congestion.delivery_rate.sample_is_app_limited());
 
-        // Delivery rate NOT updated since the delivery rate is less than previous
-        // value
+        // The higher delivery rate replaces the previous value.
         let expected_delivery_rate = (mss * 2) as u64 / rtt.as_secs();
         assert_eq!(expected_delivery_rate, 2400);
         let app_limited_delivery_rate = r.delivery_rate().to_bytes_per_second();

--- a/quiche/src/recovery/gcongestion/bbr/bandwidth_sampler.rs
+++ b/quiche/src/recovery/gcongestion/bbr/bandwidth_sampler.rs
@@ -363,8 +363,7 @@ impl MaxAckHeightTracker {
             }
         }
 
-        // If any packet sent after the start of the epoch has been acked, start a
-        // new epoch.
+        // Start a new epoch if this epoch includes any acknowledged packet.
         if self.start_new_aggregation_epoch_after_full_round &&
             last_acked_packet_number >
                 self.last_sent_packet_number_before_epoch
@@ -389,8 +388,8 @@ impl MaxAckHeightTracker {
         let aggregation_delta = ack_time.duration_since(epoch_start_time);
         let expected_bytes_acked =
             bandwidth_estimate.to_bytes_per_period(aggregation_delta) as usize;
-        // Reset the current aggregation epoch as soon as the ack arrival rate is
-        // less than or equal to the max bandwidth.
+        // Reset the current aggregation epoch as soon as the ack arrival rate
+        // is less than or equal to the max bandwidth.
         if self.aggregation_epoch_bytes <=
             (self.ack_aggregation_bandwidth_threshold *
                 expected_bytes_acked as f64) as usize
@@ -638,10 +637,9 @@ impl BandwidthSampler {
         } else if !last_acked_packet_send_state.is_valid {
             event_sample.last_packet_send_state = last_lost_packet_send_state;
         } else {
-            // If two packets are inflight and an alarm is armed to lose a packet
-            // and it wakes up late, then the first of two in flight packets could
-            // have been acknowledged before the wakeup, which re-evaluates loss
-            // detection, and could declare the later of the two lost.
+            // If a loss alarm for two in-flight packets fires late, the first
+            // packet may already be acknowledged. Reevaluating loss detection
+            // could then declare the second packet lost.
             event_sample.last_packet_send_state =
                 if last_acked_packet_num > last_lost_packet_num {
                     last_acked_packet_send_state
@@ -711,9 +709,8 @@ impl BandwidthSampler {
             self.last_acked_packet_ack_time,
             newly_acked_bytes,
         );
-        // If `extra_acked` is zero, i.e. this ack event marks the start of a new
-        // ack aggregation epoch, save `less_recent_point`, which is the
-        // last ack point of the previous epoch, as a A0 candidate.
+        // If `extra_acked` is zero, this ACK starts a new aggregation epoch.
+        // Save the previous epoch's last ACK point as an A0 candidate.
         if self.overestimate_avoidance && extra_acked == 0 {
             self.a0_candidates.push_back(
                 self.recent_ack_points
@@ -742,11 +739,8 @@ impl BandwidthSampler {
         }
 
         if self.is_app_limited {
-            // Exit app-limited phase in two cases:
-            // (1) end_of_app_limited_phase is not initialized, i.e., so far all
-            // packets are sent while there are buffered packets or pending data.
-            // (2) The current acked packet is after the sent packet marked as the
-            // end of the app limit phase.
+            // Exit the app-limited phase if no end packet was recorded, or if
+            // this acknowledged packet was sent after the recorded end packet.
             if self.end_of_app_limited_phase.is_none() ||
                 Some(packet_number) > self.end_of_app_limited_phase
             {
@@ -1062,8 +1056,8 @@ mod bandwidth_sampler_tests {
                 self.advance_time(time_between_packets);
             }
 
-            // Ack packets 1 to 20, while sending new packets at the same rate as
-            // before.
+            // Acknowledge packets 1 to 20 while sending new packets at the same
+            // rate as before.
             for i in 1..=20 {
                 self.ack_packet(i);
                 self.send_packet(i + 20, REGULAR_PACKET_SIZE, true);
@@ -1306,8 +1300,8 @@ mod bandwidth_sampler_tests {
         // Ensure only congestion controlled packets are tracked.
         assert_eq!(10, test_sender.number_of_tracked_packets());
 
-        // Ack packets 2 to 21, ignoring every even-numbered packet, while sending
-        // new packets at the same rate as before.
+        // Acknowledge packets 2 to 21, ignoring every even-numbered packet,
+        // while sending new packets at the same rate as before.
         for i in 1..=20 {
             if i % 2 == 0 {
                 test_sender.ack_packet(i);
@@ -1385,8 +1379,8 @@ mod bandwidth_sampler_tests {
 
         test_sender.send_40_and_ack_first_20(time_between_packets);
 
-        // Ack the packets 21 to 40 in the reverse order, while sending packets 41
-        // to 60.
+        // Acknowledge packets 21 to 40 in reverse order while sending packets
+        // 41 to 60.
         for i in 0..20 {
             let last_bandwidth = test_sender.ack_packet(40 - i).bandwidth;
             assert_eq!(expected_bandwidth, last_bandwidth);
@@ -1434,8 +1428,8 @@ mod bandwidth_sampler_tests {
             test_sender.advance_time(time_between_packets);
         }
 
-        // We are now app-limited. Ack 21 to 40 as usual, but do not send anything
-        // for now.
+        // We are now app-limited. Acknowledge 21 to 40 as usual, but do not
+        // send anything for now.
         test_sender.sampler.on_app_limited();
         for i in 21..=40 {
             let sample = test_sender.ack_packet(i);
@@ -1453,8 +1447,8 @@ mod bandwidth_sampler_tests {
             test_sender.advance_time(time_between_packets);
         }
 
-        // Ack packets 41 to 60, while sending packets 61 to 80.  41 to 60 should
-        // be app-limited and underestimate the bandwidth due to that.
+        // Acknowledge packets 41 to 60 while sending packets 61 to 80. These
+        // app-limited ACKs should underestimate bandwidth.
         for i in 41..=60 {
             let sample = test_sender.ack_packet(i);
             assert!(sample.state_at_send.is_app_limited, "{i}");
@@ -1467,8 +1461,8 @@ mod bandwidth_sampler_tests {
                     expected_bandwidth * 0.7
                 );
             } else {
-                // Needs further investigation: when using overestimate_avoidance,
-                // sample.bandwidth increases 17 packet earlier than expected.
+                // Needs further investigation. With `overestimate_avoidance`,
+                // `sample.bandwidth` rises 17 packets too soon.
                 assert_eq!(sample.bandwidth, expected_bandwidth, "{i}");
             }
             test_sender.send_packet(i + 20, REGULAR_PACKET_SIZE, true);
@@ -1517,9 +1511,8 @@ mod bandwidth_sampler_tests {
             test_sender.advance_time(time_between_packets);
         }
 
-        // The final measured sample for the first flight of sample is expected to
-        // be smaller than the real bandwidth, yet it should not lose more
-        // than 10%. The specific value of the error depends on the
+        // The final sample for the first flight should underestimate the real
+        // bandwidth by no more than 10%. The exact error depends on the
         // difference between the RTT and the time it takes to exhaust the
         // congestion window (i.e. in the limit when all packets are sent
         // simultaneously, last sample would indicate the real bandwidth).

--- a/quiche/src/recovery/gcongestion/bbr/windowed_filter.rs
+++ b/quiche/src/recovery/gcongestion/bbr/windowed_filter.rs
@@ -118,10 +118,8 @@ where
                 sample: new_sample,
                 time: new_time,
             });
-            // Need to iterate one more time. Check if the new best estimate is
-            // outside the window as well, since it may also have been recorded a
-            // long time ago. Don't need to iterate once more since we cover that
-            // case at the beginning of the method.
+            // The new best estimate may also be stale. Check it once more. The
+            // check at the start of the method handles further stale samples.
             if new_time - self.estimates[0].unwrap().time > self.window_length {
                 self.estimates[0] = self.estimates[1];
                 self.estimates[1] = self.estimates[2];
@@ -132,9 +130,8 @@ where
         if self.estimates[1].unwrap().sample == self.estimates[0].unwrap().sample &&
             new_time - self.estimates[1].unwrap().time > self.window_length / 4
         {
-            // A quarter of the window has passed without a better sample, so the
-            // second-best estimate is taken from the second quarter of the
-            // window.
+            // No better sample arrived for a quarter of the window, so take the
+            // second-best estimate from the second quarter.
             self.estimates[1] = Some(Sample {
                 sample: new_sample,
                 time: new_time,

--- a/quiche/src/recovery/gcongestion/bbr2/network_model.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/network_model.rs
@@ -352,10 +352,9 @@ impl BBRv2NetworkModel {
                 sample.last_packet_send_state;
         }
 
-        // Avoid updating `max_bandwidth_filter` if a) this is a loss-only event,
-        // or b) all packets in `acked_packets` did not generate valid
-        // samples. (e.g. ack of ack-only packets). In both cases,
-        // total_bytes_acked() will not change.
+        // Do not update `max_bandwidth_filter` for a loss-only event or when no
+        // acknowledged packet produced a valid sample. In either case,
+        // `total_bytes_acked()` remains unchanged.
         if let Some(sample_max) = sample.sample_max_bandwidth {
             if prior_bytes_acked != self.total_bytes_acked() {
                 congestion_event.sample_max_bandwidth = Some(sample_max);
@@ -539,10 +538,9 @@ impl BBRv2NetworkModel {
             last_bandwidth = sample_max_bandwidth;
         }
         if self.pacing_gain > params.full_bw_threshold {
-            // In STARTUP, `pacing_gain` is applied to `bandwidth_lo` in
-            // update_pacing_rate, so this backs that multiplication out to allow
-            // the pacing rate to decrease, but not below
-            // last_bandwidth * full_bw_threshold.
+            // STARTUP applies `pacing_gain` to `bandwidth_lo`. Remove that
+            // factor so pacing can decrease without falling below
+            // the threshold.
             self.bandwidth_lo = self.bandwidth_lo.max(Some(
                 last_bandwidth * (params.full_bw_threshold / self.pacing_gain),
             ));
@@ -550,8 +548,8 @@ impl BBRv2NetworkModel {
             // Ensure bandwidth_lo isn't lower than last_bandwidth.
             self.bandwidth_lo = self.bandwidth_lo.max(Some(last_bandwidth))
         }
-        // If it's the end of the round, ensure bandwidth_lo doesn't decrease more
-        // than beta.
+        // At the end of a round, ensure `bandwidth_lo` does not decrease by
+        // more than `beta`.
         if congestion_event.end_of_round_trip {
             self.bandwidth_lo = self.bandwidth_lo.max(
                 self.prior_bandwidth_lo

--- a/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
@@ -212,15 +212,13 @@ impl ProbeBW {
         cycle.rounds_in_phase = 0;
 
         if params.bw_lo_mode != BwLoMode::Default {
-            // Clear bandwidth lo if it was set in PROBE_UP, because losses in
-            // PROBE_UP should not permanently change bandwidth_lo.
-            // It's possible for bandwidth_lo to be set during REFILL, but if that
-            // was a valid value, it'll quickly be rediscovered.
+            // Clear `bandwidth_lo` if it was set in PROBE_UP because losses in
+            // that phase should not change it permanently.
+            // A valid REFILL value for `bandwidth_lo` is quickly rediscovered.
             self.model.clear_bandwidth_lo();
         }
 
-        // Pick probe wait time.
-        // TODO(vlad): actually pick time
+        // TODO(vlad): Choose a probe wait time.
         cycle.rounds_since_probe = 0;
         cycle.probe_wait_time = Some(
             params.probe_bw_probe_base_duration + Duration::from_micros(500),
@@ -321,8 +319,8 @@ impl ProbeBW {
         }
 
         // This exit condition is experimental code from Google quiche which
-        // diverges from the RFC. Use `disable_probe_down_early_exit` to override
-        // the behavior.
+        // diverges from the RFC. Use `disable_probe_down_early_exit` to
+        // override the behavior.
         if self.has_stayed_long_enough_in_probe_down(congestion_event, params) {
             self.enter_probe_cruise(congestion_event.event_time);
             return;
@@ -563,8 +561,8 @@ impl ProbeBW {
     // Used to prevent a BBR2 flow from staying in PROBE_DOWN for too
     // long, as seen in some multi-sender simulator tests.
     //
-    // This is experimental code from Google quiche and diverges from the RFC. Use
-    // `disable_probe_down_early_exit` to override the behavior.
+    // This is experimental code from Google quiche and diverges from the RFC.
+    // Use `disable_probe_down_early_exit` to override the behavior.
     // - RFC: https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-02.html#name-probebw_down
     // - Google quiche: https://github.com/google/quiche/blob/b370e7a/quiche/quic/core/congestion_control/bbr2_probe_bw.cc#L142
     fn has_stayed_long_enough_in_probe_down(
@@ -581,9 +579,9 @@ impl ProbeBW {
 
     fn raise_inflight_high_slope(&mut self, cwnd: usize) {
         let growth_this_round = 1usize << self.cycle.probe_up_rounds;
-        // The number 30 below means `growth_this_round` is capped at 1G and the
-        // lower bound of `probe_up_bytes` is (practically) 1 mss, at this
-        // speed `inflight_hi`` grows by approximately 1 packet per packet acked.
+        // Capping rounds at 30 limits `growth_this_round` to 1G and keeps
+        // `probe_up_bytes` near one MSS. This grows `inflight_hi` by about one
+        // packet per ACK.
         self.cycle.probe_up_rounds = self.cycle.probe_up_rounds.add(1).min(30);
         let probe_up_bytes = cwnd / growth_this_round;
         self.cycle.probe_up_bytes = Some(probe_up_bytes.max(DEFAULT_MSS));

--- a/quiche/src/recovery/gcongestion/bbr2/startup.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/startup.rs
@@ -101,8 +101,8 @@ impl ModeImpl for Startup {
         }
 
         // TCP BBR always exits upon excessive losses. QUIC BBRv1 does not exit
-        // upon excessive losses, if enough bandwidth growth is observed or if the
-        // sample was app limited.
+        // upon excessive losses if enough bandwidth growth is observed or the
+        // sample was app-limited.
         let check_for_excessive_loss = !congestion_event.last_packet_send_state.is_app_limited &&
                 !has_bandwidth_growth &&
                 // check for excessive loss only if not exiting for other reasons

--- a/quiche/src/recovery/gcongestion/pacer.rs
+++ b/quiche/src/recovery/gcongestion/pacer.rs
@@ -141,9 +141,8 @@ impl Pacer {
 
         // If in recovery, the connection is not coming out of quiescence.
         if bytes_in_flight == 0 && !self.sender.is_in_recovery() {
-            // Add more burst tokens anytime the connection is leaving quiescence,
-            // but limit it to the equivalent of a single bulk write,
-            // not exceeding the current CWND in packets.
+            // When leaving quiescence, replenish burst tokens up to one bulk
+            // write without exceeding the current CWND in packets.
             self.burst_tokens = self
                 .initial_burst_size
                 .min(self.sender.get_congestion_window_in_packets());
@@ -164,8 +163,8 @@ impl Pacer {
             .transfer_time(bytes as u64);
 
         if !self.pacing_limited || self.lumpy_tokens == 0 {
-            // Reset lumpy_tokens_ if either application or cwnd throttles sending
-            // or token runs out.
+            // Reset `lumpy_tokens` if the application or congestion window
+            // throttles sending, or if the token runs out.
             self.lumpy_tokens = 1.max(LUMPY_PACING_SIZE.min(
                 (self.sender.get_congestion_window_in_packets() as f64 *
                     LUMPY_PACING_CWND_FRACTION) as usize,

--- a/quiche/src/recovery/gcongestion/recovery.rs
+++ b/quiche/src/recovery/gcongestion/recovery.rs
@@ -1347,8 +1347,8 @@ mod tests {
         for subsequent_loss_count in 1..100 {
             // Double the overhead until it caps at `2.0`.
             //
-            // It takes `3` rounds of doubling for INITIAL_TIME_THRESHOLD_OVERHEAD
-            // to equal `1.0`.
+            // The initial time-threshold overhead reaches `1.0` after three
+            // rounds of doubling.
             let new_time_threshold = if subsequent_loss_count <= 3 {
                 1.0 + INITIAL_TIME_THRESHOLD_OVERHEAD *
                     2_f64.powi(subsequent_loss_count as i32)

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -289,8 +289,8 @@ pub trait RecoveryOps {
     #[cfg(test)]
     fn pto_count(&self) -> u32;
 
-    // This value might be `None` when experiment `enable_relaxed_loss_threshold`
-    // is enabled for gcongestion
+    // This value might be `None` when the `enable_relaxed_loss_threshold`
+    // experiment is enabled for gcongestion.
     #[cfg(test)]
     fn pkt_thresh(&self) -> Option<u64>;
 
@@ -1491,9 +1491,9 @@ mod tests {
         let mut r = Recovery::new(&cfg);
         assert_eq!(r.rtt(), DEFAULT_INITIAL_RTT);
 
-        // Pick time between and above thresholds for testing threshold increase.
+        // Choose times around the threshold to test its increase.
         //
-        //```
+        // ```
         //              between_thresh_ms
         //                         |
         //    initial_thresh_ms    |     spurious_thresh_ms
@@ -1502,7 +1502,7 @@ mod tests {
         //      | ................ | ..................... |
         //            THRESH_GAP         THRESH_GAP
         // ```
-        // 
+        //
         // Threshold gap time.
         const THRESH_GAP: Duration = Duration::from_millis(30);
         // Initial time theshold based on inital RTT.
@@ -1652,8 +1652,8 @@ mod tests {
         );
     }
 
-    // TODO: Implement enable_relaxed_loss_threshold and enable this test for the
-    // congestion module.
+    // TODO: Implement `enable_relaxed_loss_threshold` and enable this test for
+    // the congestion module.
     #[rstest]
     fn relaxed_thresholds_on_reordering(
         #[values("bbr2_gcongestion")] cc_algorithm_name: &str,
@@ -1666,9 +1666,9 @@ mod tests {
         let mut r = Recovery::new(&cfg);
         assert_eq!(r.rtt(), DEFAULT_INITIAL_RTT);
 
-        // Pick time between and above thresholds for testing threshold increase.
+        // Choose times around the threshold to test its increase.
         //
-        //```
+        // ```
         //              between_thresh_ms
         //                         |
         //    initial_thresh_ms    |     spurious_thresh_ms
@@ -2839,8 +2839,8 @@ mod tests {
         );
 
         // 3. Acknowledge the Initial packet.
-        // This empties the Initial space, but Application space still has data in
-        // flight.
+        // This empties the Initial space, but Application space still has data
+        // in flight.
         let mut ranges = RangeSet::default();
         ranges.insert(0..1);
         r.on_ack_received(

--- a/quiche/src/stream/mod.rs
+++ b/quiche/src/stream/mod.rs
@@ -1996,8 +1996,8 @@ mod tests {
 
         let mut streams = <StreamMap>::new(100, 100, 100);
 
-        // Streams where the urgency descends (becomes more important). No stream
-        // shares an urgency.
+        // Streams where the urgency descends (becomes more important). No
+        // stream shares an urgency.
         let input = vec![
             (0, 100),
             (4, 90),
@@ -2235,8 +2235,8 @@ mod tests {
             prioritized_writable.iter().map(|s| s.id).collect();
         assert_eq!(walk_1, vec![0, 4, 8, 12]);
 
-        // Default keys could cause duplicate entries, this is normally protected
-        // against via StreamMap.
+        // Default keys could cause duplicate entries. `StreamMap` normally
+        // prevents this.
         for id in [0, 4, 8, 12] {
             let s = Arc::new(StreamPriorityKey {
                 urgency: 0,
@@ -2408,7 +2408,7 @@ mod tests {
 
         let stream_id = 0u64;
 
-        // Write data: both stream.send.buffered_bytes() and tx_buffered increase.
+        // Writing raises `stream.send.buffered_bytes()` and `tx_buffered`.
         {
             let stream = streams
                 .get_or_create(
@@ -2426,7 +2426,7 @@ mod tests {
         assert_eq!(streams.tx_buffered(), 5);
         assert!(streams.tx_buffered_is_consistent());
 
-        // Emit data: both stream.send.buffered_bytes() and tx_buffered decrease.
+        // Emitting lowers `stream.send.buffered_bytes()` and `tx_buffered`.
         let mut buf = [0; 10];
         let written = {
             let stream = streams.get_mut(stream_id).unwrap();
@@ -2439,8 +2439,7 @@ mod tests {
         assert_eq!(streams.tx_buffered(), 0);
         assert!(streams.tx_buffered_is_consistent());
 
-        // Retransmit: both stream.send.buffered_bytes() and tx_buffered increase
-        // by actual amount retransmitted.
+        // Retransmitting raises both values by the amount retransmitted.
         let retransmitted = {
             let stream = streams.get_mut(stream_id).unwrap();
             stream.send.retransmit(0, 5)

--- a/quiche/src/stream/send_buf.rs
+++ b/quiche/src/stream/send_buf.rs
@@ -412,8 +412,8 @@ impl<F: BufFactory> SendBuf<F> {
 
             let prev_pos = buf.pos;
 
-            // Reduce the buffer's position (expand the buffer) if the retransmit
-            // range is past the buffer's starting offset.
+            // Expand the buffer by moving its position back when the retransmit
+            // range starts after the buffer offset.
             buf.pos = if off > buf.off && off <= buf.max_off() {
                 cmp::min(buf.pos, buf.start + (off - buf.off) as usize)
             } else {

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -2754,20 +2754,18 @@ fn streams_blocked_bidi_retransmit(
     // The server has not received anything yet.
     assert_eq!(pipe.server.streams_blocked_bidi_recv_count, 0);
 
-    // Trigger loss detection
+    // Trigger loss detection.
     test_utils::trigger_ack_based_loss(&mut pipe.client, &mut pipe.server);
 
-    // Trigger the lost-frames processing by calling send().  The loss handler
-    // is invoked at the start of each send_on_path() call to process any frames
-    // added to lost_frames by ack-based loss detection.
+    // Trigger lost-frame processing by calling `send()`. The loss handler runs
+    // at the start of each `send_on_path()` call to process frames added to
+    // `lost_frames` by ACK-based loss detection.
     let (len, send_info) = pipe.client.send(&mut buf).unwrap();
 
-    // After the retransmit send the sequence is:
-    //   1. loss handler: clears `streams_blocked_bidi_state.blocked_sent` to
-    //      trigger retransmission
-    //   2. emit path:    sees
-    //      `streams_blocked_bidi_state.has_pending_stream_blocked_frame()`, emits
-    //      frame, increments sent_count → 2
+    // During retransmission, the loss handler clears
+    // `streams_blocked_bidi_state.blocked_sent`. The emit path then sees
+    // `streams_blocked_bidi_state.has_pending_stream_blocked_frame()`, emits
+    // the frame, and increments `sent_count` to two.
     assert!(!pipe
         .client
         .streams_blocked_bidi_state
@@ -3963,28 +3961,28 @@ fn stream_shutdown_read_update_max_data(
         Ok((1, false))
     );
 
-    // Client sends data that the server does not read before it shuts down
-    // the read direction
+    // The client sends data that the server does not read before shutting down
+    // the read direction.
     assert_eq!(pipe.client.stream_send(0, &buf[0..20], false), Ok(20));
     assert_eq!(pipe.advance(), Ok(()));
 
-    // Server has received 21 bytes, but only 1 have been read/consumed
+    // The server received 21 bytes but consumed only one.
     assert_eq!(pipe.server.rx_data, 21);
     assert_eq!(pipe.server.flow_control.consumed(), 1);
 
     assert_eq!(pipe.client.stream_send(0, &buf, false), Ok(9));
-    // Connection level flow control limit reached
+    // The connection-level flow-control limit has been reached.
     assert_eq!(pipe.client.stream_send(0, &[0], false), Err(Error::Done));
     assert_eq!(pipe.client.stream_send(4, &[0], false), Err(Error::Done));
 
-    // Shutting down the read side, returns buffered data to flow control budget
-    // (but we are *not advancing* the pipe yet, so client limit is not increased)
+    // Shutting down the read side returns buffered data to the flow-control
+    // budget. The client limit is unchanged until the pipe advances.
     assert_eq!(pipe.server.stream_shutdown(0, Shutdown::Read, 123), Ok(()));
 
-    assert!(!pipe.server.stream_readable(0)); // nothing can be consumed
+    assert!(!pipe.server.stream_readable(0)); // Nothing can be consumed.
 
     assert_eq!(pipe.server.rx_data, 21);
-    // all bytes in the read buffer have been marked as consumed
+    // All bytes in the read buffer have been marked as consumed.
     assert_eq!(pipe.server.flow_control.consumed(), 21);
     assert_eq!(pipe.client.tx_data, 30);
     assert_eq!(pipe.client.max_tx_data, 30);
@@ -5171,9 +5169,8 @@ fn max_streams_sent_only_when_at_threshold(
 
     let mut buf = [0; 100];
 
-    // Test aged connection behavior: initial max_streams_bidi = 6, threshold = 3
-    // Complete 10 batches of 6 streams (60 total) to simulate aged connection
-    // This will increase next to 66
+    // Simulate an aged connection by completing ten batches of six streams.
+    // Starting at six with a threshold of three raises the next limit to 66.
     for batch in 0..=9 {
         // Client side: send 6 streams with fin
         for i in 0..6 {
@@ -7334,8 +7331,8 @@ fn stream_priority(
 
     // Server prioritizes streams as follows:
     //  * Stream 8 and 16 have the same priority but are non-incremental.
-    //  * Stream 4, 12 and 20 have the same priority but 20 is non-incremental and
-    //    4 and 12 are incremental.
+    //  * Stream 4, 12 and 20 have the same priority but 20 is non-incremental
+    //    and 4 and 12 are incremental.
     //  * Stream 0 is on its own.
 
     stream_recv_discard(&mut pipe.server, discard, 0).unwrap();
@@ -7918,7 +7915,7 @@ fn max_data_frames_retransmit(
 
     // Client sends stream data.
     assert_eq!(pipe.client.stream_send(0, &[42u8; 30], false), Ok(30));
-    // out of flow-control
+    // The client is out of flow-control capacity.
     assert_eq!(
         pipe.client.stream_send(0, &[42u8; 30], false),
         Err(Error::Done)
@@ -7926,17 +7923,17 @@ fn max_data_frames_retransmit(
     assert_eq!(pipe.advance(), Ok(()));
 
     assert_eq!(pipe.server.stream_recv(0, &mut buf), Ok((30, false)));
-    // Client's max_tx_data is still the same.
+    // The client's `max_tx_data` remains unchanged.
     assert_eq!(pipe.client.max_tx_data, 30);
-    // So is the servers's max_rx_data, since it hasn't sent a MAX_DATA frame yet
+    // The server's `max_rx_data` also remains unchanged because it has not sent
+    // a MAX_DATA frame yet.
     assert_eq!(pipe.server.max_rx_data(), 30);
 
     let (len, _) = pipe.server.send(&mut buf).unwrap();
     let frames =
         test_utils::decode_pkt(&mut pipe.client, &mut buf[..len]).unwrap();
 
-    // Make sure the server actually tried to send MAX_DATA and STREAM_MAX_DATA
-    // frames
+    // Ensure that the server tried to send MAX_DATA and STREAM_MAX_DATA frames.
     let mut max_data_seen = false;
     let mut max_stream_data_seen = false;
     for frame in frames {
@@ -9404,22 +9401,22 @@ fn in_handshake_config(
 
 #[cfg(feature = "boringssl-boring-crate")]
 #[rstest]
-/// Tests that MAX_STREAMS threshold is correctly calculated after changing
-/// initial_max_streams_bidi via handshake callback.
+/// Tests that the MAX_STREAMS threshold is recalculated after a handshake
+/// callback changes `initial_max_streams_bidi`.
 fn max_streams_threshold_after_handshake_callback_update(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
 ) {
     let mut buf = [0; 65535];
 
-    // Original config value - low value so threshold would be 4/2 = 2
+    // The original value of four yields a threshold of two.
     const CONFIG_INITIAL_MAX_STREAMS_BIDI: u64 = 4;
-    // Value set during handshake callback - threshold should be 100/2 = 50
+    // The callback value of 100 yields a threshold of 50.
     const CALLBACK_INITIAL_MAX_STREAMS_BIDI: u64 = 100;
 
-    // Setup server with handshake callback that changes initial_max_streams_bidi
+    // Configure a server callback that changes `initial_max_streams_bidi`.
     let mut server_tls_ctx_builder = test_utils::Pipe::default_tls_ctx_builder();
     server_tls_ctx_builder.set_select_certificate_callback(|mut hello| {
-        // Change initial_max_streams_bidi from 4 to 100 during handshake
+        // Change `initial_max_streams_bidi` from 4 to 100 during the handshake.
         <Connection>::set_initial_max_streams_bidi_in_handshake(
             hello.ssl_mut(),
             CALLBACK_INITIAL_MAX_STREAMS_BIDI,
@@ -9444,8 +9441,8 @@ fn max_streams_threshold_after_handshake_callback_update(
             .unwrap();
         config.set_initial_max_data(1000000);
         config.set_initial_max_stream_data_bidi_remote(1000);
-        // Server config uses CONFIG_INITIAL_MAX_STREAMS_BIDI, but callback
-        // changes it to CALLBACK_INITIAL_MAX_STREAMS_BIDI
+        // The server configuration uses `CONFIG_INITIAL_MAX_STREAMS_BIDI`, but
+        // the callback changes it to `CALLBACK_INITIAL_MAX_STREAMS_BIDI`.
         config.set_initial_max_streams_bidi(CONFIG_INITIAL_MAX_STREAMS_BIDI);
         config.set_cc_algorithm_name(cc_algorithm_name).unwrap();
         config.verify_peer(false);
@@ -9457,8 +9454,8 @@ fn max_streams_threshold_after_handshake_callback_update(
     )
     .unwrap();
 
-    // Complete handshake - server's callback changes max_streams to
-    // CALLBACK_INITIAL_MAX_STREAMS_BIDI so verify the client received that.
+    // Complete the handshake and verify that the client received the callback's
+    // `CALLBACK_INITIAL_MAX_STREAMS_BIDI` value.
     let (len, _) = pipe.client.send(&mut buf).unwrap();
     pipe.server_recv(&mut buf[..len]).unwrap();
 
@@ -9473,9 +9470,9 @@ fn max_streams_threshold_after_handshake_callback_update(
     assert_eq!(pipe.handshake(), Ok(()));
 
     let pre_threshold_streams = CALLBACK_INITIAL_MAX_STREAMS_BIDI / 2 - 1;
-    // Complete 49 streams to bring available down to 51
-    // With correct threshold (50), MAX_STREAMS should NOT be sent yet
-    // With buggy threshold (2), MAX_STREAMS would be sent way too early
+    // Complete 49 streams to reduce the available count to 51. The correct
+    // threshold of 50 does not send MAX_STREAMS yet, while the incorrect
+    // threshold of two sends it too early.
     for i in 0..pre_threshold_streams {
         let stream_id = i * 4;
         pipe.client.stream_send(stream_id, b"a", true).ok();
@@ -9500,18 +9497,17 @@ fn max_streams_threshold_after_handshake_callback_update(
         CALLBACK_INITIAL_MAX_STREAMS_BIDI + pre_threshold_streams
     );
 
-    // Verify MAX_STREAMS was NOT sent yet (available > threshold) With the bug
-    // (threshold = CONFIG_INITIAL_MAX_STREAMS_BIDI/2), MAX_STREAMS would have
-    // been sent when available dropped to it, and client would have more streams
-    // available.
+    // Verify that MAX_STREAMS was not sent while availability exceeds the
+    // threshold. The incorrect threshold would already have sent it and given
+    // the client more available streams.
     assert_eq!(
         pipe.client.streams.peer_streams_left_bidi(),
         CALLBACK_INITIAL_MAX_STREAMS_BIDI - pre_threshold_streams,
         "MAX_STREAMS should NOT have been sent yet."
     );
 
-    // Complete 1 more stream → available = 50 (== threshold of 50)
-    // MAX_STREAMS SHOULD be sent now
+    // Complete one more stream to reach the threshold of 50. MAX_STREAMS should
+    // now be sent.
     let stream_id = pre_threshold_streams * 4;
     pipe.client.stream_send(stream_id, b"a", true).ok();
     pipe.advance().ok();
@@ -9523,15 +9519,14 @@ fn max_streams_threshold_after_handshake_callback_update(
     pipe.client.stream_recv(stream_id, &mut buf).ok();
     pipe.advance().ok();
 
-    // Server's next should have increased by 1
+    // The server's next limit should have increased by one.
     assert_eq!(
         pipe.server.streams.max_streams_bidi_next(),
         CALLBACK_INITIAL_MAX_STREAMS_BIDI + CALLBACK_INITIAL_MAX_STREAMS_BIDI / 2
     );
 
-    // Verify MAX_STREAMS WAS sent (available <= threshold). With the bug,
-    // threshold = CONFIG_INITIAL/2 = 2, so MAX_STREAMS won't be sent until
-    // available <= 2, which we never reach in this test.
+    // Verify that MAX_STREAMS was sent once availability reached the threshold.
+    // With the incorrect threshold of two, this test would never send it.
     let streams_left = pipe.client.streams.peer_streams_left_bidi();
     assert!(
         streams_left > CALLBACK_INITIAL_MAX_STREAMS_BIDI / 2 + 1,
@@ -10746,9 +10741,9 @@ fn path_probing_dos(
     flight
         .iter_mut()
         .for_each(|(_, si)| si.from = client_addr_3);
-    // Both existing paths are in use (have DCIDs), so make_room_for_new_path()
-    // cannot evict any and returns Error::Done. Because ReusedSourceConnectionId
-    // is only emitted after successful path insertion, no event is queued.
+    // Both paths have DCIDs, so `make_room_for_new_path()` cannot evict either
+    // and returns `Error::Done`. `ReusedSourceConnectionId` is emitted only
+    // after successful insertion, so no event is queued.
     test_utils::process_flight(&mut pipe.server, flight)
         .expect("failed to process");
     assert_eq!(pipe.server.paths.len(), 2);
@@ -12089,8 +12084,8 @@ fn pmtud_probe_retry_after_loss(
         .unwrap();
     assert!(!pmtud.should_probe());
 
-    // Simulate probe loss - need 2 failures (configured via set_pmtud_max_probes)
-    // before size changes. First failure - should retry at same size
+    // Two probe failures are required before the size changes. The first
+    // failure should retry at the same size.
     pmtud.failed_probe(initial_probe_size);
     assert_eq!(pmtud.get_current_mtu(), 1200);
     assert!(pmtud.should_probe());
@@ -12394,8 +12389,8 @@ fn configuration_values_clamping() {
         octets::MAX_VAR_INT
     );
 
-    // It's fine that this will fail with an error. We just want to ensure we
-    // do not panic because of too large values that we try to encode via varint.
+    // This may return an error, but values too large for varint encoding must
+    // not cause a panic.
     assert_eq!(pipe.handshake(), Err(Error::InvalidTransportParam));
 }
 

--- a/quiche/src/tls/mod.rs
+++ b/quiche/src/tls/mod.rs
@@ -286,8 +286,8 @@ impl Context {
         // false -> 0x00 SSL_VERIFY_NONE
         let mode = i32::from(verify);
 
-        // Note: Base on two used modes(see above), it seems ok for both, bssl and
-        // ossl. If mode needs to be ored then it may need to be adjusted.
+        // The two modes above work for both BoringSSL and OpenSSL. This may
+        // need adjustment if modes must be combined.
         unsafe {
             SSL_CTX_set_verify(self.as_mut_ptr(), mode, None);
         }

--- a/quiche/src/transport_params.rs
+++ b/quiche/src/transport_params.rs
@@ -377,8 +377,7 @@ impl TransportParams {
                 // Track unknown transport parameters specially.
                 unknown_tp_id => {
                     if let Some(unknown_params) = &mut tp.unknown_params {
-                        // It is _not_ an error not to have space enough to track
-                        // an unknown parameter.
+                        // Failing to track an unknown parameter is harmless.
                         let _ = unknown_params.push(UnknownTransportParameter {
                             id: unknown_tp_id,
                             value: val.buf(),

--- a/task-killswitch/src/lib.rs
+++ b/task-killswitch/src/lib.rs
@@ -117,7 +117,7 @@ impl TaskKillswitch {
 
         let res = self.storage.add_task_if(handle, || !self.was_activated());
         if let Err(handle) = res {
-            // Killswitch was activated by the time we got a lock on the map shard
+            // The killswitch was activated before the map shard was locked.
             handle.abort();
             return None;
         }

--- a/tokio-quiche/examples/async_http3_server/main.rs
+++ b/tokio-quiche/examples/async_http3_server/main.rs
@@ -50,8 +50,7 @@ use tokio_quiche::ServerH3Driver;
 async fn main() {
     env_logger::builder().format_timestamp_nanos().init();
 
-    // Create listening socket. Note that we use `ConnectionParams::new_server()`
-    // to denote that we're creating a server.
+    // Use `ConnectionParams::new_server()` to create a listening socket.
     let args = Args::parse();
     let socket = UdpSocket::bind(&args.address)
         .await

--- a/tokio-quiche/src/http3/driver/mod.rs
+++ b/tokio-quiche/src/http3/driver/mod.rs
@@ -106,8 +106,9 @@ const DEFAULT_PRIO: h3::Priority = h3::Priority::new(3, true);
 // 1MB of max buffered data.
 #[cfg(not(any(test, debug_assertions)))]
 const STREAM_CAPACITY: usize = 16;
+// A single entry stresses `write_pending` in test and debug builds.
 #[cfg(any(test, debug_assertions))]
-const STREAM_CAPACITY: usize = 1; // Set to 1 to stress write_pending under test conditions
+const STREAM_CAPACITY: usize = 1;
 
 // For *all* flows use a shared channel with 2048 entries, which works out
 // to 3MB of max buffered data at 1500 bytes per datagram.
@@ -543,7 +544,8 @@ impl<H: DriverHooks> H3Driver<H> {
                             quiche::Shutdown::Read,
                             err,
                         );
-                        drop(try_reserve_result); // needed to drop the borrow on ctx.
+                        // Release the borrow of `ctx` before updating it.
+                        drop(try_reserve_result);
                         ctx.handle_sent_stop_sending(err);
                         // TODO: should we send an H3Event event to
                         // h3_event_sender? We can only get here if the app
@@ -571,14 +573,10 @@ impl<H: DriverHooks> H3Driver<H> {
                 };
             }
 
-            // Size the receive buffer to the contiguous, in-order data currently
-            // readable on the stream, capped at the configured maximum, so small
-            // or idle bodies don't pay for a full allocation.
-            // The readable length includes H3 framing, so it is enough to drain
-            // all currently readable body bytes. The floor
-            // (`MIN_BODY_RECV_BUF_SIZE`) keeps the allocation non-zero and large
-            // enough that a trickle of tiny reads reuses a single allocation
-            // instead of reallocating each time.
+            // Size the buffer for currently readable, in-order data, capped at
+            // the configured maximum. The readable length includes H3 framing,
+            // so it can drain all readable body bytes. The minimum keeps the
+            // allocation nonzero and amortizes a trickle of small reads.
             let want = body_recv_buf_size(
                 qconn.stream_readable_len(stream_id, self.max_recv_body_buf_size),
                 self.max_recv_body_buf_size,
@@ -588,16 +586,13 @@ impl<H: DriverHooks> H3Driver<H> {
             let body_recv_buf = self
                 .body_recv_buf
                 .get_or_insert_with(|| BytesMut::with_capacity(want).limit(want));
-            // NOTE: `body_recv_buf` is `Limit<BytesMut>` so `remaining_mut()`
-            // reports the space left until the *limit* is reached. (A plain
-            // `BytesMut` can reallocate and would always report space available.)
+            // `Limit<BytesMut>` reports only capacity below its limit. Plain
+            // `BytesMut` can reallocate and always reports available space.
             //
-            // Reallocate whenever the room left is smaller than what we want for
-            // this read. This covers an exhausted buffer, but also grows a
-            // buffer that was previously sized to a smaller readable length so a
-            // later, larger read is not throttled by leftover capacity. Capacity
-            // is kept equal to the limit so the `split()` invariant asserted
-            // below (spare capacity == remaining_mut) continues to hold.
+            // Reallocate when the remaining room cannot hold this read. This
+            // handles exhausted buffers and reads larger than the previous
+            // allocation. Keep capacity equal to the limit to preserve the
+            // `split()` invariant checked below.
             if body_recv_buf.remaining_mut() < want {
                 *body_recv_buf = BytesMut::with_capacity(want).limit(want);
             }
@@ -729,9 +724,8 @@ impl<H: DriverHooks> H3Driver<H> {
             h3::Event::Reset(code) => {
                 if let Some(ctx) = self.stream_map.get_mut(&stream_id) {
                     ctx.handle_recvd_reset(code);
-                    // See if we are waiting on this stream and close the channel
-                    // if we are. If we are not waiting, `handle_recvd_reset()`
-                    // will have taken care of closing.
+                    // Close the channel if this stream is waiting. Otherwise,
+                    // `handle_recvd_reset()` already closed it.
                     for pending in self.waiting_streams.iter_mut() {
                         match pending {
                             WaitForStream::Upstream(
@@ -970,7 +964,8 @@ impl<H: DriverHooks> H3Driver<H> {
         match self.stream_map.get_mut(&stream_id) {
             None => Ok(()),
             Some(stream) => {
-                chan.abort_send(); // Have to do it to release the associated permit
+                // Release the associated permit before retaining the channel.
+                chan.abort_send();
                 stream.send = Some(chan);
                 self.process_h3_data(qconn, stream_id)
             },
@@ -1060,14 +1055,13 @@ impl<H: DriverHooks> H3Driver<H> {
             }
         }
 
-        // Close any DATAGRAM-proxying channels when we close the stream, if they
-        // exist
+        // Close any DATAGRAM-proxying channels associated with the stream.
         if let Some(mapped_flow_id) = stream_ctx.associated_dgram_flow_id {
             self.flow_map.remove(&mapped_flow_id);
         }
 
         if qconn.is_server() {
-            // Signal the server to remove the stream from its map
+            // Signal the server to remove the stream from its map.
             let _ = self
                 .h3_event_sender
                 .send(H3Event::StreamClosed { stream_id }.into());
@@ -1271,9 +1265,8 @@ impl<H: DriverHooks> H3Driver<H> {
                     // stream properly. Once applications code
                     // is fixed, we can remove this check.
                     {
-                        // The channel closed without having written a fin. Send a
-                        // RESET_STREAM to indicate we won't be writing anything
-                        // else
+                        // No FIN was written before closure. Send RESET_STREAM
+                        // because no more data will follow.
                         let err = h3::WireErrorCode::RequestCancelled as u64;
                         let _ = qconn.stream_shutdown(
                             stream_id,

--- a/tokio-quiche/src/http3/driver/server.rs
+++ b/tokio-quiche/src/http3/driver/server.rs
@@ -115,9 +115,9 @@ impl From<H3Event> for ServerH3Event {
             H3Event::IncomingHeaders(incoming_headers) => {
                 // Server `incoming_headers` are exclusively created in
                 // `ServerHooks::handle_request`, which correctly serializes the
-                // RawPriorityValue and IsInEarlyData values.
+                // `RawPriorityValue` and `IsInEarlyData` values.
                 //
-                // See `H3Driver::process_read_event` for implementation details.
+                // `H3Driver::process_read_event` implements this behavior.
                 Self::Headers {
                     incoming_headers,
                     priority: None,

--- a/tokio-quiche/src/http3/driver/streams.rs
+++ b/tokio-quiche/src/http3/driver/streams.rs
@@ -158,9 +158,9 @@ impl StreamCtx {
         debug_assert!(!self.fin_or_reset_recv);
         self.audit_stats
             .set_sent_stop_sending_error_code(wire_err_code as i64);
-        // It is ok for us to set the `fin_reset_recv` flag here.  While the peer
-        // must still send a fin or reset_stream with its final size, we don't
-        // need to read it from the stream. Quiche will take care of that.
+        // Setting `fin_or_reset_recv` here is safe. The peer must still send
+        // FIN or RESET_STREAM with its final size, but `quiche` handles
+        // that without an application read.
         self.fin_or_reset_recv = true;
         self.send = None;
     }

--- a/tokio-quiche/src/http3/driver/tests.rs
+++ b/tokio-quiche/src/http3/driver/tests.rs
@@ -231,23 +231,23 @@ mod client_side_driver {
             .unwrap();
         helper.advance_and_run_loop().unwrap();
 
-        // server receives client body
+        // The server receives the client body.
         assert_eq!(helper.peer_server_poll(), Ok((0, h3::Event::Data)));
         assert_eq!(helper.peer_server_poll(), Err(h3::Error::Done));
         assert_eq!(helper.peer_server_recv_body_vec(0, 1024), Ok(vec![1; 5]));
 
-        // client sends fin, server sends body and fin
+        // The client sends FIN. The server sends a body and FIN.
         to_server
             .try_send(OutboundFrame::Body(Default::default(), true))
             .unwrap();
         helper.peer_server_send_body(0, &[2; 10], true).unwrap();
 
-        // Server reads fin
+        // The server reads FIN.
         helper.advance_and_run_loop().unwrap();
-        // TODO: the server sees an h3::Event::Data, but it's for an empty buffer.
-        // Ideally, it wouldn't do that.
+        // TODO: The server sees `h3::Event::Data`, but it contains an empty
+        // buffer. Ideally, it wouldn't do that.
         assert_eq!(helper.peer_server_poll(), Ok((0, h3::Event::Data)));
-        // No data to be read
+        // No data remains to be read.
         assert_eq!(
             helper.peer_server_recv_body_vec(0, 1024),
             Err(h3::Error::Done)
@@ -256,25 +256,20 @@ mod client_side_driver {
         assert_eq!(helper.peer_server_poll(), Err(h3::Error::Done));
         helper.advance_and_run_loop().unwrap();
 
-        // client receives the server body
+        // The client receives the server body.
         assert_matches!(from_server.try_recv(), Ok(InboundFrame::Body(buf, fin)) => {
             assert_eq!(buf.to_vec(), vec![2; 10]);
-            // TODO: it would be nice if we could receive the fin here, but that's not
-            // how quiche::h3 works. Instead we need another receive call on the channel
+            // TODO: It would be useful to receive FIN here, but `quiche::h3`
+            // requires another receive call on the channel.
             assert!(!fin);
         });
         helper.work_loop_iter().unwrap();
 
-        // FIXME: This is an edge case. We should not see a `Disconnected` error
-        // here. The `from_server` / `InboudFrame` channel is set to 1 in tests.
-        // What happens, is the driver reads the previous body frame, then it
-        // sees an `Event::Finished` and calls `process_h3_fin`, which sets
-        // `ctx.fin_recv`. Then it processes the pending write that sends the fin
-        // from client to server. The driver now sees both ctx.fin_read &&
-        // ctx.fin_sent and drops the context and thus the channel. Application
-        // code (H3Body) is not affected by -- it treats a disconnected channel
-        // like receiving a fin. It's a different question if it should treat it
-        // as such
+        // FIXME: This should not produce `Disconnected`. The test channel has
+        // capacity one. The driver reads the prior body, observes
+        // `Event::Finished`, then processes the pending client FIN. It drops
+        // the context and channel because both directions are finished.
+        // H3Body treats disconnection as FIN. This behavior may be incorrect.
 
         // assert_matches!(from_server.try_recv(), Ok(InboundFrame::Body(buf,
         // fin)) => {
@@ -291,12 +286,12 @@ mod client_side_driver {
         helper.complete_handshake().unwrap();
         helper.advance_and_run_loop().unwrap();
 
-        // client sends a request with fin
+        // The client sends a request with FIN.
         let stream_id = helper
             .driver_send_request(make_request_headers("GET"), true)
             .unwrap();
 
-        // servers reads request and sends response headers
+        // The server reads the request and sends response headers.
         helper.advance_and_run_loop().unwrap();
         assert_matches!(
             helper.peer_server_poll().unwrap(),
@@ -305,7 +300,7 @@ mod client_side_driver {
         helper.peer_server_send_response(0, false).unwrap();
         helper.advance_and_run_loop().unwrap();
 
-        // Client receives response headers
+        // The client receives response headers.
         let resp = assert_matches!(
             helper.driver_recv_core_event().unwrap(),
             H3Event::IncomingHeaders(headers) => { headers }
@@ -314,30 +309,30 @@ mod client_side_driver {
         assert!(!resp.read_fin);
         let mut from_server = resp.recv;
 
-        // Set the buffer size
+        // Set the buffer size.
         helper.driver_set_body_buf_size(30);
-        // Server sends an initial 10 byte body.
+        // The server sends an initial 10-byte body.
         helper.peer_server_send_body(0, &[2; 10], false).unwrap();
         helper.advance_and_run_loop().unwrap();
-        // client receives the server body
+        // The client receives the server body.
         assert_eq!(helper.driver_try_recv_body(&mut from_server).0, vec![2; 10]);
-        // another 10 bytes
+        // Receive another ten bytes.
         helper.peer_server_send_body(0, &[3; 10], false).unwrap();
         helper.advance_and_run_loop().unwrap();
         assert_eq!(helper.driver_try_recv_body(&mut from_server).0, vec![3; 10]);
-        // another 10 bytes. That should have used the initial buffer.
+        // Receive another ten bytes using the initial buffer.
         helper.peer_server_send_body(0, &[4; 10], false).unwrap();
         helper.advance_and_run_loop().unwrap();
         assert_eq!(helper.driver_try_recv_body(&mut from_server).0, vec![4; 10]);
-        // another 10 bytes. Should transparently use a new buffer
+        // Receive another ten bytes using a new buffer transparently.
         helper.peer_server_send_body(0, &[5; 10], true).unwrap();
         helper.advance_and_run_loop().unwrap();
 
         let (body, fin, _) = helper.driver_try_recv_body(&mut from_server);
         assert_eq!(body, vec![5; 10]);
-        // client receives the server FIN
+        // The client receives the server FIN.
         assert!(fin);
-        // client should have cleaned up the stream as both directions have closed
+        // The client should clean up the stream after both directions close.
         assert_eq!(helper.driver.stream_map.len(), 0);
     }
 
@@ -1184,13 +1179,11 @@ mod server_side_driver {
         );
         helper.advance_and_run_loop().unwrap();
 
-        // the client didn't send any additional data, a try_recv on the server
-        // returns empty
+        // No additional client data leaves the server's `try_recv()` empty.
         assert_matches!(from_client.try_recv(), Err(TryRecvError::Empty));
-        // The way quiche is implemented, we need to attempt a write to the stream
-        // to learn that it's closed. So we add an OutboundFrame to the
-        // channel and let the driver write it. The driver gets a
-        // StreamStopped back and closes the channel.
+        // `quiche` detects the closed stream only after a write attempt.
+        // Queue an `OutboundFrame`. The resulting `StreamStopped` error causes
+        // the driver to close the channel.
         to_client
             .try_send(OutboundFrame::Body(
                 Bytes::copy_from_slice(&[23; 10]),

--- a/tokio-quiche/src/lib.rs
+++ b/tokio-quiche/src/lib.rs
@@ -246,10 +246,9 @@ pub(crate) fn capture_quiche_logs() {
 
         slog_stdlog::init_with_level(normalized_level).unwrap();
 
-        // The slog Drain becomes `slog::Discard` when the scope_guard is dropped,
-        // and you can't set the global logger again because of a mandate
-        // in the `log` crate. We have to retain the scope guard so that the
-        // logger remains registered for the duration of the process.
+        // Dropping the scope guard replaces the slog Drain with
+        // `slog::Discard`. The `log` crate cannot reset the global
+        // logger, so retain the guard for the process lifetime.
         let _scope_guard = std::mem::ManuallyDrop::new(scope_guard);
     });
 }

--- a/tokio-quiche/src/quic/connection/map.rs
+++ b/tokio-quiche/src/quic/connection/map.rs
@@ -87,8 +87,7 @@ impl From<&ConnectionId<'_>> for CidOwned {
             .enumerate()
             .for_each(|(i, v)| cid[i] = v);
 
-        // In order to differentiate cids with zeroes as opposed to shorter cids,
-        // append the cid length.
+        // Append its length to distinguish a short CID from trailing zeroes.
         *cid.last_mut().unwrap() |= (value.len() as u64) << 56;
 
         CidOwned::Optimized(cid)

--- a/tokio-quiche/src/quic/connection/mod.rs
+++ b/tokio-quiche/src/quic/connection/mod.rs
@@ -390,8 +390,8 @@ where
             handshake_fut,
         );
 
-        // `AbortOnDropHandle` simulates task-killswitch behavior without needing
-        // to give up ownership of the `JoinHandle`.
+        // `AbortOnDropHandle` simulates task-killswitch behavior without
+        // needing to give up ownership of the `JoinHandle`.
         let handshake_abort_handle = AbortOnDropHandle::new(handshake_handle);
 
         let worker = handshake_abort_handle.await??;

--- a/tokio-quiche/src/quic/io/gso.rs
+++ b/tokio-quiche/src/quic/io/gso.rs
@@ -121,8 +121,8 @@ pub async fn send_to(
     send_buf: &[u8], segment_size: usize, tx_time: Option<Instant>,
     would_block_metric: Counter, send_to_wouldblock_duration_s: TimeHistogram,
 ) -> io::Result<usize> {
-    // An instant with the value of zero, since [`Instant`] is backed by a version
-    // of timespec this allows to extract raw values from an [`Instant`]
+    // SAFETY: This Linux-only code assumes `Instant` uses the same layout as a
+    // zero-valid timespec. The zero instant allows raw time extraction.
     const INSTANT_ZERO: Instant = unsafe { std::mem::transmute(0u128) };
 
     let mut sendmsg_retry_timer = None;

--- a/tokio-quiche/src/quic/io/utilization_estimator.rs
+++ b/tokio-quiche/src/quic/io/utilization_estimator.rs
@@ -197,8 +197,8 @@ impl MaxUtilizedBandwidthEstimator {
             start: time,
         });
 
-        // Unlike acked and lost count, sent count is computed over a window 1 rtt
-        // in the past.
+        // Unlike acknowledged and lost byte counts, the sent byte count uses a
+        // window one RTT in the past.
         self.bytes_sent_prev_round = bytes_sent;
 
         let bytes_acked = self.rounds.iter().map(|v| v.bytes_acked).sum::<u64>();
@@ -335,10 +335,8 @@ where
                 sample: new_sample,
                 time: new_time,
             });
-            // Need to iterate one more time. Check if the new best estimate is
-            // outside the window as well, since it may also have been recorded a
-            // long time ago. Don't need to iterate once more since we cover that
-            // case at the beginning of the method.
+            // The new best estimate may also be stale. Check it once more. The
+            // check at the start of the method handles further stale samples.
             if new_time - self.estimates[0].unwrap().time > self.window_length {
                 self.estimates[0] = self.estimates[1];
                 self.estimates[1] = self.estimates[2];
@@ -349,9 +347,8 @@ where
         if self.estimates[1].unwrap().sample == self.estimates[0].unwrap().sample &&
             new_time - self.estimates[1].unwrap().time > self.window_length / 4
         {
-            // A quarter of the window has passed without a better sample, so the
-            // second-best estimate is taken from the second quarter of the
-            // window.
+            // No better sample arrived for a quarter of the window, so take the
+            // second-best estimate from the second quarter.
             self.estimates[1] = Some(Sample {
                 sample: new_sample,
                 time: new_time,
@@ -390,7 +387,8 @@ mod tests {
         // First round send 30M, nothing gets acked
         estimator.new_round(now, 30_000_000, 0, 0);
 
-        assert_eq!(estimator.get().bandwidth, 0); // Not enough rounds for estimate yet
+        // There are not enough rounds for an estimate yet.
+        assert_eq!(estimator.get().bandwidth, 0);
         assert!(estimator.estimate.get_best().is_none());
 
         now += Duration::from_secs(30);
@@ -398,8 +396,9 @@ mod tests {
         // Send 60M, previous 30M gets acked
         estimator.new_round(now, 60_000_000, 0, 30_000_000);
 
-        // 30M over 30s = 1MBps = 8Mbps
-        assert_eq!(estimator.get().bandwidth, 0); // Not enough rounds for estimate yet
+        // 30 MB over 30 seconds is 1 MBps, or 8 Mbps.
+        // There are not enough rounds for an estimate yet.
+        assert_eq!(estimator.get().bandwidth, 0);
         assert_eq!(estimator.estimate.get_best().unwrap().bandwidth, 8_000_000);
 
         now += Duration::from_secs(30);
@@ -407,8 +406,9 @@ mod tests {
         // Send 90M, previous 60M gets acked
         estimator.new_round(now, 90_000_000, 0, 60_000_000);
 
-        // 90M over 60s = 1.5MBps = 12Mbps
-        assert_eq!(estimator.get().bandwidth, 0); // Not enough rounds for estimate yet
+        // 90 MB over 60 seconds is 1.5 MBps, or 12 Mbps.
+        // There are not enough rounds for an estimate yet.
+        assert_eq!(estimator.get().bandwidth, 0);
         assert_eq!(estimator.estimate.get_best().unwrap().bandwidth, 12_000_000);
 
         now += Duration::from_secs(30);
@@ -416,8 +416,9 @@ mod tests {
         // Send 10M, previous 90M gets acked
         estimator.new_round(now, 30_000_000, 0, 90_000_000);
 
-        // 180M over 90s = 2MBps = 16Mbps
-        assert_eq!(estimator.get().bandwidth, 0); // Not enough rounds for estimate yet
+        // 180 MB over 90 seconds is 2 MBps, or 16 Mbps.
+        // There are not enough rounds for an estimate yet.
+        assert_eq!(estimator.get().bandwidth, 0);
         assert_eq!(estimator.estimate.get_best().unwrap().bandwidth, 16_000_000);
 
         for _ in 0..4 {

--- a/tokio-quiche/src/quic/io/worker.rs
+++ b/tokio-quiche/src/quic/io/worker.rs
@@ -383,11 +383,9 @@ where
         let sleep = time::sleep(DEFAULT_SLEEP);
         tokio::pin!(sleep);
 
-        // When pooling is disabled we keep one persistent egress buffer for the
-        // whole connection, owned here in the IO worker and held across the loop
-        // below (including while the connection is idle) -- the pre-pooling
-        // behavior. When pooling is enabled this stays `None` and each send
-        // burst borrows a transient buffer from the per-worker pool instead.
+        // Without pooling, the IO worker owns one egress buffer for the entire
+        // connection, including idle periods. With pooling, this remains `None`
+        // and each send burst borrows a buffer from the per-worker pool.
         let mut persistent_send_buf: Option<Box<[u8]>> =
             (!self.cfg.pool_send_buffer).then(alloc_send_buffer);
 
@@ -406,10 +404,8 @@ where
             while self.write_state.has_pending_data {
                 let mut packets_sent = 0;
 
-                // Try to clear all received packets every so often, because
-                // incoming packets contain acks, and because the
-                // receive queue has a very limited size, once it is full incoming
-                // packets get stalled indefinitely
+                // Drain received packets periodically because they contain ACKs
+                // and the bounded receive queue stalls new packets when full.
                 let mut did_recv = false;
                 while let Some(pkt) = ctx
                     .in_pkt
@@ -669,8 +665,8 @@ where
             }
 
             if gcongestion_enabled {
-                // If the release time of next packet is different, or it can't be
-                // part of a burst, start the next batch
+                // Start a new batch if the next packet has a different release
+                // time or cannot be part of a burst.
                 if let Some(initial_release_decision) = initial_release_decision {
                     match qconn.get_next_release_time() {
                         Some(release)
@@ -899,24 +895,21 @@ where
         Ok(())
     }
 
-    // When a connection is established, process application data, if not the task
-    // is probably polled following a wakeup from boring, so we check if quiche
-    // has any handshake packets to send.
+    // Process application data after establishment. Before then, a BoringSSL
+    // wakeup might require quiche to send handshake packets.
     //
-    // TODO(erittenhouse): would be nice to decouple wait_for_data from the
-    // application, but wait_for_quiche relies on IOW methods, so we can't write a
-    // default implementation for ConnectionStage
+    // TODO(erittenhouse): Decouple `wait_for_data` from the application.
+    // `wait_for_quiche` depends on IOW methods, preventing a default
+    // `ConnectionStage` implementation.
     //
     // # Cancel safety
     //
-    // This future is polled as an arm of the `select!` in [`Self::work_loop`],
-    // so it MUST be cancel safe: it may be dropped at any `.await` point when
-    // another arm completes first. It stays cancel safe because
-    // [`ApplicationOverQuic::wait_for_data`] is itself required to be cancel
-    // safe, and the handshake branch keeps no state across its `.await` beyond
-    // the local `send_buf` (which is returned to the free list or freed if the
-    // future is cancelled; any bytes gathered into it are re-gathered on the
-    // next poll). Take care to preserve this property when modifying it.
+    // This future is polled as an arm of the `select!` in `Self::work_loop`, so
+    // it must be cancel-safe. Another arm may complete first and drop it at any
+    // `.await`. `ApplicationOverQuic::wait_for_data` is also cancel-safe, and
+    // the handshake branch retains only its local `send_buf` across `.await`.
+    // Cancellation returns or frees that buffer. The next poll gathers its
+    // bytes again. Preserve this property when modifying the function.
     async fn wait_for_data_or_handshake<A: ApplicationOverQuic>(
         &mut self, qconn: &mut QuicheConnection, quic_application: &mut A,
     ) -> QuicResult<WaitForDataOrHandshakeDirective> {
@@ -978,12 +971,9 @@ where
                 true,
             ) {
                 Ok(bytes_written) => {
-                    // We need to avoid consecutive calls to gather(), which write
-                    // data to the buffer, without a flush().
-                    // If we don't avoid those consecutive calls, we end
-                    // up overwriting data in the buffer or unnecessarily waiting
-                    // for more calls to drive_handshake()
-                    // before calling the handshake complete.
+                    // Do not call `gather()` twice without an intervening
+                    // `flush()`. Consecutive calls may overwrite data or delay
+                    // handshake completion.
                     if bytes_written == 0 && self.write_state.bytes_written == 0 {
                         Poll::Pending
                     } else {
@@ -1048,11 +1038,9 @@ where
     where
         A: ApplicationOverQuic,
     {
-        // This makes an assumption that the waker being set in ex_data is stable
-        // across the active task's lifetime. Moving a future that encompasses an
-        // async callback from this task across a channel, for example, will
-        // cause issues as this waker will then be stale and attempt to
-        // wake the wrong task.
+        // The `ex_data` waker must remain stable for this task. Moving a future
+        // with an async callback to another task leaves a stale waker that
+        // wakes the wrong task.
         std::future::poll_fn(|cx| {
             // Deref to pick `Connection::as_mut` over `Box::as_mut`.
             let ssl = (*qconn).as_mut();

--- a/tokio-quiche/src/quic/router/mod.rs
+++ b/tokio-quiche/src/quic/router/mod.rs
@@ -316,11 +316,11 @@ where
         } = new_connection;
 
         let Some(ref shutdown_tx) = self.shutdown_tx else {
-            // don't create new connections if we're shutting down.
+            // Do not create new connections while shutting down.
             return Ok(());
         };
         let Ok(send_permit) = self.accept_sink.try_reserve() else {
-            // drop the connection if the backlog is full. the client will retry.
+            // Drop the connection when the backlog is full. The client retries.
             return Err(
                 labels::QuicInvalidInitialPacketError::AcceptQueueOverflow.into(),
             );
@@ -472,9 +472,7 @@ where
                     Ok(r) => {
                         let filled_buf =
                             r.iovs().next().map(Vec::from).unwrap_or_default();
-                        // The slices returend by `nix::socket::recvmsg`'s result
-                        // add up to `r.bytes`. This assert is just to make sure
-                        // the code handles the result correctly.
+                        // Verify that the `recvmsg` slices total `r.bytes`.
                         debug_assert_eq!(r.bytes, filled_buf.len());
 
                         let address = match r.address {
@@ -555,10 +553,8 @@ where
                                     );
                                 },
                                 ControlMessageOwned::Ipv6OrigDstAddr(val) => {
-                                    // Don't have to flip IPv6 bytes since it's a
-                                    // byte array, not a
-                                    // series of bytes parsed as a u32 as in the
-                                    // IPv4 case
+                                    // IPv6 is a byte array and needs no swap.
+                                    // IPv4 is parsed as a `u32` and does.
                                     let source_addr = std::net::Ipv6Addr::from(
                                         val.sin6_addr.s6_addr,
                                     );
@@ -600,8 +596,9 @@ where
                                         let Ok(arr) =
                                             <[u8; 4]>::try_from(data_bytes)
                                         else {
-                                            // Should be unreachable as SO_MARK is
-                                            // a u32: https://elixir.bootlin.com/linux/v6.17/source/include/net/sock.h#L487
+                                            // SO_MARK is a `u32`. This should
+                                            // always succeed.
+                                            // https://elixir.bootlin.com/linux/v6.17/source/include/net/sock.h#L487
                                             continue;
                                         };
 
@@ -808,14 +805,13 @@ where
                 });
             }
 
-            // Fourth, update ConnectionMap before receiving packets. This ensures
-            // our SCID destinations are up-to-date (as of this moment).
-            // If this returns pending, we have processed all available commands
-            // and are registered for a wakeup on the next command.
+            // Fourth, update ConnectionMap before receiving packets so SCID
+            // destinations are current. A pending result means all available
+            // commands were processed and the next command will wake us.
             let _ = self.poll_conn_map_commands(cx);
 
-            // Finally, process up to `PACKET_RX_YIELD_AFTER` packet (batches) at
-            // once. If no more packets are available, we wait to be woken again.
+            // Finally, process up to `PACKET_RX_YIELD_AFTER` packet batches. If
+            // no more packets are available, wait to be woken again.
             for _ in 0..PACKET_RX_YIELD_AFTER {
                 ready!(self.poll_process_packet(cx));
             }
@@ -1000,12 +996,12 @@ mod tests {
         let drop_check = conn.incoming_ev_sender.clone();
         let _conn = conn.start(h3_driver);
 
-        // Poll the incoming until the connection is dropped
+        // Poll incoming events until the connection is dropped.
         time::advance(Duration::new(30, 0)).await;
         time::resume();
 
-        // NOTE: this is a smoke test - in case of issues `notified()` future will
-        // never resolve hanging the test.
+        // This is a smoke test. A failure leaves `notified()` unresolved and
+        // hangs the test.
         drop_check.closed().await;
     }
 

--- a/tokio-quiche/src/settings/config.rs
+++ b/tokio-quiche/src/settings/config.rs
@@ -236,7 +236,7 @@ fn quiche_config_with_tls(
     match tls.kind {
         #[cfg(not(feature = "rpk"))]
         CertificateKind::RawPublicKey => {
-            // TODO: don't compile this enum variant unless rpk feature is enabled
+            // TODO: Gate this variant on the `rpk` feature.
             panic!("Can't use RPK when compiled without rpk feature");
         },
         #[cfg(feature = "rpk")]

--- a/tokio-quiche/src/settings/quic.rs
+++ b/tokio-quiche/src/settings/quic.rs
@@ -442,10 +442,9 @@ impl QuicSettings {
 
     #[inline]
     fn default_listen_backlog() -> usize {
-        // Given a worst-case 1 minute handshake timeout and up to 4096 concurrent
-        // handshakes, we will dequeue at least 70 connections per second.
-        // This means this backlog size limits the queueing latency to
-        // ~15s.
+        // With a worst-case one-minute timeout and 4096 concurrent handshakes,
+        // at least 70 connections are dequeued per second. A backlog of 1024
+        // therefore limits queueing latency to about 15 seconds.
         1024
     }
 

--- a/tokio-quiche/src/socket/capabilities.rs
+++ b/tokio-quiche/src/socket/capabilities.rs
@@ -171,9 +171,8 @@ impl<'s> SocketCapabilitiesBuilder<'s> {
     /// individual packets happens in the NIC, if it supports GSO. The
     /// parameter specifies the packet size.
     pub fn gso(&mut self) -> io::Result<()> {
-        // We initialize GSO on the socket with the maximum possible segment size
-        // to prevent accidentally setting it too small and running into
-        // issues when increasing max_send_udp_payload_size later on.
+        // Initialize GSO with the maximum segment size so later increases to
+        // `max_send_udp_payload_size` do not exceed the initial setting.
         //
         // https://elixir.bootlin.com/linux/v6.14.6/source/net/ipv4/udp.c#L2998
         // https://elixir.bootlin.com/linux/v6.14.6/source/include/vdso/limits.h#L5

--- a/tokio-quiche/tests/integration_tests/async_callbacks.rs
+++ b/tokio-quiche/tests/integration_tests/async_callbacks.rs
@@ -111,14 +111,10 @@ async fn test_async_callbacks_fail_after_initial_send() {
                 SslContextBuilder::new(SslMethod::tls()).ok()?;
             ssl_ctx_builder.set_async_select_certificate_callback(|_| {
                 Ok(Box::pin(async {
-                    // Async callbacks in tokio quiche are driven by calls to
-                    // quiche's `send` and `recv` methods.
-                    // `send` and `recv` will call SSL_do_handshake once
-                    // per invocation. As such, at least 3 successful invocations
-                    // to `send` and `recv` are needed to
-                    // trigger a handshake failure in the `send`
-                    // invocation that stems from the `wait_for_data_or_handshake`
-                    // future in the select branch.
+                    // Calls to `quiche` methods drive tokio-quiche callbacks.
+                    // Each `send` or `recv` calls `SSL_do_handshake` once.
+                    // Three successful calls must complete before
+                    // `wait_for_data_or_handshake` fails from `send`.
                     yield_now().await;
                     yield_now().await;
                     yield_now().await;

--- a/tokio-quiche/tests/integration_tests/connection_close.rs
+++ b/tokio-quiche/tests/integration_tests/connection_close.rs
@@ -69,8 +69,7 @@ async fn test_requests_per_connection_limit() -> QuicResult<()> {
         });
     }
 
-    // This last action should fail due to request limits on the connection being
-    // breached
+    // This final action should exceed the request limit and fail.
     actions.push(send_headers_frame(MAX_REQS * 4, true, default_headers()));
     actions.push(Action::FlushPackets);
 

--- a/tokio-quiche/tests/integration_tests/migration.rs
+++ b/tokio-quiche/tests/integration_tests/migration.rs
@@ -149,8 +149,8 @@ async fn run_migration_test(active: bool, base_port: u16) {
             .expect("active migration should succeed");
         migrated_addr
     } else {
-        // We keep using the original client address to simulate the fact that the
-        // client doesn't know that the path changes (e.g. due to NAT rebinding).
+        // Keep the original client address to emulate an unrecognized path
+        // change, such as NAT rebinding.
         client_addr
     };
 

--- a/tokio-quiche/tests/integration_tests/mod.rs
+++ b/tokio-quiche/tests/integration_tests/mod.rs
@@ -281,8 +281,7 @@ async fn test_so_mark_receive_data() {
 
     let audit_stats = audit_stats_rx.recv().await.expect("should receive stats");
     let so_mark_data = audit_stats.initial_so_mark_data();
-    // We don't actually set SO_MARK anywhere, so we just want to ensure that the
-    // data is `Some`, indicating that we at least received the cmsg from the
-    // socket.
+    // SO_MARK is not set. Only verify that `Some` indicates receipt of the
+    // socket control message.
     assert_eq!(so_mark_data.unwrap(), &[0, 0, 0, 0]);
 }

--- a/tokio-quiche/tests/integration_tests/timeouts.rs
+++ b/tokio-quiche/tests/integration_tests/timeouts.rs
@@ -112,16 +112,14 @@ async fn test_handshake_duration_ioworker() {
         handle_connection,
     );
 
-    // TODO: migrate to h3i client to assert a CONNECTION_CLOSE was received. This
-    // will have to be the sync version so as to isolate the tokio-quiche IO
-    // loop.
+    // TODO: Use the synchronous h3i client to assert that CONNECTION_CLOSE was
+    // received while isolating the tokio-quiche IO loop.
     //
-    // Unfortunately we can't PCAP this test since encryption keys don't seem to
-    // get dumped.
+    // This test cannot use PCAP because its encryption keys are not dumped.
     //
-    // build() spawns the InboundPacketRouter and sends the Initial, which will
-    // kick the handshake off on the server-side. If all goes well, the server
-    // will close the connection and the router will time the connection out.
+    // `build()` spawns `InboundPacketRouter` and sends the Initial, starting
+    // the server handshake. The server then closes the connection, and the
+    // router times it out.
     let url = format!("{url}/1");
     let client_res = h3i_fixtures::request(&url, 1).await;
 

--- a/tools/http3_test/tests/httpbin_tests.rs
+++ b/tools/http3_test/tests/httpbin_tests.rs
@@ -842,7 +842,8 @@ mod httpbin_tests {
 
         let mut stream_data = Vec::new();
 
-        // A buffer of containing an invalid HEADERS frame encoded in wire format.
+        // A buffer of containing an invalid HEADERS frame encoded in wire
+        // format.
         let d = vec![1, 3, 1, 1, 1];
 
         let data_frame = ArbitraryStreamData {


### PR DESCRIPTION
Newer nightly rustfmt wraps comments differently now, so update the existing formatting.

Some comments are reworded to improve readability and avoid awkward wrapping.