### PR TITLE
lib: retire the DCID of the previous path on peer migration

### DIFF
--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -9155,6 +9155,39 @@ impl<F: BufFactory> Connection<F> {
                 self.paths.get_mut(active_path_id)?.active_dcid_seq;
         }
 
+        // The DCID used on the previous path is not reused by the new active
+        // path, so it is no longer associated with an actively used address
+        // and the peer should be asked to retire it (RFC 9000 Section 5.1.2).
+        //
+        // The old path is kept usable to fall back on if the new path fails
+        // validation, so only retire the DCID if there is a spare one to
+        // replace it on that path.
+        if !self.ids.zero_length_dcid() {
+            let new_dcid_seq = self.paths.get(new_pid)?.active_dcid_seq;
+
+            if let Some(old_dcid_seq) =
+                self.paths.get(active_path_id)?.active_dcid_seq
+            {
+                if new_dcid_seq != Some(old_dcid_seq) {
+                    if let Some(dcid_seq) = self.ids.lowest_available_dcid_seq() {
+                        self.ids.retire_dcid(old_dcid_seq)?;
+
+                        self.ids
+                            .link_dcid_to_path_id(dcid_seq, active_path_id)?;
+
+                        self.paths.get_mut(active_path_id)?.active_dcid_seq =
+                            Some(dcid_seq);
+
+                        trace!(
+                            "{} path ID {} changed DCID after peer migration: old seq num {} new seq num {}",
+                            self.trace_id, active_path_id, old_dcid_seq,
+                            dcid_seq
+                        );
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -11181,6 +11181,98 @@ fn connection_migration(
 }
 
 #[rstest]
+fn peer_migration_retires_previous_dcid(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut config = Config::new(PROTOCOL_VERSION).unwrap();
+    assert_eq!(config.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
+    config
+        .load_cert_chain_from_pem_file("examples/cert.crt")
+        .unwrap();
+    config
+        .load_priv_key_from_pem_file("examples/cert.key")
+        .unwrap();
+    config
+        .set_application_protos(&[b"proto1", b"proto2"])
+        .unwrap();
+    config.verify_peer(false);
+    config.set_active_connection_id_limit(3);
+    config.set_initial_max_data(30);
+    config.set_initial_max_stream_data_bidi_local(15);
+    config.set_initial_max_stream_data_bidi_remote(15);
+    config.set_initial_max_stream_data_uni(10);
+    config.set_initial_max_streams_bidi(3);
+
+    let mut pipe = pipe_with_exchanged_cids(&mut config, 16, 16, 2);
+
+    let server_addr = test_utils::Pipe::server_addr();
+    let client_addr_2 = "127.0.0.1:5678".parse().unwrap();
+
+    // Probe the new client address first, so that the server creates the
+    // path for it and assigns it a spare DCID.
+    assert_eq!(pipe.client.probe_path(client_addr_2, server_addr), Ok(1));
+    assert_eq!(pipe.advance(), Ok(()));
+    assert_eq!(
+        pipe.client.path_event_next(),
+        Some(PathEvent::Validated(client_addr_2, server_addr))
+    );
+    assert_eq!(pipe.client.path_event_next(), None);
+    assert_eq!(
+        pipe.server.path_event_next(),
+        Some(PathEvent::New(server_addr, client_addr_2))
+    );
+    assert_eq!(
+        pipe.server.path_event_next(),
+        Some(PathEvent::Validated(server_addr, client_addr_2))
+    );
+    assert_eq!(pipe.server.path_event_next(), None);
+
+    // The original path uses DCID seq 0 on the server side.
+    assert_eq!(
+        pipe.server
+            .paths
+            .get_active()
+            .expect("no active")
+            .active_dcid_seq,
+        Some(0)
+    );
+
+    // Client migrates to the probed path.
+    assert_eq!(pipe.client.migrate(client_addr_2, server_addr), Ok(1));
+    assert_eq!(pipe.client.stream_send(0, b"data", true), Ok(4));
+    assert_eq!(pipe.advance(), Ok(()));
+    assert_eq!(
+        pipe.server.path_event_next(),
+        Some(PathEvent::PeerMigrated(server_addr, client_addr_2))
+    );
+    assert_eq!(pipe.server.path_event_next(), None);
+
+    // The new active path uses a different DCID, assigned when the probed
+    // path was created.
+    let new_dcid_seq = pipe
+        .server
+        .paths
+        .get_active()
+        .expect("no active")
+        .active_dcid_seq;
+    assert_ne!(new_dcid_seq, Some(0));
+
+    // The DCID used on the previous path is no longer in use, so the server
+    // retires it, replacing it on the old path with the next available DCID
+    // (the old path is kept usable to fall back on if the new path fails
+    // validation).
+    assert_ne!(pipe.server.paths.get(0).unwrap().active_dcid_seq, Some(0));
+    assert!(pipe.server.ids.get_dcid(0).is_err());
+
+    // The retirement was advertised to the peer...
+    assert_eq!(pipe.advance(), Ok(()));
+    assert!(pipe.server.ids.retire_dcid_seqs().is_empty());
+
+    // ...and the client acknowledged it by retiring the corresponding SCID.
+    assert_eq!(pipe.client.retired_scids(), 1);
+}
+
+#[rstest]
 fn connection_migration_zero_length_cid(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
 ) {


### PR DESCRIPTION
Fixes #2447

## Summary

When the server observes peer migration, it switches the active path to a fresh Destination CID, but the DCID that was active on the previous path stays linked to it forever: no `RETIRE_CONNECTION_ID` frame is ever sent for it unless the peer later advances `retire_prior_to` or the application calls `retire_dcid()` manually. After a migration, the previous path's DCID is no longer associated with an actively used address, so it should be retired, as recommended by [RFC 9000 Section 5.1.2](https://www.rfc-editor.org/rfc/rfc9000.html#section-5.1.2).

## Solution

`on_peer_migrated()` now retires the previous path's DCID when the new active path does not reuse it:

- The DCID is removed from the identifiers and a `RETIRE_CONNECTION_ID` frame is queued (same path as the public `retire_dcid()` and the `retire_prior_to` handling take).
- The old path is re-armed with the next available DCID, mirroring what `retire_dcid()` does for the path that owned the retired CID.

The retirement is intentionally conditional:

- **DCID reuse**: if the new active path reused the previous path's DCID (the default when no spare DCID is available), that CID is still in use, so it is not retired. This preserves the existing `set_disable_dcid_reuse(false)` fallback behavior.
- **Spare availability**: the old path is kept usable on purpose — `find_candidate_path()` requires a validated path with an active DCID to fall back on when a new path fails validation (see `resilience_against_migration_attack`). Retiring without a replacement would break that fallback, so the DCID is only retired when a spare exists to replace it on the old path.
- **Zero-length DCIDs**: skipped, since they cannot be retired.

The queued `RETIRE_CONNECTION_ID` is emitted on the new active path, satisfying the RFC 9000 Section 19.15 rule that the frame must not refer to the DCID of the packet containing it.

One note for reviewers: a quiche client does not automatically issue a replacement SCID when it receives `RETIRE_CONNECTION_ID` (that is left to the application via `new_scid()`), so the server's DCID pool shrinks by one per migration until the peer replenishes it. That is inherent to retiring CIDs per the RFC; flagging it here in case maintainers want follow-up behavior for the client side.

## Testing

- New regression test `peer_migration_retires_previous_dcid` (both CC algorithm parameterizations): probe a path, migrate to it, and verify the server retires the previous DCID — removed from the identifiers, the old path re-armed with a spare, the `RETIRE_CONNECTION_ID` advertised to the peer, and the client retiring the corresponding SCID. Verified it fails without the fix (the old DCID stays in the pool) and passes with it.
- All existing migration tests pass unchanged, including `connection_migration` (the reuse case does not retire), `connection_migration_zero_length_cid` and `resilience_against_migration_attack` (fallback with no spare DCID still works).
- `cargo test -p quiche --lib`: 1092 passed.
- `cargo test --all-targets --features=async,ffi,qlog --workspace`: all pass.
- `cargo test --doc --features=async,ffi,qlog --workspace`: all pass.
- `cargo clippy --features=async,ffi,qlog --workspace --all-targets -- -D warnings`: clean.
- `cargo +nightly fmt -- --check`: clean for the touched code (two pre-existing fmt diffs exist on upstream `master` in `lib.rs`/`tests.rs`, unrelated to this change).