### PR TITLE
recovery: fix BBRv2 PROBE_RTT wedge when inflight target is below cwnd floor

### DIFF
--- a/quiche/src/recovery/gcongestion/bbr2.rs
+++ b/quiche/src/recovery/gcongestion/bbr2.rs
@@ -729,6 +729,7 @@ impl CongestionControl for BBRv2 {
                 &self.params,
                 recovery_stats,
                 self.get_congestion_window(),
+                self.cwnd_limits.min(),
             )
         {
             mode_changes_allowed -= 1;

--- a/quiche/src/recovery/gcongestion/bbr2/drain.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/drain.rs
@@ -64,6 +64,7 @@ impl ModeImpl for Drain {
         congestion_event: &mut BBRv2CongestionEvent,
         _target_bytes_inflight: usize, params: &Params,
         _recovery_stats: &mut RecoveryStats, _cwnd: usize,
+        _cwnd_lower_bound: usize,
     ) -> Mode {
         self.model.set_pacing_gain(params.drain_pacing_gain);
         // Only STARTUP can transition to DRAIN, both of them use the same cwnd

--- a/quiche/src/recovery/gcongestion/bbr2/mode.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/mode.rs
@@ -140,6 +140,7 @@ pub(super) trait ModeImpl: Debug {
         congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
         recovery_stats: &mut RecoveryStats, cwnd: usize,
+        cwnd_lower_bound: usize,
     ) -> Mode;
 
     fn get_cwnd_limits(&self, params: &Params) -> Limits<usize>;
@@ -192,6 +193,7 @@ impl Mode {
         congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
         recovery_stats: &mut RecoveryStats, cwnd: usize,
+        cwnd_lower_bound: usize,
     ) -> bool {
         let mode_before = std::mem::discriminant(self);
 
@@ -205,6 +207,7 @@ impl Mode {
             params,
             recovery_stats,
             cwnd,
+            cwnd_lower_bound,
         );
 
         let mode_after = std::mem::discriminant(self);
@@ -270,6 +273,7 @@ impl ModeImpl for Placeholder {
         self, _: usize, _: Instant, _: &[Acked], _: &[Lost],
         _: &mut BBRv2CongestionEvent, _: usize, _params: &Params,
         _recovery_stats: &mut RecoveryStats, _cwnd: usize,
+        _cwnd_lower_bound: usize,
     ) -> Mode {
         unreachable!()
     }

--- a/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_bw.rs
@@ -96,6 +96,7 @@ impl ModeImpl for ProbeBW {
         _: &[Lost], congestion_event: &mut BBRv2CongestionEvent,
         target_bytes_inflight: usize, params: &Params,
         _recovery_stats: &mut RecoveryStats, _cwnd: usize,
+        _cwnd_lower_bound: usize,
     ) -> Mode {
         if congestion_event.end_of_round_trip {
             if self.cycle.start_time != event_time {

--- a/quiche/src/recovery/gcongestion/bbr2/probe_rtt.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/probe_rtt.rs
@@ -92,11 +92,21 @@ impl ModeImpl for ProbeRTT {
         congestion_event: &mut BBRv2CongestionEvent,
         _target_bytes_inflight: usize, params: &Params,
         _recovery_stats: &mut RecoveryStats, _cwnd: usize,
+        cwnd_lower_bound: usize,
     ) -> Mode {
         match self.exit_time {
             None => {
+                // Arm the exit timer once bytes in flight drain below the
+                // PROBE_RTT inflight target, or below the connection's
+                // minimum congestion window. The latter clause matters when
+                // the inflight target is below the minimum window: without
+                // it, the cwnd floor (applied in `get_cwnd_limits`/global
+                // limits) keeps bytes in flight pinned above the target
+                // forever, the exit timer never gets armed, and the
+                // connection wedges in PROBE_RTT indefinitely.
                 if congestion_event.bytes_in_flight <=
-                    self.inflight_target(params)
+                    self.inflight_target(params) ||
+                    congestion_event.bytes_in_flight <= cwnd_lower_bound
                 {
                     self.exit_time = Some(
                         congestion_event.event_time + params.probe_rtt_duration,
@@ -153,6 +163,7 @@ impl ModeImpl for ProbeRTT {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::recovery::gcongestion::bbr2::SendTimeState;
     use crate::recovery::gcongestion::bbr2::DEFAULT_PARAMS;
     use crate::BbrParams;
     use std::time::Duration;
@@ -171,5 +182,63 @@ mod tests {
         probe_rtt.enter(Instant::now(), None, params);
         assert_eq!(probe_rtt.model.pacing_gain(), 0.8);
         assert_eq!(probe_rtt.model.cwnd_gain(), 0.5);
+    }
+
+    // Regression test for https://github.com/cloudflare/quiche/issues/2698:
+    // when the PROBE_RTT inflight target (0.5 * BDP) is below the
+    // connection's cwnd floor, bytes_in_flight can never drain to or below
+    // the target, so the exit timer must still be armed once in-flight
+    // drains to the floor instead.
+    #[test]
+    fn probe_rtt_exits_when_inflight_hits_the_cwnd_floor() {
+        let params = &DEFAULT_PARAMS;
+        // No bandwidth samples have been fed into the model yet, so the
+        // inflight target (0.5 * max_bandwidth * min_rtt) is 0 and can never
+        // be reached by a sender with any bytes in flight at all.
+        let model = BBRv2NetworkModel::new(params, Duration::from_millis(50));
+        let probe_rtt = ProbeRTT::new(model, Cycle::default());
+        assert_eq!(probe_rtt.inflight_target(params), 0);
+
+        let now = Instant::now();
+        let mut congestion_event = BBRv2CongestionEvent {
+            event_time: now,
+            prior_cwnd: 100_000,
+            prior_bytes_in_flight: 100_000,
+            bytes_in_flight: 50_000,
+            bytes_acked: 50_000,
+            bytes_lost: 0,
+            end_of_round_trip: false,
+            is_probing_for_bandwidth: false,
+            sample_max_bandwidth: None,
+            sample_min_rtt: None,
+            last_packet_send_state: SendTimeState::default(),
+        };
+        let mut recovery_stats = RecoveryStats::default();
+
+        // bytes_in_flight (50_000) is above the inflight target (0), but at
+        // or below the cwnd's lower bound (60_000, e.g. the initial cwnd) --
+        // this must still arm the exit timer, or the connection wedges in
+        // PROBE_RTT forever.
+        let next = probe_rtt.on_congestion_event(
+            100_000,
+            now,
+            &[],
+            &[],
+            &mut congestion_event,
+            0,
+            params,
+            &mut recovery_stats,
+            100_000,
+            60_000,
+        );
+
+        match next {
+            Mode::ProbeRTT(probe_rtt) => assert!(
+                probe_rtt.exit_time.is_some(),
+                "exit timer should be armed once bytes_in_flight drains \
+                 to the cwnd floor"
+            ),
+            _ => panic!("expected to remain in ProbeRTT"),
+        }
     }
 }

--- a/quiche/src/recovery/gcongestion/bbr2/startup.rs
+++ b/quiche/src/recovery/gcongestion/bbr2/startup.rs
@@ -64,6 +64,7 @@ impl ModeImpl for Startup {
         congestion_event: &mut BBRv2CongestionEvent,
         _target_bytes_inflight: usize, params: &Params,
         recovery_stats: &mut RecoveryStats, cwnd: usize,
+        _cwnd_lower_bound: usize,
     ) -> Mode {
         if self.model.full_bandwidth_reached() {
             return self.into_drain(event_time, Some(congestion_event), params);


### PR DESCRIPTION
## Summary

PROBE_RTT can only arm its 200ms exit timer once `bytes_in_flight` drains
below `inflight_target` (0.5 × BDP). When that target is below the
connection's cwnd floor (e.g. a large initial congestion window on a
low-RTT path), the floor keeps `bytes_in_flight` pinned above the target
forever, the exit timer never gets armed, and the connection wedges in
PROBE_RTT indefinitely with cwnd stuck at the floor.

Google's reference implementation (`bbr2_probe_rtt.cc`) arms the exit
timer when in-flight drops below the inflight target **or** below the
minimum congestion window, making the check exhaustive over both
cwnd-clamp outcomes:

```cpp
if (congestion_event.bytes_in_flight <= InflightTarget() ||
    congestion_event.bytes_in_flight <=
        sender_->GetMinimumCongestionWindow()) {
  exit_time_ = congestion_event.event_time + Params().probe_rtt_duration;
```

The port only kept the first clause. This PR plumbs the connection's cwnd
lower bound (`cwnd_limits.min()`) through `ModeImpl::on_congestion_event`
and restores the second clause in `ProbeRTT::on_congestion_event`.

Fixes #2698.

## Test plan

- [x] Added `probe_rtt_exits_when_inflight_hits_the_cwnd_floor`, a
      regression test that reproduces the wedge (verified it fails
      without the fix and passes with it).
- [x] `cargo test -p quiche --features gcongestion,qlog recovery::gcongestion` — 117 passed.
- [x] `cargo test -p quiche --features gcongestion,qlog,ffi,internal` — full suite, 1102 passed + 45 doc-tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)