### PR TITLE
h3: free stream state for streams reset before local finish

### DIFF
--- a/quiche/src/h3/mod.rs
+++ b/quiche/src/h3/mod.rs
@@ -2165,7 +2165,7 @@ impl Connection {
                 // Return early if the stream was reset, to avoid returning
                 // a Finished event later as well.
                 Err(Error::TransportError(crate::Error::StreamReset(e))) => {
-                    self.remove_local_finished_stream(s);
+                    self.remove_finished_stream(conn, s);
 
                     return Ok((s, Event::Reset(e)));
                 },
@@ -2985,9 +2985,18 @@ impl Connection {
         }
     }
 
-    fn remove_local_finished_stream(&mut self, stream_id: u64) {
+    // Frees the HTTP/3 state for a stream that is done in both directions:
+    // either the local side finished sending, or the transport already
+    // collected the stream (e.g. the peer reset it before the local side
+    // finished). Otherwise the entry would leak for the lifetime of the
+    // connection.
+    fn remove_finished_stream<F: BufFactory>(
+        &mut self, conn: &super::Connection<F>, stream_id: u64,
+    ) {
         if let hash_map::Entry::Occupied(stream) = self.streams.entry(stream_id) {
-            if stream.get().local_finished() {
+            if stream.get().local_finished() ||
+                conn.streams.is_collected(stream_id)
+            {
                 stream.remove();
             }
         }
@@ -2998,7 +3007,7 @@ impl Connection {
     ) -> Option<(u64, Event)> {
         let finished = self.finished_streams.pop_front()?;
 
-        self.remove_local_finished_stream(finished);
+        self.remove_finished_stream(conn, finished);
 
         if conn.stream_readable(finished) {
             // The stream is finished, but is still readable, it may indicate
@@ -8541,6 +8550,50 @@ mod tests {
         // The server stream should be gone now
         assert_eq!(s.client.streams.len(), init_streams_client);
         assert_eq!(s.server.streams.len(), init_streams_server);
+    }
+
+    #[test]
+    /// A stream reset by the peer before the local side finished sending must
+    /// not leak its HTTP/3 state: the entry should be freed once the stream is
+    /// done in both directions, even though `local_finished()` never became
+    /// true.
+    fn reset_stream_before_local_finish_frees_h3_state() {
+        let mut s = Session::new().unwrap();
+        s.handshake().unwrap();
+
+        let init_streams_server = s.server.streams.len();
+
+        // Client sends a request without fin. The server hasn't sent a
+        // response, so its local side is not finished.
+        let (stream, req) = s.send_request(false).unwrap();
+        let ev_headers = Event::Headers {
+            list: req,
+            more_frames: true,
+        };
+
+        assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        assert_eq!(s.server.streams.len(), init_streams_server + 1);
+
+        // Client resets the stream in both directions.
+        s.pipe
+            .client
+            .stream_shutdown(stream, crate::Shutdown::Write, 0x100)
+            .unwrap();
+        s.pipe
+            .client
+            .stream_shutdown(stream, crate::Shutdown::Read, 0x100)
+            .unwrap();
+
+        s.advance().ok();
+
+        assert_eq!(s.poll_server(), Ok((stream, Event::Reset(0x100))));
+        assert_eq!(s.poll_server(), Err(Error::Done));
+
+        // The HTTP/3 stream state must have been freed.
+        assert_eq!(s.server.streams.len(), init_streams_server);
+        assert!(s.pipe.server.streams.is_collected(stream));
     }
 }
 


### PR DESCRIPTION
Fixes #2524

## Summary

When a peer resets a request stream before the local side finishes sending, the HTTP/3 layer kept its `streams` entry for the lifetime of the connection. On a long-lived server facing clients that abort requests, the map grows without bound. Android has been carrying a downstream patch for this on v0.17.1 (linked in the issue).

## Problem

`remove_local_finished_stream()` only freed the h3 entry when `local_finished()` was true. The reset paths in `poll()` and `pop_finished_stream()` surface `Event::Reset` and then call that helper, which is a no-op whenever the local send direction is still open — e.g. a request received without FIN whose response was never sent.

The transport layer has no such gap: when both directions are dead it removes the stream from its own map and marks it collected (`streams::StreamMap::collect()`), which is also why this leak was silent — the dangling entry lives only in `h3::Connection::streams`.

The existing test `priority_update_request_collected_stopped` covers this scenario but only asserts on the transport map (`s.pipe.server.streams.is_collected(0)`), so the dangling h3 entry went unnoticed.

## Solution

Generalize the cleanup helper to `remove_finished_stream()`, which frees the entry when either the local side finished sending or the transport already collected the stream:

```rust
if stream.get().local_finished() || conn.streams.is_collected(stream_id) {
    stream.remove();
}
```

`is_collected()` is only true once the stream is complete in both directions (`Stream::is_complete()`), so this cannot drop state for a stream that still has work in either direction. It is applied at both reset-surfacing sites: the `StreamReset` arm in `poll()` and `pop_finished_stream()`.

Safety of the additional arm for each h3 stream type:

- Request/push streams: this is exactly the leak being fixed. After collection, h3 send paths (`do_send_body`, `send_headers`) already treat a missing entry as `FrameUnexpected`, and the PRIORITY_UPDATE receive path skips updates for collected streams via `conn.stream_closed()` without re-inserting.
- Control/QPACK streams: reset of a registered critical stream surfaces `ClosedCriticalStream` from `process_control_stream()`/`close_conn_if_critical_stream_finished()` before the reset arm, and a second critical stream is rejected as a protocol error at type detection, so this path cannot run for them.

The `local_finished()` disjunct keeps the existing behavior for streams that finish locally while the transport still buffers state (transport-owned collection stays on its own triggers).

## Testing

- New regression test `reset_stream_before_local_finish_frees_h3_state` reproduces the issue scenario (request without FIN, peer resets both directions) and asserts the h3 map drains. Verified it fails on unpatched code (`left: 4, right: 3`) and passes with the fix.
- `cargo test --all-targets --features=async,ffi,qlog --workspace`: all pass (quiche lib: 1099, including both CC algorithm parameterizations).
- `cargo test --doc --features=async,ffi,qlog --workspace`: all pass.
- `cargo clippy --features=async,ffi,qlog --workspace --all-targets -- -D warnings`: clean.
- `cargo +nightly fmt -- --check`: clean for the touched file (two pre-existing fmt diffs exist on upstream `master` in `lib.rs`/`tests.rs`, unrelated to this change).