### PR TITLE
lib: validate error codes in close() and stream_shutdown() to avoid a panic

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -137,6 +137,10 @@ enum quiche_error {
 
     /// An invalid DCID was used when connecting to a remote peer.
     QUICHE_ERR_INVALID_DCID_INITIALIZATION = -23,
+
+    // An error code provided by the application does not fit in the QUIC
+    // 62-bit variable-length integer space.
+    QUICHE_ERR_INVALID_ERROR_CODE = -24,
 };
 
 // Returns a human readable string with the quiche version number.

--- a/quiche/src/error.rs
+++ b/quiche/src/error.rs
@@ -115,6 +115,10 @@ pub enum Error {
 
     /// An invalid DCID was used when connecting to a remote peer.
     InvalidDcidInitialization,
+
+    /// An error code provided by the application does not fit in the QUIC
+    /// 62-bit variable-length integer space.
+    InvalidErrorCode,
 }
 
 /// QUIC error codes sent on the wire.
@@ -227,6 +231,7 @@ impl Error {
             Error::InvalidAckRange => -21,
             Error::OptimisticAckDetected => -22,
             Error::InvalidDcidInitialization => -23,
+            Error::InvalidErrorCode => -24,
         }
     }
 }

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -6206,14 +6206,22 @@ impl<F: BufFactory> Connection<F> {
     /// can only be closed in the [`Shutdown::Read`] direction. Using an
     /// incorrect direction will return [`InvalidStreamState`].
     ///
+    /// Returns [`InvalidErrorCode`] if `err` does not fit in a QUIC 62-bit
+    /// variable-length integer.
+    ///
     /// [`Shutdown::Read`]: enum.Shutdown.html#variant.Read
     /// [`Shutdown::Write`]: enum.Shutdown.html#variant.Write
     /// [`stream_recv()`]: struct.Connection.html#method.stream_recv
     /// [`stream_send()`]: struct.Connection.html#method.stream_send
     /// [`InvalidStreamState`]: enum.Error.html#variant.InvalidStreamState
+    /// [`InvalidErrorCode`]: enum.Error.html#variant.InvalidErrorCode
     pub fn stream_shutdown(
         &mut self, stream_id: u64, direction: Shutdown, err: u64,
     ) -> Result<()> {
+        if err > octets::MAX_VAR_INT {
+            return Err(Error::InvalidErrorCode);
+        }
+
         // Don't try to stop a local unidirectional stream.
         if direction == Shutdown::Read &&
             stream::is_local(stream_id, self.is_server) &&
@@ -7531,12 +7539,16 @@ impl<F: BufFactory> Connection<F> {
     ///
     /// Returns [`Done`] if the connection had already been closed.
     ///
+    /// Returns [`InvalidErrorCode`] if `err` does not fit in a QUIC 62-bit
+    /// variable-length integer.
+    ///
     /// Note that the connection will not be closed immediately. An application
     /// should continue calling the [`recv()`], [`send()`], [`timeout()`] and
     /// [`on_timeout()`] methods as normal, until the [`is_closed()`] method
     /// returns `true`.
     ///
     /// [`Done`]: enum.Error.html#variant.Done
+    /// [`InvalidErrorCode`]: enum.Error.html#variant.InvalidErrorCode
     /// [`recv()`]: struct.Connection.html#method.recv
     /// [`send()`]: struct.Connection.html#method.send
     /// [`timeout()`]: struct.Connection.html#method.timeout
@@ -7549,6 +7561,10 @@ impl<F: BufFactory> Connection<F> {
 
         if self.local_error.is_some() {
             return Err(Error::Done);
+        }
+
+        if err > octets::MAX_VAR_INT {
+            return Err(Error::InvalidErrorCode);
         }
 
         let is_safe_to_send_app_data =

--- a/quiche/src/tests.rs
+++ b/quiche/src/tests.rs
@@ -4221,6 +4221,39 @@ fn stream_shutdown_write(
 }
 
 #[rstest]
+// Regression test for https://github.com/cloudflare/quiche/issues/2634:
+// stream_shutdown() shares the same error-code-to-frame path as close(), so
+// an out-of-range error code must also be rejected here rather than panic
+// later in send() when the RESET_STREAM/STOP_SENDING frame is serialized.
+fn stream_shutdown_with_invalid_error_code(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut buf = [0; 65535];
+
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    assert_eq!(pipe.client.stream_send(4, b"hello, world", false), Ok(12));
+    assert_eq!(pipe.advance(), Ok(()));
+
+    let invalid_err = octets::MAX_VAR_INT + 1;
+
+    assert_eq!(
+        pipe.server.stream_shutdown(4, Shutdown::Write, invalid_err),
+        Err(Error::InvalidErrorCode)
+    );
+    assert_eq!(
+        pipe.server.stream_shutdown(4, Shutdown::Read, invalid_err),
+        Err(Error::InvalidErrorCode)
+    );
+
+    // The stream must still be usable: no reset/stop was recorded, and
+    // send() must not panic.
+    assert_eq!(pipe.server.stream_shutdown(4, Shutdown::Write, 42), Ok(()));
+    assert!(pipe.server.send(&mut buf).is_ok());
+}
+
+#[rstest]
 /// Tests that shutting down a stream restores flow control for unsent data.
 fn stream_shutdown_write_unsent_tx_cap(
     #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
@@ -8746,6 +8779,36 @@ fn close(#[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str) {
             reason: b"hello?".to_vec(),
         })
     );
+}
+
+#[rstest]
+// Regression test for https://github.com/cloudflare/quiche/issues/2634:
+// an out-of-range error code used to be accepted by `close()` and only
+// discovered (as a panic in `octets::varint_len()`) when `send()` later
+// tried to serialize the CONNECTION_CLOSE frame.
+fn close_with_invalid_error_code(
+    #[values("cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+) {
+    let mut buf = [0; 65535];
+
+    let mut pipe = test_utils::Pipe::new(cc_algorithm_name).unwrap();
+    assert_eq!(pipe.handshake(), Ok(()));
+
+    let invalid_err = octets::MAX_VAR_INT + 1;
+
+    assert_eq!(
+        pipe.client.close(false, invalid_err, b"hello?"),
+        Err(Error::InvalidErrorCode)
+    );
+    assert_eq!(
+        pipe.client.close(true, invalid_err, b"hello!"),
+        Err(Error::InvalidErrorCode)
+    );
+
+    // The connection must still be usable: no local error was recorded, and
+    // send() must not panic.
+    assert_eq!(pipe.client.close(false, 0x1234, b"hello?"), Ok(()));
+    assert!(pipe.client.send(&mut buf).is_ok());
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

`Connection::close()` and `Connection::stream_shutdown()` both accept an
arbitrary `u64` application/transport error code and store it
unvalidated. RFC 9000 requires error codes to fit in the QUIC 62-bit
variable-length integer space, but nothing enforced that here.

If a caller passes a value above `2^62 - 1`:

- `close()` stores it in `local_error` and later, in `send()`, builds a
  `CONNECTION_CLOSE` frame from it.
- `stream_shutdown()` stores it via `insert_reset`/`insert_stopped` and
  later, in `send()`, builds a `RESET_STREAM`/`STOP_SENDING` frame from
  it.

In both cases, `send()` panics before serialization: `Frame::wire_len()`
calls `octets::varint_len()`, which hits `unreachable!()` for any value
outside the 62-bit range. A caller (Rust or C, via `quiche_conn_close`/
`quiche_conn_stream_shutdown`) can crash the process this way instead of
getting a normal error back.

## Fix

- Add `Error::InvalidErrorCode` (`QUICHE_ERR_INVALID_ERROR_CODE = -24` on
  the C side).
- Validate `err <= octets::MAX_VAR_INT` up front in both `close()` and
  `stream_shutdown()`, returning the new error instead of proceeding.

Fixes #2634.

## Test plan

- [x] Added `close_with_invalid_error_code` and
      `stream_shutdown_with_invalid_error_code` regression tests
      (verified both fail — reproducing the bug — without the fix, and
      pass with it).
- [x] `cargo test -p quiche --features gcongestion,qlog,ffi,internal` —
      full suite, 1101 passed + 45 doc-tests.
- [x] Built `quiche_apps`, `tokio-quiche`, and `h3i` (which all match on
      `quiche::Error`) to confirm the new enum variant doesn't break
      downstream exhaustive matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)